### PR TITLE
Fixes aws_lambda_alias import to set function_name attribute ...

### DIFF
--- a/aws/resource_aws_lambda_alias.go
+++ b/aws/resource_aws_lambda_alias.go
@@ -204,12 +204,12 @@ func resourceAwsLambdaAliasImport(d *schema.ResourceData, meta interface{}) ([]*
 
 	conn := meta.(*AWSClient).lambdaconn
 
-	getFunctionOutput, err := conn.GetFunction(&lambda.GetFunctionInput{FunctionName: &functionName})
+	_, err := conn.GetFunction(&lambda.GetFunctionInput{FunctionName: &functionName})
 	if err != nil {
 		return nil, err
 	}
 
-	d.Set("function_name", getFunctionOutput.Configuration.FunctionArn)
+	d.Set("function_name", functionName)
 	d.Set("name", alias)
 	return []*schema.ResourceData{d}, nil
 }

--- a/aws/resource_aws_lambda_alias_test.go
+++ b/aws/resource_aws_lambda_alias_test.go
@@ -282,7 +282,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
 resource "aws_lambda_alias" "lambda_alias_test" {
   name             = "%s"
   description      = "a sample description"
-  function_name    = "${aws_lambda_function.lambda_function_test_create.arn}"
+  function_name    = "${aws_lambda_function.lambda_function_test_create.function_name}"
   function_version = "1"
 }
 `, roleName, policyName, attachmentName, funcName, aliasName)
@@ -350,7 +350,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
 resource "aws_lambda_alias" "lambda_alias_test" {
   name             = "%s"
   description      = "a sample description"
-  function_name    = "${aws_lambda_function.lambda_function_test_create.arn}"
+  function_name    = "${aws_lambda_function.lambda_function_test_create.function_name}"
   function_version = "1"
 
   routing_config {


### PR DESCRIPTION
… correctly instead of function's ARN

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12875 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_lambda_alias import sets function_name to actual aws_lambda_function's function_name
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
