### PR TITLE
r/aws_acm_certificate: Add test sweeper

### DIFF
--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"testing"
@@ -11,10 +12,75 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_acm_certificate", &resource.Sweeper{
+		Name: "aws_acm_certificate",
+		F:    testSweepAcmCertificates,
+	})
+}
+
+func testSweepAcmCertificates(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).acmconn
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListCertificatesPages(&acm.ListCertificatesInput{}, func(page *acm.ListCertificatesOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, certificate := range page.CertificateSummaryList {
+			arn := aws.StringValue(certificate.CertificateArn)
+
+			output, err := conn.DescribeCertificate(&acm.DescribeCertificateInput{
+				CertificateArn: aws.String(arn),
+			})
+			if err != nil {
+				sweeperErr := fmt.Errorf("error describing ACM certificate (%s): %w", arn, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			if len(output.Certificate.InUseBy) > 0 {
+				log.Printf("[INFO] ACM certificate (%s) is in-use, skipping", arn)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting ACM certificate: %s", arn)
+			_, err = conn.DeleteCertificate(&acm.DeleteCertificateInput{
+				CertificateArn: aws.String(arn),
+			})
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting ACM certificate (%s): %w", arn, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping ACM certificate sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		}
+		return fmt.Errorf("error retrieving ACM certificates: %s", err)
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func testAccAwsAcmCertificateDomainFromEnv(t *testing.T) string {
 	rootDomain := os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/9461.

Test sweeper for `aws_acm_certificate` sweepers.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ SWEEP=us-west-2 SWEEP_DIR=./aws/ SWEEPARGS=-sweep-run=aws_acm_certificate make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws/ -v -sweep=us-west-2 -sweep-run=aws_acm_certificate -timeout 60m
2020/04/18 18:46:18 [DEBUG] Running Sweepers for region (us-west-2):
2020/04/18 18:46:18 [DEBUG] Running Sweeper (aws_acm_certificate) in region (us-west-2)
2020/04/18 18:46:18 [INFO] Building AWS auth structure
2020/04/18 18:46:18 [INFO] Setting AWS metadata API timeout to 100ms
2020/04/18 18:46:20 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/04/18 18:46:20 [INFO] AWS Auth provider used: "EnvProvider"
2020/04/18 18:46:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/04/18 18:46:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/04/18 18:46:22 [INFO] ACM certificate (arn:aws:acm:us-west-2:123456789012:certificate/59441bc8-10e1-4679-848b-3996e65b7bbf) is in-use, skipping
2020/04/18 18:46:22 [INFO] ACM certificate (arn:aws:acm:us-west-2:123456789012:certificate/fbdf9f21-7503-495a-a68b-858a13fdefea) is in-use, skipping
2020/04/18 18:46:23 [INFO] ACM certificate (arn:aws:acm:us-west-2:123456789012:certificate/074f2af9-b6ba-4563-a18a-4330d18d673e) is in-use, skipping
2020/04/18 18:46:23 [INFO] ACM certificate (arn:aws:acm:us-west-2:123456789012:certificate/2c622a22-36c4-4077-904d-843e0bb602af) is in-use, skipping
2020/04/18 18:46:24 [INFO] ACM certificate (arn:aws:acm:us-west-2:123456789012:certificate/e58c7390-6aa0-404c-bfc9-da3365cd7416) is in-use, skipping
2020/04/18 18:46:24 [INFO] Deleting ACM certificate: arn:aws:acm:us-west-2:123456789012:certificate/962cd67e-0069-486d-83e2-7733e649a73f
2020/04/18 18:46:25 Sweeper Tests ran successfully:
	- aws_acm_certificate
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.201s
```
