### PR TITLE
r/aws_apigatewayv2_integration: suppress diff for passthrough_behavior

### DIFF
--- a/aws/resource_aws_apigatewayv2_integration.go
+++ b/aws/resource_aws_apigatewayv2_integration.go
@@ -92,6 +92,14 @@ func resourceAwsApiGatewayV2Integration() *schema.Resource {
 					apigatewayv2.PassthroughBehaviorNever,
 					apigatewayv2.PassthroughBehaviorWhenNoTemplates,
 				}, false),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// PassthroughBehavior not set for HTTP APIs
+					if old == "" && new == apigatewayv2.PassthroughBehaviorWhenNoMatch {
+						return true
+					}
+
+					return false
+				},
 			},
 			"payload_format_version": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSAPIGatewayV2Integration_basic(t *testing.T) {
+func TestAccAWSAPIGatewayV2Integration_basicWebSocket(t *testing.T) {
 	var apiId string
 	var v apigatewayv2.GetIntegrationOutput
 	resourceName := "aws_apigatewayv2_integration.test"
@@ -36,6 +36,47 @@ func TestAccAWSAPIGatewayV2Integration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "integration_type", "MOCK"),
 					resource.TestCheckResourceAttr(resourceName, "integration_uri", ""),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2IntegrationImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Integration_basicHttp(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetIntegrationOutput
+	resourceName := "aws_apigatewayv2_integration.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2IntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_httpProxy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
+					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
+					resource.TestCheckResourceAttr(resourceName, "credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_type", "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_uri", "https://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
@@ -311,6 +352,15 @@ resource "aws_apigatewayv2_api" "test" {
 `, rName)
 }
 
+func testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name                       = %[1]q
+  protocol_type              = "HTTP"
+}
+`, rName)
+}
+
 func testAccAWSAPIGatewayV2IntegrationConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_integration" "test" {
@@ -390,6 +440,18 @@ resource "aws_apigatewayv2_integration" "test" {
   passthrough_behavior          = "WHEN_NO_MATCH"
 }
 `, rName)
+}
+
+func testAccAWSAPIGatewayV2IntegrationConfig_httpProxy(rName string) string {
+	return testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName) + fmt.Sprintf(`
+resource "aws_apigatewayv2_integration" "test" {
+	api_id           = "${aws_apigatewayv2_api.test.id}"
+	integration_type = "HTTP_PROXY"
+
+	integration_method = "GET"
+	integration_uri    = "https://example.com"
+}
+`)
 }
 
 func testAccAWSAPIGatewayV2IntegrationConfig_vpcLink(rName string) string {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #11148 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_integration: Correctly handle the `passthrough_behavior` attribute for HTTP APIs
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayV2Integration_'
--- PASS: TestAccAWSAPIGatewayV2Integration_disappears (15.87s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basicHttp (18.20s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basicWebSocket (18.46s)
    TestAccAWSAPIGatewayV2Integration_Lambda: testing.go:669: Step 0 error: errors during apply:

        Error: error creating API Gateway v2 integration: BadRequestException: Invalid role ARN

          on /var/folders/5_/yp4n1h313nnck0dh22h7bzt4nbtrkm/T/tf-test295658976/main.tf line 128:
          (source code not available)


--- PASS: TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp (28.04s)
--- FAIL: TestAccAWSAPIGatewayV2Integration_Lambda (28.97s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLink (661.92s)
```

Everything seemed to work other than the lambda function test....and to be honest I'm not sure why it's failing 😕 I tried running the tests in 2 different AWS accounts, and got the same error each time. The error doesn't _appear_ to be related to my changes.