### PR TITLE
Add COIP Pools to EIP resource and datasource (Outpost)

### DIFF
--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -155,7 +155,7 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s.compute", dashIP, region)))
 		}
 	}
-
+	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
 	d.Set("customer_owned_ipv4_pool", eip.CustomerOwnedIpv4Pool)
 	d.Set("customer_owned_ip", eip.CustomerOwnedIp)
 

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -155,19 +155,9 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s.compute", dashIP, region)))
 		}
 	}
-	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
 
-	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
-	if eip.CustomerOwnedIpv4Pool != nil {
-		d.Set("customer_owned_ipv4_pool", eip.CustomerOwnedIpv4Pool)
-	} else {
-		d.Set("customer_owned_ipv4_pool", "")
-	}
-	if eip.CustomerOwnedIp != nil {
-		d.Set("customer_owned_ip", eip.CustomerOwnedIp)
-	} else {
-		d.Set("customer_owned_ip", "")
-	}
+	d.Set("customer_owned_ipv4_pool", eip.CustomerOwnedIpv4Pool)
+	d.Set("customer_owned_ip", eip.CustomerOwnedIp)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(eip.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -63,6 +63,14 @@ func dataSourceAwsEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"customer_owned_ipv4_pool": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"customer_owned_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tagsSchemaComputed(),
 		},
 	}
@@ -148,6 +156,18 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
+
+	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
+	if eip.CustomerOwnedIpv4Pool != nil {
+		d.Set("customer_owned_ipv4_pool", eip.CustomerOwnedIpv4Pool)
+	} else {
+		d.Set("customer_owned_ipv4_pool", "")
+	}
+	if eip.CustomerOwnedIp != nil {
+		d.Set("customer_owned_ip", eip.CustomerOwnedIp)
+	} else {
+		d.Set("customer_owned_ip", "")
+	}
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(eip.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -270,17 +270,9 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s.compute", dashIP, region)))
 		}
 	}
-	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
-	if address.CustomerOwnedIpv4Pool != nil {
-		d.Set("customer_owned_ipv4_pool", address.CustomerOwnedIpv4Pool)
-	} else {
-		d.Set("customer_owned_ipv4_pool", "")
-	}
-	if address.CustomerOwnedIp != nil {
-		d.Set("customer_owned_ip", address.CustomerOwnedIp)
-	} else {
-		d.Set("customer_owned_ip", "")
-	}
+
+	d.Set("customer_owned_ipv4_pool", address.CustomerOwnedIpv4Pool)
+	d.Set("customer_owned_ip", address.CustomerOwnedIp)
 
 	// On import (domain never set, which it must've been if we created),
 	// set the 'vpc' attribute depending on if we're in a VPC.

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -91,6 +91,16 @@ func resourceAwsEip() *schema.Resource {
 				Optional: true,
 			},
 
+			"customer_owned_ipv4_pool": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"customer_owned_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"public_ipv4_pool": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -118,6 +128,10 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("public_ipv4_pool"); ok {
 		allocOpts.PublicIpv4Pool = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("customer_owned_ipv4_pool"); ok {
+		allocOpts.CustomerOwnedIpv4Pool = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] EIP create configuration: %#v", allocOpts)
@@ -257,6 +271,16 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
+	if address.CustomerOwnedIpv4Pool != nil {
+		d.Set("customer_owned_ipv4_pool", address.CustomerOwnedIpv4Pool)
+	} else {
+		d.Set("customer_owned_ipv4_pool", "")
+	}
+	if address.CustomerOwnedIp != nil {
+		d.Set("customer_owned_ip", address.CustomerOwnedIp)
+	} else {
+		d.Set("customer_owned_ip", "")
+	}
 
 	// On import (domain never set, which it must've been if we created),
 	// set the 'vpc' attribute depending on if we're in a VPC.

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -270,7 +270,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("public_dns", meta.(*AWSClient).PartitionHostname(fmt.Sprintf("ec2-%s.%s.compute", dashIP, region)))
 		}
 	}
-
+	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
 	d.Set("customer_owned_ipv4_pool", address.CustomerOwnedIpv4Pool)
 	d.Set("customer_owned_ip", address.CustomerOwnedIp)
 

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -75,6 +75,8 @@ In addition to all arguments above, the following attributes are exported:
 * `public_ip` - Public IP address of Elastic IP.
 * `public_dns` - Public DNS associated with the Elastic IP address.
 * `public_ipv4_pool` - The ID of an address pool.
+* `customer_owned_ipv4_pool` - The ID of a Customer Owned IP Pool.
+* `customer_owned_ip` - Customer Owned IP.
 * `tags` - Key-value map of tags associated with Elastic IP.
 
 ~> **Note:** The data source computes the `public_dns` and `private_dns` attributes according to the [VPC DNS Guide](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-hostnames) as they are not available with the EC2 API.

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -75,7 +75,7 @@ In addition to all arguments above, the following attributes are exported:
 * `public_ip` - Public IP address of Elastic IP.
 * `public_dns` - Public DNS associated with the Elastic IP address.
 * `public_ipv4_pool` - The ID of an address pool.
-* `customer_owned_ipv4_pool` - The ID of a Customer Owned IP Pool.
+* `customer_owned_ipv4_pool` - The ID of a Customer Owned IP Pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
 * `customer_owned_ip` - Customer Owned IP.
 * `tags` - Key-value map of tags associated with Elastic IP.
 

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -105,7 +105,7 @@ The following arguments are supported:
   the Elastic IP address is associated with the primary private IP address.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `public_ipv4_pool` - (Optional) EC2 IPv4 address pool identifier or `amazon`. This option is only available for VPC EIPs.
-* `customer_owned_ipv4_pool` - (Optional) The  ID  of a customer-owned address pool.
+* `customer_owned_ipv4_pool` - The  ID  of a customer-owned address pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
 
 ~> **NOTE:** You can specify either the `instance` ID or the `network_interface` ID,
 but not both. Including both will **not** return an error from the AWS API, but will

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -126,7 +126,7 @@ In addition to all arguments above, the following attributes are exported:
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
 * `public_ipv4_pool` - EC2 IPv4 address pool identifier (if in VPC).
-* `customer_owned_ipv4_pool` - The  ID  of a customer-owned address pool.
+* `customer_owned_ipv4_pool` - The  ID  of a customer-owned address pool. For more on customer owned IP addressed check out [Customer-owned IP addresses guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-networking-components.html#ip-addressing)
 * `customer_owned_ip` - Customer owned IP.
 
 ~> **Note:** The resource computes the `public_dns` and `private_dns` attributes according to the [VPC DNS Guide](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-hostnames) as they are not available with the EC2 API.

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -105,6 +105,7 @@ The following arguments are supported:
   the Elastic IP address is associated with the primary private IP address.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `public_ipv4_pool` - (Optional) EC2 IPv4 address pool identifier or `amazon`. This option is only available for VPC EIPs.
+* `customer_owned_ipv4_pool` - (Optional) The  ID  of a customer-owned address pool.
 
 ~> **NOTE:** You can specify either the `instance` ID or the `network_interface` ID,
 but not both. Including both will **not** return an error from the AWS API, but will
@@ -125,6 +126,8 @@ In addition to all arguments above, the following attributes are exported:
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
 * `public_ipv4_pool` - EC2 IPv4 address pool identifier (if in VPC).
+* `customer_owned_ipv4_pool` - The  ID  of a customer-owned address pool.
+* `customer_owned_ip` - Customer owned IP.
 
 ~> **Note:** The resource computes the `public_dns` and `private_dns` attributes according to the [VPC DNS Guide](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-hostnames) as they are not available with the EC2 API.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12302

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add COIP Pools to EIP resource and datasource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ AWS_COIP_POOL_ID=ipv4pool-coip-<snip> make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSEIP_COIPPool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSEIP_COIPPool -timeout 120m
=== RUN   TestAccDataSourceAWSEIP_COIPPool
=== PAUSE TestAccDataSourceAWSEIP_COIPPool
=== CONT  TestAccDataSourceAWSEIP_COIPPool
--- PASS: TestAccDataSourceAWSEIP_COIPPool (56.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	57.300s

$ AWS_COIP_POOL_ID=ipv4pool-coip-<snip> make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP_COIPPool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEIP_COIPPool -timeout 120m
=== RUN   TestAccAWSEIP_COIPPool
=== PAUSE TestAccAWSEIP_COIPPool
=== CONT  TestAccAWSEIP_COIPPool
--- PASS: TestAccAWSEIP_COIPPool (49.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.674s
```
