### PR TITLE
r/cloudfront_origin_access_identity - remove from state if it doesnt exist

### DIFF
--- a/aws/resource_aws_cloudfront_origin_access_identity.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -72,6 +73,11 @@ func resourceAwsCloudFrontOriginAccessIdentityRead(d *schema.ResourceData, meta 
 
 	resp, err := conn.GetCloudFrontOriginAccessIdentity(params)
 	if err != nil {
+		if isAWSErr(err, cloudfront.ErrCodeNoSuchCloudFrontOriginAccessIdentity, "") {
+			log.Printf("[WARN] CloudFront Origin Access Identity (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/aws/resource_aws_cloudfront_origin_access_identity_test.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
+	var origin cloudfront.GetCloudFrontOriginAccessIdentityOutput
 	resourceName := "aws_cloudfront_origin_access_identity.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,7 +23,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontOriginAccessIdentityConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName),
+					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName, &origin),
 					resource.TestCheckResourceAttr(resourceName, "comment", "some comment"),
 					resource.TestMatchResourceAttr(resourceName, "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
 					resource.TestMatchResourceAttr(resourceName, "s3_canonical_user_id", regexp.MustCompile("^[a-z0-9]+")),
@@ -41,6 +42,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
 }
 
 func TestAccAWSCloudFrontOriginAccessIdentity_noComment(t *testing.T) {
+	var origin cloudfront.GetCloudFrontOriginAccessIdentityOutput
 	resourceName := "aws_cloudfront_origin_access_identity.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -51,7 +53,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_noComment(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontOriginAccessIdentityNoCommentConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName),
+					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName, &origin),
 					resource.TestMatchResourceAttr(resourceName, "caller_reference", regexp.MustCompile(fmt.Sprintf("^%s", resource.UniqueIdPrefix))),
 					resource.TestMatchResourceAttr(resourceName, "s3_canonical_user_id", regexp.MustCompile("^[a-z0-9]+")),
 					resource.TestMatchResourceAttr(resourceName, "cloudfront_access_identity_path", regexp.MustCompile("^origin-access-identity/cloudfront/[A-Z0-9]+")),
@@ -63,6 +65,27 @@ func TestAccAWSCloudFrontOriginAccessIdentity_noComment(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontOriginAccessIdentity_disappears(t *testing.T) {
+	var origin cloudfront.GetCloudFrontOriginAccessIdentityOutput
+	resourceName := "aws_cloudfront_origin_access_identity.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontOriginAccessIdentityConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName, &origin),
+					testAccCheckCloudFrontOriginAccessIdentityDisappears(&origin),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -89,7 +112,7 @@ func testAccCheckCloudFrontOriginAccessIdentityDestroy(s *terraform.State) error
 	return nil
 }
 
-func testAccCheckCloudFrontOriginAccessIdentityExistence(r string) resource.TestCheckFunc {
+func testAccCheckCloudFrontOriginAccessIdentityExistence(r string, origin *cloudfront.GetCloudFrontOriginAccessIdentityOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
 		if !ok {
@@ -105,11 +128,29 @@ func testAccCheckCloudFrontOriginAccessIdentityExistence(r string) resource.Test
 			Id: aws.String(rs.Primary.ID),
 		}
 
-		_, err := conn.GetCloudFrontOriginAccessIdentity(params)
+		resp, err := conn.GetCloudFrontOriginAccessIdentity(params)
 		if err != nil {
 			return fmt.Errorf("Error retrieving CloudFront distribution: %s", err)
 		}
+
+		*origin = *resp
+
 		return nil
+	}
+}
+
+func testAccCheckCloudFrontOriginAccessIdentityDisappears(origin *cloudfront.GetCloudFrontOriginAccessIdentityOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cloudfrontconn
+
+		params := &cloudfront.DeleteCloudFrontOriginAccessIdentityInput{
+			Id:      origin.CloudFrontOriginAccessIdentity.Id,
+			IfMatch: origin.ETag,
+		}
+
+		_, err := conn.DeleteCloudFrontOriginAccessIdentity(params)
+
+		return err
 	}
 }
 

--- a/aws/resource_aws_cloudfront_origin_access_identity_test.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity_test.go
@@ -83,7 +83,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_disappears(t *testing.T) {
 				Config: testAccAWSCloudFrontOriginAccessIdentityConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontOriginAccessIdentityExistence(resourceName, &origin),
-					testAccCheckCloudFrontOriginAccessIdentityDisappears(&origin),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudFrontOriginAccessIdentity(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -136,21 +136,6 @@ func testAccCheckCloudFrontOriginAccessIdentityExistence(r string, origin *cloud
 		*origin = *resp
 
 		return nil
-	}
-}
-
-func testAccCheckCloudFrontOriginAccessIdentityDisappears(origin *cloudfront.GetCloudFrontOriginAccessIdentityOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).cloudfrontconn
-
-		params := &cloudfront.DeleteCloudFrontOriginAccessIdentityInput{
-			Id:      origin.CloudFrontOriginAccessIdentity.Id,
-			IfMatch: origin.ETag,
-		}
-
-		_, err := conn.DeleteCloudFrontOriginAccessIdentity(params)
-
-		return err
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13067

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cloudfront_origin_access_identity: 
```

Output from acceptance testing: remove from state if it doesnt exist

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCloudFrontOriginAccessIdentity_'
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_basic (42.20s)
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_disappears (28.28s)
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_noComment (41.05s)
```
