### PR TITLE
add support for importing aws_service_discovery_private_dns_namespace

### DIFF
--- a/aws/resource_aws_service_discovery_private_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace.go
@@ -20,7 +20,7 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespace() *schema.Resource {
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), " ")
 				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-					return nil, fmt.Errorf("Unexpected format of ID (%q), expected NAMESPACE_NAME VPC-ID", d.Id())
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected NAMESPACE_ID VPC-ID", d.Id())
 				}
 				d.SetId(idParts[0])
 				d.Set("vpc", idParts[1])

--- a/aws/resource_aws_service_discovery_private_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace.go
@@ -18,9 +18,9 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespace() *schema.Resource {
 		Delete: resourceAwsServiceDiscoveryPrivateDnsNamespaceDelete,
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				idParts := strings.Split(d.Id(), " ")
+				idParts := strings.Split(d.Id(), ":")
 				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-					return nil, fmt.Errorf("Unexpected format of ID (%q), expected NAMESPACE_ID VPC-ID", d.Id())
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected NAMESPACE_ID:VPC_ID", d.Id())
 				}
 				d.SetId(idParts[0])
 				d.Set("vpc", idParts[1])

--- a/aws/resource_aws_service_discovery_private_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace.go
@@ -27,6 +27,7 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespace() *schema.Resource {
 				return []*schema.ResourceData{d}, nil
 			},
 		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -242,6 +242,6 @@ func testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc(resourceName st
 		if !ok {
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
-		return fmt.Sprintf("%s %s", rs.Primary.ID, rs.Primary.Attributes["vpc"]), nil
+		return fmt.Sprintf("%s:%s", rs.Primary.ID, rs.Primary.Attributes["vpc"]), nil
 	}
 }

--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -94,8 +94,7 @@ func testSweepServiceDiscoveryPrivateDnsNamespaces(region string) error {
 }
 
 func TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic(t *testing.T) {
-	namespace := acctest.RandString(5) + ".example.com"
-	rn := "aws_service_discovery_private_dns_namespace.test"
+	rName := acctest.RandString(5) + ".example.com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -103,12 +102,17 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfig(namespace),
+				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists("aws_service_discovery_private_dns_namespace.test"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "arn"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "hosted_zone"),
+				),
 			},
 			{
-				ResourceName:      rn,
+				ResourceName:      "aws_service_discovery_private_dns_namespace.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc(rn),
+				ImportStateIdFunc: testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc("aws_service_discovery_private_dns_namespace.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -116,8 +120,7 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic(t *testing.T) {
 }
 
 func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
-	namespace := acctest.RandString(64-len("example.com")) + ".example.com"
-	rn := "aws_service_discovery_private_dns_namespace.test"
+	rName := acctest.RandString(64-len("example.com")) + ".example.com"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -125,12 +128,17 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
 		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfig(namespace),
+				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists("aws_service_discovery_private_dns_namespace.test"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "arn"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "hosted_zone"),
+				),
 			},
 			{
-				ResourceName:      rn,
+				ResourceName:      "aws_service_discovery_private_dns_namespace.test",
 				ImportState:       true,
-				ImportStateIdFunc: testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc(rn),
+				ImportStateIdFunc: testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc("aws_service_discovery_private_dns_namespace.test"),
 				ImportStateVerify: true,
 			},
 		},
@@ -177,6 +185,17 @@ func testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy(s *terraform.Stat
 		}
 	}
 	return nil
+}
+
+func testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
 }
 
 func testAccPreCheckAWSServiceDiscovery(t *testing.T) {

--- a/website/docs/r/service_discovery_private_dns_namespace.html.markdown
+++ b/website/docs/r/service_discovery_private_dns_namespace.html.markdown
@@ -39,3 +39,11 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of a namespace.
 * `arn` - The ARN that Amazon Route 53 assigns to the namespace when you create it.
 * `hosted_zone` - The ID for the hosted zone that Amazon Route 53 creates when you create a namespace.
+
+## Import
+
+Service Discovery Private DNS Namespace can be imported using the namespace ID, e.g.
+
+```
+$ terraform import aws_service_discovery_private_dns_namespace.example 0123456789
+```

--- a/website/docs/r/service_discovery_private_dns_namespace.html.markdown
+++ b/website/docs/r/service_discovery_private_dns_namespace.html.markdown
@@ -45,5 +45,5 @@ In addition to all arguments above, the following attributes are exported:
 Service Discovery Private DNS Namespace can be imported using the namespace ID, e.g.
 
 ```
-$ terraform import aws_service_discovery_private_dns_namespace.example 0123456789
+$ terraform import aws_service_discovery_private_dns_namespace.example 0123456789 vpc-123345
 ```

--- a/website/docs/r/service_discovery_private_dns_namespace.html.markdown
+++ b/website/docs/r/service_discovery_private_dns_namespace.html.markdown
@@ -42,8 +42,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Service Discovery Private DNS Namespace can be imported using the namespace ID, e.g.
+Service Discovery Private DNS Namespace can be imported using the namespace ID and VPC ID, e.g.
 
 ```
-$ terraform import aws_service_discovery_private_dns_namespace.example 0123456789 vpc-123345
+$ terraform import aws_service_discovery_private_dns_namespace.example 0123456789:vpc-123345
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12913

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```
add support for importing aws_service_discovery_private_dns_namespace resources
```

Output from acceptance testing:
```
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (106.68s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname (107.05s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap (176.30s)
```
