### PR TITLE
service/waf, service/wafregional: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_waf_ipset_test.go
+++ b/aws/resource_aws_waf_ipset_test.go
@@ -32,7 +32,7 @@ func TestAccAWSWafIPSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.type", "IPV4"),
 					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
-					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "waf", regexp.MustCompile(`ipset/.+`)),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "waf", regexp.MustCompile("ipset/.+$")),
 				),
 			},
 			{

--- a/aws/resource_aws_wafregional_ipset_test.go
+++ b/aws/resource_aws_wafregional_ipset_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestAccAWSWafRegionalIPSet_basic(t *testing.T) {
+	resourceName := "aws_wafregional_ipset.ipset"
 	var v waf.IPSet
 	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
 
@@ -30,19 +31,15 @@ func TestAccAWSWafRegionalIPSet_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalIPSetConfig(ipsetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &v),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
-					resource.TestMatchResourceAttr("aws_wafregional_ipset.ipset", "arn",
-						regexp.MustCompile(`^arn:[\w-]+:waf-regional:[^:]+:\d{12}:ipset/.+$`)),
+					testAccCheckAWSWafRegionalIPSetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "waf-regional", regexp.MustCompile("ipset/.+$")),
 				),
 			},
 			{
-				ResourceName:      "aws_wafregional_ipset.ipset",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -84,24 +81,18 @@ func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
 				Config: testAccAWSWafRegionalIPSetConfig(ipsetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &before),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetName),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalIPSetConfigChangeName(ipsetNewName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &after),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "name", ipsetNewName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetNewName),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
@@ -126,28 +117,20 @@ func TestAccAWSWafRegionalIPSet_changeDescriptors(t *testing.T) {
 				Config: testAccAWSWafRegionalIPSetConfig(ipsetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &before),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetName),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "1"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalIPSetConfigChangeIPSetDescriptors(ipsetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &after),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.type", "IPV4"),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.value", "192.0.8.0/24"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetName),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "1"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.type", "IPV4"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.value", "192.0.8.0/24"),
 				),
 			},
 			{
@@ -217,10 +200,8 @@ func TestAccAWSWafRegionalIPSet_noDescriptors(t *testing.T) {
 				Config: testAccAWSWafRegionalIPSetConfig_noDescriptors(ipsetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &ipset),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "0"),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetName),
+					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "0"),
 				),
 			},
 			{

--- a/aws/resource_aws_wafregional_ipset_test.go
+++ b/aws/resource_aws_wafregional_ipset_test.go
@@ -48,6 +48,7 @@ func TestAccAWSWafRegionalIPSet_basic(t *testing.T) {
 }
 
 func TestAccAWSWafRegionalIPSet_disappears(t *testing.T) {
+	resourceName := "aws_wafregional_ipset.ipset"
 	var v waf.IPSet
 	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
@@ -58,7 +59,7 @@ func TestAccAWSWafRegionalIPSet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalIPSetConfig(ipsetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &v),
+					testAccCheckAWSWafRegionalIPSetExists(resourceName, &v),
 					testAccCheckAWSWafRegionalIPSetDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -68,6 +69,7 @@ func TestAccAWSWafRegionalIPSet_disappears(t *testing.T) {
 }
 
 func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
+	resourceName := "aws_wafregional_ipset.ipset"
 	var before, after waf.IPSet
 	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
 	ipsetNewName := fmt.Sprintf("ip-set-new-%s", acctest.RandString(5))
@@ -80,23 +82,23 @@ func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalIPSetConfig(ipsetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &before),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+					testAccCheckAWSWafRegionalIPSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalIPSetConfigChangeName(ipsetNewName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &after),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetNewName),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+					testAccCheckAWSWafRegionalIPSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", ipsetNewName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
-				ResourceName:      "aws_wafregional_ipset.ipset",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -105,6 +107,7 @@ func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
 }
 
 func TestAccAWSWafRegionalIPSet_changeDescriptors(t *testing.T) {
+	resourceName := "aws_wafregional_ipset.ipset"
 	var before, after waf.IPSet
 	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
 
@@ -116,25 +119,25 @@ func TestAccAWSWafRegionalIPSet_changeDescriptors(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalIPSetConfig(ipsetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &before),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "1"),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+					testAccCheckAWSWafRegionalIPSetExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.4037960608.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalIPSetConfigChangeIPSetDescriptors(ipsetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &after),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "1"),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.type", "IPV4"),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.value", "192.0.8.0/24"),
+					testAccCheckAWSWafRegionalIPSetExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.115741513.type", "IPV4"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.115741513.value", "192.0.8.0/24"),
 				),
 			},
 			{
-				ResourceName:      "aws_wafregional_ipset.ipset",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -188,6 +191,7 @@ func TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit(t *testing.T) {
 }
 
 func TestAccAWSWafRegionalIPSet_noDescriptors(t *testing.T) {
+	resourceName := "aws_wafregional_ipset.ipset"
 	var ipset waf.IPSet
 	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
 
@@ -199,13 +203,13 @@ func TestAccAWSWafRegionalIPSet_noDescriptors(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalIPSetConfig_noDescriptors(ipsetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &ipset),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "name", ipsetName),
-					resource.TestCheckResourceAttr("aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "0"),
+					testAccCheckAWSWafRegionalIPSetExists(resourceName, &ipset),
+					resource.TestCheckResourceAttr(resourceName, "name", ipsetName),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_wafregional_ipset.ipset",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_wafregional_ipset_test.go:40:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSWafRegionalIPSet_noDescriptors (19.48s)
--- PASS: TestAccAWSWafIPSet_noDescriptors (23.33s)
--- PASS: TestAccAWSWafRegionalIPSet_disappears (25.32s)
--- PASS: TestAccAWSWafRegionalIPSet_basic (31.36s)
--- PASS: TestAccAWSWafIPSet_disappears (36.46s)
--- PASS: TestAccAWSWafRegionalIPSet_changeDescriptors (40.47s)
--- PASS: TestAccAWSWafIPSet_ipv6 (40.95s)
--- PASS: TestAccAWSWafIPSet_basic (44.65s)
--- PASS: TestAccAWSWafRegionalIPSet_changeNameForceNew (45.09s)
--- PASS: TestAccAWSWafIPSet_changeDescriptors (45.78s)
--- PASS: TestAccAWSWafIPSet_changeNameForceNew (62.03s)
--- PASS: TestAccAWSWafRegionalIPSet_IpSetDescriptors_1000UpdateLimit (67.46s)
--- PASS: TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit (81.73s)
```
