### PR TITLE
Add and use 'testAccAvailableEc2InstanceTypeForAvailabilityZone' config generator

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,7 +33,7 @@ testacc: fmtcheck
 		echo "See the contributing guide for more information: https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/contributing/running-and-writing-acceptance-tests.md"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel 2 $(TESTARGS) -timeout 120m
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,7 +33,7 @@ testacc: fmtcheck
 		echo "See the contributing guide for more information: https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/contributing/running-and-writing-acceptance-tests.md"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel 2 $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/aws/resource_aws_ami_from_instance_test.go
+++ b/aws/resource_aws_ami_from_instance_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAccAWSAMIFromInstance_basic(t *testing.T) {
 	var image ec2.Image
-	rName := acctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ami_from_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -36,7 +36,7 @@ func TestAccAWSAMIFromInstance_basic(t *testing.T) {
 
 func TestAccAWSAMIFromInstance_tags(t *testing.T) {
 	var image ec2.Image
-	rName := acctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ami_from_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -129,55 +129,38 @@ func testAccCheckAWSAMIFromInstanceDestroy(s *terraform.State) error {
 	return testAccCheckAWSEbsSnapshotDestroy(s)
 }
 
-func testAccAWSAMIFromInstanceConfigBase() string {
-	return `
-data "aws_ec2_instance_type_offering" "available" {
-  filter {
-    name   = "instance-type"
-    values = ["t3.micro", "t2.micro"]
-  }
-
-  preferred_instance_types = ["t3.micro", "t2.micro"]
-}
-
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
+func testAccAWSAMIFromInstanceConfigBase(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
 
   tags = {
-    Name = "testAccAWSAMIFromInstanceConfig_TestAMI"
+    Name = %[1]q
   }
 }
-`
+`, rName))
 }
 
 func testAccAWSAMIFromInstanceConfig(rName string) string {
-	return testAccAWSAMIFromInstanceConfigBase() + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAMIFromInstanceConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_ami_from_instance" "test" {
   name               = %[1]q
   description        = "Testing Terraform aws_ami_from_instance resource"
   source_instance_id = "${aws_instance.test.id}"
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSAMIFromInstanceConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return testAccAWSAMIFromInstanceConfigBase() + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAMIFromInstanceConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_ami_from_instance" "test" {
   name               = %[1]q
   description        = "Testing Terraform aws_ami_from_instance resource"
@@ -187,11 +170,13 @@ resource "aws_ami_from_instance" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccAWSAMIFromInstanceConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAWSAMIFromInstanceConfigBase() + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAMIFromInstanceConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_ami_from_instance" "test" {
   name               = %[1]q
   description        = "Testing Terraform aws_ami_from_instance resource"
@@ -202,5 +187,5 @@ resource "aws_ami_from_instance" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -779,37 +779,10 @@ resource "aws_cloudwatch_metric_alarm" "test" {
 // EC2 Automate requires a valid EC2 instance
 // ValidationError: Invalid use of EC2 'Recover' action. i-abc123 is not a valid EC2 instance.
 func testAccAWSCloudWatchMetricAlarmConfigAlarmActionsEC2Automate(rName, action string) string {
-	return fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
-data "aws_ec2_instance_type_offering" "available" {
-  filter {
-    name   = "instance-type"
-    values = ["t3.micro", "t2.micro"]
-  }
-
-  filter {
-    name   = "location"
-    values = [aws_subnet.test.availability_zone]
-  }
-
-  location_type            = "availability-zone"
-  preferred_instance_types = ["t3.micro", "t2.micro"]
-}
-
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 data "aws_region" "current" {}
@@ -858,7 +831,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     InstanceId = aws_instance.test.id
   }
 }
-`, rName, action)
+`, rName, action))
 }
 
 func testAccAWSCloudWatchMetricAlarmConfigAlarmActionsSNSTopic(rName string) string {

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -279,6 +279,7 @@ func TestAccAWSEIP_associated_user_private_ip(t *testing.T) {
 func TestAccAWSEIP_Instance_Reassociate(t *testing.T) {
 	instanceResourceName := "aws_instance.test"
 	resourceName := "aws_eip.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -286,13 +287,13 @@ func TestAccAWSEIP_Instance_Reassociate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIP_Instance(),
+				Config: testAccAWSEIP_Instance(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
 				),
 			},
 			{
-				Config: testAccAWSEIP_Instance(),
+				Config: testAccAWSEIP_Instance(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "instance", instanceResourceName, "id"),
 				),
@@ -981,7 +982,7 @@ data "aws_availability_zones" "available" {
     values = ["opt-in-not-required"]
   }
 }
-  
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
 	tags = {
@@ -1023,41 +1024,18 @@ resource "aws_eip" "test2" {
 }
 `
 
-func testAccAWSEIP_Instance() string {
-	return `
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
-data "aws_ec2_instance_type_offering" "available" {
-  filter {
-    name   = "instance-type"
-    values = ["t3.micro", "t2.micro"]
-  }
-
-  filter {
-    name   = "location"
-    values = [aws_subnet.test.availability_zone]
-  }
-
-  location_type            = "availability-zone"
-  preferred_instance_types = ["t3.micro", "t2.micro"]
-}
-
+func testAccAWSEIP_Instance(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
 resource "aws_eip" "test" {
   instance = aws_instance.test.id
   vpc      = true
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_instance" "test" {
@@ -1067,7 +1045,7 @@ resource "aws_instance" "test" {
   subnet_id                   = aws_subnet.test.id
 
   tags = {
-    Name = "testAccAWSEIP_Instance"
+    Name = %[1]q
   }
 
   lifecycle {
@@ -1079,12 +1057,16 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-eip-disassociate"
+    Name = %[1]q
   }
 }
 
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_subnet" "test" {
@@ -1092,7 +1074,7 @@ resource "aws_subnet" "test" {
   vpc_id     = aws_vpc.test.id
 
   tags = {
-    Name = "tf-acc-eip-disassociate"
+    Name = %[1]q
   }
 }
 
@@ -1103,13 +1085,17 @@ resource "aws_route_table" "test" {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.test.id
   }
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_route_table_association" "test" {
   subnet_id      = aws_subnet.test.id
   route_table_id = aws_route_table.test.id
 }
-`
+`, rName))
 }
 
 const testAccAWSEIPAssociate_not_associated = `

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1888,7 +1888,7 @@ func TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices(t *testing.
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsEc2InstanceConfigDynamicEBSBlockDevices,
+				Config: testAccAwsEc2InstanceConfigDynamicEBSBlockDevices(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "3"),
@@ -4888,10 +4888,9 @@ data "aws_ami" "amzn-ami-minimal-hvm-instance-store" {
 // testAccLatestAmazonLinuxPvEbsAmiConfig returns the configuration for a data source that
 // describes the latest Amazon Linux AMI using PV virtualization and an EBS root device.
 // The data source is named 'amzn-ami-minimal-pv-ebs'.
-/*
 func testAccLatestAmazonLinuxPvEbsAmiConfig() string {
 	return fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+data "aws_ami" "amzn-ami-minimal-pv-ebs" {
   most_recent = true
   owners      = ["amazon"]
 
@@ -4907,7 +4906,6 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
 }
 `)
 }
-*/
 
 // testAccLatestWindowsServer2016CoreAmiConfig returns the configuration for a data source that
 // describes the latest Microsoft Windows Server 2016 Core AMI.
@@ -5132,9 +5130,10 @@ resource "aws_instance" "test" {
 `, rName))
 }
 
-const testAccAwsEc2InstanceConfigDynamicEBSBlockDevices = `
+func testAccAwsEc2InstanceConfigDynamicEBSBlockDevices() string {
+	return composeConfig(testAccLatestAmazonLinuxPvEbsAmiConfig(), `
 resource "aws_instance" "test" {
-  ami           = "ami-55a7ea65"
+  ami           = data.aws_ami.amzn-ami-minimal-pv-ebs.id
   instance_type = "m3.medium"
 
   dynamic "ebs_block_device" {
@@ -5147,7 +5146,8 @@ resource "aws_instance" "test" {
     }
   }
 }
-`
+`)
+}
 
 // testAccAvailableEc2InstanceTypeForRegion returns the configuration for a data source that describes
 // the first available EC2 instance type offering in the current region from a list of preferred instance types.

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -59,8 +59,7 @@ func testSweepSpotFleetRequests(region string) error {
 
 func TestAccAWSSpotFleetRequest_basic(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -70,7 +69,7 @@ func TestAccAWSSpotFleetRequest_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -91,8 +90,7 @@ func TestAccAWSSpotFleetRequest_basic(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_tags(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -102,7 +100,7 @@ func TestAccAWSSpotFleetRequest_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, "key1", "value1", rInt),
+				Config: testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, "key1", "value1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -116,7 +114,7 @@ func TestAccAWSSpotFleetRequest_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfigTags2(rName, validUntil, "key1", "value1updated", "key2", "value2", rInt),
+				Config: testAccAWSSpotFleetRequestConfigTags2(rName, validUntil, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -125,7 +123,7 @@ func TestAccAWSSpotFleetRequest_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, "key2", "value2", rInt),
+				Config: testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, "key2", "value2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -138,8 +136,7 @@ func TestAccAWSSpotFleetRequest_tags(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -149,7 +146,7 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -171,8 +168,7 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -182,7 +178,7 @@ func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -202,8 +198,7 @@ func TestAccAWSSpotFleetRequest_launchTemplate(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_launchTemplate_multiple(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -213,7 +208,7 @@ func TestAccAWSSpotFleetRequest_launchTemplate_multiple(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateMultipleConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateMultipleConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -227,8 +222,7 @@ func TestAccAWSSpotFleetRequest_launchTemplate_multiple(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -238,7 +232,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -258,8 +252,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateWithOverrides(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 	var before, after ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -269,7 +262,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -284,7 +277,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -299,8 +292,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 	var before, after ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -310,7 +302,7 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -319,7 +311,7 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -334,8 +326,7 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -345,7 +336,7 @@ func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -364,8 +355,7 @@ func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -375,7 +365,7 @@ func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigFleetType(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -394,8 +384,7 @@ func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -405,7 +394,7 @@ func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -424,8 +413,7 @@ func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 	var before, after ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -435,7 +423,7 @@ func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -450,7 +438,7 @@ func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -465,8 +453,7 @@ func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_updateTargetCapacity(t *testing.T) {
 	var before, after ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -476,7 +463,7 @@ func TestAccAWSSpotFleetRequest_updateTargetCapacity(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -490,14 +477,14 @@ func TestAccAWSSpotFleetRequest_updateTargetCapacity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfigTargetCapacity(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigTargetCapacity(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "target_capacity", "3"),
 				),
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -510,8 +497,7 @@ func TestAccAWSSpotFleetRequest_updateTargetCapacity(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing.T) {
 	var before, after ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -521,7 +507,7 @@ func TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -535,7 +521,7 @@ func TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing
 				ImportStateVerifyIgnore: []string{"wait_for_fulfillment"},
 			},
 			{
-				Config: testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "excess_capacity_termination_policy", "NoTermination"),
@@ -547,8 +533,7 @@ func TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing
 
 func TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -558,7 +543,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -577,8 +562,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -588,7 +572,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigWithAzs(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigWithAzs(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -613,8 +597,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -624,7 +607,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigWithSubnet(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigWithSubnet(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -643,8 +626,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -654,7 +636,7 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -679,33 +661,9 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
-	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
-			return errors.New("Missing launch specification")
-		}
-
-		spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
-
-		profile := spec.IamInstanceProfile
-		if profile == nil {
-			return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
-		}
-		//Validate the string whether it is ARN
-		re := regexp.MustCompile(`arn:aws[a-z0-9-]*:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
-		if !re.MatchString(*profile.Arn) {
-			return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
-		}
-
-		return nil
-	}
-}
-
 func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -715,7 +673,7 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) 
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -734,8 +692,7 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) 
 
 func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -745,7 +702,7 @@ func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -773,8 +730,7 @@ func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_withoutSpotPrice(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -784,7 +740,7 @@ func TestAccAWSSpotFleetRequest_withoutSpotPrice(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -803,8 +759,7 @@ func TestAccAWSSpotFleetRequest_withoutSpotPrice(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_diversifiedAllocation(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -814,7 +769,7 @@ func TestAccAWSSpotFleetRequest_diversifiedAllocation(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -834,8 +789,7 @@ func TestAccAWSSpotFleetRequest_diversifiedAllocation(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_multipleInstancePools(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -845,7 +799,7 @@ func TestAccAWSSpotFleetRequest_multipleInstancePools(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -866,8 +820,7 @@ func TestAccAWSSpotFleetRequest_multipleInstancePools(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_withWeightedCapacity(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -891,7 +844,7 @@ func TestAccAWSSpotFleetRequest_withWeightedCapacity(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					fulfillSleep(),
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
@@ -919,8 +872,7 @@ func TestAccAWSSpotFleetRequest_withWeightedCapacity(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
 	var config ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -930,7 +882,7 @@ func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestEBSConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestEBSConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &config),
 					testAccCheckAWSSpotFleetRequest_EBSAttributes(&config),
@@ -948,8 +900,7 @@ func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId(t *testing.T) {
 	var config ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -959,7 +910,7 @@ func TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId(t *t
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchSpecificationEbsBlockDeviceKmsKeyId(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestLaunchSpecificationEbsBlockDeviceKmsKeyId(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &config),
 				),
@@ -976,8 +927,7 @@ func TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId(t *t
 
 func TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId(t *testing.T) {
 	var config ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -987,7 +937,7 @@ func TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId(t *
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestLaunchSpecificationRootBlockDeviceKmsKeyId(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestLaunchSpecificationRootBlockDeviceKmsKeyId(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &config),
 				),
@@ -1004,8 +954,7 @@ func TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId(t *
 
 func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
 	var config ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -1015,7 +964,7 @@ func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestTagsConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestTagsConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &config),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "launch_specification.*", map[string]string{
@@ -1037,8 +986,7 @@ func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_placementTenancyAndGroup(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -1048,7 +996,7 @@ func TestAccAWSSpotFleetRequest_placementTenancyAndGroup(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestTenancyGroupConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestTenancyGroupConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1067,8 +1015,7 @@ func TestAccAWSSpotFleetRequest_placementTenancyAndGroup(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_WithELBs(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -1078,7 +1025,7 @@ func TestAccAWSSpotFleetRequest_WithELBs(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigWithELBs(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigWithELBs(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1098,8 +1045,7 @@ func TestAccAWSSpotFleetRequest_WithELBs(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -1108,7 +1054,7 @@ func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfigWithTargetGroups(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfigWithTargetGroups(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					resource.TestCheckResourceAttr(resourceName, "spot_request_state", "active"),
@@ -1128,8 +1074,7 @@ func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_WithInstanceStoreAmi(t *testing.T) {
 	t.Skip("Test fails due to test harness constraints")
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1138,7 +1083,7 @@ func TestAccAWSSpotFleetRequest_WithInstanceStoreAmi(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSSpotFleetRequestLaunchSpecificationWithInstanceStoreAmi(rName, rInt, validUntil),
+				Config:      testAccAWSSpotFleetRequestLaunchSpecificationWithInstanceStoreAmi(rName, validUntil),
 				ExpectError: regexp.MustCompile("Instance store backed AMIs do not provide a root device name"),
 			},
 		},
@@ -1147,8 +1092,7 @@ func TestAccAWSSpotFleetRequest_WithInstanceStoreAmi(t *testing.T) {
 
 func TestAccAWSSpotFleetRequest_disappears(t *testing.T) {
 	var sfr ec2.SpotFleetRequestConfig
-	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
@@ -1158,7 +1102,7 @@ func TestAccAWSSpotFleetRequest_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
+				Config: testAccAWSSpotFleetRequestConfig(rName, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsSpotFleetRequest(), resourceName),
@@ -1300,8 +1244,34 @@ func testAccPreCheckAWSEc2SpotFleetRequest(t *testing.T) {
 	}
 }
 
-func testAccAWSSpotFleetRequestConfigBase(rName string, rInt int) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
+	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
+			return errors.New("Missing launch specification")
+		}
+
+		spec := *sfr.SpotFleetRequestConfig.LaunchSpecifications[0]
+
+		profile := spec.IamInstanceProfile
+		if profile == nil {
+			return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
+		}
+		//Validate the string whether it is ARN
+		re := regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
+		if !re.MatchString(*profile.Arn) {
+			return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSSpotFleetRequestConfigBase(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -1310,16 +1280,17 @@ data "aws_availability_zones" "available" {
     values = ["opt-in-not-required"]
   }
 }
+
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 
   tags = {
-   Name = %[1]q
+    Name = %[1]q
   }
 }
 
-resource "aws_iam_role" "test-role" {
+resource "aws_iam_role" "test" {
   name = %[1]q
 
   assume_role_policy = <<EOF
@@ -1342,11 +1313,11 @@ resource "aws_iam_role" "test-role" {
 EOF
 
   tags = {
-   Name = %[1]q
+    Name = %[1]q
   }
 }
 
-resource "aws_iam_policy" "test-policy" {
+resource "aws_iam_policy" "test" {
   name        = %[1]q
   path        = "/"
   description = "Spot Fleet Request ACCTest Policy"
@@ -1370,28 +1341,19 @@ resource "aws_iam_policy" "test-policy" {
 EOF
 }
 
-resource "aws_iam_policy_attachment" "test-attach" {
+resource "aws_iam_policy_attachment" "test" {
   name       = %[1]q
-  roles      = ["${aws_iam_role.test-role.name}"]
-  policy_arn = "${aws_iam_policy.test-policy.arn}"
+  roles      = ["${aws_iam_role.test.name}"]
+  policy_arn = "${aws_iam_policy.test.arn}"
+}
+`, rName))
 }
 
-data "aws_ec2_instance_type_offering" "available" {
-  filter {
-    name   = "instance-type"
-    values = ["t3.micro", "t2.micro"]
-  }
-
-  preferred_instance_types = ["t3.micro", "t2.micro"]
-}
-`, rName, rInt)
-}
-
-func testAccAWSSpotFleetRequestConfig(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfig(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1402,16 +1364,16 @@ resource "aws_spot_fleet_request" "test" {
         ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
         key_name = "${aws_key_pair.test.key_name}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, tagKey1, tagValue1 string, rInt int) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, tagKey1, tagValue1 string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1425,16 +1387,16 @@ resource "aws_spot_fleet_request" "test" {
     tags = {
       %[2]q = %[3]q
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil, tagKey1, tagValue1)
 }
 
-func testAccAWSSpotFleetRequestConfigTags2(rName, validUntil, tagKey1, tagValue1, tagKey2, tagValue2 string, rInt int) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigTags2(rName, validUntil, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1449,16 +1411,16 @@ resource "aws_spot_fleet_request" "test" {
       %[2]q = %[3]q
       %[4]q = %[5]q
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.027"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1469,16 +1431,16 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         associate_public_ip_address = true
     }
-	depends_on = ["aws_iam_policy_attachment.test-attach"]
+	depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigTargetCapacity(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigTargetCapacity(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 3
     valid_until = %[1]q
     fleet_type = "request"
@@ -1488,13 +1450,13 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestLaunchTemplateConfig(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) +
+func testAccAWSSpotFleetRequestLaunchTemplateConfig(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) +
 		fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[2]q
@@ -1504,8 +1466,8 @@ resource "aws_launch_template" "test" {
 }
 
 resource "aws_spot_fleet_request" "test" {
-  iam_fleet_role                      = "${aws_iam_role.test-role.arn}"
-  spot_price                          = "0.05"
+  iam_fleet_role                      = "${aws_iam_role.test.arn}"
+  spot_price                          = "0.005"
   target_capacity                     = 2
   valid_until                         = %[1]q
   terminate_instances_with_expiration = true
@@ -1519,13 +1481,13 @@ resource "aws_spot_fleet_request" "test" {
     }
   }
 
-  depends_on = ["aws_iam_policy_attachment.test-attach"]
+  depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil, rName)
 }
 
-func testAccAWSSpotFleetRequestLaunchTemplateMultipleConfig(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) +
+func testAccAWSSpotFleetRequestLaunchTemplateMultipleConfig(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) +
 		fmt.Sprintf(`
 data "aws_ec2_instance_type_offering" "test" {
   filter {
@@ -1551,8 +1513,8 @@ resource "aws_launch_template" "test2" {
 }
 
 resource "aws_spot_fleet_request" "test" {
-  iam_fleet_role                      = "${aws_iam_role.test-role.arn}"
-  spot_price                          = "0.05"
+  iam_fleet_role                      = "${aws_iam_role.test.arn}"
+  spot_price                          = "0.005"
   target_capacity                     = 2
   valid_until                         = %[1]q
   terminate_instances_with_expiration = true
@@ -1573,13 +1535,13 @@ resource "aws_spot_fleet_request" "test" {
     }
   }
 
-  depends_on = ["aws_iam_policy_attachment.test-attach"]
+  depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil, rName)
 }
 
-func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) +
+func testAccAWSSpotFleetRequestLaunchTemplateConfigWithOverrides(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) +
 		fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name          = %[2]q
@@ -1589,8 +1551,8 @@ resource "aws_launch_template" "test" {
 }
 
 resource "aws_spot_fleet_request" "test" {
-  iam_fleet_role                      = "${aws_iam_role.test-role.arn}"
-  spot_price                          = "0.05"
+  iam_fleet_role                      = "${aws_iam_role.test.arn}"
+  spot_price                          = "0.005"
   target_capacity                     = 2
   valid_until                         = %[1]q
   terminate_instances_with_expiration = true
@@ -1615,16 +1577,16 @@ resource "aws_spot_fleet_request" "test" {
     }
   }
 
-  depends_on = ["aws_iam_policy_attachment.test-attach"]
+  depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil, rName)
 }
 
-func testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 2
     excess_capacity_termination_policy = "NoTermination"
     valid_until = %[1]q
@@ -1635,16 +1597,16 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigFleetType(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigFleetType(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 2
     valid_until = %[1]q
     fleet_type = "request"
@@ -1654,13 +1616,13 @@ resource "aws_spot_fleet_request" "test" {
         instance_type = "m1.small"
         ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigIamInstanceProfileArn(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_iam_role" "test-role1" {
     name = "tf-test-role1-%[1]s"
     assume_role_policy = <<EOF
@@ -1704,8 +1666,8 @@ resource "aws_iam_instance_profile" "test-iam-instance-profile1" {
 }
 
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 2
     valid_until = %[2]q
     terminate_instances_with_expiration = true
@@ -1717,16 +1679,16 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         iam_instance_profile_arn = "${aws_iam_instance_profile.test-iam-instance-profile1.arn}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, rName, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.01"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1736,16 +1698,16 @@ resource "aws_spot_fleet_request" "test" {
         ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
         key_name = "${aws_key_pair.test.key_name}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigWithAzs(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigWithAzs(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1762,40 +1724,43 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         availability_zone = "${data.aws_availability_zones.available.names[1]}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigWithSubnet(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigWithSubnet(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_vpc" "test" {
-    cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-spot-fleet-request-w-subnet"
-    }
+    Name = %[2]q
+  }
 }
 
 resource "aws_subnet" "test" {
-    cidr_block = "10.1.1.0/24"
-    vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
   tags = {
-        Name = "tf-acc-spot-fleet-request-w-subnet-test"
-    }
+    Name = %[2]q
+  }
 }
 
 resource "aws_subnet" "bar" {
-    cidr_block = "10.1.20.0/24"
-    vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  cidr_block        = "10.1.20.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+
   tags = {
-        Name = "tf-acc-spot-fleet-request-w-subnet-bar"
-    }
+    Name = %[2]q
+  }
 }
 
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
     spot_price = "0.05"
     target_capacity = 4
     valid_until = %[1]q
@@ -1813,38 +1778,44 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         subnet_id = "${aws_subnet.bar.id}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
-`, validUntil)
+`, validUntil, rName)
 }
 
-func testAccAWSSpotFleetRequestConfigWithELBs(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigWithELBs(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_vpc" "test" {
-    cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_subnet" "test" {
-    cidr_block = "10.1.1.0/24"
-    vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
   tags = {
-        Name = "tf-acc-spot-fleet-request-with-elb-test"
-    }
+    Name = %[1]q
+  }
 }
 
 resource "aws_subnet" "bar" {
-    cidr_block = "10.1.20.0/24"
-    vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  cidr_block        = "10.1.20.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+
   tags = {
-        Name = "tf-acc-spot-fleet-request-with-elb-bar"
-    }
+    Name = %[1]q
+  }
 }
 
 resource "aws_elb" "elb" {
-  name = "test-elb-%[1]s"
-  subnets = ["${aws_subnet.test.id}", "${aws_subnet.bar.id}"]
+  name     = %[1]q
+  subnets  = ["${aws_subnet.test.id}", "${aws_subnet.bar.id}"]
   internal = true
 
   listener {
@@ -1856,7 +1827,7 @@ resource "aws_elb" "elb" {
 }
 
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
     spot_price = "0.5"
     target_capacity = 2
     valid_until = %[2]q
@@ -1869,37 +1840,43 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         subnet_id = "${aws_subnet.test.id}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, rName, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigWithTargetGroups(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigWithTargetGroups(rName string, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_vpc" "test" {
-    cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_subnet" "test" {
-    cidr_block = "10.1.1.0/24"
-    vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
   tags = {
-        Name = "tf-acc-spot-fleet-request-with-target-groups-test"
-    }
+    Name = %[1]q
+  }
 }
 
 resource "aws_subnet" "bar" {
-    cidr_block = "10.1.20.0/24"
-    vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  cidr_block        = "10.1.20.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+
   tags = {
-        Name = "tf-acc-spot-fleet-request-with-target-groups-bar"
-    }
+    Name = %[1]q
+  }
 }
 
 resource "aws_alb" "alb" {
-  name            = "test-elb-%[1]s"
+  name            = %[1]q
   internal        = true
   subnets         = ["${aws_subnet.test.id}", "${aws_subnet.bar.id}"]
 }
@@ -1923,7 +1900,7 @@ resource "aws_alb_target_group" "target_group" {
 }
 
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
     spot_price = "0.5"
     target_capacity = 2
     valid_until = %[2]q
@@ -1936,16 +1913,16 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         subnet_id = "${aws_subnet.test.id}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, rName, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.025"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1962,32 +1939,34 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_vpc" "test" {
-    cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-spot-fleet-request-multi-instance-types"
-    }
+    Name = %[2]q
+  }
 }
 
 resource "aws_subnet" "test" {
-    cidr_block = "10.1.1.0/24"
-    vpc_id = "${aws_vpc.test.id}"
-    availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
   tags = {
-        Name = "tf-acc-spot-fleet-request-multi-instance-types"
-    }
+    Name = %[1]q
+  }
 }
 
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.035"
     target_capacity = 4
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -2004,16 +1983,16 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         subnet_id = "${aws_subnet.test.id}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
-`, validUntil)
+`, validUntil, rName)
 }
 
-func testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.035"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -2031,15 +2010,15 @@ resource "aws_spot_fleet_request" "test" {
         availability_zone = "${data.aws_availability_zones.available.names[0]}"
         spot_price = "0.05"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigWithoutSpotPrice(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -2056,15 +2035,15 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigMultipleInstancePools(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
     spot_price = "0.7"
     target_capacity = 30
     valid_until = %[1]q
@@ -2089,15 +2068,15 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
     spot_price = "0.7"
     target_capacity = 30
     valid_until = %[1]q
@@ -2122,15 +2101,15 @@ resource "aws_spot_fleet_request" "test" {
         key_name = "${aws_key_pair.test.key_name}"
         availability_zone = "${data.aws_availability_zones.available.names[0]}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
     spot_price = "0.7"
     target_capacity = 10
     valid_until = %[1]q
@@ -2150,16 +2129,16 @@ resource "aws_spot_fleet_request" "test" {
         availability_zone = "${data.aws_availability_zones.available.names[0]}"
         weighted_capacity = "3"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestEBSConfig(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestEBSConfig(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 1
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -2180,13 +2159,13 @@ resource "aws_spot_fleet_request" "test" {
         volume_size = "100"
         }
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestLaunchSpecificationEbsBlockDeviceKmsKeyId(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestLaunchSpecificationEbsBlockDeviceKmsKeyId(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 
@@ -2196,8 +2175,8 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_spot_fleet_request" "test" {
-  iam_fleet_role                      = "${aws_iam_role.test-role.arn}"
-  spot_price                          = "0.05"
+  iam_fleet_role                      = "${aws_iam_role.test.arn}"
+  spot_price                          = "0.005"
   target_capacity                     = 1
   terminate_instances_with_expiration = true
   valid_until                         = %[1]q
@@ -2222,13 +2201,13 @@ resource "aws_spot_fleet_request" "test" {
     }
   }
 
-  depends_on = ["aws_iam_policy_attachment.test-attach"]
+  depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil, rName)
 }
 
-func testAccAWSSpotFleetRequestLaunchSpecificationRootBlockDeviceKmsKeyId(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestLaunchSpecificationRootBlockDeviceKmsKeyId(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 
@@ -2238,8 +2217,8 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_spot_fleet_request" "test" {
-  iam_fleet_role                      = "${aws_iam_role.test-role.arn}"
-  spot_price                          = "0.05"
+  iam_fleet_role                      = "${aws_iam_role.test.arn}"
+  spot_price                          = "0.005"
   target_capacity                     = 1
   terminate_instances_with_expiration = true
   valid_until                         = %[1]q
@@ -2257,14 +2236,14 @@ resource "aws_spot_fleet_request" "test" {
     }
   }
 
-  depends_on = ["aws_iam_policy_attachment.test-attach"]
+  depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil, rName)
 }
 
-func testAccAWSSpotFleetRequestLaunchSpecificationWithInstanceStoreAmi(rName string, rInt int, validUntil string) string {
+func testAccAWSSpotFleetRequestLaunchSpecificationWithInstanceStoreAmi(rName string, validUntil string) string {
 	return testAccLatestAmazonLinuxHvmInstanceStoreAmiConfig() +
-		testAccAWSSpotFleetRequestConfigBase(rName, rInt) +
+		testAccAWSSpotFleetRequestConfigBase(rName) +
 		fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
@@ -2279,16 +2258,16 @@ resource "aws_spot_fleet_request" "test" {
 	  instance_type = "c3.large"
     }
 
-	depends_on = ["aws_iam_policy_attachment.test-attach"]
+	depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestTagsConfig(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestTagsConfig(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 1
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -2301,21 +2280,21 @@ resource "aws_spot_fleet_request" "test" {
             Second = "Terraform"
         }
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, validUntil)
 }
 
-func testAccAWSSpotFleetRequestTenancyGroupConfig(rName string, rInt int, validUntil string) string {
-	return testAccAWSSpotFleetRequestConfigBase(rName, rInt) + fmt.Sprintf(`
+func testAccAWSSpotFleetRequestTenancyGroupConfig(rName, validUntil string) string {
+	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_placement_group" "test" {
 	name     = "test-pg-%[1]s"
 	strategy = "cluster"
 }
 
 resource "aws_spot_fleet_request" "test" {
-    iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.05"
+    iam_fleet_role = "${aws_iam_role.test.arn}"
+    spot_price = "0.005"
     target_capacity = 2
     valid_until = %[2]q
     terminate_instances_with_expiration = true
@@ -2326,7 +2305,7 @@ resource "aws_spot_fleet_request" "test" {
 		placement_tenancy = "dedicated"
 		placement_group = "${aws_placement_group.test.name}"
     }
-    depends_on = ["aws_iam_policy_attachment.test-attach"]
+    depends_on = ["aws_iam_policy_attachment.test"]
 }
 `, rName, validUntil)
 }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1244,8 +1244,7 @@ func testAccPreCheckAWSEc2SpotFleetRequest(t *testing.T) {
 	}
 }
 
-func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
-	sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
+func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(sfr.SpotFleetRequestConfig.LaunchSpecifications) == 0 {
 			return errors.New("Missing launch specification")
@@ -1353,7 +1352,7 @@ func testAccAWSSpotFleetRequestConfig(rName, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1373,7 +1372,7 @@ func testAccAWSSpotFleetRequestConfigTags1(rName, validUntil, tagKey1, tagValue1
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1396,7 +1395,7 @@ func testAccAWSSpotFleetRequestConfigTags2(rName, validUntil, tagKey1, tagValue1
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1420,7 +1419,7 @@ func testAccAWSSpotFleetRequestConfigAssociatePublicIpAddress(rName, validUntil 
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.027"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1440,7 +1439,7 @@ func testAccAWSSpotFleetRequestConfigTargetCapacity(rName, validUntil string) st
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 3
     valid_until = %[1]q
     fleet_type = "request"
@@ -1467,7 +1466,7 @@ resource "aws_launch_template" "test" {
 
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = "${aws_iam_role.test.arn}"
-  spot_price                          = "0.005"
+  spot_price                          = "0.05"
   target_capacity                     = 2
   valid_until                         = %[1]q
   terminate_instances_with_expiration = true
@@ -1514,7 +1513,7 @@ resource "aws_launch_template" "test2" {
 
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = "${aws_iam_role.test.arn}"
-  spot_price                          = "0.005"
+  spot_price                          = "0.05"
   target_capacity                     = 2
   valid_until                         = %[1]q
   terminate_instances_with_expiration = true
@@ -1552,7 +1551,7 @@ resource "aws_launch_template" "test" {
 
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = "${aws_iam_role.test.arn}"
-  spot_price                          = "0.005"
+  spot_price                          = "0.05"
   target_capacity                     = 2
   valid_until                         = %[1]q
   terminate_instances_with_expiration = true
@@ -1586,7 +1585,7 @@ func testAccAWSSpotFleetRequestConfigExcessCapacityTermination(rName, validUntil
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 2
     excess_capacity_termination_policy = "NoTermination"
     valid_until = %[1]q
@@ -1606,7 +1605,7 @@ func testAccAWSSpotFleetRequestConfigFleetType(rName, validUntil string) string 
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     fleet_type = "request"
@@ -1667,7 +1666,7 @@ resource "aws_iam_instance_profile" "test-iam-instance-profile1" {
 
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[2]q
     terminate_instances_with_expiration = true
@@ -1688,7 +1687,7 @@ func testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName, validUntil string
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.01"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1707,7 +1706,7 @@ func testAccAWSSpotFleetRequestConfigWithAzs(rName, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1922,7 +1921,7 @@ func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName, validU
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.025"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1966,7 +1965,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.035"
+    spot_price = "0.05"
     target_capacity = 4
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -1992,7 +1991,7 @@ func testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName, validUntil strin
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.035"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -2138,7 +2137,7 @@ func testAccAWSSpotFleetRequestEBSConfig(rName, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 1
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -2176,7 +2175,7 @@ resource "aws_kms_key" "test" {
 
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = "${aws_iam_role.test.arn}"
-  spot_price                          = "0.005"
+  spot_price                          = "0.05"
   target_capacity                     = 1
   terminate_instances_with_expiration = true
   valid_until                         = %[1]q
@@ -2218,7 +2217,7 @@ resource "aws_kms_key" "test" {
 
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = "${aws_iam_role.test.arn}"
-  spot_price                          = "0.005"
+  spot_price                          = "0.05"
   target_capacity                     = 1
   terminate_instances_with_expiration = true
   valid_until                         = %[1]q
@@ -2267,7 +2266,7 @@ func testAccAWSSpotFleetRequestTagsConfig(rName, validUntil string) string {
 	return testAccAWSSpotFleetRequestConfigBase(rName) + fmt.Sprintf(`
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 1
     valid_until = %[1]q
     terminate_instances_with_expiration = true
@@ -2294,7 +2293,7 @@ resource "aws_placement_group" "test" {
 
 resource "aws_spot_fleet_request" "test" {
     iam_fleet_role = "${aws_iam_role.test.arn}"
-    spot_price = "0.005"
+    spot_price = "0.05"
     target_capacity = 2
     valid_until = %[2]q
     terminate_instances_with_expiration = true

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -269,7 +269,10 @@ func testAccCheckVolumeAttachmentDestroy(s *terraform.State) error {
 }
 
 func testAccVolumeAttachmentInstanceOnlyConfigBase(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -277,16 +280,6 @@ data "aws_availability_zones" "available" {
     name   = "opt-in-status"
     values = ["opt-in-not-required"]
   }
-}
-
-data "aws_ec2_instance_type_offering" "available" {
-  filter {
-    name   = "instance-type"
-    values = ["t3.micro", "t2.micro"]
-  }
-
-  location_type            = "availability-zone"
-  preferred_instance_types = ["t3.micro", "t2.micro"]
 }
 
 resource "aws_instance" "test" {
@@ -298,7 +291,7 @@ resource "aws_instance" "test" {
     Name = %[1]q
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccVolumeAttachmentConfigBase(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13083.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEIP_Instance_Reassociate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSEIP_Instance_Reassociate -timeout 120m
=== RUN   TestAccAWSEIP_Instance_Reassociate
=== PAUSE TestAccAWSEIP_Instance_Reassociate
=== CONT  TestAccAWSEIP_Instance_Reassociate
--- PASS: TestAccAWSEIP_Instance_Reassociate (188.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	188.142s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAMIFromInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAMIFromInstance_ -timeout 120m
=== RUN   TestAccAWSAMIFromInstance_basic
=== PAUSE TestAccAWSAMIFromInstance_basic
=== RUN   TestAccAWSAMIFromInstance_tags
=== PAUSE TestAccAWSAMIFromInstance_tags
=== CONT  TestAccAWSAMIFromInstance_basic
=== CONT  TestAccAWSAMIFromInstance_tags
--- PASS: TestAccAWSAMIFromInstance_basic (407.63s)
--- PASS: TestAccAWSAMIFromInstance_tags (422.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	422.794s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate -timeout 120m
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (240.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	240.738s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings -timeout 120m
=== RUN   TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings
=== PAUSE TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings
=== CONT  TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings
--- PASS: TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings (758.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	759.004s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSStorageGatewayGateway_GatewayType_FileS3'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSStorageGatewayGateway_GatewayType_FileS3 -timeout 120m
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_FileS3
=== PAUSE TestAccAWSStorageGatewayGateway_GatewayType_FileS3
=== CONT  TestAccAWSStorageGatewayGateway_GatewayType_FileS3
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_FileS3 (293.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	293.334s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSStorageGatewayGateway_GatewayType_Cached'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSStorageGatewayGateway_GatewayType_Cached -timeout 120m
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_Cached
=== PAUSE TestAccAWSStorageGatewayGateway_GatewayType_Cached
=== CONT  TestAccAWSStorageGatewayGateway_GatewayType_Cached
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Cached (267.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	267.986s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSpotFleetRequest_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSSpotFleetRequest_ -timeout 120m
=== RUN   TestAccAWSSpotFleetRequest_basic
=== PAUSE TestAccAWSSpotFleetRequest_basic
=== RUN   TestAccAWSSpotFleetRequest_tags
=== PAUSE TestAccAWSSpotFleetRequest_tags
=== RUN   TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== PAUSE TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== RUN   TestAccAWSSpotFleetRequest_launchTemplate
=== PAUSE TestAccAWSSpotFleetRequest_launchTemplate
=== RUN   TestAccAWSSpotFleetRequest_launchTemplate_multiple
=== PAUSE TestAccAWSSpotFleetRequest_launchTemplate_multiple
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateWithOverrides
=== PAUSE TestAccAWSSpotFleetRequest_launchTemplateWithOverrides
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (491.67s)
=== RUN   TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (459.29s)
=== RUN   TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== PAUSE TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== RUN   TestAccAWSSpotFleetRequest_fleetType
=== PAUSE TestAccAWSSpotFleetRequest_fleetType
=== RUN   TestAccAWSSpotFleetRequest_iamInstanceProfileArn
=== PAUSE TestAccAWSSpotFleetRequest_iamInstanceProfileArn
=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== PAUSE TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== RUN   TestAccAWSSpotFleetRequest_updateTargetCapacity
=== PAUSE TestAccAWSSpotFleetRequest_updateTargetCapacity
=== RUN   TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== PAUSE TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== PAUSE TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== RUN   TestAccAWSSpotFleetRequest_withoutSpotPrice
=== PAUSE TestAccAWSSpotFleetRequest_withoutSpotPrice
=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation
=== PAUSE TestAccAWSSpotFleetRequest_diversifiedAllocation
=== RUN   TestAccAWSSpotFleetRequest_multipleInstancePools
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstancePools
=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity
=== PAUSE TestAccAWSSpotFleetRequest_withWeightedCapacity
=== RUN   TestAccAWSSpotFleetRequest_withEBSDisk
=== PAUSE TestAccAWSSpotFleetRequest_withEBSDisk
=== RUN   TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
=== PAUSE TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
=== RUN   TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
=== PAUSE TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
=== RUN   TestAccAWSSpotFleetRequest_withTags
=== PAUSE TestAccAWSSpotFleetRequest_withTags
=== RUN   TestAccAWSSpotFleetRequest_placementTenancyAndGroup
=== PAUSE TestAccAWSSpotFleetRequest_placementTenancyAndGroup
=== RUN   TestAccAWSSpotFleetRequest_WithELBs
=== PAUSE TestAccAWSSpotFleetRequest_WithELBs
=== RUN   TestAccAWSSpotFleetRequest_WithTargetGroups
=== PAUSE TestAccAWSSpotFleetRequest_WithTargetGroups
=== RUN   TestAccAWSSpotFleetRequest_WithInstanceStoreAmi
--- SKIP: TestAccAWSSpotFleetRequest_WithInstanceStoreAmi (0.00s)
    resource_aws_spot_fleet_request_test.go:881: Test fails due to test harness constraints
=== RUN   TestAccAWSSpotFleetRequest_disappears
=== PAUSE TestAccAWSSpotFleetRequest_disappears
=== CONT  TestAccAWSSpotFleetRequest_basic
=== CONT  TestAccAWSSpotFleetRequest_disappears
--- PASS: TestAccAWSSpotFleetRequest_basic (275.55s)
=== CONT  TestAccAWSSpotFleetRequest_WithTargetGroups
--- PASS: TestAccAWSSpotFleetRequest_disappears (283.04s)
=== CONT  TestAccAWSSpotFleetRequest_WithELBs
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (309.71s)
=== CONT  TestAccAWSSpotFleetRequest_placementTenancyAndGroup
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (71.81s)
=== CONT  TestAccAWSSpotFleetRequest_withTags
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (464.89s)
=== CONT  TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (148.77s)
=== CONT  TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
--- PASS: TestAccAWSSpotFleetRequest_withTags (348.56s)
=== CONT  TestAccAWSSpotFleetRequest_withEBSDisk
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (149.58s)
=== CONT  TestAccAWSSpotFleetRequest_withWeightedCapacity
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (276.36s)
=== CONT  TestAccAWSSpotFleetRequest_multipleInstancePools
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (305.96s)
=== CONT  TestAccAWSSpotFleetRequest_diversifiedAllocation
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (322.14s)
=== CONT  TestAccAWSSpotFleetRequest_withoutSpotPrice
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (278.79s)
=== CONT  TestAccAWSSpotFleetRequest_overriddingSpotPrice
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (286.55s)
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (277.84s)
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (274.61s)
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (277.08s)
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (278.49s)
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (330.22s)
=== CONT  TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (246.91s)
=== CONT  TestAccAWSSpotFleetRequest_updateTargetCapacity
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (655.89s)
=== CONT  TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (806.86s)
=== CONT  TestAccAWSSpotFleetRequest_iamInstanceProfileArn
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (594.02s)
=== CONT  TestAccAWSSpotFleetRequest_fleetType
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (274.36s)
=== CONT  TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
--- PASS: TestAccAWSSpotFleetRequest_fleetType (267.13s)
=== CONT  TestAccAWSSpotFleetRequest_launchTemplateWithOverrides
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (247.06s)
=== CONT  TestAccAWSSpotFleetRequest_launchTemplate_multiple
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (276.99s)
=== CONT  TestAccAWSSpotFleetRequest_launchTemplate
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (277.20s)
=== CONT  TestAccAWSSpotFleetRequest_associatePublicIpAddress
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (265.37s)
=== CONT  TestAccAWSSpotFleetRequest_tags
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (269.71s)
--- PASS: TestAccAWSSpotFleetRequest_tags (331.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5851.188s
```
