### PR TITLE
.github/workflows/issues: Ignore collaborators for needs-triage issue labeling

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v1.0.0
     - name: Apply Issue Triage Label
       uses: actions/github@v1.0.0
-      if: github.event.action == 'opened'
+      if: github.event.action == 'opened' && !contains(['bflad', 'breathingdust', 'ewbankkit', 'gdavison', 'maryelizbeth'], github.actor)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12841

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

GitHub Actions does not seem to provide a native way to determine if the actor is a collaborator, so for now just skip based on username. The pull request labeling happens separately in hashibot, which requires a code update.

Output from acceptance testing: N/A (GitHub Actions issue workflow)