### PR TITLE
add support for importing aws_volume_attachment resource

### DIFF
--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -49,7 +49,7 @@ func TestAccAWSVolumeAttachment_skipDestroy(t *testing.T) {
 				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(rn),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"skip_destroy", // attribute only set and used on resource deletion
+					"skip_destroy", // attribute only used on resource deletion
 				},
 			},
 		},
@@ -127,8 +127,8 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(rn),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_detach", // attribute only set and used on resource deletion
-					"skip_destroy", // attribute only set and used on resource deletion
+					"force_detach", // attribute only used on resource deletion
+					"skip_destroy", // attribute only used on resource deletion
 				},
 			},
 			{
@@ -140,8 +140,8 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(rn),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"force_detach", // attribute only set and used on resource deletion
-					"skip_destroy", // attribute only set and used on resource deletion
+					"force_detach", // attribute only used on resource deletion
+					"skip_destroy", // attribute only used on resource deletion
 				},
 			},
 		},

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestAccAWSVolumeAttachment_basic(t *testing.T) {
-	rn := "aws_volume_attachment.ebs_att"
+	var i ec2.Instance
+	var v ec2.Volume
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -21,11 +23,21 @@ func TestAccAWSVolumeAttachment_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVolumeAttachmentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "device_name", "/dev/sdh"),
+					testAccCheckInstanceExists(
+						"aws_instance.web", &i),
+					testAccCheckVolumeExists(
+						"aws_ebs_volume.example", &v),
+					testAccCheckVolumeAttachmentExists(
+						"aws_volume_attachment.ebs_att", &i, &v),
+				),
 			},
 			{
-				ResourceName:      rn,
+				ResourceName:      "aws_volume_attachment.ebs_att",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(rn),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
 				ImportStateVerify: true,
 			},
 		},
@@ -33,7 +45,8 @@ func TestAccAWSVolumeAttachment_basic(t *testing.T) {
 }
 
 func TestAccAWSVolumeAttachment_skipDestroy(t *testing.T) {
-	rn := "aws_volume_attachment.ebs_att"
+	var i ec2.Instance
+	var v ec2.Volume
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -42,11 +55,21 @@ func TestAccAWSVolumeAttachment_skipDestroy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVolumeAttachmentConfigSkipDestroy,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "device_name", "/dev/sdh"),
+					testAccCheckInstanceExists(
+						"aws_instance.web", &i),
+					testAccCheckVolumeExists(
+						"aws_ebs_volume.example", &v),
+					testAccCheckVolumeAttachmentExists(
+						"aws_volume_attachment.ebs_att", &i, &v),
+				),
 			},
 			{
-				ResourceName:      rn,
+				ResourceName:      "aws_volume_attachment.ebs_att",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(rn),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"skip_destroy", // attribute only used on resource deletion
@@ -58,7 +81,7 @@ func TestAccAWSVolumeAttachment_skipDestroy(t *testing.T) {
 
 func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 	var i ec2.Instance
-	rn := "aws_volume_attachment.ebs_att"
+	var v ec2.Volume
 
 	stopInstance := func() {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
@@ -100,11 +123,21 @@ func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 			{
 				PreConfig: stopInstance,
 				Config:    testAccVolumeAttachmentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "device_name", "/dev/sdh"),
+					testAccCheckInstanceExists(
+						"aws_instance.web", &i),
+					testAccCheckVolumeExists(
+						"aws_ebs_volume.example", &v),
+					testAccCheckVolumeAttachmentExists(
+						"aws_volume_attachment.ebs_att", &i, &v),
+				),
 			},
 			{
-				ResourceName:      rn,
+				ResourceName:      "aws_volume_attachment.ebs_att",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(rn),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
 				ImportStateVerify: true,
 			},
 		},
@@ -112,7 +145,6 @@ func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 }
 
 func TestAccAWSVolumeAttachment_update(t *testing.T) {
-	rn := "aws_volume_attachment.ebs_att"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -120,11 +152,17 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVolumeAttachmentConfig_update(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "force_detach", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "skip_destroy", "false"),
+				),
 			},
 			{
-				ResourceName:      rn,
+				ResourceName:      "aws_volume_attachment.ebs_att",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(rn),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_detach", // attribute only used on resource deletion
@@ -133,11 +171,17 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 			},
 			{
 				Config: testAccVolumeAttachmentConfig_update(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "force_detach", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_volume_attachment.ebs_att", "skip_destroy", "true"),
+				),
 			},
 			{
-				ResourceName:      rn,
+				ResourceName:      "aws_volume_attachment.ebs_att",
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc(rn),
+				ImportStateIdFunc: testAccAWSVolumeAttachmentImportStateIDFunc("aws_volume_attachment.ebs_att"),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_detach", // attribute only used on resource deletion
@@ -146,6 +190,30 @@ func TestAccAWSVolumeAttachment_update(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckVolumeAttachmentExists(n string, i *ec2.Instance, v *ec2.Volume) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		for _, b := range i.BlockDeviceMappings {
+			if rs.Primary.Attributes["device_name"] == *b.DeviceName {
+				if b.Ebs.VolumeId != nil && rs.Primary.Attributes["volume_id"] == *b.Ebs.VolumeId {
+					// pass
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("Error finding instance/volume")
+	}
 }
 
 func testAccCheckVolumeAttachmentDestroy(s *terraform.State) error {

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -62,6 +62,15 @@ means attached.
 * `instance_id` - ID of the Instance
 * `volume_id` - ID of the Volume
 
+## Import
+
+EBS Volume Attachments can be imported using `DEVICE_NAME:VOLUME_ID:INSTANCE_ID`, e.g.
+
+```
+$ terraform import aws_volume_attachment.example /dev/sdh:vol-049df61146c4d7901:i-12345678
+```
+
+
 [1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html#available-ec2-device-names
 [2]: https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/device_naming.html#available-ec2-device-names
 [3]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-detaching-volume.html


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #6598

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add support for importing aws_volume_attachment resource
```

Output from acceptance testing:

```
--- PASS: TestAccAWSVolumeAttachment_attachStopped (140.33s)
--- PASS: TestAccAWSVolumeAttachment_skipDestroy (104.79s)
--- PASS: TestAccAWSVolumeAttachment_update (113.01s)
--- PASS: TestAccAWSVolumeAttachment_basic (114.40s)
```
