### PR TITLE
resource/aws_api_gateway_deployment: Add triggers argument

### DIFF
--- a/aws/resource_aws_api_gateway_deployment.go
+++ b/aws/resource_aws_api_gateway_deployment.go
@@ -43,6 +43,13 @@ func resourceAwsApiGatewayDeployment() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"variables": {
 				Type:     schema.TypeMap,
 				Optional: true,

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -10,8 +10,9 @@ description: |-
 
 Provides an API Gateway REST Deployment.
 
--> **Note:** Depends on having `aws_api_gateway_integration` inside your rest api (which in turn depends on `aws_api_gateway_method`). To avoid race conditions
-you might need to add an explicit `depends_on = ["${aws_api_gateway_integration.name}"]`.
+~> **Note:** This resource depends on having at least one `aws_api_gateway_integration` created in the REST API, which itself has other dependencies. To avoid race conditions when all resources are being created together, you need to add implicit resource references via the `triggers` argument or explicit resource references using the [resource `depends_on` meta-argument](/docs/configuration/resources.html#depends_on-explicit-resource-dependencies).
+
+-> It is recommended to enable the [resource `lifecycle` configuration block `create_before_destroy` argument](https://www.terraform.io/docs/configuration/resources.html#create_before_destroy) in this resource configuration to properly order redeployments in Terraform.
 
 ## Example Usage
 
@@ -50,6 +51,31 @@ resource "aws_api_gateway_deployment" "MyDemoDeployment" {
   variables = {
     "answer" = "42"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+### Redeployment Triggers
+
+~> **NOTE:** This is an optional and Terraform 0.12 (or later) advanced configuration that shows calculating a hash of the API's Terraform resources to determine changes that should trigger a new deployment. This value will change after the first Terraform apply of new resources, triggering an immediate redeployment, however it will stabilize afterwards except for resource changes. The `triggers` map can also be configured in other, more complex ways to fit the environment, avoiding the immediate redeployment issue.
+
+```hcl
+resource "aws_api_gateway_deployment" "MyDemoDeployment" {
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  stage_name  = "test"
+
+  triggers = {
+    redeployment = sha1(join(",", list(
+      jsonencode(aws_api_gateway_integration.example),
+    )))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 ```
 
@@ -61,6 +87,7 @@ The following arguments are supported:
 * `stage_name` - (Optional) The name of the stage. If the specified stage already exists, it will be updated to point to the new deployment. If the stage does not exist, a new one will be created and point to this deployment.
 * `description` - (Optional) The description of the deployment
 * `stage_description` - (Optional) The description of the stage
+* `triggers` - (Optional) A map of arbitrary keys and values that, when changed, will trigger a redeployment. To force a redeployment without changing these keys/values, use the [`terraform taint` command](/docs/commands/taint.html).
 * `variables` - (Optional) A map that defines variables for the stage
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #162
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/13055 (`aws_apigatewayv2_deployment` resource)
Reference: https://www.terraform.io/docs/providers/null/resource.html#triggers
Reference: https://www.terraform.io/docs/providers/random/#resource-quot-keepers-quot-
Reference: https://www.terraform.io/docs/providers/time/#resource-quot-triggers-quot-

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_api_gateway_deployment: Add `triggers` argument
```

Since it does not appear there will be functionality added anytime soon in the Terraform core to support resource configuration that automatically triggers resource recreation when referenced resources are updated, this introduces a `triggers` map argument similar to those utilized by the `null`, `random`, and `time` providers. This can be used by operators to automatically force a new resource (redeployment) using key/value criteria of their choosing. Its usage is fairly advanced, so caveats are added to the documentation.

We do not intend to add this class of argument to all Terraform AWS Provider resources due to its complexity and potentially awkward configuration, however, this is a pragmatic compromise for this particular resource which does not fit well into Terraform's usual provisioning model.

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayDeployment_basic (24.67s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageDescription (24.72s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageName (86.00s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageName_EmptyString (128.10s)
--- PASS: TestAccAWSAPIGatewayDeployment_disappears_RestApi (157.14s)
--- PASS: TestAccAWSAPIGatewayDeployment_Triggers (204.69s)
--- PASS: TestAccAWSAPIGatewayDeployment_Description (250.19s)
--- PASS: TestAccAWSAPIGatewayDeployment_Variables (432.41s)
```
