### PR TITLE
r/aws_apigatewayv2_integration: Add tls_config attribute

### DIFF
--- a/aws/resource_aws_apigatewayv2_integration.go
+++ b/aws/resource_aws_apigatewayv2_integration.go
@@ -93,11 +93,10 @@ func resourceAwsApiGatewayV2Integration() *schema.Resource {
 					apigatewayv2.PassthroughBehaviorWhenNoTemplates,
 				}, false),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// PassthroughBehavior not set for HTTP APIs
+					// Not set for HTTP APIs.
 					if old == "" && new == apigatewayv2.PassthroughBehaviorWhenNoMatch {
 						return true
 					}
-
 					return false
 				},
 			},

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -305,6 +305,12 @@ func TestAccAWSAPIGatewayV2Integration_VpcLinkHttp(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2IntegrationImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -40,6 +40,7 @@ func TestAccAWSAPIGatewayV2Integration_basicWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
 				),
 			},
 			{
@@ -146,6 +147,7 @@ func TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_templates.application/json", ""),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", "$request.body.name"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "28999"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
 				),
 			},
 			{
@@ -168,6 +170,7 @@ func TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_templates.application/xml", "#set($percent=$number/100)"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", "$request.body.id"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "51"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
 				),
 			},
 			{
@@ -210,6 +213,72 @@ func TestAccAWSAPIGatewayV2Integration_Lambda(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2IntegrationImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Integration_TlsConfig(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetIntegrationOutput
+	resourceName := "aws_apigatewayv2_integration.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2IntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_tlsConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
+					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "integration_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_uri", "https://www.example.com"),
+					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
+					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "5001"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.0.server_name_to_verify", "www.example.com"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_tlsConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
+					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test HTTPS updated"),
+					resource.TestCheckResourceAttr(resourceName, "integration_method", "POST"),
+					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_uri", "https://www.example.org"),
+					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
+					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "2.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "4999"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.0.server_name_to_verify", "www.example.org"),
 				),
 			},
 			{
@@ -252,6 +321,7 @@ func TestAccAWSAPIGatewayV2Integration_VpcLink(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "12345"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
 				),
 			},
 			{
@@ -355,8 +425,8 @@ resource "aws_apigatewayv2_api" "test" {
 func testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apigatewayv2_api" "test" {
-  name                       = %[1]q
-  protocol_type              = "HTTP"
+  name          = %[1]q
+  protocol_type = "HTTP"
 }
 `, rName)
 }
@@ -442,14 +512,41 @@ resource "aws_apigatewayv2_integration" "test" {
 `, rName)
 }
 
-func testAccAWSAPIGatewayV2IntegrationConfig_httpProxy(rName string) string {
+func testAccAWSAPIGatewayV2IntegrationConfig_tlsConfig(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_integration" "test" {
-	api_id           = "${aws_apigatewayv2_api.test.id}"
-	integration_type = "HTTP_PROXY"
+  api_id           = "${aws_apigatewayv2_api.test.id}"
+  integration_type = "HTTP_PROXY"
 
-	integration_method = "GET"
-	integration_uri    = "https://example.com"
+  connection_type      = "INTERNET"
+  description          = "Test HTTPS"
+  integration_method   = "GET"
+  integration_uri      = "https://www.example.com"
+  timeout_milliseconds = 5001
+
+  tls_config {
+    server_name_to_verify = "www.example.com"
+  }
+}
+`)
+}
+
+func testAccAWSAPIGatewayV2IntegrationConfig_tlsConfigUpdated(rName string) string {
+	return testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName) + fmt.Sprintf(`
+resource "aws_apigatewayv2_integration" "test" {
+  api_id           = "${aws_apigatewayv2_api.test.id}"
+  integration_type = "HTTP_PROXY"
+
+  connection_type        = "INTERNET"
+  description            = "Test HTTPS updated"
+  integration_method     = "POST"
+  integration_uri        = "https://www.example.org"
+  payload_format_version = "2.0"
+  timeout_milliseconds   = 4999
+
+  tls_config = {
+    server_name_to_verify = "www.example.org"
+  }
 }
 `)
 }

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -226,72 +226,7 @@ func TestAccAWSAPIGatewayV2Integration_Lambda(t *testing.T) {
 	})
 }
 
-func TestAccAWSAPIGatewayV2Integration_TlsConfig(t *testing.T) {
-	var apiId string
-	var v apigatewayv2.GetIntegrationOutput
-	resourceName := "aws_apigatewayv2_integration.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAPIGatewayV2IntegrationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAPIGatewayV2IntegrationConfig_tlsConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
-					resource.TestCheckResourceAttr(resourceName, "connection_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
-					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
-					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
-					resource.TestCheckResourceAttr(resourceName, "description", "Test HTTPS"),
-					resource.TestCheckResourceAttr(resourceName, "integration_method", "GET"),
-					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
-					resource.TestCheckResourceAttr(resourceName, "integration_uri", "https://www.example.com"),
-					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
-					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
-					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "5001"),
-					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tls_config.0.server_name_to_verify", "www.example.com"),
-				),
-			},
-			{
-				Config: testAccAWSAPIGatewayV2IntegrationConfig_tlsConfigUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
-					resource.TestCheckResourceAttr(resourceName, "connection_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
-					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
-					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
-					resource.TestCheckResourceAttr(resourceName, "description", "Test HTTPS updated"),
-					resource.TestCheckResourceAttr(resourceName, "integration_method", "POST"),
-					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
-					resource.TestCheckResourceAttr(resourceName, "integration_uri", "https://www.example.org"),
-					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
-					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "2.0"),
-					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
-					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "4999"),
-					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tls_config.0.server_name_to_verify", "www.example.org"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccAWSAPIGatewayV2IntegrationImportStateIdFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSAPIGatewayV2Integration_VpcLink(t *testing.T) {
+func TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket(t *testing.T) {
 	var apiId string
 	var v apigatewayv2.GetIntegrationOutput
 	resourceName := "aws_apigatewayv2_integration.test"
@@ -304,7 +239,7 @@ func TestAccAWSAPIGatewayV2Integration_VpcLink(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayV2IntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayV2IntegrationConfig_vpcLink(rName),
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "connection_id", vpcLinkResourceName, "id"),
@@ -322,6 +257,73 @@ func TestAccAWSAPIGatewayV2Integration_VpcLink(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "12345"),
 					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2IntegrationImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Integration_VpcLinkHttp(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetIntegrationOutput
+	resourceName := "aws_apigatewayv2_integration.test"
+	vpcLinkResourceName := "aws_apigatewayv2_vpc_link.test"
+	lbListenerResourceName := "aws_lb_listener.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2IntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "connection_id", vpcLinkResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "VPC_LINK"),
+					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test private integration"),
+					resource.TestCheckResourceAttr(resourceName, "integration_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
+					resource.TestCheckResourceAttrPair(resourceName, "integration_uri", lbListenerResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
+					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "5001"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.0.server_name_to_verify", "www.example.com"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "connection_id", vpcLinkResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "VPC_LINK"),
+					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test private integration updated"),
+					resource.TestCheckResourceAttr(resourceName, "integration_method", "POST"),
+					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
+					resource.TestCheckResourceAttrPair(resourceName, "integration_uri", lbListenerResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
+					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "4999"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.0.server_name_to_verify", "www.example.org"),
 				),
 			},
 			{
@@ -431,6 +433,52 @@ resource "aws_apigatewayv2_api" "test" {
 `, rName)
 }
 
+func testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpBase(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName),
+		testAccAWSAPIGatewayV2VpcLinkConfig_basic(rName),
+		fmt.Sprintf(`
+resource "aws_lb" "test" {
+  name = %[1]q
+
+  internal           = true
+  load_balancer_type = "network"
+  subnets            = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 80
+  protocol = "TCP"
+  vpc_id   = "${aws_vpc.test.id}"
+
+  health_check {
+    port     = 80
+    protocol = "TCP"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = "${aws_lb.test.arn}"
+  port              = "80"
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.test.arn}"
+    type             = "forward"
+  }
+}
+`, rName))
+}
+
 func testAccAWSAPIGatewayV2IntegrationConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName) + `
 resource "aws_apigatewayv2_integration" "test" {
@@ -512,47 +560,66 @@ resource "aws_apigatewayv2_integration" "test" {
 `, rName)
 }
 
-func testAccAWSAPIGatewayV2IntegrationConfig_tlsConfig(rName string) string {
+func testAccAWSAPIGatewayV2IntegrationConfig_httpProxy(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_integration" "test" {
   api_id           = "${aws_apigatewayv2_api.test.id}"
   integration_type = "HTTP_PROXY"
 
-  connection_type      = "INTERNET"
-  description          = "Test HTTPS"
+  integration_method = "GET"
+  integration_uri    = "https://example.com"
+}
+`)
+}
+
+func testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttp(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpBase(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_integration" "test" {
+  api_id           = "${aws_apigatewayv2_api.test.id}"
+  integration_type = "HTTP_PROXY"
+
+  connection_type      = "VPC_LINK"
+  connection_id        = "${aws_apigatewayv2_vpc_link.test.id}"
+  description          = "Test private integration"
   integration_method   = "GET"
-  integration_uri      = "https://www.example.com"
+  integration_uri      = "${aws_lb_listener.test.arn}"
   timeout_milliseconds = 5001
 
   tls_config {
     server_name_to_verify = "www.example.com"
   }
 }
-`)
+`))
 }
 
-func testAccAWSAPIGatewayV2IntegrationConfig_tlsConfigUpdated(rName string) string {
-	return testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName) + fmt.Sprintf(`
+func testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpUpdated(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpBase(rName),
+		fmt.Sprintf(`
 resource "aws_apigatewayv2_integration" "test" {
   api_id           = "${aws_apigatewayv2_api.test.id}"
   integration_type = "HTTP_PROXY"
 
-  connection_type        = "INTERNET"
-  description            = "Test HTTPS updated"
-  integration_method     = "POST"
-  integration_uri        = "https://www.example.org"
-  payload_format_version = "2.0"
-  timeout_milliseconds   = 4999
+  connection_type      = "VPC_LINK"
+  connection_id        = "${aws_apigatewayv2_vpc_link.test.id}"
+  description          = "Test private integration updated"
+  integration_method   = "POST"
+  integration_uri      = "${aws_lb_listener.test.arn}"
+  timeout_milliseconds = 4999
 
-  tls_config = {
+  tls_config {
     server_name_to_verify = "www.example.org"
   }
 }
-`)
+`))
 }
 
-func testAccAWSAPIGatewayV2IntegrationConfig_vpcLink(rName string) string {
-	return testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName) + fmt.Sprintf(`
+func testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkWebSocket(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName),
+		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -585,6 +652,10 @@ resource "aws_lb" "test" {
   internal           = true
   load_balancer_type = "network"
   subnets            = ["${aws_subnet.test.id}"]
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_api_gateway_vpc_link" "test" {
@@ -605,5 +676,5 @@ resource "aws_apigatewayv2_integration" "test" {
   passthrough_behavior          = "NEVER"
   timeout_milliseconds          = 12345
 }
-`, rName)
+`, rName))
 }

--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -67,6 +67,11 @@ Valid values: `WHEN_NO_MATCH`, `WHEN_NO_TEMPLATES`, `NEVER`. Default is `WHEN_NO
 * `request_templates` - (Optional) A map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. Supported only for WebSocket APIs.
 * `template_selection_expression` - (Optional) The [template selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-template-selection-expressions) for the integration.
 * `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds or 29 seconds.
+* `tls_config` - (Optional) The TLS configuration for a private integration. Supported only for HTTP APIs.
+
+The `tls_config` object supports the following:
+
+* `server_name_to_verify` - (Optional) If you specify a server name, API Gateway uses it to verify the hostname on the integration's certificate. The server name is also included in the TLS handshake to support Server Name Indication (SNI) or virtual hosting.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12971.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_integration: Add `tls_config` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Integration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Integration_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Integration_basic
=== PAUSE TestAccAWSAPIGatewayV2Integration_basic
=== RUN   TestAccAWSAPIGatewayV2Integration_disappears
=== PAUSE TestAccAWSAPIGatewayV2Integration_disappears
=== RUN   TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_Lambda
=== PAUSE TestAccAWSAPIGatewayV2Integration_Lambda
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_basic
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_Lambda
=== CONT  TestAccAWSAPIGatewayV2Integration_disappears
--- PASS: TestAccAWSAPIGatewayV2Integration_disappears (24.16s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basic (27.95s)
--- PASS: TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp (45.83s)
--- PASS: TestAccAWSAPIGatewayV2Integration_Lambda (52.04s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLinkHttp (283.54s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket (690.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	690.661s
```
