### PR TITLE
service/iam: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/data_source_aws_iam_instance_profile_test.go
+++ b/aws/data_source_aws_iam_instance_profile_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -10,6 +9,8 @@ import (
 )
 
 func TestAccAWSDataSourceIAMInstanceProfile_basic(t *testing.T) {
+	resourceName := "data.aws_iam_instance_profile.test"
+
 	roleName := fmt.Sprintf("tf-acc-ds-instance-profile-role-%d", acctest.RandInt())
 	profileName := fmt.Sprintf("tf-acc-ds-instance-profile-%d", acctest.RandInt())
 
@@ -20,19 +21,11 @@ func TestAccAWSDataSourceIAMInstanceProfile_basic(t *testing.T) {
 			{
 				Config: testAccDatasourceAwsIamInstanceProfileConfig(roleName, profileName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"data.aws_iam_instance_profile.test",
-						"arn",
-						regexp.MustCompile("^arn:[^:]+:iam::[0-9]{12}:instance-profile/testpath/"+profileName+"$"),
-					),
-					resource.TestCheckResourceAttr("data.aws_iam_instance_profile.test", "path", "/testpath/"),
-					resource.TestMatchResourceAttr(
-						"data.aws_iam_instance_profile.test",
-						"role_arn",
-						regexp.MustCompile("^arn:[^:]+:iam::[0-9]{12}:role/"+roleName+"$"),
-					),
-					resource.TestCheckResourceAttrSet("data.aws_iam_instance_profile.test", "role_id"),
-					resource.TestCheckResourceAttr("data.aws_iam_instance_profile.test", "role_name", roleName),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_iam_instance_profile.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/testpath/"),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "role_id", "aws_iam_role.test", "unique_id"),
+					resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
 				),
 			},
 		},

--- a/aws/data_source_aws_iam_policy_test.go
+++ b/aws/data_source_aws_iam_policy_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -10,6 +9,7 @@ import (
 )
 
 func TestAccAWSDataSourceIAMPolicy_basic(t *testing.T) {
+	resourceName := "data.aws_iam_policy.test"
 	policyName := fmt.Sprintf("test-policy-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -19,12 +19,11 @@ func TestAccAWSDataSourceIAMPolicy_basic(t *testing.T) {
 			{
 				Config: testAccAwsDataSourceIamPolicyConfig(policyName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_iam_policy.test", "name", policyName),
-					resource.TestCheckResourceAttr("data.aws_iam_policy.test", "description", "My test policy"),
-					resource.TestCheckResourceAttr("data.aws_iam_policy.test", "path", "/"),
-					resource.TestCheckResourceAttrSet("data.aws_iam_policy.test", "policy"),
-					resource.TestMatchResourceAttr("data.aws_iam_policy.test", "arn",
-						regexp.MustCompile(`^arn:[\w-]+:([a-zA-Z0-9\-])+:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12})?:(.*)$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", policyName),
+					resource.TestCheckResourceAttr(resourceName, "description", "My test policy"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_iam_policy.test_policy", "arn"),
 				),
 			},
 		},

--- a/aws/data_source_aws_iam_user_test.go
+++ b/aws/data_source_aws_iam_user_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -10,6 +9,8 @@ import (
 )
 
 func TestAccAWSDataSourceIAMUser_basic(t *testing.T) {
+	resourceName := "data.aws_iam_user.test"
+
 	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -19,11 +20,11 @@ func TestAccAWSDataSourceIAMUser_basic(t *testing.T) {
 			{
 				Config: testAccAwsDataSourceIAMUserConfig(userName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.aws_iam_user.test", "user_id"),
-					resource.TestCheckResourceAttr("data.aws_iam_user.test", "path", "/"),
-					resource.TestCheckResourceAttr("data.aws_iam_user.test", "permissions_boundary", ""),
-					resource.TestCheckResourceAttr("data.aws_iam_user.test", "user_name", userName),
-					resource.TestMatchResourceAttr("data.aws_iam_user.test", "arn", regexp.MustCompile("^arn:[^:]+:iam::[0-9]{12}:user/"+userName)),
+					resource.TestCheckResourceAttrPair(resourceName, "user_id", "aws_iam_user.user", "unique_id"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/"),
+					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
+					resource.TestCheckResourceAttr(resourceName, "user_name", userName),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_iam_user.user", "arn"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
terraform-provider-aws/aws/data_source_aws_iam_instance_profile_test.go:23:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/data_source_aws_iam_instance_profile_test.go:29:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/data_source_aws_iam_policy_test.go:26:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/data_source_aws_iam_user_test.go:26:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSDataSourceIAMUser_basic (21.08s)
--- PASS: TestAccAWSDataSourceIAMPolicy_basic (23.82s)
--- PASS: TestAccAWSDataSourceIAMInstanceProfile_basic (24.68s)
```
