### PR TITLE
resource/aws_route53_record: allow change record type and set_id for records with health checks

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -317,6 +317,11 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	// If health check id is present send that to AWS
+	if v, _ := d.GetChange("health_check_id"); v.(string) != "" {
+		oldRec.HealthCheckId = aws.String(v.(string))
+	}
+
 	if v, _ := d.GetChange("set_identifier"); v.(string) != "" {
 		oldRec.SetIdentifier = aws.String(v.(string))
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Somewhat relates to: [#7998](https://github.com/terraform-providers/terraform-provider-aws/issues/7998)

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_route53_record: allow set_identifier and type change with records having health checks
```

AWS Terraform provider doesnot send `health_check_id` to AWS call which causes `InvalidChangeBatch` exception when you are changing `set_identifier` or record `type` of a Route53 record.

Following is the approach to generate the issue

Create a Terraform file with the following config:

```terraform
provider "aws" {
  region = "us-east-1"
}

resource "aws_route53_zone" "awesome_zone" {
  name = "awesome.com"
}

resource "aws_route53_record" "sample-weighted-policy" {
  name           = "sample.awesome.com"
  type           = "CNAME"
  zone_id        = aws_route53_zone.awesome_zone.zone_id
  ttl            = "300"
  latency_routing_policy {
    region = "us-east-1"
  }
  set_identifier = "random-ip"
  records        = ["8.8.8.8"]
  health_check_id = "aaaaaaaa-aaaa-aaaa-aaaa-64c5b689041a"
}
```

after you do `terraform apply` and resources are created, now you have to change `set_identifier` or `type`.

for example change `type` it to something like this:

```terraform
type = "A"
```

Now when you apply the configuration, you will get an error something like `values provided do not match the current values`. The full sample error is

```bash
Error: [ERR]: Error building changeset: InvalidChangeBatch: [Tried to delete resource record set [name='sample.awesome.com.', type='CNAME', set-identifier='random-ip-one'] but the values provided do not match the current values, RRSet of type A with DNS name sample.awesome.com. is not permitted because a conflicting RRSet of type  CNAME with the same DNS name already exists in zone awesome.com.]
```

the CloudTrail event looks something like this:

```json
"eventName": "ChangeResourceRecordSets",
"userAgent": "aws-sdk-go/1.30.12 (go1.13.5; darwin; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.12.19 (+https://www.terraform.io)",
"errorCode": "InvalidChangeBatch",
"errorMessage": "[Tried to delete resource record set [name='sample.awesome.com.', type='CNAME', set-identifier='random-ip-one'] but the values provided do not match the current values, RRSet of type A with DNS name sample.awesome.com. is not permitted because a conflicting RRSet of type  CNAME with the same DNS name already exists in zone awesome.com.]",
"requestParameters": {
    "hostedZoneId": "Z00218531S7I49E5FUHDK",
    "changeBatch": {
        "comment": "Managed by Terraform",
        "changes": [
            {
                "action": "DELETE",
                "resourceRecordSet": {
                    "name": "sample.awesome.com",
                    "type": "CNAME",
                    "setIdentifier": "random-ip-one",
                    "weight": 5,
                    "tTL": 300,
                    "resourceRecords": [
                        {
                            "value": "google.com"
                        }
                    ]
                }
            },
            {
                "action": "CREATE",
                "resourceRecordSet": {
                    "name": "sample.awesome.com",
                    "type": "A",
                    "setIdentifier": "random-ip-one",
                    "weight": 5,
                    "tTL": 300,
                    "resourceRecords": [
                        {
                            "value": "8.8.8.8"
                        }
                    ]
                }
            }
        ]
    }
}
```

But when I do the same from AWS console, this is the CloudTrail event:

```json
"eventName": "ChangeResourceRecordSets",
"requestParameters": {
    "hostedZoneId": "Z0031817UFZ90O9KDB4X",
    "changeBatch": {
        "changes": [
            {
                "action": "DELETE",
                "resourceRecordSet": {
                    "name": "sample.awesome.com.",
                    "type": "A",
                    "setIdentifier": "random-ip-one",
                    "weight": 1,
                    "tTL": 300,
                    "resourceRecords": [
                        {
                            "value": "8.8.8.8"
                        }
                    ],
                    "healthCheckId": "aaaaaaaa-aaaa-aaaa-aaaa-64c5b689041a"
                }
            },
            {
                "action": "CREATE",
                "resourceRecordSet": {
                    "name": "sample.awesome.com.",
                    "type": "A",
                    "setIdentifier": "random-ip-one",
                    "weight": 1,
                    "tTL": 300,
                    "resourceRecords": [
                        {
                            "value": "8.8.8.8"
                        }
                    ],
                    "healthCheckId": "aaaaaaaa-aaaa-aaaa-aaaa-64c5b689041a"
                }
            }
        ]
    }
}
```

So as you can see AWS sends health check id while making a call to [ChangeResourceRecordSets](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html)

This fix will also work for `set_identifier` change, for example:
if you change to

```terraform
set_identifier = "random-ip"
```
