### PR TITLE
add support for importing aws_network_acl_rule resources

### DIFF
--- a/aws/resource_aws_network_acl_rule.go
+++ b/aws/resource_aws_network_acl_rule.go
@@ -235,8 +235,8 @@ func resourceAwsNetworkAclRuleRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("ipv6_cidr_block", resp.Ipv6CidrBlock)
 	d.Set("egress", resp.Egress)
 	if resp.IcmpTypeCode != nil {
-		d.Set("icmp_code", strconv.FormatInt(*resp.IcmpTypeCode.Code, 10))
-		d.Set("icmp_type", strconv.FormatInt(*resp.IcmpTypeCode.Type, 10))
+		d.Set("icmp_code", strconv.FormatInt(aws.Int64Value(resp.IcmpTypeCode.Code), 10))
+		d.Set("icmp_type", strconv.FormatInt(aws.Int64Value(resp.IcmpTypeCode.Type), 10))
 	}
 	if resp.PortRange != nil {
 		d.Set("from_port", resp.PortRange.From)

--- a/aws/resource_aws_network_acl_rule_test.go
+++ b/aws/resource_aws_network_acl_rule_test.go
@@ -169,7 +169,6 @@ func TestAccAWSNetworkAclRule_ipv6ICMP(t *testing.T) {
 
 // Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/6710
 func TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate(t *testing.T) {
-	vpcResourceName := "aws_vpc.test"
 	resourceName := "aws_network_acl_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -181,17 +180,7 @@ func TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate(t *testi
 				Config: testAccAWSNetworkAclRuleConfigIpv6VpcAssignGeneratedIpv6CidrBlockUpdate(false),
 			},
 			{
-				ResourceName:      vpcResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccAWSNetworkAclRuleConfigIpv6VpcAssignGeneratedIpv6CidrBlockUpdate(true),
-			},
-			{
-				ResourceName:      vpcResourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 			{
 				ResourceName:      resourceName,
@@ -658,7 +647,7 @@ resource "aws_network_acl_rule" "test" {
   icmp_type       = -1
   ipv6_cidr_block = "::/0"
   network_acl_id  = "${aws_network_acl.test.id}"
-  protocol        = 58
+  protocol        = "ipv6-icmp"
   rule_action     = "allow"
   rule_number     = 150
 }

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -75,7 +75,9 @@ For example, import a network ACL Rule with an argument like this:
 ```console
 $ terraform import aws_network_acl_rule.my_rule acl-7aaabd18:100:tcp:false
 ```
+
 Or by the procotol's decimal value:
+
 ```console
 $ terraform import aws_route.my_route acl-7aaabd18:100:6:false
 ```

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -64,3 +64,18 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the network ACL Rule
+
+## Import
+
+Individual rules can be imported using `NETWORK_ACL_ID:RULE_NUMBER:PROTOCOL:EGRESS`, where `PROTOCOL` can be a decimal (e.g. 6) or string (e.g. tcp) value.
+For more information on protocol numbers and keywords, see here: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+
+For example, import a network ACL Rule with an argument like this:
+
+```console
+$ terraform import aws_network_acl_rule.my_rule acl-7aaabd18:100:tcp:false
+```
+Or by the procotol's decimal value:
+```console
+$ terraform import aws_route.my_route acl-7aaabd18:100:6:false
+```

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -79,5 +79,5 @@ $ terraform import aws_network_acl_rule.my_rule acl-7aaabd18:100:tcp:false
 Or by the procotol's decimal value:
 
 ```console
-$ terraform import aws_route.my_route acl-7aaabd18:100:6:false
+$ terraform import aws_network_acl_rule.my_rule acl-7aaabd18:100:6:false
 ```

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -68,6 +68,7 @@ In addition to all arguments above, the following attributes are exported:
 ## Import
 
 Individual rules can be imported using `NETWORK_ACL_ID:RULE_NUMBER:PROTOCOL:EGRESS`, where `PROTOCOL` can be a decimal (e.g. 6) or string (e.g. tcp) value.
+If importing a rule previously provisioned by Terraform, the `PROTOCOL` must be the input value used at creation time.
 For more information on protocol numbers and keywords, see here: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 
 For example, import a network ACL Rule with an argument like this:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10983

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```
support for network_acl_rule resource importing
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSNetworkAclRule_tcpProtocol (40.08s)
--- PASS: TestAccAWSNetworkAclRule_disappears_NetworkAcl (171.46s)
--- PASS: TestAccAWSNetworkAclRule_missingParam (172.85s)
--- PASS: TestAccAWSNetworkAclRule_basic (186.02s)
--- PASS: TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears (301.98s)
--- PASS: TestAccAWSNetworkAclRule_ipv6ICMP (303.63s)
--- PASS: TestAccAWSNetworkAclRule_ipv6 (304.05s)
--- PASS: TestAccAWSNetworkAclRule_disappears (304.36s)
--- PASS: TestAccAWSNetworkAclRule_allProtocol (340.56s)
--- PASS: TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate (341.29s)
```
