### PR TITLE
r/aws_route: Remove extraneous Exists function

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -587,6 +587,22 @@ func testAccAwsRegionProviderFunc(region string, providers *[]*schema.Provider) 
 	}
 }
 
+func testAccCheckResourceDisappears(provider *schema.Provider, resource *schema.Resource, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if resourceState.Primary.ID == "" {
+			return fmt.Errorf("resource ID missing: %s", resourceName)
+		}
+
+		return resource.Delete(resource.Data(resourceState.Primary), provider.Meta())
+	}
+}
+
 func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error, providers *[]*schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		numberOfProviders := len(*providers)

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -27,7 +27,6 @@ func resourceAwsRoute() *schema.Resource {
 		Read:   resourceAwsRouteRead,
 		Update: resourceAwsRouteUpdate,
 		Delete: resourceAwsRouteDelete,
-		Exists: resourceAwsRouteExists,
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), "_")
@@ -286,6 +285,10 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("destination_cidr_block"); ok {
 		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), v.(string), "")
+			if err == nil && route != nil {
+				return nil
+			}
+
 			return resource.RetryableError(err)
 		})
 		if isResourceTimeoutError(err) {
@@ -294,11 +297,18 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Error finding route after creating it: %s", err)
 		}
+		if route == nil {
+			return fmt.Errorf("Unable to find matching route for Route Table (%s) and destination CIDR block (%s).", d.Get("route_table_id").(string), v)
+		}
 	}
 
 	if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
 		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			route, err = resourceAwsRouteFindRoute(conn, d.Get("route_table_id").(string), "", v.(string))
+			if err == nil && route != nil {
+				return nil
+			}
+
 			return resource.RetryableError(err)
 		})
 		if isResourceTimeoutError(err) {
@@ -307,10 +317,14 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Error finding route after creating it: %s", err)
 		}
+		if route == nil {
+			return fmt.Errorf("Unable to find matching route for Route Table (%s) and destination IPv6 CIDR block (%s).", d.Get("route_table_id").(string), v)
+		}
 	}
 
 	d.SetId(resourceAwsRouteID(d, route))
 	resourceAwsRouteSetResourceData(d, route)
+
 	return nil
 }
 
@@ -322,16 +336,23 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	destinationIpv6CidrBlock := d.Get("destination_ipv6_cidr_block").(string)
 
 	route, err := resourceAwsRouteFindRoute(conn, routeTableId, destinationCidrBlock, destinationIpv6CidrBlock)
+	if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
+		log.Printf("[WARN] Route Table (%s) not found, removing from state", routeTableId)
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
-		if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
-			log.Printf("[WARN] Route Table %q could not be found. Removing Route from state.",
-				routeTableId)
-			d.SetId("")
-			return nil
-		}
 		return err
 	}
+
+	if route == nil {
+		log.Printf("[WARN] Matching route not found, removing from state")
+		d.SetId("")
+		return nil
+	}
+
 	resourceAwsRouteSetResourceData(d, route)
+
 	return nil
 }
 
@@ -454,14 +475,15 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] Route delete opts: %s", deleteOpts)
 
-	var resp *ec2.DeleteRouteOutput
 	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		log.Printf("[DEBUG] Trying to delete route with opts %s", deleteOpts)
 		var err error
-		resp, err = conn.DeleteRoute(deleteOpts)
-		log.Printf("[DEBUG] Route delete result: %s", resp)
-
+		_, err = conn.DeleteRoute(deleteOpts)
 		if err == nil {
+			return nil
+		}
+
+		if isAWSErr(err, "InvalidRoute.NotFound", "") {
 			return nil
 		}
 
@@ -472,54 +494,15 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 		return resource.NonRetryableError(err)
 	})
 	if isResourceTimeoutError(err) {
-		resp, err = conn.DeleteRoute(deleteOpts)
+		_, err = conn.DeleteRoute(deleteOpts)
+	}
+	if isAWSErr(err, "InvalidRoute.NotFound", "") {
+		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("Error deleting route: %s", err)
 	}
 	return nil
-}
-
-func resourceAwsRouteExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	conn := meta.(*AWSClient).ec2conn
-	routeTableId := d.Get("route_table_id").(string)
-
-	findOpts := &ec2.DescribeRouteTablesInput{
-		RouteTableIds: []*string{&routeTableId},
-	}
-
-	res, err := conn.DescribeRouteTables(findOpts)
-	if err != nil {
-		if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
-			log.Printf("[WARN] Route Table %q could not be found.", routeTableId)
-			return false, nil
-		}
-		return false, fmt.Errorf("Error while checking if route exists: %s", err)
-	}
-
-	if len(res.RouteTables) < 1 || res.RouteTables[0] == nil {
-		log.Printf("[WARN] Route Table %q is gone, or route does not exist.",
-			routeTableId)
-		return false, nil
-	}
-
-	if v, ok := d.GetOk("destination_cidr_block"); ok {
-		for _, route := range (*res.RouteTables[0]).Routes {
-			if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == v.(string) {
-				return true, nil
-			}
-		}
-	}
-
-	if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
-		for _, route := range (*res.RouteTables[0]).Routes {
-			if route.DestinationIpv6CidrBlock != nil && *route.DestinationIpv6CidrBlock == v.(string) {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
 }
 
 // Helper: Create an ID for a route
@@ -532,7 +515,8 @@ func resourceAwsRouteID(d *schema.ResourceData, r *ec2.Route) string {
 	return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*r.DestinationCidrBlock))
 }
 
-// Helper: retrieve a route
+// resourceAwsRouteFindRoute returns any route whose destination is the specified IPv4 or IPv6 CIDR block.
+// Returns nil if the route table exists but no matching destination is found.
 func resourceAwsRouteFindRoute(conn *ec2.EC2, rtbid string, cidr string, ipv6cidr string) (*ec2.Route, error) {
 	routeTableID := rtbid
 
@@ -546,8 +530,7 @@ func resourceAwsRouteFindRoute(conn *ec2.EC2, rtbid string, cidr string, ipv6cid
 	}
 
 	if len(resp.RouteTables) < 1 || resp.RouteTables[0] == nil {
-		return nil, fmt.Errorf("Route Table %q is gone, or route does not exist.",
-			routeTableID)
+		return nil, nil
 	}
 
 	if cidr != "" {
@@ -557,8 +540,7 @@ func resourceAwsRouteFindRoute(conn *ec2.EC2, rtbid string, cidr string, ipv6cid
 			}
 		}
 
-		return nil, fmt.Errorf("Unable to find matching route for Route Table (%s) "+
-			"and destination CIDR block (%s).", rtbid, cidr)
+		return nil, nil
 	}
 
 	if ipv6cidr != "" {
@@ -568,11 +550,8 @@ func resourceAwsRouteFindRoute(conn *ec2.EC2, rtbid string, cidr string, ipv6cid
 			}
 		}
 
-		return nil, fmt.Errorf("Unable to find matching route for Route Table (%s) "+
-			"and destination IPv6 CIDR block (%s).", rtbid, ipv6cidr)
+		return nil, nil
 	}
 
-	return nil, fmt.Errorf("When trying to find a matching route for Route Table %q "+
-		"you need to specify a CIDR block of IPv6 CIDR Block", rtbid)
-
+	return nil, nil
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -55,6 +55,28 @@ func TestAccAWSRoute_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_disappears(t *testing.T) {
+	var route ec2.Route
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteBasicConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists("aws_route.bar", &route),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute(), "aws_route.bar"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_ipv6Support(t *testing.T) {
 	var route ec2.Route
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9953.

Includes `testAccCheckResourceDisappears()` from https://github.com/terraform-providers/terraform-provider-aws/pull/12864.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRoute_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 1 -run=TestAccAWSRoute_ -timeout 120m
=== RUN   TestAccAWSRoute_basic
=== PAUSE TestAccAWSRoute_basic
=== RUN   TestAccAWSRoute_disappears
=== PAUSE TestAccAWSRoute_disappears
=== RUN   TestAccAWSRoute_ipv6Support
=== PAUSE TestAccAWSRoute_ipv6Support
=== RUN   TestAccAWSRoute_ipv6ToInternetGateway
=== PAUSE TestAccAWSRoute_ipv6ToInternetGateway
=== RUN   TestAccAWSRoute_ipv6ToInstance
=== PAUSE TestAccAWSRoute_ipv6ToInstance
=== RUN   TestAccAWSRoute_ipv6ToNetworkInterface
=== PAUSE TestAccAWSRoute_ipv6ToNetworkInterface
=== RUN   TestAccAWSRoute_ipv6ToPeeringConnection
=== PAUSE TestAccAWSRoute_ipv6ToPeeringConnection
=== RUN   TestAccAWSRoute_changeRouteTable
=== PAUSE TestAccAWSRoute_changeRouteTable
=== RUN   TestAccAWSRoute_changeCidr
=== PAUSE TestAccAWSRoute_changeCidr
=== RUN   TestAccAWSRoute_noopdiff
=== PAUSE TestAccAWSRoute_noopdiff
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
=== PAUSE TestAccAWSRoute_doesNotCrashWithVPCEndpoint
=== RUN   TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
=== PAUSE TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
=== CONT  TestAccAWSRoute_basic
--- PASS: TestAccAWSRoute_basic (50.67s)
=== CONT  TestAccAWSRoute_changeRouteTable
--- PASS: TestAccAWSRoute_changeRouteTable (80.50s)
=== CONT  TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
--- PASS: TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock (366.53s)
=== CONT  TestAccAWSRoute_doesNotCrashWithVPCEndpoint
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (57.73s)
=== CONT  TestAccAWSRoute_noopdiff
--- PASS: TestAccAWSRoute_noopdiff (140.10s)
=== CONT  TestAccAWSRoute_changeCidr
--- PASS: TestAccAWSRoute_changeCidr (79.23s)
=== CONT  TestAccAWSRoute_ipv6ToInstance
--- PASS: TestAccAWSRoute_ipv6ToInstance (146.16s)
=== CONT  TestAccAWSRoute_ipv6ToPeeringConnection
--- PASS: TestAccAWSRoute_ipv6ToPeeringConnection (41.41s)
=== CONT  TestAccAWSRoute_ipv6ToNetworkInterface
--- PASS: TestAccAWSRoute_ipv6ToNetworkInterface (159.35s)
=== CONT  TestAccAWSRoute_ipv6Support
--- PASS: TestAccAWSRoute_ipv6Support (56.86s)
=== CONT  TestAccAWSRoute_ipv6ToInternetGateway
--- PASS: TestAccAWSRoute_ipv6ToInternetGateway (50.73s)
=== CONT  TestAccAWSRoute_disappears
--- PASS: TestAccAWSRoute_disappears (46.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1276.139s
```
