### PR TITLE
Implement aws_ecr_repository sweeper

### DIFF
--- a/aws/resource_aws_ecr_repository_test.go
+++ b/aws/resource_aws_ecr_repository_test.go
@@ -2,14 +2,63 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_ecr_repository", &resource.Sweeper{
+		Name: "aws_ecr_repository",
+		F:    testSweepEcrRepositories,
+	})
+}
+
+func testSweepEcrRepositories(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ecrconn
+
+	var errors error
+	err = conn.DescribeRepositoriesPages(&ecr.DescribeRepositoriesInput{}, func(page *ecr.DescribeRepositoriesOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, repository := range page.Repositories {
+			shouldForce := true
+			_, err = conn.DeleteRepository(&ecr.DeleteRepositoryInput{
+				// We should probably sweep repositories even if there are images.
+				Force:          &shouldForce,
+				RegistryId:     repository.RegistryId,
+				RepositoryName: repository.RepositoryName,
+			})
+			if err != nil {
+				errors = multierror.Append(errors, fmt.Errorf("Error deleting ECR repository: %w", err))
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping ECR repository sweep for %s: %s", region, err)
+			return nil
+		}
+		errors = multierror.Append(errors, fmt.Errorf("Error retreiving ECR repositories: %w", err))
+	}
+
+	return errors
+}
 
 func TestAccAWSEcrRepository_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ go test ./aws -v -timeout=10h -sweep=eu-west-2 -sweep-run=aws_ecr_repository
2020/04/15 21:25:50 [DEBUG] Running Sweepers for region (eu-west-2):
2020/04/15 21:25:50 [DEBUG] Running Sweeper (aws_ecr_repository) in region (eu-west-2)
2020/04/15 21:25:50 [INFO] Building AWS auth structure
2020/04/15 21:25:50 [INFO] Setting AWS metadata API timeout to 100ms
2020/04/15 21:25:50 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/04/15 21:25:50 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2020/04/15 21:25:50 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/04/15 21:25:51 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/04/15 21:25:53 Sweeper Tests ran successfully:
        - aws_ecr_repository
ok      github.com/terraform-providers/terraform-provider-aws/aws       3.087s
```
