### PR TITLE
service/rds: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_db_cluster_snapshot_test.go
+++ b/aws/resource_aws_db_cluster_snapshot_test.go
@@ -28,7 +28,7 @@ func TestAccAWSDBClusterSnapshot_basic(t *testing.T) {
 					testAccCheckDbClusterSnapshotExists(resourceName, &dbClusterSnapshot),
 					resource.TestCheckResourceAttrSet(resourceName, "allocated_storage"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zones.#"),
-					resource.TestMatchResourceAttr(resourceName, "db_cluster_snapshot_arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-snapshot:.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "db_cluster_snapshot_arn", "rds", regexp.MustCompile(fmt.Sprintf("cluster-snapshot:%s$", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "engine"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
@@ -177,7 +177,7 @@ resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
@@ -189,17 +189,17 @@ resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_db_subnet_group" "test" {
-  name       = %q
+  name       = %[1]q
   subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier   = %q
+  cluster_identifier   = %[1]q
   db_subnet_group_name = "${aws_db_subnet_group.test.name}"
   master_password      = "barbarbarbar"
   master_username      = "foo"
@@ -208,9 +208,9 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_db_cluster_snapshot" "test" {
   db_cluster_identifier          = "${aws_rds_cluster.test.id}"
-  db_cluster_snapshot_identifier = %q
+  db_cluster_snapshot_identifier = %[1]q
 }
-`, rName, rName, rName, rName, rName)
+`, rName)
 }
 
 func testAccAwsDbClusterSnapshotConfigTags1(rName, tagKey1, tagValue1 string) string {
@@ -228,7 +228,7 @@ resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
@@ -240,17 +240,17 @@ resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_db_subnet_group" "test" {
-  name       = %q
+  name       = %[1]q
   subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier   = %q
+  cluster_identifier   = %[1]q
   db_subnet_group_name = "${aws_db_subnet_group.test.name}"
   master_password      = "barbarbarbar"
   master_username      = "foo"
@@ -259,12 +259,12 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_db_cluster_snapshot" "test" {
   db_cluster_identifier          = "${aws_rds_cluster.test.id}"
-  db_cluster_snapshot_identifier = %q
+  db_cluster_snapshot_identifier = %[1]q
   tags = {
-    %q = %q
+    %[2]q = %[3]q
   }
 }
-`, rName, rName, rName, rName, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1)
 }
 
 func testAccAwsDbClusterSnapshotConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
@@ -282,7 +282,7 @@ resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
@@ -294,17 +294,17 @@ resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
-    Name = %q
+    Name = %[1]q
   }
 }
 
 resource "aws_db_subnet_group" "test" {
-  name       = %q
+  name       = %[1]q
   subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier   = %q
+  cluster_identifier   = %[1]q
   db_subnet_group_name = "${aws_db_subnet_group.test.name}"
   master_password      = "barbarbarbar"
   master_username      = "foo"
@@ -313,11 +313,11 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_db_cluster_snapshot" "test" {
   db_cluster_identifier          = "${aws_rds_cluster.test.id}"
-  db_cluster_snapshot_identifier = %q
+  db_cluster_snapshot_identifier = %[1]q
   tags = {
-    %q = %q
-    %q = %q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, rName, rName, rName, rName, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_db_event_subscription_test.go
+++ b/aws/resource_aws_db_event_subscription_test.go
@@ -28,7 +28,7 @@ func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
 				Config: testAccAWSDBEventSubscriptionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:[^:]+:es:%s$", subscriptionName))),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("es:%s$", subscriptionName))),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
 					resource.TestCheckResourceAttr(resourceName, "name", subscriptionName),
@@ -93,14 +93,10 @@ func TestAccAWSDBEventSubscription_withPrefix(t *testing.T) {
 				Config: testAccAWSDBEventSubscriptionConfigWithPrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						resourceName, "source_type", "db-instance"),
-					resource.TestMatchResourceAttr(
-						resourceName, "name", startsWithPrefix),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.Name", "name"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
+					resource.TestMatchResourceAttr(resourceName, "name", startsWithPrefix),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "name"),
 				),
 			},
 		},
@@ -122,14 +118,10 @@ func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
 				Config: testAccAWSDBEventSubscriptionConfigWithSourceIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						resourceName, "source_type", "db-parameter-group"),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
-					resource.TestCheckResourceAttr(
-						resourceName, "source_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "source_ids.#", "1"),
 				),
 			},
 			{
@@ -142,14 +134,10 @@ func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
 				Config: testAccAWSDBEventSubscriptionConfigUpdateSourceIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						resourceName, "source_type", "db-parameter-group"),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
-					resource.TestCheckResourceAttr(
-						resourceName, "source_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "source_ids.#", "2"),
 				),
 			},
 		},
@@ -171,12 +159,9 @@ func TestAccAWSDBEventSubscription_categoryUpdate(t *testing.T) {
 				Config: testAccAWSDBEventSubscriptionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						resourceName, "source_type", "db-instance"),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)),
 				),
 			},
 			{
@@ -189,10 +174,8 @@ func TestAccAWSDBEventSubscription_categoryUpdate(t *testing.T) {
 				Config: testAccAWSDBEventSubscriptionConfigUpdateCategories(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						resourceName, "source_type", "db-instance"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
 				),
 			},
 		},
@@ -275,11 +258,11 @@ func testAccCheckAWSDBEventSubscriptionDisappears(eventSubscription *rds.EventSu
 func testAccAWSDBEventSubscriptionConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic-%d"
+  name = "tf-acc-test-rds-event-subs-sns-topic-%[1]d"
 }
 
 resource "aws_db_event_subscription" "test" {
-  name        = "tf-acc-test-rds-event-subs-%d"
+  name        = "tf-acc-test-rds-event-subs-%[1]d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-instance"
 
@@ -295,7 +278,7 @@ resource "aws_db_event_subscription" "test" {
     Name = "name"
   }
 }
-`, rInt, rInt)
+`, rInt)
 }
 
 func testAccAWSDBEventSubscriptionConfigWithPrefix(rInt int) string {
@@ -327,11 +310,11 @@ resource "aws_db_event_subscription" "test" {
 func testAccAWSDBEventSubscriptionConfigUpdate(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic-%d"
+  name = "tf-acc-test-rds-event-subs-sns-topic-%[1]d"
 }
 
 resource "aws_db_event_subscription" "test" {
-  name        = "tf-acc-test-rds-event-subs-%d"
+  name        = "tf-acc-test-rds-event-subs-%[1]d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   enabled     = false
   source_type = "db-parameter-group"
@@ -344,23 +327,23 @@ resource "aws_db_event_subscription" "test" {
     Name = "new-name"
   }
 }
-`, rInt, rInt)
+`, rInt)
 }
 
 func testAccAWSDBEventSubscriptionConfigWithSourceIds(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic-%d"
+  name = "tf-acc-test-rds-event-subs-sns-topic-%[1]d"
 }
 
 resource "aws_db_parameter_group" "test" {
-  name        = "db-parameter-group-event-%d"
+  name        = "db-parameter-group-event-%[1]d"
   family      = "mysql5.6"
   description = "Test parameter group for terraform"
 }
 
 resource "aws_db_event_subscription" "test" {
-  name        = "tf-acc-test-rds-event-subs-with-ids-%d"
+  name        = "tf-acc-test-rds-event-subs-with-ids-%[1]d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-parameter-group"
   source_ids  = ["${aws_db_parameter_group.test.id}"]
@@ -373,29 +356,29 @@ resource "aws_db_event_subscription" "test" {
     Name = "name"
   }
 }
-`, rInt, rInt, rInt)
+`, rInt)
 }
 
 func testAccAWSDBEventSubscriptionConfigUpdateSourceIds(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic-%d"
+  name = "tf-acc-test-rds-event-subs-sns-topic-%[1]d"
 }
 
 resource "aws_db_parameter_group" "test" {
-  name        = "db-parameter-group-event-%d"
+  name        = "db-parameter-group-event-%[1]d"
   family      = "mysql5.6"
   description = "Test parameter group for terraform"
 }
 
 resource "aws_db_parameter_group" "test2" {
-  name        = "db-parameter-group-event-2-%d"
+  name        = "db-parameter-group-event-2-%[1]d"
   family      = "mysql5.6"
   description = "Test parameter group for terraform"
 }
 
 resource "aws_db_event_subscription" "test" {
-  name        = "tf-acc-test-rds-event-subs-with-ids-%d"
+  name        = "tf-acc-test-rds-event-subs-with-ids-%[1]d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-parameter-group"
   source_ids  = ["${aws_db_parameter_group.test.id}", "${aws_db_parameter_group.test2.id}"]
@@ -408,17 +391,17 @@ resource "aws_db_event_subscription" "test" {
     Name = "name"
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt)
 }
 
 func testAccAWSDBEventSubscriptionConfigUpdateCategories(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic-%d"
+  name = "tf-acc-test-rds-event-subs-sns-topic-%[1]d"
 }
 
 resource "aws_db_event_subscription" "test" {
-  name        = "tf-acc-test-rds-event-subs-%d"
+  name        = "tf-acc-test-rds-event-subs-%[1]d"
   sns_topic   = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-instance"
 
@@ -430,5 +413,5 @@ resource "aws_db_event_subscription" "test" {
     Name = "name"
   }
 }
-`, rInt, rInt)
+`, rInt)
 }

--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -88,24 +88,15 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "family", "mysql5.6"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.value", "utf8"),
-					resource.TestMatchResourceAttr(
-						resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", groupName))),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.value", "utf8"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("pg:%s$", groupName))),
 				),
 			},
 			{
@@ -118,32 +109,19 @@ func TestAccAWSDBParameterGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "family", "mysql5.6"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1706463059.name", "collation_connection"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1706463059.value", "utf8_unicode_ci"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2475805061.name", "collation_server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2475805061.value", "utf8_unicode_ci"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.value", "utf8"),
-					resource.TestMatchResourceAttr(
-						resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", groupName))),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1706463059.name", "collation_connection"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1706463059.value", "utf8_unicode_ci"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2475805061.name", "collation_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2475805061.value", "utf8_unicode_ci"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.value", "utf8"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("pg:%s$", groupName))),
 				),
 			},
 			{
@@ -398,8 +376,7 @@ func TestAccAWSDBParameterGroup_namePrefix(t *testing.T) {
 				Config: testAccDBParameterGroupConfig_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists("aws_db_parameter_group.test", &v),
-					resource.TestMatchResourceAttr(
-						"aws_db_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+					resource.TestMatchResourceAttr("aws_db_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
 				),
 			},
 		},
@@ -439,24 +416,15 @@ func TestAccAWSDBParameterGroup_withApplyMethod(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "family", "mysql5.6"),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Managed by Terraform"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.apply_method", "immediate"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.apply_method", "pending-reboot"),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.apply_method", "immediate"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.apply_method", "pending-reboot"),
 				),
 			},
 			{
@@ -483,10 +451,8 @@ func TestAccAWSDBParameterGroup_Only(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBParameterGroupAttributes(&v, groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "family", "mysql5.6"),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "mysql5.6"),
 				),
 			},
 			{
@@ -512,10 +478,8 @@ func TestAccAWSDBParameterGroup_MatchDefault(t *testing.T) {
 				Config: testAccAWSDBParameterGroupIncludeDefaultConfig(groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBParameterGroupExists(resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", groupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "family", "postgres9.4"),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "postgres9.4"),
 				),
 			},
 			{

--- a/aws/resource_aws_db_security_group_test.go
+++ b/aws/resource_aws_db_security_group_test.go
@@ -33,17 +33,12 @@ func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBSecurityGroupExists(resourceName, &v),
 					testAccCheckAWSDBSecurityGroupAttributes(&v),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:secgrp:.+`)),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", rName),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Managed by Terraform"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ingress.3363517775.cidr", "10.0.0.1/24"),
-					resource.TestCheckResourceAttr(
-						resourceName, "ingress.#", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "1"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("secgrp:%s$", rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "ingress.3363517775.cidr", "10.0.0.1/24"),
+					resource.TestCheckResourceAttr(resourceName, "ingress.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
 			{

--- a/aws/resource_aws_db_subnet_group_test.go
+++ b/aws/resource_aws_db_subnet_group_test.go
@@ -68,9 +68,6 @@ func testSweepRdsDbSubnetGroups(region string) error {
 func TestAccAWSDBSubnetGroup_basic(t *testing.T) {
 	var v rds.DBSubnetGroup
 
-	testCheck := func(*terraform.State) error {
-		return nil
-	}
 	resourceName := "aws_db_subnet_group.test"
 	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
 
@@ -82,23 +79,17 @@ func TestAccAWSDBSubnetGroup_basic(t *testing.T) {
 			{
 				Config: testAccDBSubnetGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDBSubnetGroupExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", rName),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Managed by Terraform"),
-					resource.TestMatchResourceAttr(
-						resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:subgrp:%s", rName))),
-					testCheck,
+					testAccCheckDBSubnetGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(fmt.Sprintf("subgrp:%s$", rName))),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"description"},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"description"},
 			},
 		},
 	})
@@ -116,10 +107,8 @@ func TestAccAWSDBSubnetGroup_namePrefix(t *testing.T) {
 			{
 				Config: testAccDBSubnetGroupConfig_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDBSubnetGroupExists(
-						resourceName, &v),
-					resource.TestMatchResourceAttr(
-						resourceName, "name", regexp.MustCompile("^tf_test-")),
+					testAccCheckDBSubnetGroupExists(resourceName, &v),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^tf_test-")),
 				),
 			},
 		},
@@ -138,8 +127,7 @@ func TestAccAWSDBSubnetGroup_generatedName(t *testing.T) {
 			{
 				Config: testAccDBSubnetGroupConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDBSubnetGroupExists(
-						resourceName, &v),
+					testAccCheckDBSubnetGroupExists(resourceName, &v),
 				),
 			},
 		},
@@ -164,21 +152,17 @@ func TestAccAWSDBSubnetGroup_withUndocumentedCharacters(t *testing.T) {
 			{
 				Config: testAccDBSubnetGroupConfig_withUnderscoresAndPeriodsAndSpaces,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDBSubnetGroupExists(
-						"aws_db_subnet_group.underscores", &v),
-					testAccCheckDBSubnetGroupExists(
-						"aws_db_subnet_group.periods", &v),
-					testAccCheckDBSubnetGroupExists(
-						"aws_db_subnet_group.spaces", &v),
+					testAccCheckDBSubnetGroupExists("aws_db_subnet_group.underscores", &v),
+					testAccCheckDBSubnetGroupExists("aws_db_subnet_group.periods", &v),
+					testAccCheckDBSubnetGroupExists("aws_db_subnet_group.spaces", &v),
 					testCheck,
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"description"},
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"description"},
 			},
 		},
 	})
@@ -197,10 +181,8 @@ func TestAccAWSDBSubnetGroup_updateDescription(t *testing.T) {
 			{
 				Config: testAccDBSubnetGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDBSubnetGroupExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Managed by Terraform"),
+					testAccCheckDBSubnetGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
 				),
 			},
 			{
@@ -213,10 +195,8 @@ func TestAccAWSDBSubnetGroup_updateDescription(t *testing.T) {
 			{
 				Config: testAccDBSubnetGroupConfig_updatedDescription(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDBSubnetGroupExists(
-						resourceName, &v),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "test description updated"),
+					testAccCheckDBSubnetGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description updated"),
 				),
 			},
 		},

--- a/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -98,27 +98,17 @@ func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-pg:.+`)),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", parameterGroupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "family", "aurora5.6"),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Test cluster parameter group for terraform"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "1"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("cluster-pg:%s", parameterGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "name", parameterGroupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "aurora5.6"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test cluster parameter group for terraform"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
 			{
@@ -131,34 +121,20 @@ func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", parameterGroupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "family", "aurora5.6"),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Test cluster parameter group for terraform"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1706463059.name", "collation_connection"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1706463059.value", "utf8_unicode_ci"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1708034931.name", "character_set_results"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.1708034931.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2475805061.name", "collation_server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2475805061.value", "utf8_unicode_ci"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name", parameterGroupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "aurora5.6"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test cluster parameter group for terraform"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1706463059.name", "collation_connection"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1706463059.value", "utf8_unicode_ci"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.name", "character_set_results"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.1708034931.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2475805061.name", "collation_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2475805061.value", "utf8_unicode_ci"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 				),
 			},
 			{
@@ -191,26 +167,16 @@ func TestAccAWSDBClusterParameterGroup_withApplyMethod(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestMatchResourceAttr(
-						resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-pg:.+`)),
-					resource.TestCheckResourceAttr(
-						resourceName, "name", parameterGroupName),
-					resource.TestCheckResourceAttr(
-						resourceName, "family", "aurora5.6"),
-					resource.TestCheckResourceAttr(
-						resourceName, "description", "Test cluster parameter group for terraform"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.name", "character_set_server"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2421266705.apply_method", "immediate"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.name", "character_set_client"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.value", "utf8"),
-					resource.TestCheckResourceAttr(
-						resourceName, "parameter.2478663599.apply_method", "pending-reboot"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("cluster-pg:%s", parameterGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "name", parameterGroupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "aurora5.6"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test cluster parameter group for terraform"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2421266705.apply_method", "immediate"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.2478663599.apply_method", "pending-reboot"),
 				),
 			},
 			{

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -102,7 +102,7 @@ func testSweepRdsClusters(region string) error {
 
 func TestAccAWSRDSCluster_basic(t *testing.T) {
 	var dbCluster rds.DBCluster
-	rInt := acctest.RandInt()
+	clusterName := acctest.RandomWithPrefix("tf-aurora-cluster")
 	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -111,10 +111,10 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterConfig(rInt),
+				Config: testAccAWSClusterConfig(clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster:.+`)),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("cluster:%s", clusterName)),
 					resource.TestCheckResourceAttr(resourceName, "backtrack_window", "0"),
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_snapshot", "false"),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
@@ -2141,17 +2141,17 @@ func TestAccAWSRDSCluster_EnableHttpEndpoint(t *testing.T) {
 	})
 }
 
-func testAccAWSClusterConfig(n int) string {
+func testAccAWSClusterConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
-  cluster_identifier              = "tf-aurora-cluster-%d"
+  cluster_identifier              = %[1]q
   database_name                   = "mydb"
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.aurora5.6"
   skip_final_snapshot             = true
 }
-`, n)
+`, rName)
 }
 
 func testAccAWSClusterConfig_AvailabilityZones(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_db_cluster_snapshot_test.go:31:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_db_event_subscription_test.go:31:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_db_parameter_group_test.go:107:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_db_parameter_group_test.go:145:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_db_security_group_test.go:36:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_db_subnet_group_test.go:91:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_rds_cluster_parameter_group_test.go:101:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_rds_cluster_parameter_group_test.go:194:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_rds_cluster_test.go:117:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSDBParameterGroup_Disappears (11.08s)
--- PASS: TestAccAWSDBSecurityGroup_basic (35.35s)
--- PASS: TestAccAWSDBParameterGroup_namePrefix (26.89s)
--- PASS: TestAccAWSDBParameterGroup_withApplyMethod (31.58s)
--- PASS: TestAccAWSDBParameterGroup_MatchDefault (32.22s)
--- PASS: TestAccAWSDBParameterGroup_generatedName (34.56s)
--- PASS: TestAccAWSDBSubnetGroup_generatedName (53.08s)
--- PASS: TestAccAWSDBParameterGroup_Only (54.63s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (22.43s)
--- PASS: TestAccAWSDBSubnetGroup_updateDescription (48.06s)
--- PASS: TestAccAWSDBParameterGroup_basic (59.63s)
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (7.42s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (9.09s)
--- PASS: TestAccAWSDBSubnetGroup_namePrefix (63.18s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (43.46s)
--- PASS: TestAccAWSDBEventSubscription_withPrefix (77.61s)
--- PASS: TestAccAWSDBClusterParameterGroup_only (22.80s)
--- PASS: TestAccAWSDBEventSubscription_disappears (85.61s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (3.42s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (68.62s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (69.33s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (89.78s)
--- PASS: TestAccAWSDBParameterGroup_limit (109.74s)
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (121.01s)
--- PASS: TestAccAWSDBSubnetGroup_basic (122.58s)
--- PASS: TestAccAWSDBEventSubscription_basicUpdate (129.53s)
--- PASS: TestAccAWSDBEventSubscription_withSourceIds (133.72s)
--- PASS: TestAccAWSDBClusterSnapshot_basic (152.30s)
--- PASS: TestAccAWSDBEventSubscription_categoryUpdate (164.20s)
--- PASS: TestAccAWSRDSCluster_basic (112.91s)
--- PASS: TestAccAWSRDSCluster_generatedName (102.21s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (137.40s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (152.61s)
--- PASS: TestAccAWSRDSCluster_Tags (126.67s)
--- PASS: TestAccAWSDBClusterSnapshot_Tags (217.04s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (117.47s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (158.75s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (140.99s)
--- PASS: TestAccAWSRDSCluster_kmsKey (128.90s)
--- PASS: TestAccAWSRDSCluster_encrypted (124.84s)
--- PASS: TestAccAWSRDSCluster_iamAuth (109.76s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (179.74s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (129.93s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (123.73s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (175.81s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (184.71s)
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (165.81s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (139.61s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (122.40s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update (117.23s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove (119.07s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global (124.70s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add (124.27s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned (134.45s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (308.47s)
--- PASS: TestAccAWSRDSCluster_Port (256.83s)
--- PASS: TestAccAWSRDSCluster_EngineMode (389.86s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (328.03s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (378.84s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (331.25s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (348.17s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (338.09s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (338.59s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (338.26s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (374.67s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (338.47s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (349.55s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (358.83s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (349.85s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (378.67s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (358.29s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (479.55s)
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (369.82s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1066.48s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1546.47s)
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1649.47s)
```

`TestAccAWSRDSCluster_s3Restore` is a pre-existing failure