### PR TITLE
Add Datasource for COIP Pool(s) (Outpost)

### DIFF
--- a/aws/data_source_aws_coip_pool.go
+++ b/aws/data_source_aws_coip_pool.go
@@ -28,7 +28,7 @@ func dataSourceAwsCoipPool() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
-			"id": {
+			"pool_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -47,7 +47,7 @@ func dataSourceAwsCoipPoolRead(d *schema.ResourceData, meta interface{}) error {
 	req := &ec2.DescribeCoipPoolsInput{}
 
 	var id string
-	if cid, ok := d.GetOk("id"); ok {
+	if cid, ok := d.GetOk("pool_id"); ok {
 		id = cid.(string)
 	}
 

--- a/aws/data_source_aws_coip_pool.go
+++ b/aws/data_source_aws_coip_pool.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsCoipPool() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCoipPoolRead,
+
+		Schema: map[string]*schema.Schema{
+			"local_gateway_route_table_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"pool_cidrs": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"tags": tagsSchemaComputed(),
+
+			"filter": ec2CustomFiltersSchema(),
+		},
+	}
+}
+
+func dataSourceAwsCoipPoolRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeCoipPoolsInput{}
+
+	var id string
+	if cid, ok := d.GetOk("id"); ok {
+		id = cid.(string)
+	}
+
+	if id != "" {
+		req.PoolIds = []*string{aws.String(id)}
+	}
+
+	filters := map[string]string{}
+
+	if v, ok := d.GetOk("local_gateway_route_table_id"); ok {
+		filters["coip-pool.local-gateway-route-table-id"] = v.(string)
+	}
+
+	req.Filters = buildEC2AttributeFilterList(filters)
+
+	if tags, tagsOk := d.GetOk("tags"); tagsOk {
+		req.Filters = append(req.Filters, buildEC2TagFilterList(
+			keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
+		)...)
+	}
+
+	req.Filters = append(req.Filters, buildEC2CustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
+	if len(req.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] Reading AWS COIP Pool: %s", req)
+	resp, err := conn.DescribeCoipPools(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil || len(resp.CoipPools) == 0 {
+		return fmt.Errorf("no matching COIP Pool found")
+	}
+	if len(resp.CoipPools) > 1 {
+		return fmt.Errorf("multiple Coip Pools matched; use additional constraints to reduce matches to a single COIP Pool")
+	}
+
+	coip := resp.CoipPools[0]
+
+	d.SetId(aws.StringValue(coip.PoolId))
+	d.Set("pool_cidrs", coip.PoolCidrs)
+	d.Set("local_gateway_route_table_id", coip.LocalGatewayRouteTableId)
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(coip.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_coip_pool_test.go
+++ b/aws/data_source_aws_coip_pool_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsCoipPool_basic(t *testing.T) {
+	rPoolId := os.Getenv("AWS_COIP_POOL_ID")
+	if rPoolId == "" {
+		t.Skip(
+			"Environment variable AWS_COIP_POOL_ID is not set. " +
+				"This environment variable must be set to the ID of " +
+				"a deployed Coip Pool to enable this test.")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsLocalGatewayConfig(rPoolId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_coip_pool.by_id", "id", rPoolId),
+					resource.TestCheckResourceAttrSet("data.aws_coip_pool.by_id", "local_gateway_route_table_id"),
+					testCheckResourceAttrGreaterThanValue("data.aws_coip_pool.by_id", "pool_cidrs.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsLocalGatewayConfig(rPoolId string) string {
+	return fmt.Sprintf(`
+data "aws_coip_pool" "by_id" {
+  id = "%s"
+}
+`, rPoolId)
+}

--- a/aws/data_source_aws_coip_pool_test.go
+++ b/aws/data_source_aws_coip_pool_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceAwsCoipPool_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsLocalGatewayConfig(rPoolId),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_coip_pool.by_id", "id", rPoolId),
+					resource.TestCheckResourceAttr("data.aws_coip_pool.by_id", "pool_id", rPoolId),
 					resource.TestCheckResourceAttrSet("data.aws_coip_pool.by_id", "local_gateway_route_table_id"),
 					testCheckResourceAttrGreaterThanValue("data.aws_coip_pool.by_id", "pool_cidrs.#", "0"),
 				),
@@ -36,7 +36,7 @@ func TestAccDataSourceAwsCoipPool_basic(t *testing.T) {
 func testAccDataSourceAwsLocalGatewayConfig(rPoolId string) string {
 	return fmt.Sprintf(`
 data "aws_coip_pool" "by_id" {
-  id = "%s"
+  pool_id = "%s"
 }
 `, rPoolId)
 }

--- a/aws/data_source_aws_coip_pools.go
+++ b/aws/data_source_aws_coip_pools.go
@@ -19,7 +19,7 @@ func dataSourceAwsCoipPools() *schema.Resource {
 
 			"tags": tagsSchemaComputed(),
 
-			"ids": {
+			"pool_ids": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -67,7 +67,7 @@ func dataSourceAwsCoipPoolsRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.SetId(time.Now().UTC().String())
-	if err := d.Set("ids", coippools); err != nil {
+	if err := d.Set("pool_ids", coippools); err != nil {
 		return fmt.Errorf("Error setting coip pool ids: %s", err)
 	}
 

--- a/aws/data_source_aws_coip_pools.go
+++ b/aws/data_source_aws_coip_pools.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsCoipPools() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCoipPoolsRead,
+		Schema: map[string]*schema.Schema{
+			"filter": ec2CustomFiltersSchema(),
+
+			"tags": tagsSchemaComputed(),
+
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCoipPoolsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeCoipPoolsInput{}
+
+	if tags, tagsOk := d.GetOk("tags"); tagsOk {
+		req.Filters = append(req.Filters, buildEC2TagFilterList(
+			keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
+		)...)
+	}
+
+	if filters, filtersOk := d.GetOk("filter"); filtersOk {
+		req.Filters = append(req.Filters, buildEC2CustomFilterList(
+			filters.(*schema.Set),
+		)...)
+	}
+	if len(req.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] DescribeCoipPools %s\n", req)
+	resp, err := conn.DescribeCoipPools(req)
+	if err != nil {
+		return err
+	}
+
+	if resp == nil || len(resp.CoipPools) == 0 {
+		return fmt.Errorf("no matching Coip Pool found")
+	}
+
+	coippools := make([]string, 0)
+
+	for _, coippool := range resp.CoipPools {
+		coippools = append(coippools, aws.StringValue(coippool.PoolId))
+	}
+
+	d.SetId(time.Now().UTC().String())
+	if err := d.Set("ids", coippools); err != nil {
+		return fmt.Errorf("Error setting coip pool ids: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_coip_pools_test.go
+++ b/aws/data_source_aws_coip_pools_test.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourceAwsCoipPools_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsCoipPoolsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCoipPoolDataSourceExists("data.aws_coip_pools.all"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsCoipPools_filters(t *testing.T) {
+	rPoolId := os.Getenv("AWS_COIP_POOL_ID")
+	if rPoolId == "" {
+		t.Skip(
+			"Environment variable AWS_COIP_POOL_ID is not set. " +
+				"This environment variable must be set to the ID of " +
+				"a deployed Coip Pool to enable this test.")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsCoipPoolsConfig_filters(rPoolId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCoipPoolDataSourceExists("data.aws_coip_pools.selected"),
+					testCheckResourceAttrGreaterThanValue("data.aws_coip_pools.selected", "ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsCoipPoolDataSourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find aws_coip_pools data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("aws_coip_pools data source ID not set")
+		}
+		return nil
+	}
+}
+
+const testAccDataSourceAwsCoipPoolsConfig = `data "aws_coip_pools" "all" {}`
+
+func testAccDataSourceAwsCoipPoolsConfig_filters(rPoolId string) string {
+	return fmt.Sprintf(`
+data "aws_coip_pools" "selected" {
+  filter {
+    name   = "coip-pool.pool-id"
+    values = ["%s"]
+  }
+}
+`, rPoolId)
+}

--- a/aws/data_source_aws_coip_pools_test.go
+++ b/aws/data_source_aws_coip_pools_test.go
@@ -41,7 +41,7 @@ func TestAccDataSourceAwsCoipPools_filters(t *testing.T) {
 				Config: testAccDataSourceAwsCoipPoolsConfig_filters(rPoolId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsCoipPoolDataSourceExists("data.aws_coip_pools.selected"),
-					testCheckResourceAttrGreaterThanValue("data.aws_coip_pools.selected", "ids.#", "0"),
+					testCheckResourceAttrGreaterThanValue("data.aws_coip_pools.selected", "pool_ids.#", "0"),
 				),
 			},
 		},

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -192,6 +192,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudtrail_service_account":                dataSourceAwsCloudTrailServiceAccount(),
 			"aws_cloudwatch_log_group":                      dataSourceAwsCloudwatchLogGroup(),
 			"aws_cognito_user_pools":                        dataSourceAwsCognitoUserPools(),
+			"aws_coip_pool":                                 dataSourceAwsCoipPool(),
+			"aws_coip_pools":                                dataSourceAwsCoipPools(),
 			"aws_codecommit_repository":                     dataSourceAwsCodeCommitRepository(),
 			"aws_cur_report_definition":                     dataSourceAwsCurReportDefinition(),
 			"aws_db_cluster_snapshot":                       dataSourceAwsDbClusterSnapshot(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3154,6 +3154,12 @@
                             <a href="#">Data Sources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>
+                                    <a href="/docs/providers/aws/d/coip_pool.html">aws_coip_pool</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/coip_pools.html">aws_coip_pools</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/d/customer_gateway.html">aws_customer_gateway</a>
                                 </li>
                                 <li>

--- a/website/docs/d/coip_pool.html.markdown
+++ b/website/docs/d/coip_pool.html.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "VPC"
+layout: "aws"
+page_title: "AWS: aws_coip_pool"
+description: |-
+    Provides details about a specific COIP Pool
+---
+
+# Data Source: aws_coip_pool
+
+`aws_coip_pool` provides details about a specific COIP Pool.
+
+This resource can prove useful when a module accepts a coip pool id as
+an input variable and needs to, for example, determine the CIDR block of that
+COIP Pool.
+
+## Example Usage
+
+The following example returns a specific coip pool ID
+
+```hcl
+variable "coip_pool_id" {}
+
+data "aws_coip_pool" "selected" {
+  id = "${var.coip_pool_id}"
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available
+COIP Pools in the current region. The given filters must match exactly one
+COIP Pool whose data will be exported as attributes.
+
+* `local_gateway_route_table_id` - (Optional) Local Gateway Route Table Id assigned to desired COIP Pool
+
+* `id` - (Optional) The id of the specific COIP Pool to retrieve.
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired COIP Pool.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCoipPools.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  A COIP Pool will be selected if any one of the given values matches.
+
+## Attributes Reference
+
+All of the argument attributes except `filter` blocks are also exported as
+result attributes. This data source will complete the data by populating
+any fields that are not included in the configuration with the data for
+the selected COIP Pool.
+
+The following attribute is additionally exported:
+
+* `pool_cidrs` - List of CIDR blocks in pool

--- a/website/docs/d/coip_pool.html.markdown
+++ b/website/docs/d/coip_pool.html.markdown
@@ -34,7 +34,7 @@ COIP Pool whose data will be exported as attributes.
 
 * `local_gateway_route_table_id` - (Optional) Local Gateway Route Table Id assigned to desired COIP Pool
 
-* `id` - (Optional) The id of the specific COIP Pool to retrieve.
+* `pool_id` - (Optional) The id of the specific COIP Pool to retrieve.
 
 * `tags` - (Optional) A mapping of tags, each pair of which must exactly match
   a pair on the desired COIP Pool.

--- a/website/docs/d/coip_pools.html.markdown
+++ b/website/docs/d/coip_pools.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "VPC"
+layout: "aws"
+page_title: "AWS: aws_coip_pools"
+description: |-
+    Provides a list of COIP Pool Ids in a region
+---
+
+# Data Source: aws_coip_pools
+
+This resource can be useful for getting back a list of COIP Pool Ids for a region.
+
+## Example Usage
+
+The following shows outputing all COIP Pool Ids.
+
+```hcl
+data "aws_vpcs" "foo" {}
+
+output "foo" {
+  value = "${data.aws_vpcs.foo.ids}"
+}
+```
+
+## Argument Reference
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired vpcs.
+
+* `filter` - (Optional) Custom filter block as described below.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCoipPools.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  A COIP Pool will be selected if any one of the given values matches.
+
+## Attributes Reference
+
+* `ids` - A list of all the COIP Pool Ids found. This data source will fail if none are found.

--- a/website/docs/d/coip_pools.html.markdown
+++ b/website/docs/d/coip_pools.html.markdown
@@ -15,17 +15,17 @@ This resource can be useful for getting back a list of COIP Pool Ids for a regio
 The following shows outputing all COIP Pool Ids.
 
 ```hcl
-data "aws_vpcs" "foo" {}
+data "aws_coip_pools" "foo" {}
 
 output "foo" {
-  value = "${data.aws_vpcs.foo.ids}"
+  value = "${data.aws_coip_pools.foo.ids}"
 }
 ```
 
 ## Argument Reference
 
 * `tags` - (Optional) A mapping of tags, each pair of which must exactly match
-  a pair on the desired vpcs.
+  a pair on the desired aws_coip_pools.
 
 * `filter` - (Optional) Custom filter block as described below.
 
@@ -40,4 +40,4 @@ which take the following arguments:
 
 ## Attributes Reference
 
-* `ids` - A list of all the COIP Pool Ids found. This data source will fail if none are found.
+* `pool_ids` - A list of all the COIP Pool Ids found. This data source will fail if none are found.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12302

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add Datasource for COIP Pool(s)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_COIP_POOL_ID=ipv4pool-coip-<snip> make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsCoipPool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsCoipPool -timeout 120m
=== RUN   TestAccDataSourceAwsCoipPool_basic
=== PAUSE TestAccDataSourceAwsCoipPool_basic
=== RUN   TestAccDataSourceAwsCoipPools_basic
=== PAUSE TestAccDataSourceAwsCoipPools_basic
=== RUN   TestAccDataSourceAwsCoipPools_filters
=== PAUSE TestAccDataSourceAwsCoipPools_filters
=== CONT  TestAccDataSourceAwsCoipPool_basic
=== CONT  TestAccDataSourceAwsCoipPools_basic
=== CONT  TestAccDataSourceAwsCoipPools_filters
--- PASS: TestAccDataSourceAwsCoipPools_basic (50.75s)
--- PASS: TestAccDataSourceAwsCoipPool_basic (50.75s)
--- PASS: TestAccDataSourceAwsCoipPools_filters (51.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.534s
```
