### PR TITLE
r/aws_kms_grant: Remove extraneous Exists function

### DIFF
--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -23,7 +23,6 @@ func resourceAwsKmsGrant() *schema.Resource {
 		Create: resourceAwsKmsGrantCreate,
 		Read:   resourceAwsKmsGrantRead,
 		Delete: resourceAwsKmsGrantDelete,
-		Exists: resourceAwsKmsGrantExists,
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				keyId, grantId, err := decodeKmsGrantId(d.Id())
@@ -297,30 +296,6 @@ func resourceAwsKmsGrantDelete(d *schema.ResourceData, meta interface{}) error {
 	err = waitForKmsGrantToBeRevoked(conn, keyId, grantId)
 
 	return err
-}
-
-func resourceAwsKmsGrantExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*AWSClient).kmsconn
-
-	keyId, grantId, err := decodeKmsGrantId(d.Id())
-	if err != nil {
-		return false, err
-	}
-
-	log.Printf("[DEBUG] Looking for Grant: %s", grantId)
-	grant, err := findKmsGrantByIdWithRetry(conn, keyId, grantId)
-
-	if err != nil {
-		if isResourceNotFoundError(err) {
-			return false, nil
-		}
-		return true, err
-	}
-	if grant != nil {
-		return true, err
-	}
-
-	return false, nil
 }
 
 func getKmsGrantById(grants []*kms.GrantListEntry, grantIdentifier string) *kms.GrantListEntry {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9953.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSKmsGrant_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSKmsGrant_ -timeout 120m
=== RUN   TestAccAWSKmsGrant_Basic
=== PAUSE TestAccAWSKmsGrant_Basic
=== RUN   TestAccAWSKmsGrant_withConstraints
=== PAUSE TestAccAWSKmsGrant_withConstraints
=== RUN   TestAccAWSKmsGrant_withRetiringPrincipal
=== PAUSE TestAccAWSKmsGrant_withRetiringPrincipal
=== RUN   TestAccAWSKmsGrant_bare
=== PAUSE TestAccAWSKmsGrant_bare
=== RUN   TestAccAWSKmsGrant_ARN
=== PAUSE TestAccAWSKmsGrant_ARN
=== RUN   TestAccAWSKmsGrant_disappears
=== PAUSE TestAccAWSKmsGrant_disappears
=== CONT  TestAccAWSKmsGrant_Basic
=== CONT  TestAccAWSKmsGrant_ARN
=== CONT  TestAccAWSKmsGrant_disappears
=== CONT  TestAccAWSKmsGrant_withRetiringPrincipal
=== CONT  TestAccAWSKmsGrant_bare
=== CONT  TestAccAWSKmsGrant_withConstraints
--- PASS: TestAccAWSKmsGrant_Basic (62.15s)
--- PASS: TestAccAWSKmsGrant_withRetiringPrincipal (62.44s)
--- PASS: TestAccAWSKmsGrant_bare (62.67s)
--- PASS: TestAccAWSKmsGrant_ARN (62.69s)
--- PASS: TestAccAWSKmsGrant_withConstraints (83.19s)
--- PASS: TestAccAWSKmsGrant_disappears (240.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	240.483s
```
