### PR TITLE
r/aws_glue_catalog_database: Remove extraneous Exists function

### DIFF
--- a/aws/resource_aws_glue_catalog_database.go
+++ b/aws/resource_aws_glue_catalog_database.go
@@ -17,7 +17,6 @@ func resourceAwsGlueCatalogDatabase() *schema.Resource {
 		Read:   resourceAwsGlueCatalogDatabaseRead,
 		Update: resourceAwsGlueCatalogDatabaseUpdate,
 		Delete: resourceAwsGlueCatalogDatabaseDelete,
-		Exists: resourceAwsGlueCatalogDatabaseExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -173,28 +172,6 @@ func resourceAwsGlueCatalogDatabaseDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error deleting Glue Catalog Database: %s", err.Error())
 	}
 	return nil
-}
-
-func resourceAwsGlueCatalogDatabaseExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	glueconn := meta.(*AWSClient).glueconn
-	catalogID, name, err := readAwsGlueCatalogID(d.Id())
-	if err != nil {
-		return false, err
-	}
-
-	input := &glue.GetDatabaseInput{
-		CatalogId: aws.String(catalogID),
-		Name:      aws.String(name),
-	}
-
-	_, err = glueconn.GetDatabase(input)
-	if err != nil {
-		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func readAwsGlueCatalogID(id string) (catalogID string, name string, err error) {

--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -13,22 +13,23 @@ import (
 )
 
 func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
-	rInt := acctest.RandInt()
 	resourceName := "aws_glue_catalog_database.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGlueDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccGlueCatalogDatabase_basic(rInt),
+				Config:  testAccGlueCatalogDatabase_basic(rName),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueCatalogDatabaseExists(resourceName),
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"name",
-						fmt.Sprintf("my_test_catalog_database_%d", rInt),
+						rName,
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
@@ -53,7 +54,7 @@ func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:  testAccGlueCatalogDatabase_full(rInt, "A test catalog from terraform"),
+				Config:  testAccGlueCatalogDatabase_full(rName, "A test catalog from terraform"),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueCatalogDatabaseExists(resourceName),
@@ -85,7 +86,7 @@ func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGlueCatalogDatabase_full(rInt, "An updated test catalog from terraform"),
+				Config: testAccGlueCatalogDatabase_full(rName, "An updated test catalog from terraform"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueCatalogDatabaseExists(resourceName),
 					resource.TestCheckResourceAttr(
@@ -121,7 +122,7 @@ func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 
 func TestAccAWSGlueCatalogDatabase_recreates(t *testing.T) {
 	resourceName := "aws_glue_catalog_database.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -129,7 +130,7 @@ func TestAccAWSGlueCatalogDatabase_recreates(t *testing.T) {
 		CheckDestroy: testAccCheckGlueDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlueCatalogDatabase_basic(rInt),
+				Config: testAccGlueCatalogDatabase_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlueCatalogDatabaseExists(resourceName),
 				),
@@ -139,14 +140,14 @@ func TestAccAWSGlueCatalogDatabase_recreates(t *testing.T) {
 				PreConfig: func() {
 					conn := testAccProvider.Meta().(*AWSClient).glueconn
 					input := &glue.DeleteDatabaseInput{
-						Name: aws.String(fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+						Name: aws.String(rName),
 					}
 					_, err := conn.DeleteDatabase(input)
 					if err != nil {
 						t.Fatalf("error deleting Glue Catalog Database: %s", err)
 					}
 				},
-				Config:             testAccGlueCatalogDatabase_basic(rInt),
+				Config:             testAccGlueCatalogDatabase_basic(rName),
 				ExpectNonEmptyPlan: true,
 				PlanOnly:           true,
 			},
@@ -184,19 +185,19 @@ func testAccCheckGlueDatabaseDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccGlueCatalogDatabase_basic(rInt int) string {
+func testAccGlueCatalogDatabase_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = "my_test_catalog_database_%d"
+  name = %[1]q
 }
-`, rInt)
+`, rName)
 }
 
-func testAccGlueCatalogDatabase_full(rInt int, desc string) string {
+func testAccGlueCatalogDatabase_full(rName, desc string) string {
 	return fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name         = "my_test_catalog_database_%d"
-  description  = "%s"
+  name         = %[1]q
+  description  = %[2]q
   location_uri = "my-location"
 
   parameters = {
@@ -205,7 +206,7 @@ resource "aws_glue_catalog_database" "test" {
     param3 = 50
   }
 }
-`, rInt, desc)
+`, rName, desc)
 }
 
 func testAccCheckGlueCatalogDatabaseExists(name string) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/9953.



Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSGlueCatalogDatabase_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSGlueCatalogDatabase_ -timeout 120m
=== RUN   TestAccAWSGlueCatalogDatabase_full
=== PAUSE TestAccAWSGlueCatalogDatabase_full
=== RUN   TestAccAWSGlueCatalogDatabase_recreates
=== PAUSE TestAccAWSGlueCatalogDatabase_recreates
=== CONT  TestAccAWSGlueCatalogDatabase_full
=== CONT  TestAccAWSGlueCatalogDatabase_recreates
--- PASS: TestAccAWSGlueCatalogDatabase_recreates (24.64s)
--- PASS: TestAccAWSGlueCatalogDatabase_full (54.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	54.740s
```
