### PR TITLE
Fix acceptance test error for aws_sns_sms_preferences

### DIFF
--- a/aws/resource_aws_sns_sms_preferences.go
+++ b/aws/resource_aws_sns_sms_preferences.go
@@ -14,7 +14,7 @@ import (
 func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error) {
 	vInt, _ := strconv.Atoi(v.(string))
 	if vInt < 0 {
-		errors = append(errors, fmt.Errorf("Error setting SMS preferences: monthly spend limit value [%d] must be >= 0!", vInt))
+		errors = append(errors, fmt.Errorf("error setting SMS preferences: monthly spend limit value [%d] must be >= 0", vInt))
 	}
 	return
 }
@@ -22,7 +22,7 @@ func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error)
 func validateDeliverySamplingRate(v interface{}, k string) (ws []string, errors []error) {
 	vInt, _ := strconv.Atoi(v.(string))
 	if vInt < 0 || vInt > 100 {
-		errors = append(errors, fmt.Errorf("Error setting SMS preferences: default percentage of success to sample value [%d] must be between 0 and 100!", vInt))
+		errors = append(errors, fmt.Errorf("error setting SMS preferences: default percentage of success to sample value [%d] must be between 0 and 100", vInt))
 	}
 	return
 }
@@ -154,12 +154,14 @@ func resourceAwsSnsSmsPreferencesDelete(d *schema.ResourceData, meta interface{}
 	// Reset the attributes to their default value
 	attrs := map[string]*string{}
 	for tfAttrName, defValue := range smsAttributeDefaultValues {
-		attrs[smsAttributeMap[tfAttrName]] = &defValue
+		attrs[smsAttributeMap[tfAttrName]] = aws.String(defValue)
 	}
 
-	params := &sns.SetSMSAttributesInput{Attributes: attrs}
+	params := &sns.SetSMSAttributesInput{
+		Attributes: attrs,
+	}
 	if _, err := snsconn.SetSMSAttributes(params); err != nil {
-		return fmt.Errorf("Error resetting SMS preferences: %s", err)
+		return fmt.Errorf("Error resetting SMS preferences: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_sns_sms_preferences_test.go
+++ b/aws/resource_aws_sns_sms_preferences_test.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -29,6 +29,8 @@ func TestAccAWSSNSSMSPreferences(t *testing.T) {
 }
 
 func testAccAWSSNSSMSPreferences_empty(t *testing.T) {
+	resourceName := "aws_sns_sms_preferences.test_pref"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -37,12 +39,12 @@ func testAccAWSSNSSMSPreferences_empty(t *testing.T) {
 			{
 				Config: testAccAWSSNSSMSPreferencesConfig_empty,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "monthly_spend_limit"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "delivery_status_iam_role_arn"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "delivery_status_success_sampling_rate"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "default_sender_id"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "default_sms_type"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "usage_report_s3_bucket"),
+					resource.TestCheckNoResourceAttr(resourceName, "monthly_spend_limit"),
+					resource.TestCheckNoResourceAttr(resourceName, "delivery_status_iam_role_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, "delivery_status_success_sampling_rate"),
+					resource.TestCheckNoResourceAttr(resourceName, "default_sender_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "default_sms_type"),
+					resource.TestCheckNoResourceAttr(resourceName, "usage_report_s3_bucket"),
 				),
 			},
 		},
@@ -50,6 +52,8 @@ func testAccAWSSNSSMSPreferences_empty(t *testing.T) {
 }
 
 func testAccAWSSNSSMSPreferences_defaultSMSType(t *testing.T) {
+	resourceName := "aws_sns_sms_preferences.test_pref"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -58,12 +62,12 @@ func testAccAWSSNSSMSPreferences_defaultSMSType(t *testing.T) {
 			{
 				Config: testAccAWSSNSSMSPreferencesConfig_defSMSType,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "monthly_spend_limit"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "delivery_status_iam_role_arn"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "delivery_status_success_sampling_rate"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "default_sender_id"),
-					resource.TestCheckResourceAttr("aws_sns_sms_preferences.test_pref", "default_sms_type", "Transactional"),
-					resource.TestCheckNoResourceAttr("aws_sns_sms_preferences.test_pref", "usage_report_s3_bucket"),
+					resource.TestCheckNoResourceAttr(resourceName, "monthly_spend_limit"),
+					resource.TestCheckNoResourceAttr(resourceName, "delivery_status_iam_role_arn"),
+					resource.TestCheckNoResourceAttr(resourceName, "delivery_status_success_sampling_rate"),
+					resource.TestCheckNoResourceAttr(resourceName, "default_sender_id"),
+					resource.TestCheckResourceAttr(resourceName, "default_sms_type", "Transactional"),
+					resource.TestCheckNoResourceAttr(resourceName, "usage_report_s3_bucket"),
 				),
 			},
 		},
@@ -71,6 +75,8 @@ func testAccAWSSNSSMSPreferences_defaultSMSType(t *testing.T) {
 }
 
 func testAccAWSSNSSMSPreferences_almostAll(t *testing.T) {
+	resourceName := "aws_sns_sms_preferences.test_pref"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -79,9 +85,9 @@ func testAccAWSSNSSMSPreferences_almostAll(t *testing.T) {
 			{
 				Config: testAccAWSSNSSMSPreferencesConfig_almostAll,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_sns_sms_preferences.test_pref", "monthly_spend_limit", "1"),
-					resource.TestCheckResourceAttr("aws_sns_sms_preferences.test_pref", "default_sms_type", "Transactional"),
-					resource.TestCheckResourceAttr("aws_sns_sms_preferences.test_pref", "usage_report_s3_bucket", "some-bucket"),
+					resource.TestCheckResourceAttr(resourceName, "monthly_spend_limit", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_sms_type", "Transactional"),
+					resource.TestCheckResourceAttr(resourceName, "usage_report_s3_bucket", "some-bucket"),
 				),
 			},
 		},
@@ -89,7 +95,9 @@ func testAccAWSSNSSMSPreferences_almostAll(t *testing.T) {
 }
 
 func testAccAWSSNSSMSPreferences_deliveryRole(t *testing.T) {
-	arnRole := regexp.MustCompile(`^arn:aws:iam::\d+:role/test_smsdelivery_role$`)
+	resourceName := "aws_sns_sms_preferences.test_pref"
+	iamRoleName := "aws_iam_role.test_smsdelivery_role"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -98,8 +106,8 @@ func testAccAWSSNSSMSPreferences_deliveryRole(t *testing.T) {
 			{
 				Config: testAccAWSSNSSMSPreferencesConfig_deliveryRole,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_sns_sms_preferences.test_pref", "delivery_status_iam_role_arn", arnRole),
-					resource.TestCheckResourceAttr("aws_sns_sms_preferences.test_pref", "delivery_status_success_sampling_rate", "75"),
+					resource.TestCheckResourceAttrPair(resourceName, "delivery_status_iam_role_arn", iamRoleName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_status_success_sampling_rate", "75"),
 				),
 			},
 		},
@@ -121,13 +129,17 @@ func testAccCheckAWSSNSSMSPrefsDestroy(s *terraform.State) error {
 			return nil
 		}
 
-		for attrName, attrValue := range attrs.Attributes {
-			if aws.StringValue(attrValue) != "" {
-				return fmt.Errorf("expected SMS attribute %q to be empty, but received: %s", attrName, aws.StringValue(attrValue))
+		var attrErrs *multierror.Error
+
+		// The API is returning undocumented keys, e.g. "UsageReportS3Enabled". Only check the keys we're aware of.
+		for _, snsAttrName := range smsAttributeMap {
+			v := aws.StringValue(attrs.Attributes[snsAttrName])
+			if v != "" {
+				attrErrs = multierror.Append(attrErrs, fmt.Errorf("expected SMS attribute %q to be empty, but received: %q", snsAttrName, v))
 			}
 		}
 
-		return nil
+		return attrErrs.ErrorOrNil()
 	}
 
 	return nil
@@ -143,12 +155,17 @@ resource "aws_sns_sms_preferences" "test_pref" {
 `
 const testAccAWSSNSSMSPreferencesConfig_almostAll = `
 resource "aws_sns_sms_preferences" "test_pref" {
-	monthly_spend_limit = "1"
-	default_sms_type = "Transactional"
+	monthly_spend_limit    = "1"
+	default_sms_type       = "Transactional"
 	usage_report_s3_bucket = "some-bucket"
 }
 `
 const testAccAWSSNSSMSPreferencesConfig_deliveryRole = `
+resource "aws_sns_sms_preferences" "test_pref" {
+	delivery_status_iam_role_arn          = "${aws_iam_role.test_smsdelivery_role.arn}"
+	delivery_status_success_sampling_rate = "75"
+}
+
 resource "aws_iam_role" "test_smsdelivery_role" {
     name = "test_smsdelivery_role"
     path = "/"
@@ -185,10 +202,5 @@ resource "aws_iam_role_policy" "test_smsdelivery_role_policy" {
   ]
 }
 POLICY
-}
-
-resource "aws_sns_sms_preferences" "test_pref" {
-	delivery_status_iam_role_arn = "${aws_iam_role.test_smsdelivery_role.arn}"
-	delivery_status_success_sampling_rate = "75"
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
$ make testacc TESTARGS='-run=TestAccAWSSNSSMSPreferences'

--- FAIL: TestAccAWSSNSSMSPreferences (69.86s)
    --- FAIL: TestAccAWSSNSSMSPreferences/almostAll (16.25s)
        testing.go:730: Error destroying resource! WARNING: Dangling resources
            may exist. The full state and error is shown below.
            
            Error: Check failed: expected SMS attribute "UsageReportS3Enabled" to be empty, but received: "true"
            
            State: <no state>
    --- FAIL: TestAccAWSSNSSMSPreferences/defaultSMSType (16.09s)
        testing.go:730: Error destroying resource! WARNING: Dangling resources
            may exist. The full state and error is shown below.
            
            Error: Check failed: expected SMS attribute "UsageReportS3Enabled" to be empty, but received: "true"
            
            State: <no state>
    --- FAIL: TestAccAWSSNSSMSPreferences/deliveryRole (18.54s)
        testing.go:730: Error destroying resource! WARNING: Dangling resources
            may exist. The full state and error is shown below.
            
            Error: Check failed: expected SMS attribute "UsageReportS3Enabled" to be empty, but received: "true"
            
            State: <no state>
    --- FAIL: TestAccAWSSNSSMSPreferences/empty (18.97s)
        testing.go:730: Error destroying resource! WARNING: Dangling resources
            may exist. The full state and error is shown below.
            
            Error: Check failed: expected SMS attribute "UsageReportS3Enabled" to be empty, but received: "true"
            
            State: <no state>
```

After fix:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSNSSMSPreferences'

--- PASS: TestAccAWSSNSSMSPreferences (65.07s)
    --- PASS: TestAccAWSSNSSMSPreferences/defaultSMSType (15.44s)
    --- PASS: TestAccAWSSNSSMSPreferences/deliveryRole (18.78s)
    --- PASS: TestAccAWSSNSSMSPreferences/empty (15.47s)
    --- PASS: TestAccAWSSNSSMSPreferences/almostAll (15.38s)
```
