### PR TITLE
Fixing zone_id reference

### DIFF
--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -36,7 +36,7 @@ data "aws_route53_zone" "zone" {
 resource "aws_route53_record" "cert_validation" {
   name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
   type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
+  zone_id = "${data.aws_route53_zone.zone.zone_id}"
   records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
   ttl     = 60
 }
@@ -74,7 +74,7 @@ data "aws_route53_zone" "zone_alt" {
 resource "aws_route53_record" "cert_validation" {
   name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
   type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
+  zone_id = "${data.aws_route53_zone.zone.zone_id}"
   records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
   ttl     = 60
 }
@@ -82,7 +82,7 @@ resource "aws_route53_record" "cert_validation" {
 resource "aws_route53_record" "cert_validation_alt1" {
   name    = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_name}"
   type    = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone.id}"
+  zone_id = "${data.aws_route53_zone.zone.zone_id}"
   records = ["${aws_acm_certificate.cert.domain_validation_options.1.resource_record_value}"]
   ttl     = 60
 }
@@ -90,7 +90,7 @@ resource "aws_route53_record" "cert_validation_alt1" {
 resource "aws_route53_record" "cert_validation_alt2" {
   name    = "${aws_acm_certificate.cert.domain_validation_options.2.resource_record_name}"
   type    = "${aws_acm_certificate.cert.domain_validation_options.2.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.zone_alt.id}"
+  zone_id = "${data.aws_route53_zone.zone_alt.zone_id}"
   records = ["${aws_acm_certificate.cert.domain_validation_options.2.resource_record_value}"]
   ttl     = 60
 }


### PR DESCRIPTION
`zone_id` was being referenced as just `id` from the `aws_route53_zone` data sources in the example.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

```release-note
`aws_acm_certificate_validation` documentation update to fix erroneous `zone_id` references in the `aws_route53_zone` data source.
```

Output from acceptance testing:
