### PR TITLE
resource/aws_route53_health_check: Validate reference_name

### DIFF
--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -128,6 +128,12 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				// The max length of the reference name is 64 characters for the API.
+				// Terraform appends a 37-character unique ID to the provided
+				// reference_name. This limits the length of the resource argument to 27.
+				//
+				// Example generated suffix: -terraform-20190122200019880700000001
+				ValidateFunc: validation.StringLenBetween(0, (64 - resource.UniqueIDSuffixLength - 11)),
 			},
 			"enable_sni": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Support plan-time validation for the length of the `reference_name argument`. Since this resource auto-appends a unique string to the provided argument, this is necessary to avoid obtuse errors on apply. This ensures the provided `reference_name` plus the generated string is no longer than 64 chars, the actual API limit.

Since the generated unique ID is 26 chars, the `reference_name` argument cannot exceed 38 characters.

Closes #7248

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_route53_health_check: Support plan-time validation for `reference_name` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

Output from Terraform run with patched build:

```
Error: expected length of reference_name to be in the range (0 - 38), got test-long-reference-name-1111111111111111111111111

  on example.tf line 880, in resource "aws_route53_health_check" "example":
 880: resource "aws_route53_health_check" "example" {
```