### PR TITLE
tests/provider: Introduce shared disappears TestCheckFunc, refactor Backup testing to implement and verify

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -587,6 +587,22 @@ func testAccAwsRegionProviderFunc(region string, providers *[]*schema.Provider) 
 	}
 }
 
+func testAccCheckResourceDisappears(provider *schema.Provider, resource *schema.Resource, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource ID missing:: %s", resourceName)
+		}
+
+		return resource.Delete(resource.Data(resourceState.Primary), provider.Meta())
+	}
+}
+
 func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error, providers *[]*schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		numberOfProviders := len(*providers)

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -596,7 +596,7 @@ func testAccCheckResourceDisappears(provider *schema.Provider, resource *schema.
 		}
 
 		if resourceState.Primary.ID == "" {
-			return fmt.Errorf("resource ID missing:: %s", resourceName)
+			return fmt.Errorf("resource ID missing: %s", resourceName)
 		}
 
 		return resource.Delete(resource.Data(resourceState.Primary), provider.Meta())

--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -465,7 +465,7 @@ func TestAccAwsBackupPlan_disappears(t *testing.T) {
 				Config: testAccAwsBackupPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupPlanExists(resourceName, &plan, &ruleNameMap),
-					testAccCheckAwsBackupPlanDisappears(&plan),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupPlan(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -494,20 +494,6 @@ func testAccCheckAwsBackupPlanDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckAwsBackupPlanDisappears(backupPlan *backup.GetBackupPlanOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).backupconn
-
-		input := &backup.DeleteBackupPlanInput{
-			BackupPlanId: backupPlan.BackupPlanId,
-		}
-
-		_, err := conn.DeleteBackupPlan(input)
-
-		return err
-	}
 }
 
 func testAccCheckAwsBackupPlanExists(name string, plan *backup.GetBackupPlanOutput, ruleNameMap *map[string]string) resource.TestCheckFunc {

--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -39,6 +39,8 @@ func TestAccAwsBackupSelection_basic(t *testing.T) {
 func TestAccAwsBackupSelection_disappears(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
 	rInt := acctest.RandInt()
+	resourceName := "aws_backup_selection.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
@@ -47,8 +49,8 @@ func TestAccAwsBackupSelection_disappears(t *testing.T) {
 			{
 				Config: testAccBackupSelectionConfigBasic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupSelectionExists("aws_backup_selection.test", &selection1),
-					testAccCheckAwsBackupSelectionDisappears(&selection1),
+					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupSelection(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -187,21 +189,6 @@ func testAccCheckAwsBackupSelectionExists(name string, selection *backup.GetBack
 		*selection = *output
 
 		return nil
-	}
-}
-
-func testAccCheckAwsBackupSelectionDisappears(selection *backup.GetBackupSelectionOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).backupconn
-
-		input := &backup.DeleteBackupSelectionInput{
-			BackupPlanId: selection.BackupPlanId,
-			SelectionId:  selection.SelectionId,
-		}
-
-		_, err := conn.DeleteBackupSelection(input)
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_backup_vault_test.go
+++ b/aws/resource_aws_backup_vault_test.go
@@ -124,7 +124,7 @@ func TestAccAwsBackupVault_disappears(t *testing.T) {
 				Config: testAccBackupVaultConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupVaultExists(resourceName, &vault),
-					testAccCheckAwsBackupVaultDisappears(&vault),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupVault(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -174,18 +174,6 @@ func testAccCheckAwsBackupVaultExists(name string, vault *backup.DescribeBackupV
 		*vault = *resp
 
 		return nil
-	}
-}
-
-func testAccCheckAwsBackupVaultDisappears(vault *backup.DescribeBackupVaultOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).backupconn
-		params := &backup.DeleteBackupVaultInput{
-			BackupVaultName: vault.BackupVaultName,
-		}
-		_, err := conn.DeleteBackupVault(params)
-
-		return err
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

A common problem in Terraform Providers is the need to verify that a Terraform Resource will successfully remove itself from the Terraform state when externally deleted. In an effort to test this functionality, the Terraform AWS Provider has implemented testing, commonly named `_disappears` in each resource's acceptance testing, where each test includes a `TestCheckFunc` that manually reimplements the deletion functionality of the resource.

This change proposes the introduction of a shared `TestCheckFunc` that can prevent the necessity of manually reimplementing the resource deletion code in a `TestCheckFunc` for each resource. If acceptable, a GitHub issue will be created outlining a refactoring and documentation proposal for the provider codebase.

It is worth noting that in the future, the Terraform Plugin SDK's acceptance testing framework could introduce native functionality for this type of common testing, but this shared `TestCheckFunc` is an effort to reduce a current development pain point.

Output from acceptance testing:

```
--- PASS: TestAccAwsBackupVault_disappears (13.75s)
--- PASS: TestAccAwsBackupPlan_disappears (18.15s)
--- PASS: TestAccAwsBackupSelection_disappears (24.02s)
```