### PR TITLE
resource/aws_glue_trigger: Remove incorrectly implemented ConflictsWith

### DIFF
--- a/aws/resource_aws_glue_trigger.go
+++ b/aws/resource_aws_glue_trigger.go
@@ -102,9 +102,8 @@ func resourceAwsGlueTrigger() *schema.Resource {
 										}, false),
 									},
 									"state": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"predicate.0.conditions.0.crawl_state"},
+										Type:     schema.TypeString,
+										Optional: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											glue.JobRunStateFailed,
 											glue.JobRunStateStopped,
@@ -113,9 +112,8 @@ func resourceAwsGlueTrigger() *schema.Resource {
 										}, false),
 									},
 									"crawl_state": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"predicate.0.conditions.0.state"},
+										Type:     schema.TypeString,
+										Optional: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											glue.CrawlStateRunning,
 											glue.CrawlStateSucceeded,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Fixes an upcoming `schema.InternalValidate()` failure in the next minor version of the SDK. Future failures will be caught via unit testing once we have updated. `ConflictsWith` should only be used with `Type: TypeList` and `MaxItems: 1` configuration blocks. Since `conditions` is expected to have at least one element, we do not want the schema to reflect functionality that may not work as expected after the first element.

Output from acceptance testing:

```
--- PASS: TestAccAWSGlueTrigger_Basic (23.50s)
--- PASS: TestAccAWSGlueTrigger_WorkflowName (23.77s)
--- PASS: TestAccAWSGlueTrigger_Description (36.48s)
--- PASS: TestAccAWSGlueTrigger_Tags (53.76s)
--- PASS: TestAccAWSGlueTrigger_Predicate (74.52s)
--- PASS: TestAccAWSGlueTrigger_Schedule (74.80s)
--- PASS: TestAccAWSGlueTrigger_Crawler (85.77s)
--- PASS: TestAccAWSGlueTrigger_Enabled (87.89s)
```
