### PR TITLE
(Outpost) Add Local Gateway Route Table datasources

### DIFF
--- a/aws/data_source_aws_local_gateway_route_table.go
+++ b/aws/data_source_aws_local_gateway_route_table.go
@@ -1,0 +1,117 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsLocalGatewayRouteTable() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLocalGatewayRouteTableRead,
+
+		Schema: map[string]*schema.Schema{
+			"local_gateway_route_table_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"local_gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"outpost_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"tags": tagsSchemaComputed(),
+
+			"filter": ec2CustomFiltersSchema(),
+		},
+	}
+}
+
+func dataSourceAwsLocalGatewayRouteTableRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeLocalGatewayRouteTablesInput{}
+
+	var id string
+	if cid, ok := d.GetOk("local_gateway_route_table_id"); ok {
+		id = cid.(string)
+	}
+
+	if id != "" {
+		req.LocalGatewayRouteTableIds = []*string{aws.String(id)}
+	}
+
+	filters := map[string]string{}
+
+	if v, ok := d.GetOk("local_gateway_id"); ok {
+		filters["local-gateway-id"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("outpost_arn"); ok {
+		filters["outpost-arn"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("state"); ok {
+		filters["state"] = v.(string)
+	}
+
+	req.Filters = buildEC2AttributeFilterList(filters)
+
+	if tags, tagsOk := d.GetOk("tags"); tagsOk {
+		req.Filters = append(req.Filters, buildEC2TagFilterList(
+			keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
+		)...)
+	}
+
+	req.Filters = append(req.Filters, buildEC2CustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
+	if len(req.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] Reading AWS Local Gateway Route Table: %s", req)
+	resp, err := conn.DescribeLocalGatewayRouteTables(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil || len(resp.LocalGatewayRouteTables) == 0 {
+		return fmt.Errorf("no matching Local Gateway Route Table found")
+	}
+	if len(resp.LocalGatewayRouteTables) > 1 {
+		return fmt.Errorf("multiple Local Gateway Route Tables matched; use additional constraints to reduce matches to a single Local Gateway Route Table")
+	}
+
+	localgatewayroutetable := resp.LocalGatewayRouteTables[0]
+
+	d.SetId(aws.StringValue(localgatewayroutetable.LocalGatewayRouteTableId))
+	d.Set("local_gateway_id", localgatewayroutetable.LocalGatewayId)
+	d.Set("outpost_arn", localgatewayroutetable.OutpostArn)
+	d.Set("state", localgatewayroutetable.State)
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(localgatewayroutetable.Tags).IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_local_gateway_route_table_test.go
+++ b/aws/data_source_aws_local_gateway_route_table_test.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsLocalGatewayRouteTable_basic(t *testing.T) {
+	rLocalGatewayRouteTableId := os.Getenv("AWS_LOCAL_GATEWAY_ROUTE_TABLE_ID")
+	if rLocalGatewayRouteTableId == "" {
+		t.Skip(
+			"Environment variable AWS_LOCAL_GATEWAY_ROUTE_TABLE_ID is not set. " +
+				"This environment variable must be set to the ID of " +
+				"a deployed Local Gateway Route Table to enable this test.")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsLocalGatewayRouteTableConfig(rLocalGatewayRouteTableId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_local_gateway_route_table.by_id", "local_gateway_route_table_id", rLocalGatewayRouteTableId),
+					resource.TestCheckResourceAttrSet("data.aws_local_gateway_route_table.by_id", "local_gateway_id"),
+					resource.TestCheckResourceAttrSet("data.aws_local_gateway_route_table.by_id", "outpost_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_local_gateway_route_table.by_id", "state"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsLocalGatewayRouteTableConfig(rLocalGatewayRouteTableId string) string {
+	return fmt.Sprintf(`
+data "aws_local_gateway_route_table" "by_id" {
+  local_gateway_route_table_id = "%s"
+}
+`, rLocalGatewayRouteTableId)
+}

--- a/aws/data_source_aws_local_gateway_route_tables.go
+++ b/aws/data_source_aws_local_gateway_route_tables.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsLocalGatewayRouteTables() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLocalGatewayRouteTablesRead,
+		Schema: map[string]*schema.Schema{
+			"filter": ec2CustomFiltersSchema(),
+
+			"tags": tagsSchemaComputed(),
+
+			"local_gateway_route_table_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceAwsLocalGatewayRouteTablesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeLocalGatewayRouteTablesInput{}
+
+	if tags, tagsOk := d.GetOk("tags"); tagsOk {
+		req.Filters = append(req.Filters, buildEC2TagFilterList(
+			keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
+		)...)
+	}
+
+	if filters, filtersOk := d.GetOk("filter"); filtersOk {
+		req.Filters = append(req.Filters, buildEC2CustomFilterList(
+			filters.(*schema.Set),
+		)...)
+	}
+	if len(req.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] DescribeLocalGatewayRouteTables %s\n", req)
+	resp, err := conn.DescribeLocalGatewayRouteTables(req)
+	if err != nil {
+		return err
+	}
+
+	if resp == nil || len(resp.LocalGatewayRouteTables) == 0 {
+		return fmt.Errorf("no matching Local Gateway Route Table found")
+	}
+
+	localgatewayroutetables := make([]string, 0)
+
+	for _, localgatewayroutetable := range resp.LocalGatewayRouteTables {
+		localgatewayroutetables = append(localgatewayroutetables, aws.StringValue(localgatewayroutetable.LocalGatewayRouteTableId))
+	}
+
+	d.SetId(time.Now().UTC().String())
+	if err := d.Set("local_gateway_route_table_ids", localgatewayroutetables); err != nil {
+		return fmt.Errorf("Error setting local gateway route table ids: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_local_gateway_route_tables.go
+++ b/aws/data_source_aws_local_gateway_route_tables.go
@@ -34,17 +34,13 @@ func dataSourceAwsLocalGatewayRouteTablesRead(d *schema.ResourceData, meta inter
 
 	req := &ec2.DescribeLocalGatewayRouteTablesInput{}
 
-	if tags, tagsOk := d.GetOk("tags"); tagsOk {
-		req.Filters = append(req.Filters, buildEC2TagFilterList(
-			keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
-		)...)
-	}
+	req.Filters = append(req.Filters, buildEC2TagFilterList(
+		keyvaluetags.New(d.Get("tags").(map[string]interface{})).Ec2Tags(),
+	)...)
 
-	if filters, filtersOk := d.GetOk("filter"); filtersOk {
-		req.Filters = append(req.Filters, buildEC2CustomFilterList(
-			filters.(*schema.Set),
-		)...)
-	}
+	req.Filters = append(req.Filters, buildEC2CustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
 	if len(req.Filters) == 0 {
 		// Don't send an empty filters list; the EC2 API won't accept it.
 		req.Filters = nil

--- a/aws/data_source_aws_local_gateway_route_tables_test.go
+++ b/aws/data_source_aws_local_gateway_route_tables_test.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourceAwsLocalGatewayRouteTables_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsLocalGatewayRouteTablesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLocalGatewayRouteTableDataSourceExists("data.aws_local_gateway_route_tables.all"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsLocalGatewayRouteTables_filters(t *testing.T) {
+	rLocalGatewayRouteTableId := os.Getenv("AWS_LOCAL_GATEWAY_ROUTE_TABLE_ID")
+	if rLocalGatewayRouteTableId == "" {
+		t.Skip(
+			"Environment variable AWS_LOCAL_GATEWAY_ROUTE_TABLE_ID is not set. " +
+				"This environment variable must be set to the ID of " +
+				"a deployed Local Gateway Route Table to enable this test.")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsLocalGatewayRouteTablesConfig_filters(rLocalGatewayRouteTableId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLocalGatewayRouteTableDataSourceExists("data.aws_local_gateway_route_tables.selected"),
+					testCheckResourceAttrGreaterThanValue("data.aws_local_gateway_route_tables.selected", "local_gateway_route_table_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsLocalGatewayRouteTableDataSourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find aws_local_gateway_route_tables data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("aws_local_gateway_route_tables data source ID not set")
+		}
+		return nil
+	}
+}
+
+const testAccDataSourceAwsLocalGatewayRouteTablesConfig = `data "aws_local_gateway_route_tables" "all" {}`
+
+func testAccDataSourceAwsLocalGatewayRouteTablesConfig_filters(rLocalGatewayRouteTableId string) string {
+	return fmt.Sprintf(`
+data "aws_local_gateway_route_tables" "selected" {
+  filter {
+    name   = "local-gateway-route-table-id"
+    values = ["%s"]
+  }
+}
+`, rLocalGatewayRouteTableId)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -262,6 +262,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_lambda_layer_version":                      dataSourceAwsLambdaLayerVersion(),
 			"aws_launch_configuration":                      dataSourceAwsLaunchConfiguration(),
 			"aws_launch_template":                           dataSourceAwsLaunchTemplate(),
+			"aws_local_gateway_route_table":                 dataSourceAwsLocalGatewayRouteTable(),
+			"aws_local_gateway_route_tables":                dataSourceAwsLocalGatewayRouteTables(),
 			"aws_mq_broker":                                 dataSourceAwsMqBroker(),
 			"aws_msk_cluster":                               dataSourceAwsMskCluster(),
 			"aws_msk_configuration":                         dataSourceAwsMskConfiguration(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3184,6 +3184,12 @@
                                     <a href="/docs/providers/aws/d/internet_gateway.html">aws_internet_gateway</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/d/local_gateway_route_table.html">aws_local_gateway_route_table</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/local_gateway_route_tables.html">aws_local_gateway_route_tables</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/d/nat_gateway.html">aws_nat_gateway</a>
                                 </li>
                                 <li>

--- a/website/docs/d/local_gateway_route_table.html.markdown
+++ b/website/docs/d/local_gateway_route_table.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "VPC"
+layout: "aws"
+page_title: "AWS: aws_local_gateway_route_table"
+description: |-
+    Provides details about a specific Local Gateway Route Table
+---
+
+# Data Source: aws_local_gateway_route_table
+
+`aws_local_gateway_route_table` provides details about a specific Local Gateway Route Table.
+
+This resource can prove useful when a module accepts a local gateway route table id as
+an input variable and needs to, for example, find the associated Outpost or Local Gateway.
+
+## Example Usage
+
+The following example returns a specific local gateway route table ID
+
+```hcl
+variable "aws_local_gateway_route_table" {}
+data "aws_local_gateway_route_table" "selected" {
+  local_gateway_route_table_id = "${var.aws_local_gateway_route_table}"
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available
+Local Gateway Route Tables in the current region. The given filters must match exactly one
+Local Gateway Route Table whose data will be exported as attributes.
+
+* `local_gateway_route_table_id` - (Optional) Local Gateway Route Table Id assigned to desired local gateway route table
+
+* `local_gateway_id` - (Optional) The id of the specific local gateway route table to retrieve.
+
+* `outpost_arn` - (Optional) The arn of the Outpost the local gateway route table is associated with.
+
+* `state` - (Optional) The state of the local gateway route table.
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired local gateway route table.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLocalGatewayRouteTables.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  A local gateway route table will be selected if any one of the given values matches.

--- a/website/docs/d/local_gateway_route_tables.html.markdown
+++ b/website/docs/d/local_gateway_route_tables.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "VPC"
+layout: "aws"
+page_title: "AWS: aws_local_gateway_route_table"
+description: |-
+    Provides a list of Local Gateway Route Table Ids in a region
+---
+
+# Data Source: aws_local_gateway_route_table
+
+This resource can be useful for getting back a list of Local Gateway Route Table Ids for a region.
+
+## Example Usage
+
+The following shows outputing all Local Gateway Route Table Ids.
+
+```hcl
+data "aws_local_gateway_route_table" "foo" {}
+output "foo" {
+  value = "${data.aws_local_gateway_route_table.foo.ids}"
+}
+```
+
+## Argument Reference
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired local gateway route table.
+
+* `filter` - (Optional) Custom filter block as described below.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLocalGatewayRouteTables.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  A Local Gateway Route Table will be selected if any one of the given values matches.
+
+## Attributes Reference
+
+* `local_gateway_route_table_ids` - A list of all the Local Gateway Route Table Ids found. 
+This data source will fail if none are found.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12302

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds Local Gateway Route Table(s) data source
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsLocalGatewayRouteTable'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsLocalGatewayRouteTable -timeout 120m
=== RUN   TestAccDataSourceAwsLocalGatewayRouteTable_basic
=== PAUSE TestAccDataSourceAwsLocalGatewayRouteTable_basic
=== RUN   TestAccDataSourceAwsLocalGatewayRouteTables_basic
=== PAUSE TestAccDataSourceAwsLocalGatewayRouteTables_basic
=== RUN   TestAccDataSourceAwsLocalGatewayRouteTables_filters
=== PAUSE TestAccDataSourceAwsLocalGatewayRouteTables_filters
=== CONT  TestAccDataSourceAwsLocalGatewayRouteTable_basic
=== CONT  TestAccDataSourceAwsLocalGatewayRouteTables_filters
=== CONT  TestAccDataSourceAwsLocalGatewayRouteTables_basic
--- PASS: TestAccDataSourceAwsLocalGatewayRouteTables_filters (53.06s)
--- PASS: TestAccDataSourceAwsLocalGatewayRouteTables_basic (53.30s)
--- PASS: TestAccDataSourceAwsLocalGatewayRouteTable_basic (53.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.959s
```
