### PR TITLE
r/aws_route: allow using compressed IPV6 CIDR

### DIFF
--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 // How long to sleep if a limit-exceeded event happens
@@ -54,14 +54,19 @@ func resourceAwsRoute() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"destination_cidr_block": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsCIDR,
 			},
 			"destination_ipv6_cidr_block": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsCIDR,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return isIpv6CidrsEquals(old, new)
+				},
 			},
 
 			"destination_prefix_list_id": {
@@ -318,7 +323,7 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 	route, err := resourceAwsRouteFindRoute(conn, routeTableId, destinationCidrBlock, destinationIpv6CidrBlock)
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidRouteTableID.NotFound" {
+		if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
 			log.Printf("[WARN] Route Table %q could not be found. Removing Route from state.",
 				routeTableId)
 			d.SetId("")
@@ -485,7 +490,7 @@ func resourceAwsRouteExists(d *schema.ResourceData, meta interface{}) (bool, err
 
 	res, err := conn.DescribeRouteTables(findOpts)
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidRouteTableID.NotFound" {
+		if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
 			log.Printf("[WARN] Route Table %q could not be found.", routeTableId)
 			return false, nil
 		}
@@ -558,7 +563,7 @@ func resourceAwsRouteFindRoute(conn *ec2.EC2, rtbid string, cidr string, ipv6cid
 
 	if ipv6cidr != "" {
 		for _, route := range (*resp.RouteTables[0]).Routes {
-			if route.DestinationIpv6CidrBlock != nil && Ipv6CidrsEquals(aws.StringValue(route.DestinationIpv6CidrBlock), ipv6cidr) {
+			if route.DestinationIpv6CidrBlock != nil && isIpv6CidrsEquals(aws.StringValue(route.DestinationIpv6CidrBlock), ipv6cidr) {
 				return route, nil
 			}
 		}

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -558,7 +558,7 @@ func resourceAwsRouteFindRoute(conn *ec2.EC2, rtbid string, cidr string, ipv6cid
 
 	if ipv6cidr != "" {
 		for _, route := range (*resp.RouteTables[0]).Routes {
-			if route.DestinationIpv6CidrBlock != nil && *route.DestinationIpv6CidrBlock == ipv6cidr {
+			if route.DestinationIpv6CidrBlock != nil && Ipv6CidrsEquals(aws.StringValue(route.DestinationIpv6CidrBlock), ipv6cidr) {
 				return route, nil
 			}
 		}

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -798,54 +798,52 @@ resource "aws_route" "pc" {
 
 var testAccAWSRouteConfigIpv6 = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-  cidr_block = "10.1.0.0/16"
+  cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
+
   tags = {
     Name = "terraform-testacc-route-ipv6"
   }
 }
 
 resource "aws_egress_only_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_route" "bar" {
-	route_table_id = "${aws_route_table.foo.id}"
-	destination_ipv6_cidr_block = "::/0"
-	egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
+  route_table_id              = "${aws_route_table.foo.id}"
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = "${aws_egress_only_internet_gateway.foo.id}"
 }
-
-
 `)
 
 var testAccAWSRouteConfigIpv6Expanded = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-  cidr_block = "10.1.0.0/16"
+  cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
+
   tags = {
     Name = "terraform-testacc-route-ipv6"
   }
 }
 
 resource "aws_egress_only_internet_gateway" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_route_table" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_route" "bar" {
-	route_table_id = "${aws_route_table.foo.id}"
-	destination_ipv6_cidr_block = "::/0"
-	egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
+  route_table_id              = "${aws_route_table.foo.id}"
+  destination_ipv6_cidr_block = "::0/0"
+  egress_only_gateway_id      = "${aws_egress_only_internet_gateway.foo.id}"
 }
-
-
 `)
 
 var testAccAWSRouteBasicConfigChangeCidr = fmt.Sprint(`

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -151,6 +151,10 @@ func TestAccAWSRoute_ipv6ToInstance(t *testing.T) {
 				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.internal-default-route-ipv6"),
 				ImportStateVerify: true,
 			},
+			{
+				Config:   testAccAWSRouteConfigIpv6InstanceExpanded,
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -761,7 +765,110 @@ resource "aws_route" "internal-default-route-ipv6" {
   destination_ipv6_cidr_block = "::/0"
   instance_id = "${aws_instance.test-router.id}"
 }
+`)
 
+var testAccAWSRouteConfigIpv6InstanceExpanded = fmt.Sprintf(`
+resource "aws_vpc" "examplevpc" {
+  cidr_block = "10.100.0.0/16"
+  enable_dns_hostnames = true
+  assign_generated_ipv6_cidr_block = true
+  tags = {
+    Name = "terraform-testacc-route-ipv6-instance"
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_internet_gateway" "internet" {
+  vpc_id = "${aws_vpc.examplevpc.id}"
+
+  tags = {
+    Name = "terraform-testacc-route-ipv6-instance"
+  }
+}
+
+resource "aws_route" "igw" {
+  route_table_id = "${aws_vpc.examplevpc.main_route_table_id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id = "${aws_internet_gateway.internet.id}"
+}
+
+resource "aws_route" "igw-ipv6" {
+  route_table_id = "${aws_vpc.examplevpc.main_route_table_id}"
+  destination_ipv6_cidr_block = "::0/0"
+  gateway_id = "${aws_internet_gateway.internet.id}"
+}
+
+resource "aws_subnet" "router-network" {
+  cidr_block = "10.100.1.0/24"
+  vpc_id = "${aws_vpc.examplevpc.id}"
+  ipv6_cidr_block = "${cidrsubnet(aws_vpc.examplevpc.ipv6_cidr_block, 8, 1)}"
+  assign_ipv6_address_on_creation = true
+  map_public_ip_on_launch = true
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  tags = {
+    Name = "tf-acc-route-ipv6-instance-router"
+  }
+}
+
+resource "aws_subnet" "client-network" {
+  cidr_block = "10.100.10.0/24"
+  vpc_id = "${aws_vpc.examplevpc.id}"
+  ipv6_cidr_block = "${cidrsubnet(aws_vpc.examplevpc.ipv6_cidr_block, 8, 2)}"
+  assign_ipv6_address_on_creation = true
+  map_public_ip_on_launch = false
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  tags = {
+    Name = "tf-acc-route-ipv6-instance-client"
+  }
+}
+
+resource "aws_route_table" "client-routes" {
+  vpc_id = "${aws_vpc.examplevpc.id}"
+}
+
+resource "aws_route_table_association" "client-routes" {
+  route_table_id = "${aws_route_table.client-routes.id}"
+  subnet_id = "${aws_subnet.client-network.id}"
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+      name   = "name"
+      values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+  filter {
+      name   = "virtualization-type"
+      values = ["hvm"]
+  }
+  owners = ["099720109477"]
+}
+
+resource "aws_instance" "test-router" {
+  ami = "${data.aws_ami.ubuntu.image_id}"
+  instance_type = "t2.small"
+  subnet_id = "${aws_subnet.router-network.id}"
+}
+
+resource "aws_route" "internal-default-route" {
+  route_table_id = "${aws_route_table.client-routes.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  instance_id = "${aws_instance.test-router.id}"
+}
+
+resource "aws_route" "internal-default-route-ipv6" {
+  route_table_id = "${aws_route_table.client-routes.id}"
+  destination_ipv6_cidr_block = "::0/0"
+  instance_id = "${aws_instance.test-router.id}"
+}
 `)
 
 var testAccAWSRouteConfigIpv6PeeringConnection = fmt.Sprintf(`
@@ -874,6 +981,17 @@ resource "aws_route" "bar" {
 `)
 
 var testAccAWSRouteNoopChange = fmt.Sprint(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
   tags = {
@@ -886,6 +1004,7 @@ resource "aws_route_table" "test" {
 }
 
 resource "aws_subnet" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.10.10.0/24"
   tags = {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -5703,6 +5703,9 @@ func flattenRoute53ResolverRuleTargetIps(targetAddresses []*route53resolver.Targ
 }
 
 func isIpv6CidrsEquals(first, second string) bool {
+	if first == "" || second == "" {
+		return false
+	}
 	_, firstMask, _ := net.ParseCIDR(first)
 	_, secondMask, _ := net.ParseCIDR(second)
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"reflect"
 	"regexp"
 	"sort"
@@ -5699,4 +5700,11 @@ func flattenRoute53ResolverRuleTargetIps(targetAddresses []*route53resolver.Targ
 	}
 
 	return vTargetIps
+}
+
+func Ipv6CidrsEquals(first, second string) bool {
+	_, firstMask, _ := net.ParseCIDR(first)
+	_, secondMask, _ := net.ParseCIDR(second)
+
+	return firstMask.String() == secondMask.String()
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -5702,7 +5702,7 @@ func flattenRoute53ResolverRuleTargetIps(targetAddresses []*route53resolver.Targ
 	return vTargetIps
 }
 
-func Ipv6CidrsEquals(first, second string) bool {
+func isIpv6CidrsEquals(first, second string) bool {
 	_, firstMask, _ := net.ParseCIDR(first)
 	_, secondMask, _ := net.ParseCIDR(second)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3422

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_route: allow using compressed IPV6 CIDR
resource_aws_route: plan time validation to `destination_cidr_block` and `destination_ipv6_cidr_block`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRoute_'
--- PASS: TestAccAWSRoute_basic (105.68s)
--- PASS: TestAccAWSRoute_ipv6ToInstance (273.99s)
--- PASS: TestAccAWSRoute_ipv6ToNetworkInterface (220.43s)
--- PASS: TestAccAWSRoute_changeRouteTable (161.76s)
--- PASS: TestAccAWSRoute_changeCidr (168.26s)
--- PASS: TestAccAWSRoute_noopdiff (234.62s)
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (120.08s)
--- PASS: TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock (431.19s)


Cant Run there test at my local env, can't create egress internet gateways need help with this.
--- FAIL: TestAccAWSRoute_ipv6Support (48.93s)
--- FAIL: TestAccAWSRoute_ipv6ToInternetGateway (67.01s)
--- FAIL: TestAccAWSRoute_ipv6ToPeeringConnection (48.35s)
```
