### PR TITLE
resource/aws_emr_instance_group: Extend instance group timeout by 50%

### DIFF
--- a/aws/resource_aws_emr_instance_group.go
+++ b/aws/resource_aws_emr_instance_group.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	emrInstanceGroupCreateTimeout = 10 * time.Minute
-	emrInstanceGroupUpdateTimeout = 10 * time.Minute
+	emrInstanceGroupCreateTimeout = 15 * time.Minute
+	emrInstanceGroupUpdateTimeout = 15 * time.Minute
 )
 
 func resourceAwsEMRInstanceGroup() *schema.Resource {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_emr_instance_group: Extend instance group timeout from 10m to 15m
```

After the addition of https://github.com/terraform-providers/terraform-provider-aws/pull/11688, I'm experiencing difficulties in using task nodes. Currently my task nodes are taking ~10-11 minutes to come up healthy, this is extending the timeout by 50% to allow more cushion for task nodes to spin up. 

Output from acceptance testing:

Currently there are no acceptance tests for these consts and unsure how to mock/test this scenario 
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

