### PR TITLE
resource/aws_dms_endpoint: Add kafka_settings configuration block and kafka to engine_name validation

### DIFF
--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
 
 * `certificate_arn` - (Optional, Default: empty string) The Amazon Resource Name (ARN) for the certificate.
 * `database_name` - (Optional) The name of the endpoint database.
+* `elasticsearch_settings` - (Optional) Configuration block with Elasticsearch settings. Detailed below.
 * `endpoint_id` - (Required) The database endpoint identifier.
 
     - Must contain from 1 to 255 alphanumeric characters or hyphens.
@@ -53,20 +54,77 @@ The following arguments are supported:
     - Must not contain two consecutive hyphens
 
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
-* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `aurora | aurora-postgresql| azuredb | db2 | docdb | dynamodb | elasticsearch | kinesis | mariadb | mongodb | mysql | oracle | postgres | redshift | s3 | sqlserver | sybase`.
+* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `aurora | aurora-postgresql| azuredb | db2 | docdb | dynamodb | elasticsearch | kafka | kinesis | mariadb | mongodb | mysql | oracle | postgres | redshift | s3 | sqlserver | sybase`.
 * `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.ConnectionAttributes.html).
+* `kafka_settings` - (Optional) Configuration block with Kafka settings. Detailed below.
+* `kinesis_settings` - (Optional) Configuration block with Kinesis settings. Detailed below.
 * `kms_key_arn` - (Required when `engine_name` is `mongodb`, optional otherwise) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
+* `mongodb_settings` - (Optional) Configuration block with MongoDB settings. Detailed below.
 * `password` - (Optional) The password to be used to login to the endpoint database.
 * `port` - (Optional) The port used by the endpoint database.
+* `s3_settings` - (Optional) Configuration block with S3 settings. Detailed below.
 * `server_name` - (Optional) The host name of the server.
+* `service_access_role` - (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
 * `ssl_mode` - (Optional, Default: none) The SSL mode to use for the connection. Can be one of `none | require | verify-ca | verify-full`
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `username` - (Optional) The user name to be used to login to the endpoint database.
-* `service_access_role` - (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
-* `mongodb_settings` - (Optional) Settings for the source MongoDB endpoint. Available settings are `auth_type` (default: `password`), `auth_mechanism` (default: `default`), `nesting_level` (default: `none`), `extract_doc_id` (default: `false`), `docs_to_investigate` (default: `1000`) and `auth_source` (default: `admin`). For more details, see [Using MongoDB as a Source for AWS DMS](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html).
-* `s3_settings` - (Optional) Settings for the target S3 endpoint. Available settings are `service_access_role_arn`, `external_table_definition`, `csv_row_delimiter` (default: `\\n`), `csv_delimiter` (default: `,`), `bucket_folder`, `bucket_name` and `compression_type` (default: `NONE`). For more details, see [Using Amazon S3 as a Target for AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html).
-* `elasticsearch_settings` - (Optional) Settings for the target Elasticsearch. Available settings are `service_access_role_arn`, `endpoint_uri`, `error_retry_duration` (default: `300`) and `full_load_error_percentage` (default: `10`). For more details, see [Using an Amazon Elasticsearch Service Cluster as a Target for AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Elasticsearch.html).
-* `kinesis_settings` - (Optional) Settings for the target Kinesis endpoint. Available settings are `message_format`, `service_access_role_arn`, and `stream_arn`. For more details, see [Using Amazon Kinesis Data Streams as a Target for AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Kinesis.html).
+
+### elasticsearch_settings Arguments
+
+-> Additional information can be found in the [Using Amazon Elasticsearch Service as a Target for AWS Database Migration Service documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Elasticsearch.html).
+
+The `elasticsearch_settings` configuration block supports the following arguments:
+
+* `endpoint_uri` - (Required) Endpoint for the Elasticsearch cluster.
+* `error_retry_duration` - (Optional) Maximum number of seconds for which DMS retries failed API requests to the Elasticsearch cluster. Defaults to `300`.
+* `full_load_error_percentage` - (Optional) Maximum percentage of records that can fail to be written before a full load operation stops. Defaults to `10`.
+* `service_access_role_arn` - (Required) Amazon Resource Name (ARN) of the IAM Role with permissions to write to the Elasticsearch cluster.
+
+### kafka_settings Arguments
+
+-> Additional information can be found in the [Using Apache Kafka as a Target for AWS Database Migration Service documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Kafka.html).
+
+The `kafka_settings` configuration block supports the following arguments:
+
+* `broker` - (Required) Kafka broker location. Specify in the form broker-hostname-or-ip:port.
+* `topic` - (Optional) Kafka topic for migration. Defaults to `kafka-default-topic`.
+
+### kinesis_settings Arguments
+
+-> Additional information can be found in the [Using Amazon Kinesis Data Streams as a Target for AWS Database Migration Service documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Kinesis.html).
+
+The `kinesis_settings` configuration block supports the following arguments:
+
+* `message_format` - (Optional) Output format for the records created. Defaults to `json`. Valid values are `json` and `json_unformatted` (a single line with no tab).
+* `service_access_role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM Role with permissions to write to the Kinesis data stream.
+* `stream_arn` - (Optional) Amazon Resource Name (ARN) of the Kinesis data stream.
+
+### mongodb_settings Arguments
+
+-> Additional information can be found in the [Using MongoDB as a Source for AWS DMS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html).
+
+The `mongodb_settings` configuration block supports the following arguments:
+
+* `auth_mechanism` - (Optional) Authentication mechanism to access the MongoDB source endpoint. Defaults to `default`.
+* `auth_source` - (Optional) Authentication database name. Not used when `auth_type` is `no`. Defaults to `admin`.
+* `auth_type` - (Optional) Authentication type to access the MongoDB source endpoint. Defaults to `password`.
+* `docs_to_investigate` - (Optional) Number of documents to preview to determine the document organization. Use this setting when `nesting_level` is set to `one`. Defaults to `1000`.
+* `extract_doc_id` - (Optional) Document ID. Use this setting when `nesting_level` is set to `none`. Defaults to `false`.
+* `nesting_level` - (Optional) Specifies either document or table mode. Defaults to `none`. Valid values are `one` (table mode) and `none` (document mode).
+
+### s3_settings Arguments
+
+-> Additional information can be found in the [Using Amazon S3 as a Source for AWS Database Migration Service documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.S3.html) and [Using Amazon S3 as a Target for AWS Database Migration Service documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html).
+
+The `s3_settings` configuration block supports the following arguments:
+
+* `bucket_folder` - (Optional) S3 Bucket Object prefix.
+* `bucket_name` - (Optional) S3 Bucket name.
+* `compression_type` - (Optional) Set to compress target files. Defaults to `NONE`. Valid values are `GZIP` and `NONE`.
+* `csv_delimiter` - (Optional) Delimiter used to separate columns in the source files. Defaults to `,`.
+* `csv_row_delimiter` - (Optional) Delimiter used to separate rows in the source files. Defaults to `\n`.
+* `external_table_definition` - (Optional) JSON document that describes how AWS DMS should interpret the data.
+* `service_access_role_arn` - (Optional) Amazon Resource Name (ARN) of the IAM Role with permissions to read from or write to the S3 Bucket.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12836 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_dms_endpoint: Add kafka_settings configuration block and kafka to engine_name validation
```

Also expands and organizes the resource configuration block documentation.

Output from acceptance testing:

```
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch_FullLoadErrorPercentage (27.99s)
--- PASS: TestAccAwsDmsEndpoint_Kafka_Broker (28.18s)
--- PASS: TestAccAwsDmsEndpoint_Kafka_Topic (28.43s)
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch_ErrorRetryDuration (28.58s)
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch (28.86s)
--- PASS: TestAccAwsDmsEndpoint_Basic (28.94s)
--- PASS: TestAccAwsDmsEndpoint_Db2 (29.24s)
--- PASS: TestAccAwsDmsEndpoint_DocDB (29.25s)
--- PASS: TestAccAwsDmsEndpoint_MongoDb (35.75s)
--- PASS: TestAccAwsDmsEndpoint_DynamoDb (38.06s)
--- PASS: TestAccAwsDmsEndpoint_S3 (39.34s)
--- PASS: TestAccAwsDmsEndpoint_Kinesis (83.57s)
```
