### PR TITLE
service/vpn: tech debt: replace custom validation functions

### DIFF
--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -620,7 +620,7 @@ func xmlConfigToTunnelInfo(xmlConfig string) (*TunnelInfo, error) {
 func validateVpnConnectionTunnelPreSharedKey() schema.SchemaValidateFunc {
 	return validation.All(
 		validation.StringLenBetween(8, 64),
-		validation.StringDoesNotMatch(regexp.MustCompile(`(?i)^0`), "cannot start with zero character"),
+		validation.StringDoesNotMatch(regexp.MustCompile(`^0`), "cannot start with zero character"),
 		validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z_.]+$`), "can only contain alphanumeric, period and underscore characters"),
 	)
 }

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -139,6 +139,7 @@ func TestAccAWSVpnConnection_TransitGatewayID(t *testing.T) {
 }
 
 func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
+	badCidrRangeErr := regexp.MustCompile(`expected \w+ to not be any of \[[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/30\s?]+\]`)
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_vpn_connection.test"
 	var vpn ec2.VpnConnection
@@ -153,11 +154,11 @@ func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
 			// Checking CIDR blocks
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "not-a-cidr"),
-				ExpectError: regexp.MustCompile(`must contain a valid CIDR`),
+				ExpectError: regexp.MustCompile(`invalid CIDR address: not-a-cidr`),
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.254.0/31"),
-				ExpectError: regexp.MustCompile(`must be /30 CIDR`),
+				ExpectError: regexp.MustCompile(`expected "\w+" to contain a network Value with between 30 and 30 significant bits`),
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "172.16.0.0/30"),
@@ -165,41 +166,41 @@ func TestAccAWSVpnConnection_tunnelOptions(t *testing.T) {
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.0.0/30"),
-				ExpectError: regexp.MustCompile(`cannot be 169.254.0.0/30`),
+				ExpectError: badCidrRangeErr,
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.1.0/30"),
-				ExpectError: regexp.MustCompile(`cannot be 169.254.1.0/30`),
+				ExpectError: badCidrRangeErr,
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.2.0/30"),
-				ExpectError: regexp.MustCompile(`cannot be 169.254.2.0/30`),
+				ExpectError: badCidrRangeErr,
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.3.0/30"),
-				ExpectError: regexp.MustCompile(`cannot be 169.254.3.0/30`),
+				ExpectError: badCidrRangeErr,
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.4.0/30"),
-				ExpectError: regexp.MustCompile(`cannot be 169.254.4.0/30`),
+				ExpectError: badCidrRangeErr,
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.5.0/30"),
-				ExpectError: regexp.MustCompile(`cannot be 169.254.5.0/30`),
+				ExpectError: badCidrRangeErr,
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "12345678", "169.254.169.252/30"),
-				ExpectError: regexp.MustCompile(`cannot be 169.254.169.252/30`),
+				ExpectError: badCidrRangeErr,
 			},
 
 			// Checking PreShared Key
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "1234567", "169.254.254.0/30"),
-				ExpectError: regexp.MustCompile(`must be between 8 and 64 characters in length`),
+				ExpectError: regexp.MustCompile(`expected length of \w+ to be in the range \(8 - 64\)`),
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, acctest.RandStringFromCharSet(65, acctest.CharSetAlpha), "169.254.254.0/30"),
-				ExpectError: regexp.MustCompile(`must be between 8 and 64 characters in length`),
+				ExpectError: regexp.MustCompile(`expected length of \w+ to be in the range \(8 - 64\)`),
 			},
 			{
 				Config:      testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn, "01234567", "169.254.254.0/30"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11872

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```-->
I couldn't run the acceptance tests since I was getting a 400 - AWS claims my account has too many virtual private gateways and can't seem to figure out why that it is. Submitting as "best-effort" PR.
