### PR TITLE
r/aws_wafregional_xss_match_set: Fix 'panic: interface conversion: interface {} is *schema.Set, not []interface {}'

### DIFF
--- a/aws/resource_aws_wafregional_xss_match_set.go
+++ b/aws/resource_aws_wafregional_xss_match_set.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsWafRegionalXssMatchSet() *schema.Resource {
@@ -32,7 +33,7 @@ func resourceAwsWafRegionalXssMatchSet() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"field_to_match": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -44,6 +45,15 @@ func resourceAwsWafRegionalXssMatchSet() *schema.Resource {
 									"type": {
 										Type:     schema.TypeString,
 										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											wafregional.MatchFieldTypeUri,
+											wafregional.MatchFieldTypeSingleQueryArg,
+											wafregional.MatchFieldTypeQueryString,
+											wafregional.MatchFieldTypeMethod,
+											wafregional.MatchFieldTypeHeader,
+											wafregional.MatchFieldTypeBody,
+											wafregional.MatchFieldTypeAllQueryArgs,
+										}, false),
 									},
 								},
 							},
@@ -51,6 +61,14 @@ func resourceAwsWafRegionalXssMatchSet() *schema.Resource {
 						"text_transformation": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								wafregional.TextTransformationUrlDecode,
+								wafregional.TextTransformationNone,
+								wafregional.TextTransformationHtmlEntityDecode,
+								wafregional.TextTransformationCompressWhiteSpace,
+								wafregional.TextTransformationCmdLine,
+								wafregional.TextTransformationLowercase,
+							}, false),
 						},
 					},
 				},
@@ -79,9 +97,16 @@ func resourceAwsWafRegionalXssMatchSetCreate(d *schema.ResourceData, meta interf
 	}
 	resp := out.(*waf.CreateXssMatchSetOutput)
 
-	d.SetId(*resp.XssMatchSet.XssMatchSetId)
+	d.SetId(aws.StringValue(resp.XssMatchSet.XssMatchSetId))
 
-	return resourceAwsWafRegionalXssMatchSetUpdate(d, meta)
+	if v, ok := d.Get("xss_match_tuple").(*schema.Set); ok && v.Len() > 0 {
+		err := updateXssMatchSetResourceWR(d.Id(), nil, v.List(), conn, region)
+		if err != nil {
+			return fmt.Errorf("Failed updating regional WAF XSS Match Set: %s", err)
+		}
+	}
+
+	return resourceAwsWafRegionalXssMatchSetRead(d, meta)
 }
 
 func resourceAwsWafRegionalXssMatchSetRead(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_wafregional_xss_match_set_test.go
+++ b/aws/resource_aws_wafregional_xss_match_set_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccAWSWafRegionalXssMatchSet_basic(t *testing.T) {
 	var v waf.XssMatchSet
-	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,19 +23,19 @@ func TestAccAWSWafRegionalXssMatchSet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafRegionalXssMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafRegionalXssMatchSetConfig(xssMatchSet),
+				Config: testAccAWSWafRegionalXssMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "name", xssMatchSet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.2316364334.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.text_transformation", "NONE"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.3756326843.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.3756326843.type", "URI"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.599421078.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.599421078.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.599421078.field_to_match.0.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.599421078.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.41660541.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.41660541.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.41660541.field_to_match.0.type", "URI"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.41660541.text_transformation", "NONE"),
 				),
 			},
 			{
@@ -49,8 +49,8 @@ func TestAccAWSWafRegionalXssMatchSet_basic(t *testing.T) {
 
 func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.XssMatchSet
-	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
-	xssMatchSetNewName := fmt.Sprintf("xssMatchSetNewName-%s", acctest.RandString(5))
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -59,10 +59,10 @@ func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafRegionalXssMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafRegionalXssMatchSetConfig(xssMatchSet),
+				Config: testAccAWSWafRegionalXssMatchSetConfig(rName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "name", xssMatchSet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
 				),
 			},
@@ -72,10 +72,10 @@ func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSWafRegionalXssMatchSetConfigChangeName(xssMatchSetNewName),
+				Config: testAccAWSWafRegionalXssMatchSetConfigChangeName(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &after),
-					resource.TestCheckResourceAttr(resourceName, "name", xssMatchSetNewName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
 				),
 			},
@@ -85,7 +85,7 @@ func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 
 func TestAccAWSWafRegionalXssMatchSet_disappears(t *testing.T) {
 	var v waf.XssMatchSet
-	xssMatchSet := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -94,7 +94,7 @@ func TestAccAWSWafRegionalXssMatchSet_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafRegionalXssMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafRegionalXssMatchSetConfig(xssMatchSet),
+				Config: testAccAWSWafRegionalXssMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &v),
 					testAccCheckAWSWafRegionalXssMatchSetDisappears(&v),
@@ -107,7 +107,7 @@ func TestAccAWSWafRegionalXssMatchSet_disappears(t *testing.T) {
 
 func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 	var before, after waf.XssMatchSet
-	setName := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -116,19 +116,19 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafRegionalXssMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafRegionalXssMatchSetConfig(setName),
+				Config: testAccAWSWafRegionalXssMatchSetConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "name", setName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.2316364334.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2018581549.text_transformation", "NONE"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.3756326843.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.field_to_match.3756326843.type", "URI"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2786024938.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.599421078.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.599421078.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.599421078.field_to_match.0.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.599421078.text_transformation", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.41660541.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.41660541.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.41660541.field_to_match.0.type", "URI"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.41660541.text_transformation", "NONE"),
 				),
 			},
 			{
@@ -137,19 +137,19 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSWafRegionalXssMatchSetConfig_changeTuples(setName),
+				Config: testAccAWSWafRegionalXssMatchSetConfig_changeTuples(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &after),
-					resource.TestCheckResourceAttr(resourceName, "name", setName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2893682529.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2893682529.field_to_match.4253810390.data", "GET"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2893682529.field_to_match.4253810390.type", "METHOD"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.2893682529.text_transformation", "HTML_ENTITY_DECODE"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.4270311415.field_to_match.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.4270311415.field_to_match.281401076.data", ""),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.4270311415.field_to_match.281401076.type", "BODY"),
-					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.4270311415.text_transformation", "CMD_LINE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.42378128.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.42378128.field_to_match.0.data", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.42378128.field_to_match.0.type", "METHOD"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.42378128.text_transformation", "HTML_ENTITY_DECODE"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.3815294338.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.3815294338.field_to_match.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.3815294338.field_to_match.0.type", "BODY"),
+					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.3815294338.text_transformation", "CMD_LINE"),
 				),
 			},
 		},
@@ -158,7 +158,7 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 
 func TestAccAWSWafRegionalXssMatchSet_noTuples(t *testing.T) {
 	var ipset waf.XssMatchSet
-	setName := fmt.Sprintf("xssMatchSet-%s", acctest.RandString(5))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_xss_match_set.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -167,10 +167,10 @@ func TestAccAWSWafRegionalXssMatchSet_noTuples(t *testing.T) {
 		CheckDestroy: testAccCheckAWSWafRegionalXssMatchSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSWafRegionalXssMatchSetConfig_noTuples(setName),
+				Config: testAccAWSWafRegionalXssMatchSetConfig_noTuples(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &ipset),
-					resource.TestCheckResourceAttr(resourceName, "name", setName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "0"),
 				),
 			},
@@ -283,10 +283,10 @@ func testAccCheckAWSWafRegionalXssMatchSetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSWafRegionalXssMatchSetConfig(name string) string {
+func testAccAWSWafRegionalXssMatchSetConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_xss_match_set" "test" {
-  name = "%s"
+  name = %[1]q
 
   xss_match_tuple {
     text_transformation = "NONE"
@@ -304,13 +304,13 @@ resource "aws_wafregional_xss_match_set" "test" {
     }
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccAWSWafRegionalXssMatchSetConfigChangeName(name string) string {
+func testAccAWSWafRegionalXssMatchSetConfigChangeName(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_xss_match_set" "test" {
-  name = "%s"
+  name = %[1]q
 
   xss_match_tuple {
     text_transformation = "NONE"
@@ -328,13 +328,13 @@ resource "aws_wafregional_xss_match_set" "test" {
     }
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccAWSWafRegionalXssMatchSetConfig_changeTuples(name string) string {
+func testAccAWSWafRegionalXssMatchSetConfig_changeTuples(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_xss_match_set" "test" {
-  name = "%s"
+  name = %[1]q
 
   xss_match_tuple {
     text_transformation = "CMD_LINE"
@@ -353,13 +353,13 @@ resource "aws_wafregional_xss_match_set" "test" {
     }
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccAWSWafRegionalXssMatchSetConfig_noTuples(name string) string {
+func testAccAWSWafRegionalXssMatchSetConfig_noTuples(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_xss_match_set" "test" {
-  name = "%s"
+  name = %[1]q
 }
-`, name)
+`, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13014.

Also add read after create and plan-time validations, similar to https://github.com/terraform-providers/terraform-provider-aws/pull/12777.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_xss_match_set: Fix crash during resource update
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSWafRegionalXssMatchSet_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSWafRegionalXssMatchSet_ -timeout 120m
=== RUN   TestAccAWSWafRegionalXssMatchSet_basic
=== PAUSE TestAccAWSWafRegionalXssMatchSet_basic
=== RUN   TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalXssMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalXssMatchSet_disappears
=== RUN   TestAccAWSWafRegionalXssMatchSet_changeTuples
=== PAUSE TestAccAWSWafRegionalXssMatchSet_changeTuples
=== RUN   TestAccAWSWafRegionalXssMatchSet_noTuples
=== PAUSE TestAccAWSWafRegionalXssMatchSet_noTuples
=== CONT  TestAccAWSWafRegionalXssMatchSet_basic
=== CONT  TestAccAWSWafRegionalXssMatchSet_changeTuples
=== CONT  TestAccAWSWafRegionalXssMatchSet_disappears
=== CONT  TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
=== CONT  TestAccAWSWafRegionalXssMatchSet_noTuples
--- PASS: TestAccAWSWafRegionalXssMatchSet_noTuples (26.75s)
--- PASS: TestAccAWSWafRegionalXssMatchSet_disappears (30.52s)
--- PASS: TestAccAWSWafRegionalXssMatchSet_basic (35.65s)
--- FAIL: TestAccAWSWafRegionalXssMatchSet_changeTuples (54.18s)
    testing.go:669: Step 2 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_wafregional_xss_match_set.test
          id:                                      "da4c4cf8-24d3-4749-aef3-13a9b487abe5" => "da4c4cf8-24d3-4749-aef3-13a9b487abe5"
          name:                                    "tf-acc-test-8703340596436274492" => "tf-acc-test-8703340596436274492"
          xss_match_tuple.#:                       "2" => "2"
          xss_match_tuple.0.field_to_match.#:      "1" => "1"
          xss_match_tuple.0.field_to_match.0.data: "" => "GET"
          xss_match_tuple.0.field_to_match.0.type: "BODY" => "METHOD"
          xss_match_tuple.0.text_transformation:   "CMD_LINE" => "HTML_ENTITY_DECODE"
          xss_match_tuple.1.field_to_match.#:      "1" => "1"
          xss_match_tuple.1.field_to_match.0.data: "" => ""
          xss_match_tuple.1.field_to_match.0.type: "METHOD" => "BODY"
          xss_match_tuple.1.text_transformation:   "HTML_ENTITY_DECODE" => "CMD_LINE"
        
        
        
        STATE:
        
        aws_wafregional_xss_match_set.test:
          ID = da4c4cf8-24d3-4749-aef3-13a9b487abe5
          provider = provider.aws
          name = tf-acc-test-8703340596436274492
          xss_match_tuple.# = 2
          xss_match_tuple.0.field_to_match.# = 1
          xss_match_tuple.0.field_to_match.0.data = 
          xss_match_tuple.0.field_to_match.0.type = BODY
          xss_match_tuple.0.text_transformation = CMD_LINE
          xss_match_tuple.1.field_to_match.# = 1
          xss_match_tuple.1.field_to_match.0.data = 
          xss_match_tuple.1.field_to_match.0.type = METHOD
          xss_match_tuple.1.text_transformation = HTML_ENTITY_DECODE
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeNameForceNew (56.69s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	56.745s
FAIL
GNUmakefile:26: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
