### PR TITLE
Add event_bus_name to aws_cloudwatch_event_rule

### DIFF
--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -86,6 +86,7 @@ func TestAccAWSCloudWatchEventRule_basic(t *testing.T) {
 					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "events", regexp.MustCompile(`rule/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckNoResourceAttr(resourceName, "event_bus_name"),
 					resource.TestCheckResourceAttr(resourceName, "schedule_expression", "rate(1 hour)"),
 					resource.TestCheckResourceAttr(resourceName, "role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -398,6 +399,7 @@ func testAccAWSCloudWatchEventRuleConfig(name string) string {
 resource "aws_cloudwatch_event_rule" "test" {
 	name = "%s"
 	schedule_expression = "rate(1 hour)"
+	event_bus_name = "default"
 }
 `, name)
 }

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -64,6 +64,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional) The rule's name. Conflicts with `name`.
 * `schedule_expression` - (Required, if `event_pattern` isn't specified) The scheduling expression.
 	For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`.
+* `event_bus_name` - (Optional) The event bus to associate with this rule. If you omit this, the `default` event bus is used.
 * `event_pattern` - (Required, if `schedule_expression` isn't specified) Event pattern
 	described a JSON object.
 	See full documentation of [CloudWatch Events and Event Patterns](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CloudWatchEventsandEventPatterns.html) for details.
@@ -82,7 +83,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Cloudwatch Event Rules can be imported using the `name`, e.g.
+Cloudwatch Event Rules can be imported using the `event_bus_name/rule_name` (if you omit `event_bus_name`, the `default` event bus will be used), e.g.
 
 ```
 $ terraform import aws_cloudwatch_event_rule.console capture-console-sign-in


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/9330

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cloudwatch_event_rule: Add `event_bus_name`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventRule -timeout 120m
=== RUN   TestAccAWSCloudWatchEventRule_basic
=== PAUSE TestAccAWSCloudWatchEventRule_basic
=== RUN   TestAccAWSCloudWatchEventRule_role
=== PAUSE TestAccAWSCloudWatchEventRule_role
=== RUN   TestAccAWSCloudWatchEventRule_description
=== PAUSE TestAccAWSCloudWatchEventRule_description
=== RUN   TestAccAWSCloudWatchEventRule_pattern
=== PAUSE TestAccAWSCloudWatchEventRule_pattern
=== RUN   TestAccAWSCloudWatchEventRule_prefix
=== PAUSE TestAccAWSCloudWatchEventRule_prefix
=== RUN   TestAccAWSCloudWatchEventRule_tags
=== PAUSE TestAccAWSCloudWatchEventRule_tags
=== RUN   TestAccAWSCloudWatchEventRule_IsEnabled
=== PAUSE TestAccAWSCloudWatchEventRule_IsEnabled
=== CONT  TestAccAWSCloudWatchEventRule_basic
=== CONT  TestAccAWSCloudWatchEventRule_prefix
=== CONT  TestAccAWSCloudWatchEventRule_IsEnabled
=== CONT  TestAccAWSCloudWatchEventRule_tags
=== CONT  TestAccAWSCloudWatchEventRule_description
=== CONT  TestAccAWSCloudWatchEventRule_role
=== CONT  TestAccAWSCloudWatchEventRule_pattern
--- PASS: TestAccAWSCloudWatchEventRule_prefix (39.03s)
--- PASS: TestAccAWSCloudWatchEventRule_role (58.84s)
--- PASS: TestAccAWSCloudWatchEventRule_pattern (73.82s)
--- PASS: TestAccAWSCloudWatchEventRule_description (74.00s)
--- PASS: TestAccAWSCloudWatchEventRule_basic (76.13s)
--- PASS: TestAccAWSCloudWatchEventRule_tags (104.42s)
--- PASS: TestAccAWSCloudWatchEventRule_IsEnabled (106.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	106.479s
...
```
