### PR TITLE
service/ec2: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -23,7 +22,7 @@ func TestAccAWSInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "ami", resourceName, "ami"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
-					testAccMatchResourceAttrRegionalARN(datasourceName, "arn", "ec2", regexp.MustCompile(`instance/i-.+`)),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
 					resource.TestCheckNoResourceAttr(datasourceName, "user_data_base64"),
 					resource.TestCheckResourceAttr(datasourceName, "outpost_arn", ""),
 				),
@@ -502,17 +501,17 @@ resource "aws_instance" "test" {
 
   tags = {
     Name     = "HelloWorld"
-    TestSeed = "%d"
+    TestSeed = "%[1]d"
   }
 }
 
 data "aws_instance" "test" {
   instance_tags = {
     Name     = "${aws_instance.test.tags["Name"]}"
-    TestSeed = "%d"
+    TestSeed = "%[1]d"
   }
 }
-`, rInt, rInt)
+`, rInt)
 }
 
 // filter on tag, populate more attributes

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -31,113 +30,65 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsSubnetConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "id", snResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "owner_id", snResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "availability_zone", snResourceName, "availability_zone"),
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
-					resource.TestCheckResourceAttrPair(
-						ds1ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds1ResourceName, "cidr_block", cidr),
-					resource.TestCheckResourceAttr(
-						ds1ResourceName, "tags.Name", tag),
-					testAccMatchResourceAttrRegionalARN(ds1ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
-					resource.TestCheckResourceAttr(
-						ds1ResourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", snResourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "owner_id", snResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "availability_zone", snResourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckResourceAttr(ds1ResourceName, "cidr_block", cidr),
+					resource.TestCheckResourceAttr(ds1ResourceName, "tags.Name", tag),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "id", snResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "owner_id", snResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "availability_zone", snResourceName, "availability_zone"),
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
-					resource.TestCheckResourceAttrPair(
-						ds2ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds2ResourceName, "cidr_block", cidr),
-					resource.TestCheckResourceAttr(
-						ds2ResourceName, "tags.Name", tag),
-					testAccMatchResourceAttrRegionalARN(ds2ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
-					resource.TestCheckResourceAttr(
-						ds2ResourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "id", snResourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "owner_id", snResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "availability_zone", snResourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckResourceAttr(ds2ResourceName, "cidr_block", cidr),
+					resource.TestCheckResourceAttr(ds2ResourceName, "tags.Name", tag),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "id", snResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "owner_id", snResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "availability_zone", snResourceName, "availability_zone"),
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
-					resource.TestCheckResourceAttrPair(
-						ds3ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds3ResourceName, "cidr_block", cidr),
-					resource.TestCheckResourceAttr(
-						ds3ResourceName, "tags.Name", tag),
-					testAccMatchResourceAttrRegionalARN(ds3ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
-					resource.TestCheckResourceAttr(
-						ds3ResourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "id", snResourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "owner_id", snResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "availability_zone", snResourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckResourceAttr(ds3ResourceName, "cidr_block", cidr),
+					resource.TestCheckResourceAttr(ds3ResourceName, "tags.Name", tag),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "id", snResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "owner_id", snResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "availability_zone", snResourceName, "availability_zone"),
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
-					resource.TestCheckResourceAttrPair(
-						ds4ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds4ResourceName, "cidr_block", cidr),
-					resource.TestCheckResourceAttr(
-						ds4ResourceName, "tags.Name", tag),
-					testAccMatchResourceAttrRegionalARN(ds4ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
-					resource.TestCheckResourceAttr(
-						ds4ResourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "id", snResourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "owner_id", snResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "availability_zone", snResourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckResourceAttr(ds4ResourceName, "cidr_block", cidr),
+					resource.TestCheckResourceAttr(ds4ResourceName, "tags.Name", tag),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds4ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "id", snResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "owner_id", snResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "availability_zone", snResourceName, "availability_zone"),
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
-					resource.TestCheckResourceAttrPair(
-						ds5ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds5ResourceName, "cidr_block", cidr),
-					resource.TestCheckResourceAttr(
-						ds5ResourceName, "tags.Name", tag),
-					testAccMatchResourceAttrRegionalARN(ds5ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
-					resource.TestCheckResourceAttr(
-						ds5ResourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "id", snResourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "owner_id", snResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "availability_zone", snResourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckResourceAttr(ds5ResourceName, "cidr_block", cidr),
+					resource.TestCheckResourceAttr(ds5ResourceName, "tags.Name", tag),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds5ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
-					resource.TestCheckResourceAttrPair(
-						ds6ResourceName, "id", snResourceName, "id"),
-					resource.TestCheckResourceAttrPair(
-						ds6ResourceName, "owner_id", snResourceName, "owner_id"),
-					resource.TestCheckResourceAttrPair(
-						ds6ResourceName, "availability_zone", snResourceName, "availability_zone"),
-					resource.TestCheckResourceAttrPair(
-						ds6ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
-					resource.TestCheckResourceAttrPair(
-						ds6ResourceName, "vpc_id", vpcResourceName, "id"),
-					resource.TestCheckResourceAttr(
-						ds6ResourceName, "cidr_block", cidr),
-					resource.TestCheckResourceAttr(
-						ds6ResourceName, "tags.Name", tag),
-					testAccMatchResourceAttrRegionalARN(ds6ResourceName, "arn", "ec2", regexp.MustCompile(`subnet/subnet-.+`)),
-					resource.TestCheckResourceAttr(
-						ds6ResourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "id", snResourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "owner_id", snResourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "availability_zone", snResourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "availability_zone_id", snResourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckResourceAttr(ds6ResourceName, "cidr_block", cidr),
+					resource.TestCheckResourceAttr(ds6ResourceName, "tags.Name", tag),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds6ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 				),
 			},
 		},
@@ -156,10 +107,8 @@ func TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsSubnetConfigIpv6WithDataSourceFilter(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
-					resource.TestCheckResourceAttrSet(
-						"data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block"),
+					resource.TestCheckResourceAttrSet("data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
+					resource.TestCheckResourceAttrSet("data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block"),
 				),
 			},
 		},
@@ -178,8 +127,7 @@ func TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsSubnetConfigIpv6WithDataSourceIpv6CidrBlock(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
+					resource.TestCheckResourceAttrSet("data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
 				),
 			},
 		},

--- a/aws/resource_aws_ec2_traffic_mirror_target_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_target_test.go
@@ -28,13 +28,12 @@ func TestAccAWSEc2TrafficMirrorTarget_nlb(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEc2TrafficMirrorTargetDestroy,
 		Steps: []resource.TestStep{
-			//create
 			{
 				Config: testAccTrafficMirrorTargetConfigNlb(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TrafficMirrorTargetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestMatchResourceAttr(resourceName, "network_load_balancer_arn", regexp.MustCompile("arn:aws:elasticloadbalancing:.*")),
+					resource.TestCheckResourceAttrPair(resourceName, "network_load_balancer_arn", "aws_lb.lb", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -61,7 +60,6 @@ func TestAccAWSEc2TrafficMirrorTarget_eni(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEc2TrafficMirrorTargetDestroy,
 		Steps: []resource.TestStep{
-			//create
 			{
 				Config: testAccTrafficMirrorTargetConfigEni(rName, description),
 				Check: resource.ComposeTestCheckFunc(

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -280,7 +280,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "0"), // This is an instance store AMI
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`instance/i-[a-z0-9]+`)),
 				),
 			},
 			{

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -691,7 +691,7 @@ func TestAccAWSSecurityGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists(resourceName, &group),
 					testAccCheckAWSSecurityGroupAttributes(&group),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:[^:]+:security-group/.+$`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`security-group/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", "terraform_acceptance_test_example"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Used in the terraform acceptance tests"),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -148,23 +148,15 @@ func TestAccAWSSubnet_basic(t *testing.T) {
 			{
 				Config: testAccSubnetConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetExists(
-						resourceName, &v),
+					testAccCheckSubnetExists(resourceName, &v),
 					testCheck,
 					// ipv6 should be empty if disabled so we can still use the property in conditionals
-					resource.TestCheckResourceAttr(
-						resourceName, "ipv6_cidr_block", ""),
-					resource.TestMatchResourceAttr(
-						resourceName,
-						"arn",
-						regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:subnet/subnet-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_block", ""),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile("subnet/subnet-.+$")),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttrSet(
-						resourceName, "availability_zone"),
-					resource.TestCheckResourceAttrSet(
-						resourceName, "availability_zone_id"),
-					resource.TestCheckResourceAttr(
-						resourceName, "outpost_arn", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 				),
 			},
 			{
@@ -219,8 +211,7 @@ func TestAccAWSSubnet_ipv6(t *testing.T) {
 			{
 				Config: testAccSubnetConfigIpv6,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetExists(
-						resourceName, &before),
+					testAccCheckSubnetExists(resourceName, &before),
 					testAccCheckAwsSubnetIpv6BeforeUpdate(t, &before),
 				),
 			},
@@ -232,16 +223,14 @@ func TestAccAWSSubnet_ipv6(t *testing.T) {
 			{
 				Config: testAccSubnetConfigIpv6UpdateAssignIpv6OnCreation,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetExists(
-						resourceName, &after),
+					testAccCheckSubnetExists(resourceName, &after),
 					testAccCheckAwsSubnetIpv6AfterUpdate(t, &after),
 				),
 			},
 			{
 				Config: testAccSubnetConfigIpv6UpdateIpv6Cidr,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetExists(
-						resourceName, &after),
+					testAccCheckSubnetExists(resourceName, &after),
 
 					testAccCheckAwsSubnetNotRecreated(t, &before, &after),
 				),
@@ -263,8 +252,7 @@ func TestAccAWSSubnet_enableIpv6(t *testing.T) {
 			{
 				Config: testAccSubnetConfigPreIpv6,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetExists(
-						resourceName, &subnet),
+					testAccCheckSubnetExists(resourceName, &subnet),
 				),
 			},
 			{
@@ -275,8 +263,7 @@ func TestAccAWSSubnet_enableIpv6(t *testing.T) {
 			{
 				Config: testAccSubnetConfigIpv6,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetExists(
-						resourceName, &subnet),
+					testAccCheckSubnetExists(resourceName, &subnet),
 				),
 			},
 		},
@@ -296,12 +283,9 @@ func TestAccAWSSubnet_availabilityZoneId(t *testing.T) {
 			{
 				Config: testAccSubnetConfigAvailabilityZoneId,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttrSet(
-						resourceName, "availability_zone"),
-					resource.TestCheckResourceAttr(
-						resourceName, "availability_zone_id", "usw2-az3"),
+					testAccCheckSubnetExists(resourceName, &v),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone_id", "usw2-az3"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/data_source_aws_instance_test.go:26:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_subnet_test.go:49:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_subnet_test.go:66:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_subnet_test.go:83:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_subnet_test.go:100:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_subnet_test.go:117:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/data_source_aws_subnet_test.go:134:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_ec2_traffic_mirror_target_test.go:37:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_instance_test.go:281:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_security_group_test.go:694:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_subnet_test.go:156:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (68.66s)
--- PASS: TestAccDataSourceAwsSubnet_basic (14.52s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (83.62s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (84.16s)
--- PASS: TestAccAWSInstanceDataSource_VPC (89.78s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (92.00s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (96.55s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (103.04s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (20.42s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (107.24s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (30.13s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (116.30s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (116.75s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (122.62s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (122.55s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (125.33s)
--- PASS: TestAccAWSInstanceDataSource_basic (128.81s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (128.98s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (158.45s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_eni (76.62s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (64.25s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (186.89s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (63.82s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (189.31s)
--- PASS: TestAccAWSInstance_inEc2Classic (87.94s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (10.24s)
--- PASS: TestAccAWSInstance_blockDevices (80.47s)
--- PASS: TestAccAWSInstance_rootInstanceStore (90.18s)
--- PASS: TestAccAWSInstance_basic (131.24s)
--- PASS: TestAccAWSInstanceDataSource_tags (248.15s)
--- PASS: TestAccAWSInstance_placementGroup (67.04s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (258.21s)
--- PASS: TestAccAWSInstance_userDataBase64 (136.60s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (74.54s)
--- PASS: TestAccAWSInstance_vpc (83.10s)
--- PASS: TestAccAWSInstance_disableApiTermination (111.70s)
--- PASS: TestAccAWSInstance_sourceDestCheck (125.81s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_nlb (211.18s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (194.21s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (79.97s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (181.06s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (194.30s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (76.88s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (82.74s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_disappears (240.92s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_tags (246.63s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (181.05s)
--- PASS: TestAccAWSInstance_privateIP (64.74s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (147.53s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (64.93s)
--- PASS: TestAccAWSInstance_keyPairCheck (64.08s)
--- PASS: TestAccAWSInstance_volumeTags (101.51s)
--- PASS: TestAccAWSInstance_tags (116.39s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (63.36s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (94.94s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (67.46s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (67.47s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (76.58s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (111.65s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (112.39s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (338.41s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (122.96s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (102.76s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (76.24s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (145.82s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (126.77s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (103.40s)
--- PASS: TestAccAWSInstance_multipleRegions (279.54s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS (152.43s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (65.88s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (235.16s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (74.72s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (237.83s)
--- PASS: TestAccAWSInstance_changeInstanceType (241.97s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (85.57s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (186.44s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (94.67s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (304.42s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (95.70s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (139.97s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (105.19s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (85.57s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (95.57s)
--- PASS: TestAccAWSSecurityGroup_allowAll (12.67s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (187.42s)
--- PASS: TestAccAWSSecurityGroup_IPRangeAndSecurityGroupWithSameRules (17.98s)
--- PASS: TestAccAWSSecurityGroup_sourceSecurityGroup (24.01s)
--- PASS: TestAccAWSSecurityGroup_IPRangesWithSameRules (16.83s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (197.77s)
--- PASS: TestAccAWSSecurityGroup_basic (13.09s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (105.24s)
--- PASS: TestAccAWSSecurityGroup_egressConfigMode (28.92s)
--- PASS: TestAccAWSSecurityGroup_ingressConfigMode (26.29s)
--- PASS: TestAccAWSSecurityGroup_ruleGathering (25.40s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (188.35s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (90.74s)
--- PASS: TestAccAWSSecurityGroup_ipv6 (13.24s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (185.99s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (103.66s)
--- PASS: TestAccAWSSecurityGroup_namePrefix (20.48s)
--- PASS: TestAccAWSSecurityGroup_self (18.41s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (219.51s)
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (24.34s)
--- PASS: TestAccAWSSecurityGroup_vpc (27.53s)
--- PASS: TestAccAWSSecurityGroup_defaultEgressVPC (16.11s)
--- PASS: TestAccAWSSecurityGroup_defaultEgressClassic (15.64s)
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (2.15s)
--- PASS: TestAccAWSSecurityGroup_drift (12.06s)
--- PASS: TestAccAWSSecurityGroup_generatedName (21.94s)
--- PASS: TestAccAWSSecurityGroup_change (33.22s)
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (37.05s)
--- PASS: TestAccAWSSecurityGroup_multiIngress (35.59s)
--- PASS: TestAccAWSSecurityGroup_driftComplex (19.13s)
--- PASS: TestAccAWSInstance_metadataOptions (109.57s)
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (12.71s)
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (20.49s)
--- PASS: TestAccAWSSecurityGroup_tags (24.54s)
--- PASS: TestAccAWSSecurityGroup_ruleDescription (42.97s)
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGsClassic (21.09s)
--- PASS: TestAccAWSInstance_hibernation (146.02s)
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGsVPC (30.00s)
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (22.18s)
--- PASS: TestAccAWSSecurityGroup_ingressWithPrefixList (32.59s)
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (37.01s)
--- PASS: TestAccAWSSubnet_basic (18.43s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (194.46s)
--- PASS: TestAccAWSSubnet_availabilityZoneId (18.13s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend (46.12s)
--- PASS: TestAccAWSSubnet_ignoreTags (38.67s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededPrepend (47.11s)
--- PASS: TestAccAWSSubnet_enableIpv6 (36.61s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAllNew (47.05s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAppend (56.27s)
--- PASS: TestAccAWSSecurityGroup_rulesDropOnError (48.14s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (272.45s)
--- PASS: TestAccAWSSubnet_ipv6 (44.07s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (302.22s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (323.32s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (244.43s)
--- PASS: TestAccAWSInstance_disappears (231.75s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (306.47s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesFalse (633.54s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesTrue (643.96s)

--- FAIL: TestAccAWSInstance_instanceProfileChange (186.10s)
```

This PR does not introduce any new test failures.