### PR TITLE
rd/ebs_volume - support multi attach

### DIFF
--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -38,6 +38,10 @@ func dataSourceAwsEbsVolume() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"multi_attach": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"volume_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -145,6 +149,7 @@ func volumeDescriptionAttributes(d *schema.ResourceData, client *AWSClient, volu
 	d.Set("snapshot_id", volume.SnapshotId)
 	d.Set("volume_type", volume.VolumeType)
 	d.Set("outpost_arn", volume.OutpostArn)
+	d.Set("multi_attach", volume.MultiAttachEnabled)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().IgnoreConfig(client.IgnoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/data_source_aws_ebs_volume.go
+++ b/aws/data_source_aws_ebs_volume.go
@@ -38,7 +38,7 @@ func dataSourceAwsEbsVolume() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"multi_attach": {
+			"multi_attach_enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
@@ -149,7 +149,7 @@ func volumeDescriptionAttributes(d *schema.ResourceData, client *AWSClient, volu
 	d.Set("snapshot_id", volume.SnapshotId)
 	d.Set("volume_type", volume.VolumeType)
 	d.Set("outpost_arn", volume.OutpostArn)
-	d.Set("multi_attach", volume.MultiAttachEnabled)
+	d.Set("multi_attach_enabled", volume.MultiAttachEnabled)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().IgnoreConfig(client.IgnoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -44,7 +44,7 @@ func TestAccAWSEbsVolumeDataSource_multipleFilters(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEbsVolumeDataSourceID(dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "size", resourceName, "size"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "volume_type", resourceName, "volume_type"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume_type", "gp2"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
 				),
 			},

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -24,7 +24,7 @@ func TestAccAWSEbsVolumeDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "size", resourceName, "size"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "outpost_arn", resourceName, "outpost_arn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "multi_attach", resourceName, "multi_attach"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "multi_attach_enabled", resourceName, "multi_attach_enabled"),
 				),
 			},
 		},

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -117,7 +117,7 @@ resource "aws_ebs_volume" "test" {
   }
 }
 
-data "aws_ebs_volume" "ebs_volume" {
+data "aws_ebs_volume" "test" {
   most_recent = true
   filter {
     name = "tag:Name"

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestAccAWSEbsVolumeDataSource_basic(t *testing.T) {
+	resourceName := "aws_ebs_volume.test"
+	dataSourceName := "data.aws_ebs_volume.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -16,12 +19,12 @@ func TestAccAWSEbsVolumeDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsEbsVolumeDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsEbsVolumeDataSourceID("data.aws_ebs_volume.ebs_volume"),
-					resource.TestCheckResourceAttrSet("data.aws_ebs_volume.ebs_volume", "arn"),
-					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "size", "40"),
-					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.%", "1"),
-					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.Name", "External Volume"),
-					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "outpost_arn", ""),
+					testAccCheckAwsEbsVolumeDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "size", resourceName, "size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "outpost_arn", resourceName, "outpost_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "multi_attach", resourceName, "multi_attach"),
 				),
 			},
 		},
@@ -29,6 +32,9 @@ func TestAccAWSEbsVolumeDataSource_basic(t *testing.T) {
 }
 
 func TestAccAWSEbsVolumeDataSource_multipleFilters(t *testing.T) {
+	resourceName := "aws_ebs_volume.test"
+	dataSourceName := "data.aws_ebs_volume.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -36,11 +42,10 @@ func TestAccAWSEbsVolumeDataSource_multipleFilters(t *testing.T) {
 			{
 				Config: testAccCheckAwsEbsVolumeDataSourceConfigWithMultipleFilters,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsEbsVolumeDataSourceID("data.aws_ebs_volume.ebs_volume"),
-					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "size", "10"),
-					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "volume_type", "gp2"),
-					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.%", "1"),
-					resource.TestCheckResourceAttr("data.aws_ebs_volume.ebs_volume", "tags.Name", "External Volume 1"),
+					testAccCheckAwsEbsVolumeDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "size", resourceName, "size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "volume_type", resourceName, "volume_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags", resourceName, "tags"),
 				),
 			},
 		},
@@ -71,7 +76,7 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_ebs_volume" "example" {
+resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
   size = 40
@@ -80,7 +85,7 @@ resource "aws_ebs_volume" "example" {
   }
 }
 
-data "aws_ebs_volume" "ebs_volume" {
+data "aws_ebs_volume" "test" {
   most_recent = true
   filter {
     name = "tag:Name"
@@ -88,7 +93,7 @@ data "aws_ebs_volume" "ebs_volume" {
   }
   filter {
     name = "volume-type"
-    values = ["${aws_ebs_volume.example.type}"]
+    values = ["${aws_ebs_volume.test.type}"]
   }
 }
 `
@@ -103,7 +108,7 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_ebs_volume" "external1" {
+resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
   size = 10
@@ -120,11 +125,11 @@ data "aws_ebs_volume" "ebs_volume" {
   }
   filter {
     name = "size"
-    values = ["${aws_ebs_volume.external1.size}"]
+    values = ["${aws_ebs_volume.test.size}"]
   }
   filter {
     name = "volume-type"
-    values = ["${aws_ebs_volume.external1.type}"]
+    values = ["${aws_ebs_volume.test.type}"]
   }
 }
 `

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -56,6 +56,12 @@ func resourceAwsEbsVolume() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateArn,
 			},
+			"multi_attach": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"size": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -102,6 +108,9 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	if value, ok := d.GetOk("snapshot_id"); ok {
 		request.SnapshotId = aws.String(value.(string))
 	}
+	if value, ok := d.GetOk("multi_attach"); ok {
+		request.MultiAttachEnabled = aws.Bool(value.(bool))
+	}
 	if value, ok := d.GetOk("outpost_arn"); ok {
 		request.OutpostArn = aws.String(value.(string))
 	}
@@ -117,9 +126,9 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	iops := d.Get("iops").(int)
-	if t != "io1" && iops > 0 {
+	if t != ec2.VolumeTypeIo1 && iops > 0 {
 		log.Printf("[WARN] IOPs is only valid for storate type io1 for EBS Volumes")
-	} else if t == "io1" {
+	} else if t == ec2.VolumeTypeIo1 {
 		// We add the iops value without validating it's size, to allow AWS to
 		// enforce a size requirement (currently 100)
 		request.Iops = aws.Int64(int64(iops))
@@ -135,8 +144,8 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	log.Println("[DEBUG] Waiting for Volume to become available")
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"creating"},
-		Target:     []string{"available"},
+		Pending:    []string{ec2.VolumeStateCreating},
+		Target:     []string{ec2.VolumeStateAvailable},
 		Refresh:    volumeStateRefreshFunc(conn, *result.VolumeId),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,
@@ -185,8 +194,8 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"creating", "modifying"},
-			Target:     []string{"available", "in-use"},
+			Pending:    []string{ec2.VolumeStateCreating, ec2.VolumeModificationStateModifying},
+			Target:     []string{ec2.VolumeStateAvailable, ec2.VolumeStateInUse},
 			Refresh:    volumeStateRefreshFunc(conn, *result.VolumeModification.VolumeId),
 			Timeout:    5 * time.Minute,
 			Delay:      10 * time.Second,
@@ -247,7 +256,7 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 
 	response, err := conn.DescribeVolumes(request)
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVolume.NotFound" {
+		if isAWSErr(err, "InvalidVolume.NotFound", "") {
 			d.SetId("")
 			return nil
 		}
@@ -275,6 +284,7 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("size", aws.Int64Value(volume.Size))
 	d.Set("snapshot_id", aws.StringValue(volume.SnapshotId))
 	d.Set("outpost_arn", aws.StringValue(volume.OutpostArn))
+	d.Set("multi_attach", volume.MultiAttachEnabled)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -56,10 +56,9 @@ func resourceAwsEbsVolume() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateArn,
 			},
-			"multi_attach": {
+			"multi_attach_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
 			},
 			"size": {
@@ -108,7 +107,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	if value, ok := d.GetOk("snapshot_id"); ok {
 		request.SnapshotId = aws.String(value.(string))
 	}
-	if value, ok := d.GetOk("multi_attach"); ok {
+	if value, ok := d.GetOk("multi_attach_enabled"); ok {
 		request.MultiAttachEnabled = aws.Bool(value.(bool))
 	}
 	if value, ok := d.GetOk("outpost_arn"); ok {
@@ -284,7 +283,7 @@ func resourceAwsEbsVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("size", aws.Int64Value(volume.Size))
 	d.Set("snapshot_id", aws.StringValue(volume.SnapshotId))
 	d.Set("outpost_arn", aws.StringValue(volume.OutpostArn))
-	d.Set("multi_attach", volume.MultiAttachEnabled)
+	d.Set("multi_attach_enabled", volume.MultiAttachEnabled)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(volume.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -375,6 +375,27 @@ func TestAccAWSEBSVolume_outpost(t *testing.T) {
 	})
 }
 
+func TestAccAWSEBSVolume_disappears(t *testing.T) {
+	var v ec2.Volume
+	resourceName := "aws_ebs_volume.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEbsVolumeConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEbsVolume(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckVolumeDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -329,7 +329,7 @@ func TestAccAWSEBSVolume_multiAttach(t *testing.T) {
 				Config: testAccAwsEbsVolumeConfigMultiAttach(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "multi_attach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "multi_attach", "true"),
 				),
 			},
 			{

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -317,6 +317,7 @@ func TestAccAWSEBSVolume_withTags(t *testing.T) {
 func TestAccAWSEBSVolume_multiAttach(t *testing.T) {
 	var v ec2.Volume
 	resourceName := "aws_ebs_volume.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -325,7 +326,7 @@ func TestAccAWSEBSVolume_multiAttach(t *testing.T) {
 		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsEbsVolumeConfigMultiAttach,
+				Config: testAccAwsEbsVolumeConfigMultiAttach(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "multi_attach", "false"),
@@ -750,7 +751,8 @@ resource "aws_ebs_volume" "test" {
 `, outpostArn)
 }
 
-const testAccAwsEbsVolumeConfigMultiAttach = `
+func testAccAwsEbsVolumeConfigMultiAttach(rName string) string {
+	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -762,8 +764,14 @@ data "aws_availability_zones" "available" {
 
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  type         = "io1"
-  multi_attach = true
-  size         = 1
+  type              = "io1"
+  multi_attach      = true
+  size              = 4
+  iops              = 100
+
+  tags = {
+    Name = %[1]q
+  }
 }
-`
+`, rName)
+}

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -89,7 +89,7 @@ func TestAccAWSEBSVolume_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "gp2"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
-					resource.TestCheckResourceAttr(resourceName, "multi_attach", "false"),
+					resource.TestCheckResourceAttr(resourceName, "multi_attach_enabled", "false"),
 				),
 			},
 			{
@@ -329,7 +329,7 @@ func TestAccAWSEBSVolume_multiAttach(t *testing.T) {
 				Config: testAccAwsEbsVolumeConfigMultiAttach(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "multi_attach", "true"),
+					resource.TestCheckResourceAttr(resourceName, "multi_attach_enabled", "true"),
 				),
 			},
 			{
@@ -764,10 +764,10 @@ data "aws_availability_zones" "available" {
 
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  type              = "io1"
-  multi_attach      = true
-  size              = 4
-  iops              = 100
+  type                 = "io1"
+  multi_attach_enabled = true
+  size                 = 4
+  iops                 = 100
 
   tags = {
     Name = %[1]q

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -50,7 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 * `availability_zone` - The AZ where the EBS volume exists.
 * `encrypted` - Whether the disk is encrypted.
 * `iops` - The amount of IOPS for the disk.
-* `multi_attach` - (Optional) Specifies whether Amazon EBS Multi-Attach is enabled.
+* `multi_attach_enabled` - (Optional) Specifies whether Amazon EBS Multi-Attach is enabled.
 * `size` - The size of the drive in GiBs.
 * `snapshot_id` - The snapshot_id the EBS volume is based off.
 * `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -50,6 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 * `availability_zone` - The AZ where the EBS volume exists.
 * `encrypted` - Whether the disk is encrypted.
 * `iops` - The amount of IOPS for the disk.
+* `multi_attach` - (Optional) Specifies whether Amazon EBS Multi-Attach is enabled.
 * `size` - The size of the drive in GiBs.
 * `snapshot_id` - The snapshot_id the EBS volume is based off.
 * `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `availability_zone` - (Required) The AZ where the EBS volume will exist.
 * `encrypted` - (Optional) If true, the disk will be encrypted.
 * `iops` - (Optional) The amount of IOPS to provision for the disk.
-* `multi_attach` - (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported exclusively on `io1` volumes.
+* `multi_attach_enabled` - (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported exclusively on `io1` volumes.
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
 * `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost.

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 * `availability_zone` - (Required) The AZ where the EBS volume will exist.
 * `encrypted` - (Optional) If true, the disk will be encrypted.
 * `iops` - (Optional) The amount of IOPS to provision for the disk.
+* `multi_attach` - (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported exclusively on `io1` volumes.
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
 * `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13104

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ebs_volume: support multi attach
data_source_aws_ebs_volume: support multi attach
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEBSVolume_'
--- PASS: TestAccAWSEBSVolume_basic (66.31s)
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (295.79s)
--- PASS: TestAccAWSEBSVolume_updateSize (132.89s)
--- PASS: TestAccAWSEBSVolume_updateType (129.24s)
--- PASS: TestAccAWSEBSVolume_updateIops (135.13s)
--- PASS: TestAccAWSEBSVolume_kmsKey (115.12s)
--- PASS: TestAccAWSEBSVolume_NoIops (70.87s)
--- PASS: TestAccAWSEBSVolume_withTags (63.95s)
--- PASS: TestAccAWSEBSVolume_multiAttach (66.32s)

--- PASS: TestAccAWSEbsVolumeDataSource_basic (77.00s)
--- PASS: TestAccAWSEbsVolumeDataSource_multipleFilters (81.83s)

```
