### PR TITLE
add support for importing aws_ssm_maintenance_window_target resource

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -19,12 +19,12 @@ func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
 		Delete: resourceAwsSsmMaintenanceWindowTargetDelete,
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				idParts := strings.Split(d.Id(), ":")
+				idParts := strings.Split(d.Id(), "/")
 				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-					return nil, fmt.Errorf("Unexpected format of ID (%q), expected WINDOW_TARGET_ID:WINDOW_ID", d.Id())
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected WINDOW_ID/WINDOW_TARGET_ID", d.Id())
 				}
-				d.SetId(idParts[0])
-				d.Set("window_id", idParts[1])
+				d.Set("window_id", idParts[0])
+				d.SetId(idParts[1])
 				return []*schema.ResourceData{d}, nil
 			},
 		},

--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -2,13 +2,13 @@ package aws
 
 import (
 	"fmt"
-	"log"
-	"regexp"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"log"
+	"regexp"
+	"strings"
 )
 
 func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
@@ -17,6 +17,17 @@ func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
 		Read:   resourceAwsSsmMaintenanceWindowTargetRead,
 		Update: resourceAwsSsmMaintenanceWindowTargetUpdate,
 		Delete: resourceAwsSsmMaintenanceWindowTargetDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), ":")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected WINDOW_TARGET_ID:WINDOW_ID", d.Id())
+				}
+				d.SetId(idParts[0])
+				d.Set("window_id", idParts[1])
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"window_id": {

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
-	var maint ssm.MaintenanceWindowTarget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,26 +22,18 @@ func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type", ssm.MaintenanceWindowResourceTypeInstance),
-				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTargetImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription(t *testing.T) {
-	var maint ssm.MaintenanceWindowTarget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -52,16 +43,12 @@ func TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetNoNameOrDescriptionConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
-				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTargetImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -91,7 +78,6 @@ func TestAccAWSSSMMaintenanceWindowTarget_validation(t *testing.T) {
 }
 
 func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
-	var maint ssm.MaintenanceWindowTarget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -101,40 +87,27 @@ func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
-				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTargetImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfigUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
-					resource.TestCheckResourceAttr(resourceName, "owner_information", "something"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Updated"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "new-value"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only - updated"),
-				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTargetImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSSSMMaintenanceWindowTarget_resourceGroup(t *testing.T) {
-	var maint ssm.MaintenanceWindowTarget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -144,19 +117,12 @@ func TestAccAWSSSMMaintenanceWindowTarget_resourceGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetBasicResourceGroupConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "resource-groups:ResourceTypeFilters"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "AWS::EC2::INSTANCE"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.1", "AWS::EC2::VPC"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "resource-groups:Name"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "resource-group-name"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
-					resource.TestCheckResourceAttr(resourceName, "resource_type", ssm.MaintenanceWindowResourceTypeResourceGroup),
-				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTargetImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -408,4 +374,15 @@ resource "aws_ssm_maintenance_window_target" "test" {
   }
 }
 `, rName, tName, tDesc)
+}
+
+func testAccAWSSSMMaintenanceWindowTargetImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s:%s", rs.Primary.ID, rs.Primary.Attributes["window_id"]), nil
+	}
 }

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -447,6 +447,6 @@ func testAccAWSSSMMaintenanceWindowTargetImportStateIdFunc(resourceName string) 
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		return fmt.Sprintf("%s:%s", rs.Primary.ID, rs.Primary.Attributes["window_id"]), nil
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["window_id"], rs.Primary.ID), nil
 	}
 }

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
+	var maint ssm.MaintenanceWindowTarget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,6 +23,19 @@ func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", ssm.MaintenanceWindowResourceTypeInstance),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -34,6 +48,7 @@ func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
 }
 
 func TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription(t *testing.T) {
+	var maint ssm.MaintenanceWindowTarget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,6 +58,16 @@ func TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetNoNameOrDescriptionConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -78,6 +103,7 @@ func TestAccAWSSSMMaintenanceWindowTarget_validation(t *testing.T) {
 }
 
 func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
+	var maint ssm.MaintenanceWindowTarget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -87,6 +113,18 @@ func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Name2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.1", "acceptance_test2"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -96,6 +134,18 @@ func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
 			},
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetBasicConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
+					resource.TestCheckResourceAttr(resourceName, "owner_information", "something"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "tag:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "acceptance_test"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "tag:Updated"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "new-value"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only - updated"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -108,6 +158,7 @@ func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
 }
 
 func TestAccAWSSSMMaintenanceWindowTarget_resourceGroup(t *testing.T) {
+	var maint ssm.MaintenanceWindowTarget
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ssm_maintenance_window_target.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -117,6 +168,19 @@ func TestAccAWSSSMMaintenanceWindowTarget_resourceGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSSMMaintenanceWindowTargetBasicResourceGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "resource-groups:ResourceTypeFilters"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "AWS::EC2::INSTANCE"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.1", "AWS::EC2::VPC"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "resource-groups:Name"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "resource-group-name"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "This resource is for test purpose only"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", ssm.MaintenanceWindowResourceTypeResourceGroup),
+				),
 			},
 			{
 				ResourceName:      resourceName,

--- a/website/docs/r/ssm_maintenance_window_target.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_target.html.markdown
@@ -73,3 +73,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the maintenance window target.
+
+## Import
+
+SSM Maintenance Window targets can be imported using `WINDOW_TARGET_ID:WINDOW_ID`, e.g.
+
+```
+$ terraform import aws_ssm_maintenance_window_target.example 23639a0b-ddbc-4bca-9e72-78d96EXAMPLE:mw-0c50858d01EXAMPLE
+```

--- a/website/docs/r/ssm_maintenance_window_target.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_target.html.markdown
@@ -76,8 +76,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SSM Maintenance Window targets can be imported using `WINDOW_TARGET_ID:WINDOW_ID`, e.g.
+SSM Maintenance Window targets can be imported using `WINDOW_ID/WINDOW_TARGET_ID`, e.g.
 
 ```
-$ terraform import aws_ssm_maintenance_window_target.example 23639a0b-ddbc-4bca-9e72-78d96EXAMPLE:mw-0c50858d01EXAMPLE
+$ terraform import aws_ssm_maintenance_window_target.example mw-0c50858d01EXAMPLE/23639a0b-ddbc-4bca-9e72-78d96EXAMPLE
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12910 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add support for importing aws_ssm_maintenance_window_target resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_validation (2.48s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_disappears (12.73s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription (13.92s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_resourceGroup (14.07s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_basic (14.45s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_update (24.63s)
```
