### PR TITLE
af-south-1 (Cape Town)

### DIFF
--- a/aws/data_source_aws_cloudtrail_service_account.go
+++ b/aws/data_source_aws_cloudtrail_service_account.go
@@ -11,6 +11,7 @@ import (
 // See https://docs.aws.amazon.com/govcloud-us/latest/ug-east/verifying-cloudtrail.html
 // See https://docs.aws.amazon.com/govcloud-us/latest/ug-west/verifying-cloudtrail.html
 var cloudTrailServiceAccountPerRegionMap = map[string]string{
+	"af-south-1":     "525921808201",
 	"ap-east-1":      "119688915426",
 	"ap-northeast-1": "216624486486",
 	"ap-northeast-2": "492519147666",

--- a/aws/data_source_aws_elastic_beanstalk_hosted_zone.go
+++ b/aws/data_source_aws_elastic_beanstalk_hosted_zone.go
@@ -8,6 +8,7 @@ import (
 
 // See http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region
 var elasticBeanstalkHostedZoneIds = map[string]string{
+	"af-south-1":     "Z1EI3BVKMKK4AM",
 	"ap-southeast-1": "Z16FZ9L249IFLT",
 	"ap-southeast-2": "Z2PCDNR3VC2G1N",
 	"ap-east-1":      "ZPWYUBWRU171A",

--- a/aws/data_source_aws_elb_hosted_zone_id.go
+++ b/aws/data_source_aws_elb_hosted_zone_id.go
@@ -9,6 +9,7 @@ import (
 // See http://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
 // See https://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#elb_region
 var elbHostedZoneIdPerRegionMap = map[string]string{
+	"af-south-1":     "Z268VQBMOI5EKX",
 	"ap-east-1":      "Z3DQVH9N71FHZ0",
 	"ap-northeast-1": "Z14GRHDCWA56QT",
 	"ap-northeast-2": "ZWKZPGTI48KDX",

--- a/aws/data_source_aws_elb_service_account.go
+++ b/aws/data_source_aws_elb_service_account.go
@@ -9,6 +9,7 @@ import (
 
 // See http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy
 var elbAccountIdPerRegionMap = map[string]string{
+	"af-south-1":     "098369216593",
 	"ap-east-1":      "754344448648",
 	"ap-northeast-1": "582318560864",
 	"ap-northeast-2": "600734575887",

--- a/aws/data_source_aws_redshift_service_account.go
+++ b/aws/data_source_aws_redshift_service_account.go
@@ -15,6 +15,7 @@ var redshiftServiceAccountPerRegionMap = map[string]string{
 	"us-east-2":      "391106570357",
 	"us-west-1":      "262260360010",
 	"us-west-2":      "902366379725",
+	"af-south-1":     "365689465814",
 	"ap-east-1":      "313564881002",
 	"ap-south-1":     "865932855811",
 	"ap-northeast-3": "090321488786",

--- a/aws/hosted_zones.go
+++ b/aws/hosted_zones.go
@@ -9,6 +9,7 @@ import "fmt"
 // See https://docs.aws.amazon.com/pt_br/govcloud-us/latest/ug-east/using-govcloud-endpoints.html
 // See https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html
 var hostedZoneIDsMap = map[string]string{
+	"af-south-1":     "Z11KHD8FBVPUYU",
 	"ap-east-1":      "ZNB98KWMFR0R6",
 	"ap-northeast-1": "Z2M4EHUR26P7ZW",
 	"ap-northeast-2": "Z3W03O7B5YMIYP",


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#new-region

working on getting [Elastic Beanstalk](https://docs.aws.amazon.com/general/latest/gr/elasticbeanstalk.html#elasticbeanstalk_region) and [S3](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region) documented

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
af-south-1 (Cape Town) account and hosted zone IDs
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
