### PR TITLE
Use latest SQL version in IoT Topic Rule example

### DIFF
--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -16,7 +16,7 @@ resource "aws_iot_topic_rule" "rule" {
   description = "Example rule"
   enabled     = true
   sql         = "SELECT * FROM 'topic/test'"
-  sql_version = "2015-10-08"
+  sql_version = "2016-03-23"
 
   sns {
     message_format = "RAW"


### PR DESCRIPTION
The IoT rule SQL version in the example given had a bunch of bugs resulting in data fields being lost. See https://docs.aws.amazon.com/iot/latest/developerguide/iot-rule-sql-version.html. 

To save others from my own copy/paste downfall, I've updated the example to use the later SQL version.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

```release-note
N/A
```

Output from acceptance testing:

N/A