### PR TITLE
service/iam: replace custom SchemaValidateFunc with provided ones

### DIFF
--- a/aws/resource_aws_iam_group.go
+++ b/aws/resource_aws_iam_group.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsIamGroup() *schema.Resource {
@@ -33,7 +34,7 @@ func resourceAwsIamGroup() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validateAwsIamGroupName,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`), fmt.Sprintf("must only contain alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs")),
 			},
 			"path": {
 				Type:     schema.TypeString,
@@ -129,14 +130,4 @@ func resourceAwsIamGroupDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting IAM Group %s: %s", d.Id(), err)
 	}
 	return nil
-}
-
-func validateAwsIamGroupName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs allowed in %q: %q",
-			k, value))
-	}
-	return
 }

--- a/aws/resource_aws_iam_group.go
+++ b/aws/resource_aws_iam_group.go
@@ -32,9 +32,12 @@ func resourceAwsIamGroup() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`), fmt.Sprintf("must only contain alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs")),
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`),
+					fmt.Sprintf("must only contain alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs"),
+				),
 			},
 			"path": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_group_test.go
+++ b/aws/resource_aws_iam_group_test.go
@@ -13,43 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestValidateIamGroupName(t *testing.T) {
-	validNames := []string{
-		"test-group",
-		"test_group",
-		"testgroup123",
-		"TestGroup",
-		"Test-Group",
-		"test.group",
-		"test.123,group",
-		"testgroup@hashicorp",
-		"test+group@hashicorp.com",
-	}
-	for _, v := range validNames {
-		_, errs := validateAwsIamGroupName(v, "name")
-		if len(errs) != 0 {
-			t.Fatalf("%q should be a valid IAM Group name: %q", v, errs)
-		}
-	}
-
-	invalidNames := []string{
-		"!",
-		"/",
-		" ",
-		":",
-		";",
-		"test name",
-		"/slash-at-the-beginning",
-		"slash-at-the-end/",
-	}
-	for _, v := range invalidNames {
-		_, errs := validateAwsIamGroupName(v, "name")
-		if len(errs) == 0 {
-			t.Fatalf("%q should be an invalid IAM Group name", v)
-		}
-	}
-}
-
 func TestAccAWSIAMGroup_basic(t *testing.T) {
 	var conf iam.GetGroupOutput
 	resourceName := "aws_iam_group.test"

--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -46,8 +46,8 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.All(
-					validation.StringLenBetween(1, 128), 
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 128),
 					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
 				),
 			},
@@ -57,8 +57,8 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.All(
-					validation.StringLenBetween(1, 64), 
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 64),
 					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
 				),
 			},

--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -46,7 +46,10 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.All(validation.StringLenBetween(1, 128), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
+				ValidateFunc:  validation.All(
+					validation.StringLenBetween(1, 128), 
+					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+				),
 			},
 
 			"name_prefix": {
@@ -54,7 +57,10 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.All(validation.StringLenBetween(1, 64), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
+				ValidateFunc:  validation.All(
+					validation.StringLenBetween(1, 64), 
+					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+				),
 			},
 
 			"path": {

--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsIamInstanceProfile() *schema.Resource {
@@ -45,19 +46,7 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8196-L8201
-					value := v.(string)
-					if len(value) > 128 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 128 characters", k))
-					}
-					if !regexp.MustCompile(`^[\w+=,.@-]+$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q must match [\\w+=,.@-]", k))
-					}
-					return
-				},
+				ValidateFunc:  validation.All(validation.StringLenBetween(1, 128), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
 			},
 
 			"name_prefix": {
@@ -65,19 +54,7 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8196-L8201
-					value := v.(string)
-					if len(value) > 64 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 64 characters, name is limited to 128", k))
-					}
-					if !regexp.MustCompile(`^[\w+=,.@-]+$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q must match [\\w+=,.@-]", k))
-					}
-					return
-				},
+				ValidateFunc:  validation.All(validation.StringLenBetween(1, 64), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
 			},
 
 			"path": {

--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -48,7 +48,7 @@ func resourceAwsIamPolicy() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.All(
+				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 128),
 					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
 				),
@@ -58,7 +58,7 @@ func resourceAwsIamPolicy() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.All(
+				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 96),
 					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
 				),

--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsIamPolicy() *schema.Resource {
@@ -47,38 +48,14 @@ func resourceAwsIamPolicy() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8329-L8334
-					value := v.(string)
-					if len(value) > 128 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 128 characters", k))
-					}
-					if !regexp.MustCompile(`^[\w+=,.@-]*$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q must match [\\w+=,.@-]", k))
-					}
-					return
-				},
+				ValidateFunc:  validation.All(validation.StringLenBetween(1, 128), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8329-L8334
-					value := v.(string)
-					if len(value) > 96 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 96 characters, name is limited to 128", k))
-					}
-					if !regexp.MustCompile(`^[\w+=,.@-]*$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q must match [\\w+=,.@-]", k))
-					}
-					return
-				},
+				ValidateFunc:  validation.All(validation.StringLenBetween(1, 96), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -48,14 +48,20 @@ func resourceAwsIamPolicy() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.All(validation.StringLenBetween(1, 128), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
+				ValidateFunc:  validation.All(
+					validation.StringLenBetween(1, 128),
+					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+				),
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.All(validation.StringLenBetween(1, 96), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
+				ValidateFunc:  validation.All(
+					validation.StringLenBetween(1, 96),
+					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+				),
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -43,7 +43,10 @@ func resourceAwsIamRole() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.All(validation.StringLenBetween(1, 64), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 64),
+					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+				),
 			},
 
 			"name_prefix": {
@@ -51,7 +54,10 @@ func resourceAwsIamRole() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.All(validation.StringLenBetween(1, 32), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 32),
+					validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]"),
+				),
 			},
 
 			"path": {

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -43,19 +43,7 @@ func resourceAwsIamRole() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8329-L8334
-					value := v.(string)
-					if len(value) > 64 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 64 characters", k))
-					}
-					if !regexp.MustCompile(`^[\w+=,.@-]*$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q must match [\\w+=,.@-]", k))
-					}
-					return
-				},
+				ValidateFunc:  validation.All(validation.StringLenBetween(1, 64), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
 			},
 
 			"name_prefix": {
@@ -63,19 +51,7 @@ func resourceAwsIamRole() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8329-L8334
-					value := v.(string)
-					if len(value) > 32 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 32 characters, name is limited to 64", k))
-					}
-					if !regexp.MustCompile(`^[\w+=,.@-]*$`).MatchString(value) {
-						errors = append(errors, fmt.Errorf(
-							"%q must match [\\w+=,.@-]", k))
-					}
-					return
-				},
+				ValidateFunc:  validation.All(validation.StringLenBetween(1, 32), validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]*$`), "must match [\\w+=,.@-]")),
 			},
 
 			"path": {

--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -43,9 +43,12 @@ func resourceAwsIamUser() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`), fmt.Sprintf("must only contain alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs")),
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`),
+					fmt.Sprintf("must only contain alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs"),
+				),
 			},
 			"path": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -45,7 +45,7 @@ func resourceAwsIamUser() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validateAwsIamUserName,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`), fmt.Sprintf("must only contain alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs")),
 			},
 			"path": {
 				Type:     schema.TypeString,
@@ -242,16 +242,6 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-}
-
-func validateAwsIamUserName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs allowed in %q: %q",
-			k, value))
-	}
-	return
 }
 
 func deleteAwsIamUserGroupMemberships(conn *iam.IAM, username string) error {

--- a/aws/resource_aws_iam_user_test.go
+++ b/aws/resource_aws_iam_user_test.go
@@ -18,43 +18,6 @@ import (
 	"github.com/pquerna/otp/totp"
 )
 
-func TestValidateIamUserName(t *testing.T) {
-	validNames := []string{
-		"test-user",
-		"test_user",
-		"testuser123",
-		"TestUser",
-		"Test-User",
-		"test.user",
-		"test.123,user",
-		"testuser@hashicorp",
-		"test+user@hashicorp.com",
-	}
-	for _, v := range validNames {
-		_, errors := validateAwsIamUserName(v, "name")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid IAM User name: %q", v, errors)
-		}
-	}
-
-	invalidNames := []string{
-		"!",
-		"/",
-		" ",
-		":",
-		";",
-		"test name",
-		"/slash-at-the-beginning",
-		"slash-at-the-end/",
-	}
-	for _, v := range invalidNames {
-		_, errors := validateAwsIamUserName(v, "name")
-		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid IAM User name", v)
-		}
-	}
-}
-
 func init() {
 	resource.AddTestSweepers("aws_iam_user", &resource.Sweeper{
 		Name: "aws_iam_user",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: #11872

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSIAMGroup_nameChange (37.66s)
--- PASS: TestAccAWSIAMGroup_basic (41.33s)

--- PASS: TestAccAWSIAMInstanceProfile_withoutRole (22.81s)
--- PASS: TestAccAWSIAMInstanceProfile_basic (26.42s)
--- PASS: TestAccAWSIAMInstanceProfile_withRoleNotRoles (26.49s)
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (26.62s)

--- PASS: TestAccAWSIAMPolicy_disappears (18.30s)
--- PASS: TestAccAWSIAMPolicy_basic (25.80s)
--- PASS: TestAccAWSIAMPolicy_description (25.93s)
--- PASS: TestAccAWSIAMPolicy_namePrefix (26.13s)
--- PASS: TestAccAWSIAMPolicy_path (26.13s)
--- PASS: TestAccAWSIAMPolicy_policy (43.53s)

--- PASS: TestAccAWSIAMRole_badJSON (2.65s)
--- PASS: TestAccAWSIAMRole_disappears (18.17s)
--- PASS: TestAccAWSIAMRole_basic (24.06s)
--- PASS: TestAccAWSIAMRole_namePrefix (24.35s)
--- PASS: TestAccAWSIAMRole_force_detach_policies (29.42s)
--- PASS: TestAccAWSIAMRole_tags (39.39s)
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (41.98s)
--- PASS: TestAccAWSIAMRole_testNameChange (50.72s)
--- PASS: TestAccAWSIAMRole_basicWithDescription (54.37s)
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (85.03s)

--- PASS: TestAccAWSUser_disappears (18.00s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (26.15s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (26.69s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (26.97s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (27.28s)
--- PASS: TestAccAWSUser_pathChange (38.76s)
--- PASS: TestAccAWSUser_nameChange (38.98s)
--- PASS: TestAccAWSUser_basic (39.10s)
--- PASS: TestAccAWSUser_tags (41.03s)
--- PASS: TestAccAWSUser_permissionsBoundary (87.66s)
```
