### PR TITLE
resource/aws_rds_cluster: Support aurora-mysql and aurora-postgres Global Clusters

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -1074,7 +1074,7 @@ func TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance(t *testing.T) {
 	})
 }
 
-func TestAccAWSRDSCluster_GlobalClusterIdentifier(t *testing.T) {
+func TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global(t *testing.T) {
 	var dbCluster1 rds.DBCluster
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1087,7 +1087,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRDSClusterConfig_GlobalClusterIdentifier(rName),
+				Config: testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Global(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, "global_cluster_identifier", globalClusterResourceName, "id"),
@@ -1109,7 +1109,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier(t *testing.T) {
 	})
 }
 
-func TestAccAWSRDSCluster_GlobalClusterIdentifier_Add(t *testing.T) {
+func TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add(t *testing.T) {
 	var dbCluster1 rds.DBCluster
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1140,14 +1140,14 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Add(t *testing.T) {
 				},
 			},
 			{
-				Config:      testAccAWSRDSClusterConfig_GlobalClusterIdentifier(rName),
+				Config:      testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Global(rName),
 				ExpectError: regexp.MustCompile(`Existing RDS Clusters cannot be added to an existing RDS Global Cluster`),
 			},
 		},
 	})
 }
 
-func TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove(t *testing.T) {
+func TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove(t *testing.T) {
 	var dbCluster1 rds.DBCluster
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1160,7 +1160,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRDSClusterConfig_GlobalClusterIdentifier(rName),
+				Config: testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Global(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, "global_cluster_identifier", globalClusterResourceName, "id"),
@@ -1189,7 +1189,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove(t *testing.T) {
 	})
 }
 
-func TestAccAWSRDSCluster_GlobalClusterIdentifier_Update(t *testing.T) {
+func TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update(t *testing.T) {
 	var dbCluster1 rds.DBCluster
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1203,7 +1203,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Update(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRDSClusterConfig_GlobalClusterIdentifier_Update(rName, globalClusterResourceName1),
+				Config: testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Global_Update(rName, globalClusterResourceName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
 					resource.TestCheckResourceAttrPair(resourceName, "global_cluster_identifier", globalClusterResourceName1, "id"),
@@ -1222,8 +1222,43 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Update(t *testing.T) {
 				},
 			},
 			{
-				Config:      testAccAWSRDSClusterConfig_GlobalClusterIdentifier_Update(rName, globalClusterResourceName2),
+				Config:      testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Global_Update(rName, globalClusterResourceName2),
 				ExpectError: regexp.MustCompile(`Existing RDS Clusters cannot be migrated between existing RDS Global Clusters`),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned(t *testing.T) {
+	var dbCluster1 rds.DBCluster
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	globalClusterResourceName := "aws_rds_global_cluster.test"
+	resourceName := "aws_rds_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Provisioned(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
+					resource.TestCheckResourceAttrPair(resourceName, "global_cluster_identifier", globalClusterResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})
@@ -3009,7 +3044,7 @@ resource "aws_rds_cluster" "test" {
 `, rName)
 }
 
-func testAccAWSRDSClusterConfig_GlobalClusterIdentifier(rName string) string {
+func testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Global(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_global_cluster" "test" {
   global_cluster_identifier = %q
@@ -3026,7 +3061,7 @@ resource "aws_rds_cluster" "test" {
 `, rName, rName)
 }
 
-func testAccAWSRDSClusterConfig_GlobalClusterIdentifier_Update(rName, globalClusterIdentifierResourceName string) string {
+func testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Global_Update(rName, globalClusterIdentifierResourceName string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_global_cluster" "test" {
   count = 2
@@ -3043,6 +3078,26 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot       = true
 }
 `, rName, rName, globalClusterIdentifierResourceName)
+}
+
+func testAccAWSRDSClusterConfig_GlobalClusterIdentifier_EngineMode_Provisioned(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test" {
+  engine                    = "aurora-postgresql"
+  engine_version            = "10.11"
+  global_cluster_identifier = %[1]q
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier        = %[1]q
+  engine                    = aws_rds_global_cluster.test.engine
+  engine_version            = aws_rds_global_cluster.test.engine_version
+  global_cluster_identifier = aws_rds_global_cluster.test.id
+  master_password           = "barbarbarbar"
+  master_username           = "foo"
+  skip_final_snapshot       = true
+}
+`, rName)
 }
 
 func testAccAWSRDSClusterConfig_ScalingConfiguration(rName string, autoPause bool, maxCapacity, minCapacity, secondsUntilAutoPause int, timeoutAction string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12499
Closes #12524
Reference: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html
Reference: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DBCluster.html (`EngineMode` note)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* resource/aws_rds_cluster: Due to recent API support for Aurora MySQL 5.7 and PostgreSQL Global Clusters which implemented the engine mode as `provisioned` instead of the previous `global` for Aurora MySQL 5.6, the resource now requires the `DescribeGlobalClusters` API call. Restrictive IAM permissions may require updates.

BUG FIXES:

* resource/aws_rds_cluster: Prevent unexpected `global_cluster_identifier` differences and deletion error with `aurora-mysql` and `aurora-postgresql` Global Cluster members
```

API support for Aurora MySQL 5.7 and PostgreSQL Global Clusters implemented their `EngineMode` as `provisioned` instead of the previous Aurora MySQL 5.6 `EngineMode` of `global`. The logic previously used this engine mode to guard the `DescribeGlobalCluster` and `RemoveFromGlobalCluster` API calls, however we will now need to call `DescribeGlobalCluster` for `provisioned` engine mode clusters to perform drift detection and properly handle deletion. We prefer this simple logic change at the expense of potential IAM permissions updates for operators versus complex version handling in the resource, which could be very bug prone over time.

Previously in AWS Commerical before conditional update:

```
    TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned: testing.go:669: Step 0 error: Check failed: Check 2/2 error: aws_rds_cluster.test: Attribute 'global_cluster_identifier' expected "tf-acc-test-3671312550212388967", got ""
    TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned: testing.go:730: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: error deleting RDS Cluster (tf-acc-test-3671312550212388967): InvalidDBClusterStateFault: This cluster is a part of a global cluster, please remove it from globalcluster first
```

Previously in AWS GovCloud (US) before error handling update:

```
    TestAccAWSRDSCluster_basic: testing.go:730: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: error reading RDS Global Cluster information for DB Cluster (tf-aurora-cluster-7839236307155079826): InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
```

Output from acceptance testing in AWS Commercial (test failure present on master and unrelated):

```
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (125.61s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (165.81s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (179.76s)
--- PASS: TestAccAWSRDSCluster_basic (141.21s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (123.01s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (225.08s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (134.93s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (179.89s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (336.41s)
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (342.08s)
--- PASS: TestAccAWSRDSCluster_encrypted (138.67s)
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1680.90s)
--- PASS: TestAccAWSRDSCluster_EngineMode (430.89s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (138.57s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (162.91s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (175.39s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (156.68s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1094.60s)
--- PASS: TestAccAWSRDSCluster_generatedName (122.45s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global (122.20s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add (133.04s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove (150.16s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update (147.49s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned (140.56s)
--- PASS: TestAccAWSRDSCluster_iamAuth (176.97s)
--- PASS: TestAccAWSRDSCluster_kmsKey (177.05s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (4.86s)
--- PASS: TestAccAWSRDSCluster_Port (263.90s)

--- FAIL: TestAccAWSRDSCluster_s3Restore (1510.33s)
    TestAccAWSRDSCluster_s3Restore: testing.go:669: Step 0 error: errors during apply:

        Error: Error waiting for RDS Cluster state to be "available": unexpected state 'migration-failed', wanted target 'available'. last error: %!s(<nil>)

--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (353.62s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (387.43s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (426.21s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (375.94s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (427.08s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (389.84s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (448.81s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (386.66s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (353.51s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (353.74s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (396.24s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (376.32s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (352.28s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (379.29s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (348.69s)
--- PASS: TestAccAWSRDSCluster_Tags (160.20s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (164.84s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (169.77s)
```

Output from acceptance testing in AWS GovCloud (US) (this resource testing has not been fully updated to support this partition, but shows existing functionality working as before):

```
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (129.68s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (215.28s)
--- PASS: TestAccAWSRDSCluster_basic (159.62s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (138.63s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (253.30s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (172.06s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (215.43s)
--- PASS: TestAccAWSRDSCluster_encrypted (171.10s)
--- PASS: TestAccAWSRDSCluster_iamAuth (169.61s)
--- PASS: TestAccAWSRDSCluster_kmsKey (175.66s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (453.06s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (515.03s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (401.20s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (400.98s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (432.35s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (443.88s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (400.99s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (444.46s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (498.80s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (456.84s)
--- PASS: TestAccAWSRDSCluster_Tags (159.57s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (222.58s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (173.80s)
```