### PR TITLE
service/docdb: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_docdb_cluster_parameter_group_test.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestAccAWSDocDBClusterParameterGroup_basic(t *testing.T) {
 	var v docdb.DBClusterParameterGroup
+	resourceName := "aws_docdb_cluster_parameter_group.bar"
 
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
 
@@ -26,22 +27,18 @@ func TestAccAWSDocDBClusterParameterGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSDocDBClusterParameterGroupConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestMatchResourceAttr(
-						"aws_docdb_cluster_parameter_group.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:cluster-pg:%s", parameterGroupName))),
-					resource.TestCheckResourceAttr(
-						"aws_docdb_cluster_parameter_group.bar", "name", parameterGroupName),
-					resource.TestCheckResourceAttr(
-						"aws_docdb_cluster_parameter_group.bar", "family", "docdb3.6"),
-					resource.TestCheckResourceAttr(
-						"aws_docdb_cluster_parameter_group.bar", "description", "Managed by Terraform"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.#", "0"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.%", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster-pg:%s$", parameterGroupName))),
+					resource.TestCheckResourceAttr(resourceName, "name", parameterGroupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "docdb3.6"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_docdb_cluster_parameter_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -61,8 +58,7 @@ func TestAccAWSDocDBClusterParameterGroup_namePrefix(t *testing.T) {
 				Config: testAccAWSDocDBClusterParameterGroupConfig_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.test", &v),
-					resource.TestMatchResourceAttr(
-						"aws_docdb_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+					resource.TestMatchResourceAttr("aws_docdb_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
 				),
 			},
 			{
@@ -100,6 +96,7 @@ func TestAccAWSDocDBClusterParameterGroup_generatedName(t *testing.T) {
 
 func TestAccAWSDocDBClusterParameterGroup_Description(t *testing.T) {
 	var v docdb.DBClusterParameterGroup
+	resourceName := "aws_docdb_cluster_parameter_group.bar"
 
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
 
@@ -111,13 +108,13 @@ func TestAccAWSDocDBClusterParameterGroup_Description(t *testing.T) {
 			{
 				Config: testAccAWSDocDBClusterParameterGroupConfig_Description(parameterGroupName, "custom description"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "description", "custom description"),
+					resource.TestCheckResourceAttr(resourceName, "description", "custom description"),
 				),
 			},
 			{
-				ResourceName:      "aws_docdb_cluster_parameter_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -127,6 +124,7 @@ func TestAccAWSDocDBClusterParameterGroup_Description(t *testing.T) {
 
 func TestAccAWSDocDBClusterParameterGroup_disappears(t *testing.T) {
 	var v docdb.DBClusterParameterGroup
+	resourceName := "aws_docdb_cluster_parameter_group.bar"
 
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
 
@@ -138,7 +136,7 @@ func TestAccAWSDocDBClusterParameterGroup_disappears(t *testing.T) {
 			{
 				Config: testAccAWSDocDBClusterParameterGroupConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDocDBClusterParameterGroupDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -149,6 +147,7 @@ func TestAccAWSDocDBClusterParameterGroup_disappears(t *testing.T) {
 
 func TestAccAWSDocDBClusterParameterGroup_Parameter(t *testing.T) {
 	var v docdb.DBClusterParameterGroup
+	resourceName := "aws_docdb_cluster_parameter_group.bar"
 
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
 
@@ -160,28 +159,28 @@ func TestAccAWSDocDBClusterParameterGroup_Parameter(t *testing.T) {
 			{
 				Config: testAccAWSDocDBClusterParameterGroupConfig_Parameter(parameterGroupName, "tls", "disabled"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.#", "1"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.3297634353.apply_method", "pending-reboot"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.3297634353.name", "tls"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.3297634353.value", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3297634353.apply_method", "pending-reboot"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3297634353.name", "tls"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.3297634353.value", "disabled"),
 				),
 			},
 			{
-				ResourceName:      "aws_docdb_cluster_parameter_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSDocDBClusterParameterGroupConfig_Parameter(parameterGroupName, "tls", "enabled"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.#", "1"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.4005179180.apply_method", "pending-reboot"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.4005179180.name", "tls"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.4005179180.value", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.4005179180.apply_method", "pending-reboot"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.4005179180.name", "tls"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.4005179180.value", "enabled"),
 				),
 			},
 		},
@@ -190,6 +189,7 @@ func TestAccAWSDocDBClusterParameterGroup_Parameter(t *testing.T) {
 
 func TestAccAWSDocDBClusterParameterGroup_Tags(t *testing.T) {
 	var v docdb.DBClusterParameterGroup
+	resourceName := "aws_docdb_cluster_parameter_group.bar"
 
 	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
 
@@ -201,33 +201,33 @@ func TestAccAWSDocDBClusterParameterGroup_Tags(t *testing.T) {
 			{
 				Config: testAccAWSDocDBClusterParameterGroupConfig_Tags(parameterGroupName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
-				ResourceName:      "aws_docdb_cluster_parameter_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSDocDBClusterParameterGroupConfig_Tags(parameterGroupName, "key1", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.key1", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value2"),
 				),
 			},
 			{
 				Config: testAccAWSDocDBClusterParameterGroupConfig_Tags(parameterGroupName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
terraform-provider-aws/aws/resource_aws_docdb_cluster_parameter_group_test.go:31:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (14.75s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (19.24s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (19.61s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (19.67s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (19.70s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (32.78s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (43.79s)
```
