### PR TITLE
service/s3: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/data_source_aws_s3_bucket_test.go
+++ b/aws/data_source_aws_s3_bucket_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -11,7 +10,6 @@ import (
 
 func TestAccDataSourceS3Bucket_basic(t *testing.T) {
 	rInt := acctest.RandInt()
-	arnRegexp := regexp.MustCompile(`^arn:aws[\w-]*:s3:::`)
 	region := testAccGetRegion()
 	hostedZoneID, _ := HostedZoneIDForRegion(region)
 
@@ -23,14 +21,11 @@ func TestAccDataSourceS3Bucket_basic(t *testing.T) {
 				Config: testAccAWSDataSourceS3BucketConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists("data.aws_s3_bucket.bucket"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket.bucket", "arn", arnRegexp),
+					resource.TestCheckResourceAttrPair("data.aws_s3_bucket.bucket", "arn", "aws_s3_bucket.bucket", "arn"),
 					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "region", region),
-					testAccCheckS3BucketDomainName(
-						"data.aws_s3_bucket.bucket", "bucket_domain_name", testAccBucketName(rInt)),
-					resource.TestCheckResourceAttr(
-						"data.aws_s3_bucket.bucket", "bucket_regional_domain_name", testAccBucketRegionalDomainName(rInt, region)),
-					resource.TestCheckResourceAttr(
-						"data.aws_s3_bucket.bucket", "hosted_zone_id", hostedZoneID),
+					testAccCheckS3BucketDomainName("data.aws_s3_bucket.bucket", "bucket_domain_name", testAccBucketName(rInt)),
+					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "bucket_regional_domain_name", testAccBucketRegionalDomainName(rInt, region)),
+					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "hosted_zone_id", hostedZoneID),
 					resource.TestCheckNoResourceAttr("data.aws_s3_bucket.bucket", "website_endpoint"),
 				),
 			},
@@ -50,10 +45,8 @@ func TestAccDataSourceS3Bucket_website(t *testing.T) {
 				Config: testAccAWSDataSourceS3BucketWebsiteConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists("data.aws_s3_bucket.bucket"),
-					testAccCheckAWSS3BucketWebsite(
-						"data.aws_s3_bucket.bucket", "index.html", "error.html", "", ""),
-					testAccCheckS3BucketWebsiteEndpoint(
-						"data.aws_s3_bucket.bucket", "website_endpoint", testAccBucketName(rInt), region),
+					testAccCheckAWSS3BucketWebsite("data.aws_s3_bucket.bucket", "index.html", "error.html", "", ""),
+					testAccCheckS3BucketWebsiteEndpoint("data.aws_s3_bucket.bucket", "website_endpoint", testAccBucketName(rInt), region),
 				),
 			},
 		},

--- a/aws/data_source_aws_s3_bucket_test.go
+++ b/aws/data_source_aws_s3_bucket_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceS3Bucket_basic(t *testing.T) {
-	rInt := acctest.RandInt()
+	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	region := testAccGetRegion()
 	hostedZoneID, _ := HostedZoneIDForRegion(region)
 
@@ -18,13 +18,13 @@ func TestAccDataSourceS3Bucket_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDataSourceS3BucketConfig_basic(rInt),
+				Config: testAccAWSDataSourceS3BucketConfig_basic(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists("data.aws_s3_bucket.bucket"),
 					resource.TestCheckResourceAttrPair("data.aws_s3_bucket.bucket", "arn", "aws_s3_bucket.bucket", "arn"),
 					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "region", region),
-					testAccCheckS3BucketDomainName("data.aws_s3_bucket.bucket", "bucket_domain_name", testAccBucketName(rInt)),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "bucket_regional_domain_name", testAccBucketRegionalDomainName(rInt, region)),
+					testAccCheckS3BucketDomainName("data.aws_s3_bucket.bucket", "bucket_domain_name", bucketName),
+					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "bucket_regional_domain_name", testAccBucketRegionalDomainName(bucketName, region)),
 					resource.TestCheckResourceAttr("data.aws_s3_bucket.bucket", "hosted_zone_id", hostedZoneID),
 					resource.TestCheckNoResourceAttr("data.aws_s3_bucket.bucket", "website_endpoint"),
 				),
@@ -34,7 +34,7 @@ func TestAccDataSourceS3Bucket_basic(t *testing.T) {
 }
 
 func TestAccDataSourceS3Bucket_website(t *testing.T) {
-	rInt := acctest.RandInt()
+	bucketName := acctest.RandomWithPrefix("tf-test-bucket")
 	region := testAccGetRegion()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,33 +42,33 @@ func TestAccDataSourceS3Bucket_website(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDataSourceS3BucketWebsiteConfig(rInt),
+				Config: testAccAWSDataSourceS3BucketWebsiteConfig(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists("data.aws_s3_bucket.bucket"),
 					testAccCheckAWSS3BucketWebsite("data.aws_s3_bucket.bucket", "index.html", "error.html", "", ""),
-					testAccCheckS3BucketWebsiteEndpoint("data.aws_s3_bucket.bucket", "website_endpoint", testAccBucketName(rInt), region),
+					testAccCheckS3BucketWebsiteEndpoint("data.aws_s3_bucket.bucket", "website_endpoint", bucketName, region),
 				),
 			},
 		},
 	})
 }
 
-func testAccAWSDataSourceS3BucketConfig_basic(randInt int) string {
+func testAccAWSDataSourceS3BucketConfig_basic(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = "tf-test-bucket-%d"
+  bucket = %[1]q
 }
 
 data "aws_s3_bucket" "bucket" {
   bucket = "${aws_s3_bucket.bucket.id}"
 }
-`, randInt)
+`, bucketName)
 }
 
-func testAccAWSDataSourceS3BucketWebsiteConfig(randInt int) string {
+func testAccAWSDataSourceS3BucketWebsiteConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = "tf-test-bucket-%d"
+  bucket = %[1]q
   acl    = "public-read"
 
   website {
@@ -80,5 +80,5 @@ resource "aws_s3_bucket" "bucket" {
 data "aws_s3_bucket" "bucket" {
   bucket = "${aws_s3_bucket.bucket.id}"
 }
-`, randInt)
+`, bucketName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
terraform-provider-aws/aws/data_source_aws_s3_bucket_test.go:26:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws-private/aws/resource_aws_s3_bucket_test.go:189:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccDataSourceS3Bucket_basic (28.76s)
--- PASS: TestAccDataSourceS3Bucket_website (30.00s)
```

```
--- PASS: TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock (24.65s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (25.31s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (25.90s)
--- PASS: TestAccAWSS3Bucket_region (27.79s)
--- PASS: TestAccAWSS3Bucket_basic (32.38s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (35.00s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (38.99s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (45.71s)
--- PASS: TestAccAWSS3Bucket_objectLock (46.26s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (47.46s)
--- PASS: TestAccAWSS3Bucket_acceleration (49.01s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (14.99s)
--- PASS: TestAccAWSS3Bucket_generatedName (27.64s)
--- PASS: TestAccAWSS3Bucket_namePrefix (26.83s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (61.53s)
--- PASS: TestAccAWSS3Bucket_Versioning (65.03s)
--- PASS: TestAccAWSS3Bucket_Policy (65.05s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (65.84s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (26.26s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (27.03s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (47.11s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (26.35s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (45.18s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (24.27s)
--- PASS: TestAccAWSS3Bucket_Logging (39.65s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (47.67s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation (104.56s)
--- PASS: TestAccAWSS3Bucket_GrantToAcl (43.44s)
--- PASS: TestAccAWSS3Bucket_AclToGrant (43.03s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (46.21s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (63.72s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (65.99s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (122.78s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (80.39s)
--- PASS: TestAccAWSS3Bucket_UpdateGrant (65.04s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (127.70s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (176.82s)
--- PASS: TestAccAWSS3Bucket_Replication (194.29s)
--- FAIL: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (53.20s)
--- FAIL: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (42.27s)
```

Introduces no new failures
