### PR TITLE
fix tagging for default route table

### DIFF
--- a/aws/resource_aws_default_route_table.go
+++ b/aws/resource_aws_default_route_table.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsDefaultRouteTable() *schema.Resource {
@@ -43,13 +45,15 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 
 						"ipv6_cidr_block": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 
 						"egress_only_gateway_id": {
@@ -122,6 +126,12 @@ func resourceAwsDefaultRouteTableCreate(d *schema.ResourceData, meta interface{}
 	log.Printf("[DEBUG] Revoking default routes for Default Route Table for %s", d.Id())
 	if err := revokeAllRouteTableRules(d.Id(), meta); err != nil {
 		return err
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		if err := keyvaluetags.Ec2CreateTags(conn, d.Id(), v); err != nil {
+			return fmt.Errorf("error adding tags: %s", err)
+		}
 	}
 
 	return resourceAwsRouteTableUpdate(d, meta)

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -469,12 +469,20 @@ resource "aws_subnet" "test" {
   }
 }
 
-resource "aws_ec2_transit_gateway" "test" {}
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = "tf-acc-test-ec2-default-route-table-transit-gateway-id"
+  }
+}
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
   subnet_ids         = ["${aws_subnet.test.id}"]
   transit_gateway_id = "${aws_ec2_transit_gateway.test.id}"
   vpc_id             = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-test-ec2-default-route-table-transit-gateway-id"
+  }
 }
 
 resource "aws_default_route_table" "test" {
@@ -490,40 +498,42 @@ resource "aws_default_route_table" "test" {
 
 const testAccDefaultRouteTable_vpc_endpoint = `
 resource "aws_vpc" "test" {
-    cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
 
   tags = {
-        Name = "terraform-testacc-default-route-table-vpc-endpoint"
-    }
+    Name = "terraform-testacc-default-route-table-vpc-endpoint"
+  }
 }
 
 resource "aws_internet_gateway" "igw" {
-    vpc_id = "${aws_vpc.test.id}"
+  vpc_id = "${aws_vpc.test.id}"
 
   tags = {
-        Name = "test"
-    }
+    Name = "terraform-testacc-default-route-table-vpc-endpoint"
+  }
 }
 
 resource "aws_vpc_endpoint" "s3" {
-    vpc_id = "${aws_vpc.test.id}"
-    service_name = "com.amazonaws.us-west-2.s3"
-    route_table_ids = [
-        "${aws_vpc.test.default_route_table_id}"
-    ]
+    vpc_id          = "${aws_vpc.test.id}"
+    service_name    = "com.amazonaws.us-west-2.s3"
+    route_table_ids = ["${aws_vpc.test.default_route_table_id}"]
+
+  tags = {
+    Name = "terraform-testacc-default-route-table-vpc-endpoint"
+  }
 }
 
 resource "aws_default_route_table" "foo" {
-    default_route_table_id = "${aws_vpc.test.default_route_table_id}"
+  default_route_table_id = "${aws_vpc.test.default_route_table_id}"
 
   tags = {
         Name = "test"
-    }
+  }
 
-    route {
-        cidr_block = "0.0.0.0/0"
-        gateway_id = "${aws_internet_gateway.igw.id}"
-    }
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.igw.id}"
+  }
 }
 `
 

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -497,6 +497,8 @@ resource "aws_default_route_table" "test" {
 }
 
 const testAccDefaultRouteTable_vpc_endpoint = `
+data "aws_region" "current" {}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -515,7 +517,7 @@ resource "aws_internet_gateway" "igw" {
 
 resource "aws_vpc_endpoint" "s3" {
     vpc_id          = "${aws_vpc.test.id}"
-    service_name    = "com.amazonaws.us-west-2.s3"
+    service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
     route_table_ids = ["${aws_vpc.test.default_route_table_id}"]
 
   tags = {

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -82,6 +81,7 @@ func testSweepRouteTables(region string) error {
 
 func TestAccAWSRouteTable_basic(t *testing.T) {
 	var v ec2.RouteTable
+	resourceName := "aws_route_table.test"
 
 	testCheck := func(*terraform.State) error {
 		if len(v.Routes) != 2 {
@@ -128,31 +128,29 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route_table.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteTableConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(
-						"aws_route_table.foo", &v),
+					testAccCheckRouteTableExists(resourceName, &v),
 					testCheck,
-					testAccCheckResourceAttrAccountID("aws_route_table.foo", "owner_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
 			{
-				ResourceName:      "aws_route_table.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: testAccRouteTableConfigChange,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(
-						"aws_route_table.foo", &v),
+					testAccCheckRouteTableExists(resourceName, &v),
 					testCheckChange,
-					testAccCheckResourceAttrAccountID("aws_route_table.foo", "owner_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
 		},
@@ -161,6 +159,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 
 func TestAccAWSRouteTable_instance(t *testing.T) {
 	var v ec2.RouteTable
+	resourceName := "aws_route_table.test"
 
 	testCheck := func(*terraform.State) error {
 		if len(v.Routes) != 2 {
@@ -184,20 +183,19 @@ func TestAccAWSRouteTable_instance(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route_table.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteTableConfigInstance,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(
-						"aws_route_table.foo", &v),
+					testAccCheckRouteTableExists(resourceName, &v),
 					testCheck,
 				),
 			},
 			{
-				ResourceName:      "aws_route_table.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -207,6 +205,7 @@ func TestAccAWSRouteTable_instance(t *testing.T) {
 
 func TestAccAWSRouteTable_ipv6(t *testing.T) {
 	var v ec2.RouteTable
+	resourceName := "aws_route_table.test"
 
 	testCheck := func(*terraform.State) error {
 		// Expect 3: 2 IPv6 (local + all outbound) + 1 IPv4
@@ -219,19 +218,19 @@ func TestAccAWSRouteTable_ipv6(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route_table.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRouteTableConfigIpv6,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists("aws_route_table.foo", &v),
+					testAccCheckRouteTableExists(resourceName, &v),
 					testCheck,
 				),
 			},
 			{
-				ResourceName:      "aws_route_table.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -240,8 +239,8 @@ func TestAccAWSRouteTable_ipv6(t *testing.T) {
 }
 
 func TestAccAWSRouteTable_tags(t *testing.T) {
-	var route_table ec2.RouteTable
-	resourceName := "aws_route_table.foo"
+	var routeTable ec2.RouteTable
+	resourceName := "aws_route_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -252,9 +251,9 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 			{
 				Config: testAccRouteTableConfigTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(resourceName, &route_table),
+					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.test", "bar"),
 				),
 			},
 			{
@@ -265,7 +264,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 			{
 				Config: testAccRouteTableConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(resourceName, &route_table),
+					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.bar", "baz"),
 				),
@@ -276,9 +275,11 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 
 // For GH-13545, Fixes panic on an empty route config block
 func TestAccAWSRouteTable_panicEmptyRoute(t *testing.T) {
+	resourceName := "aws_route_table.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route_table.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
@@ -384,11 +385,7 @@ func testAccCheckRouteTableDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error is what we want
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-		if ec2err.Code() != "InvalidRouteTableID.NotFound" {
+		if !isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
 			return err
 		}
 	}
@@ -428,6 +425,7 @@ func testAccCheckRouteTableExists(n string, v *ec2.RouteTable) resource.TestChec
 // Right now there is no VPC Peering resource
 func TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 	var v ec2.RouteTable
+	resourceName := "aws_route_table.test"
 
 	testCheck := func(*terraform.State) error {
 		if len(v.Routes) != 2 {
@@ -456,13 +454,12 @@ func TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 			{
 				Config: testAccRouteTableVpcPeeringConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(
-						"aws_route_table.foo", &v),
+					testAccCheckRouteTableExists(resourceName, &v),
 					testCheck,
 				),
 			},
 			{
-				ResourceName:      "aws_route_table.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -473,6 +470,7 @@ func TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 	var v ec2.RouteTable
 	var vgw ec2.VpnGateway
+	resourceName := "aws_route_table.test"
 
 	testCheck := func(*terraform.State) error {
 		if len(v.PropagatingVgws) != 1 {
@@ -502,15 +500,13 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 			{
 				Config: testAccRouteTableVgwRoutePropagationConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(
-						"aws_route_table.foo", &v),
-					testAccCheckVpnGatewayExists(
-						"aws_vpn_gateway.foo", &vgw),
+					testAccCheckRouteTableExists(resourceName, &v),
+					testAccCheckVpnGatewayExists("aws_vpn_gateway.test", &vgw),
 					testCheck,
 				),
 			},
 			{
-				ResourceName:      "aws_route_table.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -519,82 +515,85 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 }
 
 const testAccRouteTableConfig = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+  	Name = "terraform-testacc-route-table"
+  }
 }
 
-resource "aws_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	tags = {
-		Name = "terraform-testacc-route-table"
-	}
+  tags = {
+  	Name = "terraform-testacc-route-table"
+  }
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	route {
-		cidr_block = "10.2.0.0/16"
-		gateway_id = "${aws_internet_gateway.foo.id}"
-	}
+  route {
+    cidr_block = "10.2.0.0/16"
+    gateway_id = "${aws_internet_gateway.test.id}"
+  }
 }
 `
 
 const testAccRouteTableConfigChange = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-route-table"
+  }
 }
 
-resource "aws_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	tags = {
-		Name = "terraform-testacc-route-table"
-	}
+  tags = {
+    Name = "terraform-testacc-route-table"
+  }
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	route {
-		cidr_block = "10.3.0.0/16"
-		gateway_id = "${aws_internet_gateway.foo.id}"
-	}
+  route {
+    cidr_block = "10.3.0.0/16"
+    gateway_id = "${aws_internet_gateway.test.id}"
+  }
 
-	route {
-		cidr_block = "10.4.0.0/16"
-		gateway_id = "${aws_internet_gateway.foo.id}"
-	}
+  route {
+    cidr_block = "10.4.0.0/16"
+    gateway_id = "${aws_internet_gateway.test.id}"
+  }
 }
 `
 
 const testAccRouteTableConfigIpv6 = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
+
   tags = {
     Name = "terraform-testacc-route-table-ipv6"
   }
 }
 
-resource "aws_egress_only_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_egress_only_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	route {
-		ipv6_cidr_block = "::/0"
-		egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
-	}
+  route {
+    ipv6_cidr_block = "::/0"
+    egress_only_gateway_id = "${aws_egress_only_internet_gateway.test.id}"
+  }
 }
 `
 
@@ -614,154 +613,160 @@ data "aws_ami" "amzn-ami-minimal-hvm" {
   }
 }
 
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table-instance"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+  	Name = "terraform-testacc-route-table-instance"
+  }
 }
 
-resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
-	tags = {
-		Name = "tf-acc-route-table-instance"
-	}
+resource "aws_subnet" "test" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.test.id}"
+
+  tags = {
+  	Name = "tf-acc-route-table-instance"
+  }
 }
 
-resource "aws_instance" "foo" {
+resource "aws_instance" "test" {
   ami           = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
   instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.foo.id}"
+  subnet_id     = "${aws_subnet.test.id}"
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	route {
-		cidr_block = "10.2.0.0/16"
-		instance_id = "${aws_instance.foo.id}"
-	}
+  route {
+    cidr_block = "10.2.0.0/16"
+    instance_id = "${aws_instance.test.id}"
+  }
 }
 `
 
 const testAccRouteTableConfigTags = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table-tags"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-route-table-tags"
+  }
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	tags = {
-		foo = "bar"
-	}
+  tags = {
+    foo = "bar"
+  }
 }
 `
 
 const testAccRouteTableConfigTagsUpdate = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table-tags"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-route-table-tags"
+  }
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	tags = {
-		bar = "baz"
-	}
+  tags = {
+    bar = "baz"
+  }
 }
 `
 
 // VPC Peering connections are prefixed with pcx
 const testAccRouteTableVpcPeeringConfig = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table-vpc-peering-foo"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+  tags = {
+    Name = "terraform-testacc-route-table-vpc-peering-foo"
+  }
 }
 
-resource "aws_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	tags = {
-		Name = "terraform-testacc-route-table-vpc-peering-foo"
-	}
+  tags = {
+    Name = "terraform-testacc-route-table-vpc-peering-foo"
+  }
 }
 
 resource "aws_vpc" "bar" {
-	cidr_block = "10.3.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table-vpc-peering-bar"
-	}
+  cidr_block = "10.3.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-route-table-vpc-peering-bar"
+  }
 }
 
 resource "aws_internet_gateway" "bar" {
-	vpc_id = "${aws_vpc.bar.id}"
+  vpc_id = "${aws_vpc.bar.id}"
 
-	tags = {
-		Name = "terraform-testacc-route-table-vpc-peering-bar"
-	}
+  tags = {
+    Name = "terraform-testacc-route-table-vpc-peering-bar"
+  }
 }
 
-resource "aws_vpc_peering_connection" "foo" {
-		vpc_id = "${aws_vpc.foo.id}"
-		peer_vpc_id = "${aws_vpc.bar.id}"
-	tags = {
-			foo = "bar"
-		}
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  peer_vpc_id = "${aws_vpc.bar.id}"
+
+  tags = {
+    foo = "bar"
+  }
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-	route {
-		cidr_block = "10.2.0.0/16"
-		vpc_peering_connection_id = "${aws_vpc_peering_connection.foo.id}"
-	}
+  route {
+    cidr_block = "10.2.0.0/16"
+    vpc_peering_connection_id = "${aws_vpc_peering_connection.test.id}"
+  }
 }
 `
 
 const testAccRouteTableVgwRoutePropagationConfig = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table-vgw-route-propagation"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-route-table-vgw-route-propagation"
+  }
 }
 
-resource "aws_vpn_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_vpn_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-
-	propagating_vgws = ["${aws_vpn_gateway.foo.id}"]
+resource "aws_route_table" "test" {
+  vpc_id           = "${aws_vpc.test.id}"
+  propagating_vgws = ["${aws_vpn_gateway.test.id}"]
 }
 `
 
 // For GH-13545
 const testAccRouteTableConfigPanicEmptyRoute = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.2.0.0/16"
-	tags = {
-		Name = "terraform-testacc-route-table-panic-empty-route"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.2.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-route-table-panic-empty-route"
+  }
 }
 
-resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
 
-  route {
-  }
+  route {}
 }
 `
 

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -253,7 +253,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.test", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{


### PR DESCRIPTION
+ add plan time validation

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12839

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_route_table: add plan time validation to `cidr_block` and `ipv6_cidr_block`
resource_aws_default_route_table: add plan time validation to `cidr_block` and `ipv6_cidr_block`
resource_aws_default_route_table: fix tag on create
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDefaultRouteTable_'
--- PASS: TestAccAWSDefaultRouteTable_disappears_Vpc (40.32s)
--- PASS: TestAccAWSDefaultRouteTable_Route (168.88s)
--- PASS: TestAccAWSDefaultRouteTable_swap (137.80s)
--- PASS: TestAccAWSDefaultRouteTable_Route_TransitGatewayID (319.80s)
--- PASS: TestAccAWSDefaultRouteTable_vpc_endpoint (89.90s)
--- PASS: TestAccAWSDefaultRouteTable_tags (153.86s)
```

```
$ make testacc TESTARGS='-run=TestAccAWSRouteTable_'
--- PASS: TestAccAWSRouteTable_basic (147.88s)
--- PASS: TestAccAWSRouteTable_instance (187.01s)
--- PASS: TestAccAWSRouteTable_tags (115.74s)
--- PASS: TestAccAWSRouteTable_panicEmptyRoute (46.56s)
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (201.41s)
--- PASS: TestAccAWSRouteTable_Route_TransitGatewayID (389.70s)
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (97.22s)

both of these failed because i lack permissions to run these
--- FAIL: TestAccAWSRouteTable_ipv6 (40.87s)
--- FAIL: TestAccAWSRouteTable_vpcPeering (59.77s)
```
