### PR TITLE
service/codedeploy: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -30,76 +31,49 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
-					resource.TestMatchResourceAttr(
-						"aws_codedeploy_deployment_group.test", "service_role_arn",
-						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf-acc-test-.*")),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "app_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_group_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", "aws_iam_role.test", "arn"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "blue_green_deployment_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "blue_green_deployment_config.#", "0"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2916377465.key", "filterkey"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2916377465.value", "filtervalue"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.2916377465.key", "filterkey"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.2916377465.value", "filtervalue"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "trigger_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_configuration.#", "0"),
 				),
 			},
 			{
 				Config: testAccAWSCodeDeployDeploymentGroupModified(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-updated-"+rName),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
-					resource.TestMatchResourceAttr(
-						"aws_codedeploy_deployment_group.test", "service_role_arn",
-						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf-acc-test-updated-.*")),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "app_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_group_name", "tf-acc-test-updated-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", "aws_iam_role.test_updated", "arn"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2369538975.key", "filterkey"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.2369538975.key", "filterkey"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "trigger_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -108,6 +82,7 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentGroup_basic_tagSet(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
+	resourceName := "aws_codedeploy_deployment_group.test"
 
 	rName := acctest.RandString(5)
 
@@ -119,77 +94,49 @@ func TestAccAWSCodeDeployDeploymentGroup_basic_tagSet(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentGroup(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-"+rName),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
-					resource.TestMatchResourceAttr(
-						"aws_codedeploy_deployment_group.test", "service_role_arn",
-						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf-acc-test-.*")),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "app_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_group_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", "aws_iam_role.test", "arn"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2916377593.ec2_tag_filter.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.key", "filterkey"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.value", "filtervalue"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.2916377593.ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.key", "filterkey"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.type", "KEY_AND_VALUE"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.2916377593.ec2_tag_filter.2916377465.value", "filtervalue"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "0"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "trigger_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_configuration.#", "0"),
 				),
 			},
 			{
 				Config: testAccAWSCodeDeployDeploymentGroupModified(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.test", &group),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "app_name", "tf-acc-test-"+rName),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_group_name", "tf-acc-test-updated-"+rName),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "deployment_config_name", "CodeDeployDefault.OneAtATime"),
-					resource.TestMatchResourceAttr(
-						"aws_codedeploy_deployment_group.test", "service_role_arn",
-						regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/tf-acc-test-updated-.*")),
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "app_name", "tf-acc-test-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_group_name", "tf-acc-test-updated-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", "CodeDeployDefault.OneAtATime"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", "aws_iam_role.test_updated", "arn"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2369538847.ec2_tag_filter.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.key", "filterkey"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "ec2_tag_filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.2369538847.ec2_tag_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.key", "filterkey"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.type", "KEY_AND_VALUE"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_set.2369538847.ec2_tag_filter.2369538975.value", "anotherfiltervalue"),
+					resource.TestCheckResourceAttr(resourceName, "ec2_tag_filter.#", "0"),
 
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "alarm_configuration.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "auto_rollback_configuration.#", "0"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.test", "trigger_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "alarm_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rollback_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_codedeploy_deployment_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.test"),
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -2388,7 +2335,7 @@ func testAccAWSCodeDeployDeploymentGroupModified(rName string, tagGroup bool) st
 resource "aws_codedeploy_deployment_group" "test" {
   app_name              = aws_codedeploy_app.test.name
   deployment_group_name = "tf-acc-test-updated-%[1]s"
-  service_role_arn      = aws_iam_role.test_new.arn
+  service_role_arn      = aws_iam_role.test_updated.arn
   %[2]s
 }
 
@@ -2398,7 +2345,7 @@ resource "aws_codedeploy_app" "test" {
 
 resource "aws_iam_role_policy" "test" {
   name   = "tf-acc-test-%[1]s"
-  role   = aws_iam_role.test_new.id
+  role   = aws_iam_role.test_updated.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2425,7 +2372,7 @@ EOF
 
 }
 
-resource "aws_iam_role" "test_new" {
+resource "aws_iam_role" "test_updated" {
   name               = "tf-acc-test-updated-%[1]s"
   assume_role_policy = <<EOF
 {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
terraform-provider-aws/aws/resource_aws_codedeploy_deployment_group_test.go:40:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/resource_aws_codedeploy_deployment_group_test.go:76:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/resource_aws_codedeploy_deployment_group_test.go:129:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
terraform-provider-aws/aws/resource_aws_codedeploy_deployment_group_test.go:164:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (35.13s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (39.06s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (48.85s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (48.91s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (49.77s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (51.83s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (51.90s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (57.42s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (59.05s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (60.81s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (62.03s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (63.02s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (63.94s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (65.08s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (66.21s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (67.86s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (72.31s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (80.96s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (34.61s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (49.90s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (46.00s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (31.98s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (47.52s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (47.65s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (51.72s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (45.76s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (50.30s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (56.55s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (58.64s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (136.92s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (209.66s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (299.52s)
```
