### PR TITLE
resource/aws_apigatewayv2_deployment: Add triggers argument

### DIFF
--- a/aws/resource_aws_apigatewayv2_deployment.go
+++ b/aws/resource_aws_apigatewayv2_deployment.go
@@ -37,6 +37,12 @@ func resourceAwsApiGatewayV2Deployment() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1024),
 			},
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }

--- a/aws/resource_aws_apigatewayv2_deployment_test.go
+++ b/aws/resource_aws_apigatewayv2_deployment_test.go
@@ -71,6 +71,58 @@ func TestAccAWSAPIGatewayV2Deployment_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayV2Deployment_Triggers(t *testing.T) {
+	var apiId string
+	var deployment1, deployment2, deployment3, deployment4 apigatewayv2.GetDeploymentOutput
+	resourceName := "aws_apigatewayv2_deployment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2DeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2DeploymentConfigTriggers(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2DeploymentExists(resourceName, &apiId, &deployment1),
+				),
+				// Due to how the Terraform state is handled for resources during creation,
+				// any SHA1 of whole resources will change after first apply, then stabilize.
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAWSAPIGatewayV2DeploymentConfigTriggers(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2DeploymentExists(resourceName, &apiId, &deployment2),
+					testAccCheckAWSAPIGatewayV2DeploymentRecreated(&deployment1, &deployment2),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2DeploymentConfigTriggers(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2DeploymentExists(resourceName, &apiId, &deployment3),
+					testAccCheckAWSAPIGatewayV2DeploymentNotRecreated(&deployment2, &deployment3),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccAWSAPIGatewayV2DeploymentImportStateIdFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"triggers"},
+			},
+			{
+				Config: testAccAWSAPIGatewayV2DeploymentConfigTriggers(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2DeploymentExists(resourceName, &apiId, &deployment4),
+					testAccCheckAWSAPIGatewayV2DeploymentRecreated(&deployment3, &deployment4),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAPIGatewayV2DeploymentDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
 
@@ -138,6 +190,26 @@ func testAccCheckAWSAPIGatewayV2DeploymentExists(n string, vApiId *string, v *ap
 	}
 }
 
+func testAccCheckAWSAPIGatewayV2DeploymentNotRecreated(i, j *apigatewayv2.GetDeploymentOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreatedDate) != aws.TimeValue(j.CreatedDate) {
+			return fmt.Errorf("API Gateway V2 Deployment recreated")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayV2DeploymentRecreated(i, j *apigatewayv2.GetDeploymentOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreatedDate) == aws.TimeValue(j.CreatedDate) {
+			return fmt.Errorf("API Gateway V2 Deployment not recreated")
+		}
+
+		return nil
+	}
+}
+
 func testAccAWSAPIGatewayV2DeploymentImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -158,4 +230,41 @@ resource "aws_apigatewayv2_deployment" "test" {
   depends_on  = ["aws_apigatewayv2_route.test"]
 }
 `, description)
+}
+
+func testAccAWSAPIGatewayV2DeploymentConfigTriggers(rName string, apiKeyRequired bool) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name                       = %[1]q
+  protocol_type              = "WEBSOCKET"
+  route_selection_expression = "$request.body.action"
+}
+
+resource "aws_apigatewayv2_integration" "test" {
+  api_id           = "${aws_apigatewayv2_api.test.id}"
+  integration_type = "MOCK"
+}
+
+resource "aws_apigatewayv2_route" "test" {
+  api_id           = aws_apigatewayv2_api.test.id
+  api_key_required = %[2]t
+  route_key        = "$default"
+  target           = "integrations/${aws_apigatewayv2_integration.test.id}"
+}
+
+resource "aws_apigatewayv2_deployment" "test" {
+  api_id      = aws_apigatewayv2_api.test.id
+
+  triggers = {
+    redeployment = sha1(join(",", list(
+      jsonencode(aws_apigatewayv2_integration.test),
+      jsonencode(aws_apigatewayv2_route.test),
+    )))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`, rName, apiKeyRequired)
 }

--- a/website/docs/r/apigatewayv2_deployment.html.markdown
+++ b/website/docs/r/apigatewayv2_deployment.html.markdown
@@ -11,7 +11,9 @@ description: |-
 Manages an Amazon API Gateway Version 2 deployment.
 More information can be found in the [Amazon API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api.html).
 
--> **Note:** Creating a deployment for an API requires at least one `aws_apigatewayv2_route` resource associated with that API.
+-> **Note:** Creating a deployment for an API requires at least one `aws_apigatewayv2_route` resource associated with that API. To avoid race conditions when all resources are being created together, you need to add implicit resource references via the `triggers` argument or explicit resource references using the [resource `depends_on` meta-argument](/docs/configuration/resources.html#depends_on-explicit-resource-dependencies).
+
+-> It is recommended to enable the [resource `lifecycle` configuration block `create_before_destroy` argument](https://www.terraform.io/docs/configuration/resources.html#create_before_destroy) in this resource configuration to properly order redeployments in Terraform.
 
 ## Example Usage
 
@@ -21,6 +23,32 @@ More information can be found in the [Amazon API Gateway Developer Guide](https:
 resource "aws_apigatewayv2_deployment" "example" {
   api_id      = "${aws_apigatewayv2_route.example.api_id}"
   description = "Example deployment"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+### Redeployment Triggers
+
+-> **NOTE:** This is an optional and Terraform 0.12 (or later) advanced configuration that shows calculating a hash of the API's Terraform resources to determine changes that should trigger a new deployment. This value will change after the first Terraform apply of new resources, triggering an immediate redeployment, however it will stabilize afterwards except for resource changes. The `triggers` map can also be configured in other, more complex ways to fit the environment, avoiding the immediate redeployment issue.
+
+```hcl
+resource "aws_apigatewayv2_deployment" "example" {
+  api_id      = aws_apigatewayv2_api.example.id
+  description = "Example deployment"
+
+  triggers = {
+    redeployment = sha1(join(",", list(
+      jsonencode(aws_apigatewayv2_integration.example),
+      jsonencode(aws_apigatewayv2_route.example),
+    )))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 ```
 
@@ -30,6 +58,7 @@ The following arguments are supported:
 
 * `api_id` - (Required) The API identifier.
 * `description` - (Optional) The description for the deployment resource.
+* `triggers` - (Optional) A map of arbitrary keys and values that, when changed, will trigger a redeployment. To force a redeployment without changing these keys/values, use the [`terraform taint` command](/docs/commands/taint.html).
 
 ## Attribute Reference
 
@@ -45,3 +74,5 @@ In addition to all arguments above, the following attributes are exported:
 ```
 $ terraform import aws_apigatewayv2_deployment.example aabbccddee/1122334
 ```
+
+The `triggers` argument cannot be imported.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/162
Closes #12961
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/13054 (aws_api_gateway_deployment resource)
Reference: https://www.terraform.io/docs/providers/null/resource.html#triggers
Reference: https://www.terraform.io/docs/providers/random/#resource-quot-keepers-quot-
Reference: https://www.terraform.io/docs/providers/time/#resource-quot-triggers-quot-

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_apigatewayv2_deployment: Add `triggers` argument
```

Since it does not appear there will be functionality added anytime soon in the Terraform core to support resource configuration that automatically triggers resource recreation when referenced resources are updated, this introduces a `triggers` map argument similar to those utilized by the `null`, `random`, and `time` providers. This can be used by operators to automatically force a new resource (redeployment) using key/value criteria of their choosing. Its usage is fairly advanced, so caveats are added to the documentation.

We do not intend to add this class of argument to all Terraform AWS Provider resources due to its complexity and potentially awkward configuration, however, this is a pragmatic compromise for this particular resource which does not fit well into Terraform's usual provisioning model.

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayV2Deployment_disappears (23.05s)
--- PASS: TestAccAWSAPIGatewayV2Deployment_basic (41.80s)
--- PASS: TestAccAWSAPIGatewayV2Deployment_Triggers (70.95s)
```