### PR TITLE
resource/emr_cluster: Remove deprecated (helper/schema.ResourceData).Partial() and (helper/schema.ResourceData).SetPartial()

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -212,10 +212,9 @@ func resourceAwsEMRCluster() *schema.Resource {
 							Computed: true,
 						},
 						"instance_profile": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validateArn,
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
 						},
 						"service_access_security_group": {
 							Type:     schema.TypeString,
@@ -594,10 +593,9 @@ func resourceAwsEMRCluster() *schema.Resource {
 				},
 			},
 			"service_role": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Required:     true,
-				ValidateFunc: validateArn,
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
 			},
 			"scale_down_behavior": {
 				Type:     schema.TypeString,
@@ -615,10 +613,9 @@ func resourceAwsEMRCluster() *schema.Resource {
 				Optional: true,
 			},
 			"autoscaling_role": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Optional:     true,
-				ValidateFunc: validateArn,
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
 			},
 			"visible_to_all_users": {
 				Type:     schema.TypeBool,

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -747,7 +747,7 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 	} else if coreInstanceCount > 0 && coreInstanceType != "" {
 		coreInstanceGroupConfig := &emr.InstanceGroupConfig{
 			InstanceCount: aws.Int64(int64(d.Get("core_instance_count").(int))),
-			InstanceRole:  aws.String("CORE"),
+			InstanceRole:  aws.String(emr.InstanceRoleTypeCore),
 			InstanceType:  aws.String(d.Get("core_instance_type").(string)),
 		}
 		instanceConfig.InstanceGroups = append(instanceConfig.InstanceGroups, coreInstanceGroupConfig)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: #12083
Reference: #12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resouce_aws_emr_cluster: add plan time validation to `instance_profile`, `service_role` and `autoscaling_role`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSEMRCluster_basic (532.74s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (648.76s)
```
