### PR TITLE
r/aws_snapshot_create_volume_permission: Remove extraneous Exists function

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -587,6 +587,22 @@ func testAccAwsRegionProviderFunc(region string, providers *[]*schema.Provider) 
 	}
 }
 
+func testAccCheckResourceDisappears(provider *schema.Provider, resource *schema.Resource, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource ID missing: %s", resourceName)
+		}
+
+		return resource.Delete(resource.Data(resourceState.Primary), provider.Meta())
+	}
+}
+
 func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error, providers *[]*schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		numberOfProviders := len(*providers)

--- a/aws/resource_aws_snapshot_create_volume_permission_test.go
+++ b/aws/resource_aws_snapshot_create_volume_permission_test.go
@@ -14,6 +14,7 @@ func TestAccAWSSnapshotCreateVolumePermission_Basic(t *testing.T) {
 	accountId := "111122223333"
 
 	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAWSSnapshotCreateVolumePermissionDestroy,
 		Steps: []resource.TestStep{
@@ -21,7 +22,7 @@ func TestAccAWSSnapshotCreateVolumePermission_Basic(t *testing.T) {
 			{
 				Config: testAccAWSSnapshotCreateVolumePermissionConfig(true, accountId),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckResourceGetAttr("aws_ebs_snapshot.example_snapshot", "id", &snapshotId),
+					testCheckResourceGetAttr("aws_ebs_snapshot.test", "id", &snapshotId),
 					testAccAWSSnapshotCreateVolumePermissionExists(&accountId, &snapshotId),
 				),
 			},
@@ -31,6 +32,28 @@ func TestAccAWSSnapshotCreateVolumePermission_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccAWSSnapshotCreateVolumePermissionDestroyed(&accountId, &snapshotId),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSnapshotCreateVolumePermission_disappears(t *testing.T) {
+	var snapshotId string
+	accountId := "111122223333"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAWSSnapshotCreateVolumePermissionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSnapshotCreateVolumePermissionConfig(true, accountId),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckResourceGetAttr("aws_ebs_snapshot.test", "id", &snapshotId),
+					testAccAWSSnapshotCreateVolumePermissionExists(&accountId, &snapshotId),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSnapshotCreateVolumePermission(), "aws_snapshot_create_volume_permission.test"),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -93,7 +116,7 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_ebs_volume" "example" {
+resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 
@@ -102,8 +125,8 @@ resource "aws_ebs_volume" "example" {
   }
 }
 
-resource "aws_ebs_snapshot" "example_snapshot" {
-  volume_id = "${aws_ebs_volume.example.id}"
+resource "aws_ebs_snapshot" "test" {
+  volume_id = "${aws_ebs_volume.test.id}"
 }
 `
 
@@ -112,8 +135,8 @@ resource "aws_ebs_snapshot" "example_snapshot" {
 	}
 
 	return base + fmt.Sprintf(`
-resource "aws_snapshot_create_volume_permission" "self-test" {
-  snapshot_id = "${aws_ebs_snapshot.example_snapshot.id}"
+resource "aws_snapshot_create_volume_permission" "test" {
+  snapshot_id = "${aws_ebs_snapshot.test.id}"
   account_id  = %q
 }
 `, accountID)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9953.

Includes `testAccCheckResourceDisappears()` from https://github.com/terraform-providers/terraform-provider-aws/pull/12864.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSnapshotCreateVolumePermission_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSSnapshotCreateVolumePermission_ -timeout 120m
=== RUN   TestAccAWSSnapshotCreateVolumePermission_Basic
=== PAUSE TestAccAWSSnapshotCreateVolumePermission_Basic
=== RUN   TestAccAWSSnapshotCreateVolumePermission_disappears
=== PAUSE TestAccAWSSnapshotCreateVolumePermission_disappears
=== CONT  TestAccAWSSnapshotCreateVolumePermission_Basic
=== CONT  TestAccAWSSnapshotCreateVolumePermission_disappears
--- PASS: TestAccAWSSnapshotCreateVolumePermission_disappears (78.06s)
--- PASS: TestAccAWSSnapshotCreateVolumePermission_Basic (78.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	78.969s
```
