### PR TITLE
Support Kafka connection type for AWS Glue

### DIFF
--- a/aws/resource_aws_glue_connection.go
+++ b/aws/resource_aws_glue_connection.go
@@ -41,6 +41,7 @@ func resourceAwsGlueConnection() *schema.Resource {
 					glue.ConnectionTypeJdbc,
 					glue.ConnectionTypeSftp,
 					glue.ConnectionTypeMongodb,
+					glue.ConnectionTypeKafka,
 				}, false),
 			},
 			"description": {

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -122,6 +122,37 @@ func TestAccAWSGlueConnection_MongoDB(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueConnection_Kafka(t *testing.T) {
+	var connection glue.Connection
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueConnectionConfig_Kafka(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					resource.TestCheckResourceAttr(resourceName, "connection_properties.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "connection_properties.KAFKA_BOOTSTRAP_SERVERS", "a.terraformtest.com:9094,b.terraformtest.com:9094"),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "KAFKA"),
+					resource.TestCheckResourceAttr(resourceName, "match_criteria.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "physical_connection_requirements.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueConnection_Description(t *testing.T) {
 	var connection glue.Connection
 
@@ -483,6 +514,20 @@ resource "aws_glue_connection" "test" {
   }
   
   connection_type = "MONGODB"
+
+  name = "%s"
+}
+`, rName)
+}
+
+func testAccAWSGlueConnectionConfig_Kafka(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_connection" "test" {
+  connection_properties = {
+	KAFKA_BOOTSTRAP_SERVERS = "a.terraformtest.com:9094,b.terraformtest.com:9094"
+  }
+  
+  connection_type = "KAFKA"
 
   name = "%s"
 }

--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `catalog_id` – (Optional) The ID of the Data Catalog in which to create the connection. If none is supplied, the AWS account ID is used by default.
 * `connection_properties` – (Required) A map of key-value pairs used as parameters for this connection.
-* `connection_type` – (Optional) The type of the connection. Supported are: `JDBC`, `MONGODB`. Defaults to `JBDC`.
+* `connection_type` – (Optional) The type of the connection. Supported are: `JDBC`, `MONGODB`, `KAFKA`. Defaults to `JBDC`.
 * `description` – (Optional) Description of the connection.
 * `match_criteria` – (Optional) A list of criteria that can be used in selecting this connection.
 * `name` – (Required) The name of the connection.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #13038 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
support Kafka connection type for AWS Glue
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueConnection_Kafka'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGlueConnection_Kafka -timeout 120m
=== RUN   TestAccAWSGlueConnection_Kafka
=== PAUSE TestAccAWSGlueConnection_Kafka
=== CONT  TestAccAWSGlueConnection_Kafka
--- PASS: TestAccAWSGlueConnection_Kafka (39.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       41.373s
```
