### PR TITLE
service/kms: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/data_source_aws_kms_alias_test.go
+++ b/aws/data_source_aws_kms_alias_test.go
@@ -22,11 +22,9 @@ func TestAccDataSourceAwsKmsAlias_AwsService(t *testing.T) {
 				Config: testAccDataSourceAwsKmsAlias_name(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsKmsAliasCheckExists(resourceName),
-					//lintignore:AWSAT001
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:kms:[^:]+:[^:]+:%s$", name))),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "kms", name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					//lintignore:AWSAT001
-					resource.TestMatchResourceAttr(resourceName, "target_key_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:kms:[^:]+:[^:]+:key/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}$"))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "target_key_arn", "kms", regexp.MustCompile(`key/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}`)),
 					resource.TestMatchResourceAttr(resourceName, "target_key_id", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}$"))),
 				),
 			},

--- a/aws/data_source_aws_kms_alias_test.go
+++ b/aws/data_source_aws_kms_alias_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -23,8 +22,10 @@ func TestAccDataSourceAwsKmsAlias_AwsService(t *testing.T) {
 				Config: testAccDataSourceAwsKmsAlias_name(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsKmsAliasCheckExists(resourceName),
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:kms:[^:]+:[^:]+:%s$", name))),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					//lintignore:AWSAT001
 					resource.TestMatchResourceAttr(resourceName, "target_key_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:kms:[^:]+:[^:]+:key/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}$"))),
 					resource.TestMatchResourceAttr(resourceName, "target_key_id", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}$"))),
 				),
@@ -46,7 +47,9 @@ func TestAccDataSourceAwsKmsAlias_CMK(t *testing.T) {
 				Config: testAccDataSourceAwsKmsAlias_CMK(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsKmsAliasCheckExists(datasourceAliasResourceName),
-					testAccDataSourceAwsKmsAliasCheckCMKAttributes(aliasResourceName, datasourceAliasResourceName),
+					resource.TestCheckResourceAttrPair(datasourceAliasResourceName, "arn", aliasResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceAliasResourceName, "target_key_arn", aliasResourceName, "target_key_arn"),
+					resource.TestCheckResourceAttrPair(datasourceAliasResourceName, "target_key_id", aliasResourceName, "target_key_id"),
 				),
 			},
 		},
@@ -58,49 +61,6 @@ func testAccDataSourceAwsKmsAliasCheckExists(name string) resource.TestCheckFunc
 		_, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		return nil
-	}
-}
-
-func testAccDataSourceAwsKmsAliasCheckCMKAttributes(aliasResourceName, datasourceAliasResourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[datasourceAliasResourceName]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", datasourceAliasResourceName)
-		}
-
-		kmsKeyRs, ok := s.RootModule().Resources[aliasResourceName]
-		if !ok {
-			return fmt.Errorf("can't find %s in state", aliasResourceName)
-		}
-
-		attr := rs.Primary.Attributes
-
-		if attr["arn"] != kmsKeyRs.Primary.Attributes["arn"] {
-			return fmt.Errorf(
-				"arn is %s; want %s",
-				attr["arn"],
-				kmsKeyRs.Primary.Attributes["arn"],
-			)
-		}
-
-		expectedTargetKeyArnSuffix := fmt.Sprintf("key/%s", kmsKeyRs.Primary.Attributes["target_key_id"])
-		if !strings.HasSuffix(attr["target_key_arn"], expectedTargetKeyArnSuffix) {
-			return fmt.Errorf(
-				"target_key_arn is %s; want suffix %s",
-				attr["target_key_arn"],
-				expectedTargetKeyArnSuffix,
-			)
-		}
-
-		if attr["target_key_id"] != kmsKeyRs.Primary.Attributes["target_key_id"] {
-			return fmt.Errorf(
-				"target_key_id is %s; want %s",
-				attr["target_key_id"],
-				kmsKeyRs.Primary.Attributes["target_key_id"],
-			)
 		}
 
 		return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
terraform-provider-aws/aws/data_source_aws_kms_alias_test.go:26:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/data_source_aws_kms_alias_test.go:28:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccDataSourceAwsKmsAlias_AwsService (18.62s)
--- PASS: TestAccDataSourceAwsKmsAlias_CMK (42.67s)
```
