### PR TITLE
service/cloudwatchevents: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -90,6 +89,8 @@ func testSweepCloudWatchEventTargets(region string) error {
 }
 
 func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_target.test"
+
 	var target events.Target
 	rName1 := acctest.RandString(5)
 	rName2 := acctest.RandString(5)
@@ -107,27 +108,25 @@ func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchEventTargetConfig(ruleName, snsTopicName1, targetID1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.moobar", "rule", ruleName),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.moobar", "target_id", targetID1),
-					resource.TestMatchResourceAttr("aws_cloudwatch_event_target.moobar", "arn",
-						regexp.MustCompile(fmt.Sprintf(":%s$", snsTopicName1))),
+					testAccCheckCloudWatchEventTargetExists(resourceName, &target),
+					resource.TestCheckResourceAttr(resourceName, "rule", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "target_id", targetID1),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_sns_topic.test", "arn"),
 				),
 			},
 			{
 				Config: testAccAWSCloudWatchEventTargetConfig(ruleName, snsTopicName2, targetID2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.moobar", "rule", ruleName),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.moobar", "target_id", targetID2),
-					resource.TestMatchResourceAttr("aws_cloudwatch_event_target.moobar", "arn",
-						regexp.MustCompile(fmt.Sprintf(":%s$", snsTopicName2))),
+					testAccCheckCloudWatchEventTargetExists(resourceName, &target),
+					resource.TestCheckResourceAttr(resourceName, "rule", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "target_id", targetID2),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_sns_topic.test", "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_cloudwatch_event_target.moobar",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.moobar"),
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -135,6 +134,8 @@ func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 }
 
 func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_target.test"
+
 	var target events.Target
 	rName := acctest.RandString(5)
 	ruleName := fmt.Sprintf("tf-acc-cw-event-rule-missing-target-id-%s", rName)
@@ -148,16 +149,15 @@ func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchEventTargetConfigMissingTargetId(ruleName, snsTopicName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.moobar", "rule", ruleName),
-					resource.TestMatchResourceAttr("aws_cloudwatch_event_target.moobar", "arn",
-						regexp.MustCompile(fmt.Sprintf(":%s$", snsTopicName))),
+					testAccCheckCloudWatchEventTargetExists(resourceName, &target),
+					resource.TestCheckResourceAttr(resourceName, "rule", ruleName),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_sns_topic.test", "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_cloudwatch_event_target.moobar",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.moobar"),
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -165,6 +165,7 @@ func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
 }
 
 func TestAccAWSCloudWatchEventTarget_full(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_target.test"
 	var target events.Target
 	rName := acctest.RandString(5)
 	ruleName := fmt.Sprintf("tf-acc-cw-event-rule-full-%s", rName)
@@ -179,19 +180,18 @@ func TestAccAWSCloudWatchEventTarget_full(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchEventTargetConfig_full(ruleName, targetID, ssmDocumentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.foobar", &target),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.foobar", "rule", ruleName),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.foobar", "target_id", targetID),
-					resource.TestMatchResourceAttr("aws_cloudwatch_event_target.foobar", "arn",
-						regexp.MustCompile("^arn:aws:kinesis:.*:stream/tf_ssm_Document")),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.foobar", "input", "{ \"source\": [\"aws.cloudtrail\"] }\n"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.foobar", "input_path", ""),
+					testAccCheckCloudWatchEventTargetExists(resourceName, &target),
+					resource.TestCheckResourceAttr(resourceName, "rule", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "target_id", targetID),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_kinesis_stream.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "input", "{ \"source\": [\"aws.cloudtrail\"] }\n"),
+					resource.TestCheckResourceAttr(resourceName, "input_path", ""),
 				),
 			},
 			{
-				ResourceName:      "aws_cloudwatch_event_target.foobar",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc("aws_cloudwatch_event_target.foobar"),
+				ImportStateIdFunc: testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -426,18 +426,18 @@ func testAccAWSCloudWatchEventTargetImportStateIdFunc(resourceName string) resou
 
 func testAccAWSCloudWatchEventTargetConfig(ruleName, snsTopicName, targetID string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_event_rule" "foo" {
+resource "aws_cloudwatch_event_rule" "test" {
   name                = "%s"
   schedule_expression = "rate(1 hour)"
 }
 
-resource "aws_cloudwatch_event_target" "moobar" {
-  rule      = "${aws_cloudwatch_event_rule.foo.name}"
+resource "aws_cloudwatch_event_target" "test" {
+  rule      = "${aws_cloudwatch_event_rule.test.name}"
   target_id = "%s"
-  arn       = "${aws_sns_topic.moon.arn}"
+  arn       = "${aws_sns_topic.test.arn}"
 }
 
-resource "aws_sns_topic" "moon" {
+resource "aws_sns_topic" "test" {
   name = "%s"
 }
 `, ruleName, targetID, snsTopicName)
@@ -445,17 +445,17 @@ resource "aws_sns_topic" "moon" {
 
 func testAccAWSCloudWatchEventTargetConfigMissingTargetId(ruleName, snsTopicName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_event_rule" "foo" {
+resource "aws_cloudwatch_event_rule" "test" {
   name                = "%s"
   schedule_expression = "rate(1 hour)"
 }
 
-resource "aws_cloudwatch_event_target" "moobar" {
-  rule = "${aws_cloudwatch_event_rule.foo.name}"
-  arn  = "${aws_sns_topic.moon.arn}"
+resource "aws_cloudwatch_event_target" "test" {
+  rule = "${aws_cloudwatch_event_rule.test.name}"
+  arn  = "${aws_sns_topic.test.arn}"
 }
 
-resource "aws_sns_topic" "moon" {
+resource "aws_sns_topic" "test" {
   name = "%s"
 }
 `, ruleName, snsTopicName)
@@ -463,7 +463,7 @@ resource "aws_sns_topic" "moon" {
 
 func testAccAWSCloudWatchEventTargetConfig_full(ruleName, targetName, rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_event_rule" "foo" {
+resource "aws_cloudwatch_event_rule" "test" {
   name                = "%s"
   schedule_expression = "rate(1 hour)"
   role_arn            = "${aws_iam_role.role.arn}"
@@ -512,18 +512,18 @@ resource "aws_iam_role_policy" "test_policy" {
 EOF
 }
 
-resource "aws_cloudwatch_event_target" "foobar" {
-  rule      = "${aws_cloudwatch_event_rule.foo.name}"
+resource "aws_cloudwatch_event_target" "test" {
+  rule      = "${aws_cloudwatch_event_rule.test.name}"
   target_id = "%s"
 
   input = <<INPUT
 { "source": ["aws.cloudtrail"] }
 INPUT
 
-  arn = "${aws_kinesis_stream.test_stream.arn}"
+  arn = "${aws_kinesis_stream.test.arn}"
 }
 
-resource "aws_kinesis_stream" "test_stream" {
+resource "aws_kinesis_stream" "test" {
   name        = "%s_kinesis_test"
   shard_count = 1
 }
@@ -532,7 +532,7 @@ resource "aws_kinesis_stream" "test_stream" {
 
 func testAccAWSCloudWatchEventTargetConfigSsmDocument(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_document" "foo" {
+resource "aws_ssm_document" "test" {
   name          = "%s"
   document_type = "Command"
 
@@ -571,7 +571,7 @@ PATTERN
 }
 
 resource "aws_cloudwatch_event_target" "test" {
-  arn      = "${aws_ssm_document.foo.arn}"
+  arn      = "${aws_ssm_document.test.arn}"
   rule     = "${aws_cloudwatch_event_rule.console.id}"
   role_arn = "${aws_iam_role.test_role.arn}"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
terraform-provider-aws/aws/resource_aws_cloudwatch_event_target_test.go:113:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/resource_aws_cloudwatch_event_target_test.go:123:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/resource_aws_cloudwatch_event_target_test.go:153:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/resource_aws_cloudwatch_event_target_test.go:185:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSCloudWatchEventTarget_missingTargetId (19.20s)
--- PASS: TestAccAWSCloudWatchEventTarget_sqs (19.50s)
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (23.16s)
--- PASS: TestAccAWSCloudWatchEventTarget_basic (33.75s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (34.49s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (35.08s)
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (38.70s)
--- PASS: TestAccAWSCloudWatchEventTarget_kinesis (61.04s)
--- PASS: TestAccAWSCloudWatchEventTarget_full (61.48s)
--- PASS: TestAccAWSCloudWatchEventTarget_batch (86.80s)
```
