### PR TITLE
r/aws_apigatewayv2_stage: Correctly handle diffs for HTTP API 'default_route_settings.logging_level' attribute, plus the special '$default' stage

### DIFF
--- a/aws/resource_aws_apigatewayv2_api_mapping_test.go
+++ b/aws/resource_aws_apigatewayv2_api_mapping_test.go
@@ -264,7 +264,7 @@ resource "aws_apigatewayv2_domain_name" "test" {
 }
 
 func testAccAWSAPIGatewayV2ApiMappingConfig_basic(rName, certificateArn string) string {
-	return testAccAWSAPIGatewayV2ApiMappingConfig_base(rName, certificateArn) + testAccAWSAPIGatewayV2StageConfig_basic(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2ApiMappingConfig_base(rName, certificateArn) + testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_api_mapping" "test" {
   api_id      = "${aws_apigatewayv2_api.test.id}"
   domain_name = "${aws_apigatewayv2_domain_name.test.id}"
@@ -274,7 +274,7 @@ resource "aws_apigatewayv2_api_mapping" "test" {
 }
 
 func testAccAWSAPIGatewayV2ApiMappingConfig_apiMappingKey(rName, certificateArn, apiMappingKey string) string {
-	return testAccAWSAPIGatewayV2ApiMappingConfig_base(rName, certificateArn) + testAccAWSAPIGatewayV2StageConfig_basic(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2ApiMappingConfig_base(rName, certificateArn) + testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_api_mapping" "test" {
   api_id      = "${aws_apigatewayv2_api.test.id}"
   domain_name = "${aws_apigatewayv2_domain_name.test.id}"

--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -15,6 +15,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
+const (
+	apigatewayv2DefaultStageName = "$default"
+)
+
 func resourceAwsApiGatewayV2Stage() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsApiGatewayV2StageCreate,
@@ -93,6 +97,13 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 								apigatewayv2.LoggingLevelInfo,
 								apigatewayv2.LoggingLevelOff,
 							}, false),
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// Not set for HTTP APIs.
+								if old == "" && new == apigatewayv2.LoggingLevelOff {
+									return true
+								}
+								return false
+							},
 						},
 						"throttling_burst_limit": {
 							Type:     schema.TypeInt,
@@ -260,15 +271,6 @@ func resourceAwsApiGatewayV2StageRead(d *schema.ResourceData, meta interface{}) 
 	}
 	d.Set("deployment_id", resp.DeploymentId)
 	d.Set("description", resp.Description)
-	executionArn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "execute-api",
-		Region:    region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("%s/%s", apiId, stageName),
-	}.String()
-	d.Set("execution_arn", executionArn)
-	d.Set("invoke_url", fmt.Sprintf("wss://%s.execute-api.%s.amazonaws.com/%s", apiId, region, stageName))
 	d.Set("name", stageName)
 	err = d.Set("route_settings", flattenApiGatewayV2RouteSettings(resp.RouteSettings))
 	if err != nil {
@@ -280,6 +282,33 @@ func resourceAwsApiGatewayV2StageRead(d *schema.ResourceData, meta interface{}) 
 	}
 	if err := d.Set("tags", keyvaluetags.Apigatewayv2KeyValueTags(resp.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	apiOutput, err := conn.GetApi(&apigatewayv2.GetApiInput{
+		ApiId: aws.String(apiId),
+	})
+	if err != nil {
+		return fmt.Errorf("error reading API Gateway v2 API (%s): %s", apiId, err)
+	}
+
+	switch aws.StringValue(apiOutput.ProtocolType) {
+	case apigatewayv2.ProtocolTypeWebsocket:
+		executionArn := arn.ARN{
+			Partition: meta.(*AWSClient).partition,
+			Service:   "execute-api",
+			Region:    region,
+			AccountID: meta.(*AWSClient).accountid,
+			Resource:  fmt.Sprintf("%s/%s", apiId, stageName),
+		}.String()
+		d.Set("execution_arn", executionArn)
+		d.Set("invoke_url", fmt.Sprintf("wss://%s.execute-api.%s.amazonaws.com/%s", apiId, region, stageName))
+	case apigatewayv2.ProtocolTypeHttp:
+		d.Set("execution_arn", "")
+		if stageName == apigatewayv2DefaultStageName {
+			d.Set("invoke_url", fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com/", apiId, region))
+		} else {
+			d.Set("invoke_url", fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com/%s", apiId, region, stageName))
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSAPIGatewayV2Stage_basic(t *testing.T) {
+func TestAccAWSAPIGatewayV2Stage_basicWebSocket(t *testing.T) {
 	var apiId string
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
@@ -25,7 +25,7 @@ func TestAccAWSAPIGatewayV2Stage_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayV2StageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayV2StageConfig_basic(rName),
+				Config: testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
@@ -58,6 +58,96 @@ func TestAccAWSAPIGatewayV2Stage_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayV2Stage_basicHttp(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetStageOutput
+	resourceName := "aws_apigatewayv2_stage.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2StageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2StageConfig_basicHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "execution_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", testAccGetRegion(), rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2StageImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Stage_defaultHttpStage(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetStageOutput
+	resourceName := "aws_apigatewayv2_stage.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2StageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2StageConfig_defaultHttpStage(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+/stages/\$default`)),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "execution_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/", testAccGetRegion()))),
+					resource.TestCheckResourceAttr(resourceName, "name", "$default"),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2StageImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSAPIGatewayV2Stage_disappears(t *testing.T) {
 	var apiId string
 	var v apigatewayv2.GetStageOutput
@@ -70,7 +160,7 @@ func TestAccAWSAPIGatewayV2Stage_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayV2StageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayV2StageConfig_basic(rName),
+				Config: testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					testAccCheckAWSAPIGatewayV2StageDisappears(&apiId, &v),
@@ -264,7 +354,7 @@ func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAPIGatewayV2StageConfig_basic(rName),
+				Config: testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
@@ -388,7 +478,7 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettings(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAPIGatewayV2StageConfig_basic(rName),
+				Config: testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
@@ -456,7 +546,7 @@ func TestAccAWSAPIGatewayV2Stage_StageVariables(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAPIGatewayV2StageConfig_basic(rName),
+				Config: testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
@@ -524,7 +614,7 @@ func TestAccAWSAPIGatewayV2Stage_Tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSAPIGatewayV2StageConfig_basic(rName),
+				Config: testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
@@ -641,7 +731,7 @@ func testAccCheckAWSAPIGatewayV2StageAccessLogDestinationArn(resourceName, resou
 	}
 }
 
-func testAccAWSAPIGatewayV2StageConfig_api(rName string) string {
+func testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apigatewayv2_api" "test" {
   name                       = %[1]q
@@ -651,8 +741,17 @@ resource "aws_apigatewayv2_api" "test" {
 `, rName)
 }
 
-func testAccAWSAPIGatewayV2StageConfig_basic(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_api(rName) + fmt.Sprintf(`
+func testAccAWSAPIGatewayV2StageConfig_apiHttp(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName string) string {
+	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
   name   = %[1]q
@@ -660,8 +759,26 @@ resource "aws_apigatewayv2_stage" "test" {
 `, rName)
 }
 
+func testAccAWSAPIGatewayV2StageConfig_basicHttp(rName string) string {
+	return testAccAWSAPIGatewayV2StageConfig_apiHttp(rName) + fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id = "${aws_apigatewayv2_api.test.id}"
+  name   = %[1]q
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2StageConfig_defaultHttpStage(rName string) string {
+	return testAccAWSAPIGatewayV2StageConfig_apiHttp(rName) + fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id = "${aws_apigatewayv2_api.test.id}"
+  name   = "$default"
+}
+`)
+}
+
 func testAccAWSAPIGatewayV2StageConfig_accessLogSettings(rName, format string) string {
-	return testAccAWSAPIGatewayV2StageConfig_api(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -724,7 +841,7 @@ resource "aws_apigatewayv2_stage" "test" {
 }
 
 func testAccAWSAPIGatewayV2StageConfig_clientCertificateIdAndDescription(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_api(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_client_certificate" "test" {
   description = %[1]q
 }
@@ -740,7 +857,7 @@ resource "aws_apigatewayv2_stage" "test" {
 }
 
 func testAccAWSAPIGatewayV2StageConfig_clientCertificateIdAndDescriptionUpdated(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_api(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_client_certificate" "test" {
   description = %[1]q
 }
@@ -756,7 +873,7 @@ resource "aws_apigatewayv2_stage" "test" {
 }
 
 func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettings(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_api(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
   name   = %[1]q
@@ -784,7 +901,7 @@ resource "aws_apigatewayv2_stage" "test" {
 }
 
 func testAccAWSAPIGatewayV2StageConfig_routeSettings(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_api(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
   name   = %[1]q
@@ -807,7 +924,7 @@ resource "aws_apigatewayv2_stage" "test" {
 }
 
 func testAccAWSAPIGatewayV2StageConfig_stageVariables(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_api(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
   name   = %[1]q
@@ -821,7 +938,7 @@ resource "aws_apigatewayv2_stage" "test" {
 }
 
 func testAccAWSAPIGatewayV2StageConfig_tags(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_api(rName) + fmt.Sprintf(`
+	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
   name   = %[1]q

--- a/website/docs/r/apigatewayv2_stage.html.markdown
+++ b/website/docs/r/apigatewayv2_stage.html.markdown
@@ -75,6 +75,7 @@ In addition to all arguments above, the following attributes are exported:
 * `execution_arn` - The ARN prefix to be used in an [`aws_lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn` attribute
 or in an [`aws_iam_policy`](/docs/providers/aws/r/iam_policy.html) to authorize access to the [`@connections` API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html).
 See the [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-control-access-iam.html) for details.
+Set only for WebSocket APIs.
 * `invoke_url` - The URL to invoke the API pointing to the stage,
   e.g. `wss://z4675bid1j.execute-api.eu-west-2.amazonaws.com/example-stage`, or `https://z4675bid1j.execute-api.eu-west-2.amazonaws.com/`
 

--- a/website/docs/r/apigatewayv2_stage.html.markdown
+++ b/website/docs/r/apigatewayv2_stage.html.markdown
@@ -76,7 +76,7 @@ In addition to all arguments above, the following attributes are exported:
 or in an [`aws_iam_policy`](/docs/providers/aws/r/iam_policy.html) to authorize access to the [`@connections` API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-how-to-call-websocket-api-connections.html).
 See the [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-control-access-iam.html) for details.
 * `invoke_url` - The URL to invoke the API pointing to the stage,
-  e.g. `wss://z4675bid1j.execute-api.eu-west-2.amazonaws.com/example-stage`
+  e.g. `wss://z4675bid1j.execute-api.eu-west-2.amazonaws.com/example-stage`, or `https://z4675bid1j.execute-api.eu-west-2.amazonaws.com/`
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12893.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_stage: Correctly handle the `default_route_settings.logging_level` attribute for HTTP APIs
resource/aws_apigatewayv2_stage: Only set the `execute_arn` attribute for WebSocket APIs
resource/aws_apigatewayv2_stage: Set the correct `invoke_url` attribute for HTTP APIs and the `$default` stage name
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Stage_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Stage_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Stage_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== PAUSE TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== RUN   TestAccAWSAPIGatewayV2Stage_disappears
=== PAUSE TestAccAWSAPIGatewayV2Stage_disappears
=== RUN   TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== PAUSE TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== RUN   TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== PAUSE TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== RUN   TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings
=== PAUSE TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings
=== RUN   TestAccAWSAPIGatewayV2Stage_Deployment
=== PAUSE TestAccAWSAPIGatewayV2Stage_Deployment
=== RUN   TestAccAWSAPIGatewayV2Stage_RouteSettings
=== PAUSE TestAccAWSAPIGatewayV2Stage_RouteSettings
=== RUN   TestAccAWSAPIGatewayV2Stage_StageVariables
=== PAUSE TestAccAWSAPIGatewayV2Stage_StageVariables
=== RUN   TestAccAWSAPIGatewayV2Stage_Tags
=== PAUSE TestAccAWSAPIGatewayV2Stage_Tags
=== CONT  TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== CONT  TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings
=== CONT  TestAccAWSAPIGatewayV2Stage_Tags
=== CONT  TestAccAWSAPIGatewayV2Stage_StageVariables
=== CONT  TestAccAWSAPIGatewayV2Stage_RouteSettings
=== CONT  TestAccAWSAPIGatewayV2Stage_Deployment
=== CONT  TestAccAWSAPIGatewayV2Stage_disappears
=== CONT  TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== CONT  TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== CONT  TestAccAWSAPIGatewayV2Stage_basicHttp
=== CONT  TestAccAWSAPIGatewayV2Stage_AccessLogSettings
--- PASS: TestAccAWSAPIGatewayV2Stage_disappears (26.40s)
--- PASS: TestAccAWSAPIGatewayV2Stage_basicWebSocket (31.48s)
--- PASS: TestAccAWSAPIGatewayV2Stage_defaultHttpStage (32.43s)
--- PASS: TestAccAWSAPIGatewayV2Stage_Tags (49.49s)
--- PASS: TestAccAWSAPIGatewayV2Stage_StageVariables (50.10s)
--- PASS: TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings (50.33s)
--- PASS: TestAccAWSAPIGatewayV2Stage_RouteSettings (50.62s)
--- PASS: TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription (51.49s)
--- PASS: TestAccAWSAPIGatewayV2Stage_basicHttp (57.67s)
--- PASS: TestAccAWSAPIGatewayV2Stage_Deployment (62.39s)
--- PASS: TestAccAWSAPIGatewayV2Stage_AccessLogSettings (78.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	78.933s
```
