### PR TITLE
Replace 'testAccPreCheckOffersEc2InstanceType' with 'aws_ec2_instance_type_offering' data source

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1236,24 +1236,6 @@ func testAccHasDefaultVpc(t *testing.T) bool {
 	return true
 }
 
-// testAccPreCheckOffersEc2InstanceType checks that the test region offers the specified EC2 instance type.
-func testAccPreCheckOffersEc2InstanceType(t *testing.T, instanceType string) {
-	client := testAccProvider.Meta().(*AWSClient)
-
-	resp, err := client.ec2conn.DescribeInstanceTypeOfferings(&ec2.DescribeInstanceTypeOfferingsInput{
-		Filters: buildEC2AttributeFilterList(map[string]string{
-			"instance-type": instanceType,
-		}),
-		LocationType: aws.String(ec2.LocationTypeRegion),
-	})
-	if testAccPreCheckSkipError(err) || len(resp.InstanceTypeOfferings) == 0 {
-		t.Skipf("skipping tests; %s does not offer EC2 instance type: %s", client.region, instanceType)
-	}
-	if err != nil {
-		t.Fatalf("error describing EC2 instance type offerings: %s", err)
-	}
-}
-
 func testAccAWSProviderConfigEndpoints(endpoints string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Following up from [this comment](https://github.com/terraform-providers/terraform-provider-aws/pull/12491#discussion_r399474683):

> Now that there is the aws_ec2_instance_type_offering data source, we can use that to selectively pick out of a list of preferred instance types.

Remove `testAccPreCheckOffersEc2InstanceType` and use the `aws_ec2_instance_type_offering` data source to select an EC2 instance type.

Relates https://github.com/terraform-providers/terraform-provider-aws/pull/12491.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstanceDataSource_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstanceDataSource_metadataOptions -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_metadataOptions
=== PAUSE TestAccAWSInstanceDataSource_metadataOptions
=== CONT  TestAccAWSInstanceDataSource_metadataOptions
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (130.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	131.023s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_metadataOptions -timeout 120m
=== RUN   TestAccAWSInstance_metadataOptions
=== PAUSE TestAccAWSInstance_metadataOptions
=== CONT  TestAccAWSInstance_metadataOptions
--- PASS: TestAccAWSInstance_metadataOptions (113.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	114.045s
```
