### PR TITLE
data-source/aws_api_gateway_rest_api: Prevent error with VPC Endpoint configured APIs

### DIFF
--- a/aws/data_source_aws_api_gateway_rest_api.go
+++ b/aws/data_source_aws_api_gateway_rest_api.go
@@ -59,7 +59,7 @@ func dataSourceAwsApiGatewayRestApi() *schema.Resource {
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"vpc_endpoint_ids": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},

--- a/aws/data_source_aws_api_gateway_rest_api_test.go
+++ b/aws/data_source_aws_api_gateway_rest_api_test.go
@@ -1,14 +1,13 @@
 package aws
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
+func TestAccDataSourceAwsApiGatewayRestApi_basic(t *testing.T) {
 	rName := acctest.RandString(8)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
 	resourceName := "aws_api_gateway_rest_api.test"
@@ -17,7 +16,10 @@ func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsApiGatewayRestApiConfig(rName),
+				Config: composeConfig(
+					testAccAWSAPIGatewayRestAPIConfig_Name(rName),
+					testAccDataSourceAwsApiGatewayRestApiConfigName(),
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
@@ -36,14 +38,41 @@ func TestAccDataSourceAwsApiGatewayRestApi(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAwsApiGatewayRestApiConfig(r string) string {
-	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "test" {
-  name = "%[1]s"
+func TestAccDataSourceAwsApiGatewayRestApi_EndpointConfiguration_VpcEndpointIds(t *testing.T) {
+	rName := acctest.RandString(8)
+	dataSourceName := "data.aws_api_gateway_rest_api.test"
+	resourceName := "aws_api_gateway_rest_api.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: composeConfig(
+					testAccAWSAPIGatewayRestAPIConfig_VPCEndpointConfiguration(rName),
+					testAccDataSourceAwsApiGatewayRestApiConfigName(),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "root_resource_id", resourceName, "root_resource_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy", resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "api_key_source", resourceName, "api_key_source"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "minimum_compression_size", resourceName, "minimum_compression_size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "binary_media_types", resourceName, "binary_media_types"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "endpoint_configuration", resourceName, "endpoint_configuration"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "execution_arn", resourceName, "execution_arn"),
+				),
+			},
+		},
+	})
 }
 
+func testAccDataSourceAwsApiGatewayRestApiConfigName() string {
+	return `
 data "aws_api_gateway_rest_api" "test" {
-  name = "${aws_api_gateway_rest_api.test.name}"
+  name = aws_api_gateway_rest_api.test.name
 }
-`, r)
+`
 }

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -483,7 +483,7 @@ func flattenApiGatewayEndpointConfiguration(endpointConfiguration *apigateway.En
 	}
 
 	if len(endpointConfiguration.VpcEndpointIds) > 0 {
-		m["vpc_endpoint_ids"] = flattenStringSet(endpointConfiguration.VpcEndpointIds)
+		m["vpc_endpoint_ids"] = aws.StringValueSlice(endpointConfiguration.VpcEndpointIds)
 	}
 
 	return []interface{}{m}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/12350
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8223

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_api_gateway_rest_api: Prevent error with VPC Endpoint configured APIs
```

Previously:

```
    TestAccDataSourceAwsApiGatewayRestApi_EndpointConfiguration_VpcEndpointIds: testing.go:669: Step 0 error: errors during apply:

        Error: error setting endpoint_configuration: endpoint_configuration.0.vpc_endpoint_ids: '': source data must be an array or slice, got struct

          on /var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/tf-test660234204/main.tf line 62:
          (source code not available)
```

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsApiGatewayRestApi_basic (18.71s)
--- PASS: TestAccDataSourceAwsApiGatewayRestApi_EndpointConfiguration_VpcEndpointIds (151.75s)

--- PASS: TestAccAWSAPIGatewayRestApi_tags (66.14s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (89.86s)
--- PASS: TestAccAWSAPIGatewayRestApi_disappears (118.54s)
--- PASS: TestAccAWSAPIGatewayRestApi_api_key_source (187.17s)
--- PASS: TestAccAWSAPIGatewayRestApi_openapi (239.32s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VPCEndpoint (370.75s)
--- PASS: TestAccAWSAPIGatewayRestApi_policy (459.60s)
--- PASS: TestAccAWSAPIGatewayRestApi_basic (505.99s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private (690.91s)
```
