### PR TITLE
Do not send kms_arn in glue security configuration if mode is SSES3

### DIFF
--- a/aws/resource_aws_glue_security_configuration.go
+++ b/aws/resource_aws_glue_security_configuration.go
@@ -273,7 +273,9 @@ func expandGlueS3Encryption(m map[string]interface{}) *glue.S3Encryption {
 	}
 
 	if v, ok := m["kms_key_arn"]; ok {
-		s3Encryption.KmsKeyArn = aws.String(v.(string))
+		if v.(string) != "" {
+			s3Encryption.KmsKeyArn = aws.String(v.(string))
+		}
 	}
 
 	return s3Encryption

--- a/aws/resource_aws_glue_security_configuration_test.go
+++ b/aws/resource_aws_glue_security_configuration_test.go
@@ -208,7 +208,7 @@ func TestAccAWSGlueSecurityConfiguration_S3Encryption_S3EncryptionMode_SSES3(t *
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.0.s3_encryption_mode", "SSE-S3"),
-					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.0.kms_key_arn", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.0.kms_key_arn"),
 				),
 			},
 			{


### PR DESCRIPTION

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #12879

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSGlueSecurityConfiguration_S3Encryption_S3EncryptionMode_SSES3'
```
