### PR TITLE
service/guardduty: Support GuardDuty Organizations

### DIFF
--- a/aws/internal/service/guardduty/waiter/status.go
+++ b/aws/internal/service/guardduty/waiter/status.go
@@ -48,7 +48,7 @@ func getOrganizationAdminAccount(conn *guardduty.GuardDuty, adminAccountID strin
 
 			if aws.StringValue(adminAccount.AdminAccountId) == adminAccountID {
 				result = adminAccount
-				break
+				return false
 			}
 		}
 

--- a/aws/internal/service/guardduty/waiter/status.go
+++ b/aws/internal/service/guardduty/waiter/status.go
@@ -1,0 +1,59 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// AdminStatus NotFound
+	AdminStatusNotFound = "NotFound"
+
+	// AdminStatus Unknown
+	AdminStatusUnknown = "Unknown"
+)
+
+// AdminAccountAdminStatus fetches the AdminAccount and its AdminStatus
+func AdminAccountAdminStatus(conn *guardduty.GuardDuty, adminAccountID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		adminAccount, err := getOrganizationAdminAccount(conn, adminAccountID)
+
+		if err != nil {
+			return nil, AdminStatusUnknown, err
+		}
+
+		if adminAccount == nil {
+			return adminAccount, AdminStatusNotFound, nil
+		}
+
+		return adminAccount, aws.StringValue(adminAccount.AdminStatus), nil
+	}
+}
+
+// TODO: Migrate to shared internal package for aws package and this package
+func getOrganizationAdminAccount(conn *guardduty.GuardDuty, adminAccountID string) (*guardduty.AdminAccount, error) {
+	input := &guardduty.ListOrganizationAdminAccountsInput{}
+	var result *guardduty.AdminAccount
+
+	err := conn.ListOrganizationAdminAccountsPages(input, func(page *guardduty.ListOrganizationAdminAccountsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, adminAccount := range page.AdminAccounts {
+			if adminAccount == nil {
+				continue
+			}
+
+			if aws.StringValue(adminAccount.AdminAccountId) == adminAccountID {
+				result = adminAccount
+				break
+			}
+		}
+
+		return !lastPage
+	})
+
+	return result, err
+}

--- a/aws/internal/service/guardduty/waiter/waiter.go
+++ b/aws/internal/service/guardduty/waiter/waiter.go
@@ -1,0 +1,59 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for an AdminAccount to return Enabled
+	AdminAccountEnabledTimeout = 5 * time.Minute
+
+	// Maximum amount of time to wait for an AdminAccount to return NotFound
+	AdminAccountNotFoundTimeout = 5 * time.Minute
+
+	// Maximum amount of time to wait for membership to propagate
+	// When removing Organization Admin Accounts, there is eventual
+	// consistency even after the account is no longer listed.
+	// Reference error message:
+	// BadRequestException: The request is rejected because the current account cannot delete detector while it has invited or associated members.
+	MembershipPropagationTimeout = 2 * time.Minute
+)
+
+// AdminAccountEnabled waits for an AdminAccount to return Enabled
+func AdminAccountEnabled(conn *guardduty.GuardDuty, adminAccountID string) (*guardduty.AdminAccount, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{AdminStatusNotFound},
+		Target:  []string{guardduty.AdminStatusEnabled},
+		Refresh: AdminAccountAdminStatus(conn, adminAccountID),
+		Timeout: AdminAccountNotFoundTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*guardduty.AdminAccount); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// AdminAccountNotFound waits for an AdminAccount to return NotFound
+func AdminAccountNotFound(conn *guardduty.GuardDuty, adminAccountID string) (*guardduty.AdminAccount, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{guardduty.AdminStatusDisableInProgress},
+		Target:  []string{AdminStatusNotFound},
+		Refresh: AdminAccountAdminStatus(conn, adminAccountID),
+		Timeout: AdminAccountNotFoundTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*guardduty.AdminAccount); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -590,6 +590,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_guardduty_invite_accepter":                           resourceAwsGuardDutyInviteAccepter(),
 			"aws_guardduty_ipset":                                     resourceAwsGuardDutyIpset(),
 			"aws_guardduty_member":                                    resourceAwsGuardDutyMember(),
+			"aws_guardduty_organization_admin_account":                resourceAwsGuardDutyOrganizationAdminAccount(),
+			"aws_guardduty_organization_configuration":                resourceAwsGuardDutyOrganizationConfiguration(),
 			"aws_guardduty_threatintelset":                            resourceAwsGuardDutyThreatintelset(),
 			"aws_iam_access_key":                                      resourceAwsIamAccessKey(),
 			"aws_iam_account_alias":                                   resourceAwsIamAccountAlias(),

--- a/aws/resource_aws_guardduty_detector.go
+++ b/aws/resource_aws_guardduty_detector.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/guardduty/waiter"
 )
 
 func resourceAwsGuardDutyDetector() *schema.Resource {
@@ -106,14 +108,32 @@ func resourceAwsGuardDutyDetectorUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceAwsGuardDutyDetectorDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).guarddutyconn
-	input := guardduty.DeleteDetectorInput{
+
+	input := &guardduty.DeleteDetectorInput{
 		DetectorId: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Delete GuardDuty Detector: %s", input)
-	_, err := conn.DeleteDetector(&input)
-	if err != nil {
-		return fmt.Errorf("Deleting GuardDuty Detector '%s' failed: %s", d.Id(), err.Error())
+	err := resource.Retry(waiter.MembershipPropagationTimeout, func() *resource.RetryError {
+		_, err := conn.DeleteDetector(input)
+
+		if isAWSErr(err, guardduty.ErrCodeBadRequestException, "cannot delete detector while it has invited or associated members") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteDetector(input)
 	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting GuardDuty Detector (%s): %w", d.Id(), err)
+	}
+
 	return nil
 }

--- a/aws/resource_aws_guardduty_organization_admin_account.go
+++ b/aws/resource_aws_guardduty_organization_admin_account.go
@@ -49,7 +49,7 @@ func resourceAwsGuardDutyOrganizationAdminAccountCreate(d *schema.ResourceData, 
 	d.SetId(adminAccountID)
 
 	if _, err := waiter.AdminAccountEnabled(conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for GuardDuty Organization Admin Account (%s) enable: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for GuardDuty Organization Admin Account (%s) to enable: %w", d.Id(), err)
 	}
 
 	return resourceAwsGuardDutyOrganizationAdminAccountRead(d, meta)
@@ -89,7 +89,7 @@ func resourceAwsGuardDutyOrganizationAdminAccountDelete(d *schema.ResourceData, 
 	}
 
 	if _, err := waiter.AdminAccountNotFound(conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for GuardDuty Organization Admin Account (%s) disable: %w", d.Id(), err)
+		return fmt.Errorf("error waiting for GuardDuty Organization Admin Account (%s) to disable: %w", d.Id(), err)
 	}
 
 	return nil
@@ -111,7 +111,7 @@ func getGuardDutyOrganizationAdminAccount(conn *guardduty.GuardDuty, adminAccoun
 
 			if aws.StringValue(adminAccount.AdminAccountId) == adminAccountID {
 				result = adminAccount
-				break
+				return false
 			}
 		}
 

--- a/aws/resource_aws_guardduty_organization_admin_account.go
+++ b/aws/resource_aws_guardduty_organization_admin_account.go
@@ -1,0 +1,122 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/guardduty/waiter"
+)
+
+func resourceAwsGuardDutyOrganizationAdminAccount() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGuardDutyOrganizationAdminAccountCreate,
+		Read:   resourceAwsGuardDutyOrganizationAdminAccountRead,
+		Delete: resourceAwsGuardDutyOrganizationAdminAccountDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"admin_account_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsAccountId,
+			},
+		},
+	}
+}
+
+func resourceAwsGuardDutyOrganizationAdminAccountCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	adminAccountID := d.Get("admin_account_id").(string)
+
+	input := &guardduty.EnableOrganizationAdminAccountInput{
+		AdminAccountId: aws.String(adminAccountID),
+	}
+
+	_, err := conn.EnableOrganizationAdminAccount(input)
+
+	if err != nil {
+		return fmt.Errorf("error enabling GuardDuty Organization Admin Account (%s): %w", adminAccountID, err)
+	}
+
+	d.SetId(adminAccountID)
+
+	if _, err := waiter.AdminAccountEnabled(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for GuardDuty Organization Admin Account (%s) enable: %w", d.Id(), err)
+	}
+
+	return resourceAwsGuardDutyOrganizationAdminAccountRead(d, meta)
+}
+
+func resourceAwsGuardDutyOrganizationAdminAccountRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	adminAccount, err := getGuardDutyOrganizationAdminAccount(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error reading GuardDuty Organization Admin Account (%s): %w", d.Id(), err)
+	}
+
+	if adminAccount == nil {
+		log.Printf("[WARN] GuardDuty Organization Admin Account (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("admin_account_id", adminAccount.AdminAccountId)
+
+	return nil
+}
+
+func resourceAwsGuardDutyOrganizationAdminAccountDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	input := &guardduty.DisableOrganizationAdminAccountInput{
+		AdminAccountId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DisableOrganizationAdminAccount(input)
+
+	if err != nil {
+		return fmt.Errorf("error disabling GuardDuty Organization Admin Account (%s): %w", d.Id(), err)
+	}
+
+	if _, err := waiter.AdminAccountNotFound(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for GuardDuty Organization Admin Account (%s) disable: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func getGuardDutyOrganizationAdminAccount(conn *guardduty.GuardDuty, adminAccountID string) (*guardduty.AdminAccount, error) {
+	input := &guardduty.ListOrganizationAdminAccountsInput{}
+	var result *guardduty.AdminAccount
+
+	err := conn.ListOrganizationAdminAccountsPages(input, func(page *guardduty.ListOrganizationAdminAccountsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, adminAccount := range page.AdminAccounts {
+			if adminAccount == nil {
+				continue
+			}
+
+			if aws.StringValue(adminAccount.AdminAccountId) == adminAccountID {
+				result = adminAccount
+				break
+			}
+		}
+
+		return !lastPage
+	})
+
+	return result, err
+}

--- a/aws/resource_aws_guardduty_organization_admin_account_test.go
+++ b/aws/resource_aws_guardduty_organization_admin_account_test.go
@@ -1,0 +1,109 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func testAccAwsGuardDutyOrganizationAdminAccount_basic(t *testing.T) {
+	resourceName := "aws_guardduty_organization_admin_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOrganizationsAccountPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsGuardDutyOrganizationAdminAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardDutyOrganizationAdminAccountConfigSelf(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsGuardDutyOrganizationAdminAccountExists(resourceName),
+					testAccCheckResourceAttrAccountID(resourceName, "admin_account_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsGuardDutyOrganizationAdminAccountDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).guarddutyconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_guardduty_organization_admin_account" {
+			continue
+		}
+
+		adminAccount, err := getGuardDutyOrganizationAdminAccount(conn, rs.Primary.ID)
+
+		if isAWSErr(err, guardduty.ErrCodeBadRequestException, "organization is not in use") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if adminAccount == nil {
+			continue
+		}
+
+		return fmt.Errorf("expected GuardDuty Organization Admin Account (%s) to be removed", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckAwsGuardDutyOrganizationAdminAccountExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).guarddutyconn
+
+		adminAccount, err := getGuardDutyOrganizationAdminAccount(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if adminAccount == nil {
+			return fmt.Errorf("GuardDuty Organization Admin Account (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccGuardDutyOrganizationAdminAccountConfigSelf() string {
+	return `
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}"]
+  feature_set                   = "ALL"
+}
+
+resource "aws_guardduty_detector" "test" {}
+
+resource "aws_guardduty_organization_admin_account" "test" {
+  depends_on = [aws_organizations_organization.test]
+
+  admin_account_id = data.aws_caller_identity.current.account_id
+}
+`
+}

--- a/aws/resource_aws_guardduty_organization_configuration.go
+++ b/aws/resource_aws_guardduty_organization_configuration.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsGuardDutyOrganizationConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGuardDutyOrganizationConfigurationUpdate,
+		Read:   resourceAwsGuardDutyOrganizationConfigurationRead,
+		Update: resourceAwsGuardDutyOrganizationConfigurationUpdate,
+		Delete: schema.Noop,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"auto_enable": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"detector_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func resourceAwsGuardDutyOrganizationConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	detectorID := d.Get("detector_id").(string)
+
+	input := &guardduty.UpdateOrganizationConfigurationInput{
+		AutoEnable: aws.Bool(d.Get("auto_enable").(bool)),
+		DetectorId: aws.String(detectorID),
+	}
+
+	_, err := conn.UpdateOrganizationConfiguration(input)
+
+	if err != nil {
+		return fmt.Errorf("error updating GuardDuty Organization Configuration (%s): %w", detectorID, err)
+	}
+
+	d.SetId(detectorID)
+
+	return resourceAwsGuardDutyOrganizationConfigurationRead(d, meta)
+}
+
+func resourceAwsGuardDutyOrganizationConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+
+	input := &guardduty.DescribeOrganizationConfigurationInput{
+		DetectorId: aws.String(d.Id()),
+	}
+
+	output, err := conn.DescribeOrganizationConfiguration(input)
+
+	if isAWSErr(err, guardduty.ErrCodeBadRequestException, "The request is rejected because the input detectorId is not owned by the current account.") {
+		log.Printf("[WARN] GuardDuty Organization Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading GuardDuty Organization Configuration (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error reading GuardDuty Organization Configuration (%s): empty response", d.Id())
+	}
+
+	d.Set("detector_id", d.Id())
+	d.Set("auto_enable", output.AutoEnable)
+
+	return nil
+}

--- a/aws/resource_aws_guardduty_organization_configuration_test.go
+++ b/aws/resource_aws_guardduty_organization_configuration_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func testAccAwsGuardDutyOrganizationConfiguration_basic(t *testing.T) {
+	detectorResourceName := "aws_guardduty_detector.test"
+	resourceName := "aws_guardduty_organization_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccOrganizationsAccountPreCheck(t)
+		},
+		Providers: testAccProviders,
+		// GuardDuty Organization Configuration cannot be deleted separately.
+		// Ensure parent resource is destroyed instead.
+		CheckDestroy: testAccCheckAwsGuardDutyDetectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGuardDutyOrganizationConfigurationConfigAutoEnable(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGuardDutyOrganizationConfigurationConfigAutoEnable(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGuardDutyOrganizationConfigurationConfigAutoEnable(autoEnable bool) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}"]
+  feature_set                   = "ALL"
+}
+
+resource "aws_guardduty_detector" "test" {}
+
+resource "aws_guardduty_organization_admin_account" "test" {
+  depends_on = [aws_organizations_organization.test]
+
+  admin_account_id = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_guardduty_organization_configuration" "test" {
+  depends_on = [aws_guardduty_organization_admin_account.test]
+
+  auto_enable = %[1]t
+  detector_id = aws_guardduty_detector.test.id
+}
+`, autoEnable)
+}

--- a/aws/resource_aws_guardduty_test.go
+++ b/aws/resource_aws_guardduty_test.go
@@ -18,6 +18,12 @@ func TestAccAWSGuardDuty(t *testing.T) {
 			"basic":  testAccAwsGuardDutyIpset_basic,
 			"import": testAccAwsGuardDutyIpset_import,
 		},
+		"OrganizationAdminAccount": {
+			"basic": testAccAwsGuardDutyOrganizationAdminAccount_basic,
+		},
+		"OrganizationConfiguration": {
+			"basic": testAccAwsGuardDutyOrganizationConfiguration_basic,
+		},
 		"ThreatIntelSet": {
 			"basic":  testAccAwsGuardDutyThreatintelset_basic,
 			"import": testAccAwsGuardDutyThreatintelset_import,

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1765,6 +1765,12 @@
                                     <a href="/docs/providers/aws/r/guardduty_member.html">aws_guardduty_member</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/guardduty_organization_admin_account.html">aws_guardduty_organization_admin_account</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/guardduty_organization_configuration.html">aws_guardduty_organization_configuration</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/guardduty_threatintelset.html">aws_guardduty_threatintelset</a>
                                 </li>
                             </ul>

--- a/website/docs/r/guardduty_organization_admin_account.html.markdown
+++ b/website/docs/r/guardduty_organization_admin_account.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "GuardDuty"
+layout: "aws"
+page_title: "AWS: aws_guardduty_organization_admin_account"
+description: |-
+  Manages a GuardDuty Organization Admin Account
+---
+
+# Resource: aws_guardduty_organization_admin_account
+
+Manages a GuardDuty Organization Admin Account. The AWS account utilizing this resource must be an Organizations master account. More information about Organizations support in GuardDuty can be found in the [GuardDuty User Guide](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html).
+
+## Example Usage
+
+```hcl
+resource "aws_organizations_organization" "example" {
+  aws_service_access_principals = ["guardduty.amazonaws.com"]
+  feature_set                   = "ALL"
+}
+
+resource "aws_guardduty_detector" "example" {}
+
+resource "aws_guardduty_organization_admin_account" "example" {
+  depends_on = [aws_organizations_organization.example]
+
+  admin_account_id = "123456789012"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `admin_account_id` - (Required) AWS account identifier to designate as a delegated administrator for GuardDuty.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - AWS account identifier.
+
+## Import
+
+GuardDuty Organization Admin Account can be imported using the AWS account ID, e.g.
+
+```
+$ terraform import aws_guardduty_organization_admin_account.example 123456789012
+```

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "GuardDuty"
+layout: "aws"
+page_title: "AWS: aws_guardduty_organization_configuration"
+description: |-
+  Manages the GuardDuty Organization Configuration
+---
+
+# Resource: aws_guardduty_organization_configuration
+
+Manages the GuardDuty Organization Configuration in the current AWS Region. The AWS account utilizing this resource must have been assigned as a delegated Organization administrator account, e.g. via the [`aws_guardduty_organization_admin_account` resource](/docs/providers/aws/r/guardduty_organization_admin_account.html). More information about Organizations support in GuardDuty can be found in the [GuardDuty User Guide](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html).
+
+~> **NOTE:** This is an advanced Terraform resource. Terraform will automatically assume management of the GuardDuty Organization Configuration without import and perform no actions on removal from the Terraform configuration.
+
+## Example Usage
+
+```hcl
+resource "aws_guardduty_detector" "example" {
+  enable = true
+}
+
+resource "aws_guardduty_organization_configuration" "example" {
+  auto_enable = true
+  detector_id = aws_guardduty_detector.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auto_enable` - (Required) When this setting is enabled, all new accounts that are created in, or added to, the organization are added as a member accounts of the organization’s GuardDuty delegated administrator and GuardDuty is enabled in that AWS Region.
+* `detector_id` - (Required) The detector ID of the GuardDuty account.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Identifier of the GuardDuty Detector.
+
+## Import
+
+GuardDuty Organization Configurations can be imported using the GuardDuty Detector ID, e.g.
+
+```
+$ terraform import aws_guardduty_organization_configuration.example 00b00fd5aecc0ab60a708659477e9617
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13005
Closes #13006

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:

* **New Resource:** `aws_guardduty_organization_admin_account`
* **New Resource:** `aws_guardduty_organization_configuration`
```

Output from acceptance testing (from the Organizations testing account):

```
--- PASS: TestAccAWSGuardDuty (137.70s)
    --- PASS: TestAccAWSGuardDuty/Detector (58.97s)
        --- PASS: TestAccAWSGuardDuty/Detector/basic (41.45s)
        --- PASS: TestAccAWSGuardDuty/Detector/import (17.52s)
    --- PASS: TestAccAWSGuardDuty/OrganizationAdminAccount (31.74s)
        --- PASS: TestAccAWSGuardDuty/OrganizationAdminAccount/basic (31.74s)
    --- PASS: TestAccAWSGuardDuty/OrganizationConfiguration (46.99s)
        --- PASS: TestAccAWSGuardDuty/OrganizationConfiguration/basic (46.99s)
```
