### PR TITLE
autoscaling: set conflict between availability_zones and vpc_zone_identifier

### DIFF
--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -97,6 +97,16 @@ func suppressOpenIdURL(k, old, new string, d *schema.ResourceData) bool {
 	return oldUrl.String() == newUrl.String()
 }
 
+func suppressAutoscalingGroupAvailabilityZoneDiffs(k, old, new string, d *schema.ResourceData) bool {
+	// If VPC zone identifiers are provided then there is no need to explicitly
+	// specify availability zones.
+	if _, ok := d.GetOk("vpc_zone_identifier"); ok {
+		return true
+	}
+
+	return false
+}
+
 func suppressCloudFormationTemplateBodyDiffs(k, old, new string, d *schema.ResourceData) bool {
 	normalizedOld, err := normalizeCloudFormationTemplate(old)
 

--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -97,16 +97,6 @@ func suppressOpenIdURL(k, old, new string, d *schema.ResourceData) bool {
 	return oldUrl.String() == newUrl.String()
 }
 
-func suppressAutoscalingGroupAvailabilityZoneDiffs(k, old, new string, d *schema.ResourceData) bool {
-	// If VPC zone identifiers are provided then there is no need to explicitly
-	// specify availability zones.
-	if _, ok := d.GetOk("vpc_zone_identifier"); ok {
-		return true
-	}
-
-	return false
-}
-
 func suppressCloudFormationTemplateBodyDiffs(k, old, new string, d *schema.ResourceData) bool {
 	normalizedOld, err := normalizeCloudFormationTemplate(old)
 

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -253,11 +253,12 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			},
 
 			"availability_zones": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Type:             schema.TypeSet,
+				Optional:         true,
+				Computed:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				Set:              schema.HashString,
+				DiffSuppressFunc: suppressAutoscalingGroupAvailabilityZoneDiffs,
 			},
 
 			"placement_group": {

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -253,12 +253,11 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			},
 
 			"availability_zones": {
-				Type:             schema.TypeSet,
-				Optional:         true,
-				Computed:         true,
-				Elem:             &schema.Schema{Type: schema.TypeString},
-				Set:              schema.HashString,
-				DiffSuppressFunc: suppressAutoscalingGroupAvailabilityZoneDiffs,
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 
 			"placement_group": {

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -277,11 +277,12 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			},
 
 			"vpc_zone_identifier": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"availability_zones"},
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
 			},
 
 			"termination_policies": {

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -1342,39 +1342,6 @@ func TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier(t *testing.T) {
 	})
 }
 
-func TestAccAWSAutoScalingGroup_emptyAvailabilityZones(t *testing.T) {
-	var group autoscaling.Group
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAutoScalingGroupConfig_emptyAvailabilityZones,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.test", &group),
-					resource.TestCheckResourceAttr("aws_autoscaling_group.test", "availability_zones.#", "1"),
-				),
-			},
-			{
-				ResourceName:      "aws_autoscaling_group.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"force_delete",
-					"initial_lifecycle_hook",
-					"name_prefix",
-					"tag",
-					"tags",
-					"wait_for_capacity_timeout",
-					"wait_for_elb_capacity",
-				},
-			},
-		},
-	})
-}
-
 func TestAccAWSAutoScalingGroup_launchTemplate(t *testing.T) {
 	var group autoscaling.Group
 
@@ -3367,7 +3334,6 @@ resource "aws_autoscaling_group" "test" {
 
   availability_zones   = ["us-west-2a"]
   launch_configuration = "${aws_launch_configuration.test.name}"
-  vpc_zone_identifier  = []
 }
 
 data "aws_ami" "test_ami" {
@@ -3383,59 +3349,6 @@ data "aws_ami" "test_ami" {
 resource "aws_launch_configuration" "test" {
   image_id      = "${data.aws_ami.test_ami.id}"
   instance_type = "t1.micro"
-}
-`
-
-const testAccAWSAutoScalingGroupConfig_emptyAvailabilityZones = `
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-  tags = {
-    Name = "terraform-testacc-autoscaling-group-empty-azs"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  # t2.micro is not supported in us-west-2d
-  blacklisted_zone_ids = ["usw2-az4"]
-  state                = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-  
-resource "aws_subnet" "test" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  vpc_id     = "${aws_vpc.test.id}"
-  cidr_block = "10.0.0.0/16"
-  tags = {
-    Name = "tf-acc-autoscaling-group-empty-availability-zones"
-  }
-}
-
-resource "aws_autoscaling_group" "test" {
-  min_size = 0
-  max_size = 0
-
-  availability_zones   = []
-  launch_configuration = "${aws_launch_configuration.test.name}"
-  vpc_zone_identifier  = ["${aws_subnet.test.id}"]
-}
-
-data "aws_ami" "test_ami" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-hvm-*-x86_64-gp2"]
-  }
-}
-
-resource "aws_launch_configuration" "test" {
-  image_id      = "${data.aws_ami.test_ami.id}"
-  instance_type = "t2.micro"
 }
 `
 

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -168,7 +168,7 @@ The following arguments are supported:
 * `max_size` - (Required) The maximum size of the auto scale group.
 * `min_size` - (Required) The minimum size of the auto scale group.
     (See also [Waiting for Capacity](#waiting-for-capacity) below.)
-* `availability_zones` - (Required only for EC2-Classic) A list of one or more availability zones for the group. This parameter should not be specified when using `vpc_zone_identifier`.
+* `availability_zones` - (Required only for EC2-Classic) A list of one or more availability zones for the group. This parameter conflicts with `vpc_zone_identifier`.
 * `default_cooldown` - (Optional) The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
 * `launch_configuration` - (Optional) The name of the launch configuration to use.
 * `launch_template` - (Optional) Nested argument with Launch template specification to use to launch instances. Defined below.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR adds `ConflictsWith` to `vpc_zone_identifier`, ensuring that a user that has passed VPC subnet IDs does not also pass a set of AZ names. This configuration would have previously resulted in an error on apply and now will trigger and error during validation.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to https://github.com/terraform-providers/terraform-provider-aws/issues/9622

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Prevent `availability_zones` and `vpc_zone_identifier` from being specified together
```
