### PR TITLE
Fix tfproviderlint AWSR002 errors

### DIFF
--- a/aws/data_source_aws_backup_plan.go
+++ b/aws/data_source_aws_backup_plan.go
@@ -36,6 +36,8 @@ func dataSourceAwsBackupPlan() *schema.Resource {
 
 func dataSourceAwsBackupPlanRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).backupconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
 	id := d.Get("plan_id").(string)
 
 	resp, err := conn.GetBackupPlan(&backup.GetBackupPlanInput{
@@ -54,7 +56,7 @@ func dataSourceAwsBackupPlanRead(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return fmt.Errorf("error listing tags for Backup Plan (%s): %s", id, err)
 	}
-	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/data_source_aws_backup_vault.go
+++ b/aws/data_source_aws_backup_vault.go
@@ -36,6 +36,8 @@ func dataSourceAwsBackupVault() *schema.Resource {
 
 func dataSourceAwsBackupVaultRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).backupconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
 	name := d.Get("name").(string)
 	input := &backup.DescribeBackupVaultInput{
 		BackupVaultName: aws.String(name),
@@ -56,7 +58,7 @@ func dataSourceAwsBackupVaultRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return fmt.Errorf("error listing tags for Backup Vault (%s): %s", name, err)
 	}
-	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/13039.
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/13035.

Fixes

```console
$ make lint
==> Checking source code against linters...
/home/kit/wrk/src/github.com/terraform-providers/terraform-provider-aws/aws/data_source_aws_backup_plan.go:57:26: AWSR002: missing (keyvaluetags.KeyValueTags).IgnoreConfig()
56		}
57		if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
58			return fmt.Errorf("error setting tags: %s", err)
/home/kit/wrk/src/github.com/terraform-providers/terraform-provider-aws/aws/data_source_aws_backup_vault.go:59:26: AWSR002: missing (keyvaluetags.KeyValueTags).IgnoreConfig()
58		}
59		if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
60			return fmt.Errorf("error setting tags: %s", err)
GNUmakefile:60: recipe for target 'lint' failed
make: *** [lint] Error 3
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
