### PR TITLE
Support empty associate_public_ip_address in launch_template data sources

### DIFF
--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -240,7 +240,7 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"associate_public_ip_address": {
-							Type:     schema.TypeBool,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"delete_on_termination": {


### PR DESCRIPTION
This ports the changes from #10157 to the launch_template data source.

# Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #12067

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
BUG FIXES:
* data-source/aws_launch_template: Fix error when associate_public_ip_address is empty
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplateDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_tags
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_tags
=== RUN   TestAccAWSLaunchTemplateDataSource_metadataOptions
=== PAUSE TestAccAWSLaunchTemplateDataSource_metadataOptions
=== RUN   TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== PAUSE TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_metadataOptions
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_tags
=== CONT  TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (28.96s)
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (29.06s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (29.14s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (29.30s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (63.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.092s
```
