### PR TITLE
Make ES Domain in-place upgrade's timeout configurable

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -28,6 +28,10 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 			State: resourceAwsElasticSearchDomainImport,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Update: schema.DefaultTimeout(60 * time.Minute),
+		},
+
 		CustomizeDiff: customdiff.Sequence(
 			customdiff.ForceNewIf("elasticsearch_version", func(d *schema.ResourceDiff, meta interface{}) bool {
 				newVersion := d.Get("elasticsearch_version").(string)
@@ -843,7 +847,7 @@ func resourceAwsElasticSearchDomainUpdate(d *schema.ResourceData, meta interface
 
 				return out, aws.StringValue(out.StepStatus), nil
 			},
-			Timeout:    60 * time.Minute, // TODO: Make this configurable. Large ES domains may take a very long time to upgrade
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second, // The upgrade status isn't instantly available for the current upgrade so will either be nil or reflect a previous upgrade
 		}

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -1109,6 +1109,10 @@ resource "aws_elasticsearch_domain" "test" {
   snapshot_options {
     automated_snapshot_start_hour = %d
   }
+
+  timeouts {
+    update = "180m"
+  }
 }
 `, randInt, instanceInt, snapshotInt)
 }

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -310,6 +310,12 @@ In addition to all arguments above, the following attributes are exported:
 * `vpc_options.0.availability_zones` - If the domain was created inside a VPC, the names of the availability zones the configured `subnet_ids` were created inside.
 * `vpc_options.0.vpc_id` - If the domain was created inside a VPC, the ID of the VPC.
 
+## Timeouts
+
+`aws_elasticsearch_domain` provides the following [Timeouts](/docs/configuration/resources.html#operation-timeouts) configuration options:
+
+* `update` - (Optional, Default: `60m`) How long to wait for updates.
+
 ## Import
 
 Elasticsearch domains can be imported using the `domain_name`, e.g.


### PR DESCRIPTION
Make ES Domain in-place upgrade's timeout configurable

It is common that upgrading the ES version of running ES domains
will take around several hours. The official developer guide is
also mentioning about that:

> Amazon ES starts the upgrade, which can take from 15 minutes to several hours to complete. Kibana might be unavailable during some or all of the upgrade.
> https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-version-migration.html

You will be able to define the timeout as follows

```tf
resource "aws_elasticsearch_domain" "example" {
  # ... other configuration ...

  timeouts {
    update = "180m"
  }
}
```

NOTE: This feature was introduced at https://github.com/terraform-providers/terraform-provider-aws/pull/6243

---

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes -

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
