### PR TITLE
r/aws_flow_log: Add test sweeper

### DIFF
--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -28,7 +28,7 @@ func init() {
 			"aws_ec2_client_vpn_endpoint",
 			"aws_eks_cluster",
 			"aws_elasticsearch_domain",
-			// Not currently implemented: "aws_flow_log",
+			"aws_flow_log",
 			"aws_glue_job",
 			// Not currently implemented: "aws_kinesis_analytics_application",
 			"aws_kinesis_firehose_delivery_stream",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13093.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_flow_log make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_flow_log -timeout 60m
2020/05/04 15:38:21 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/04 15:38:21 [DEBUG] Running Sweeper (aws_flow_log) in region (us-west-2)
2020/05/04 15:38:21 [INFO] Building AWS auth structure
2020/05/04 15:38:21 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/04 15:38:23 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/04 15:38:23 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/04 15:38:23 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 15:38:23 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 15:38:24 [INFO] Deleting Flow Log: fl-0d418070a0bd8c2f2
2020/05/04 15:38:24 [INFO] Deleting Flow Log: fl-0a8119e67002bbcad
2020/05/04 15:38:25 Sweeper Tests ran successfully:
	- aws_flow_log
2020/05/04 15:38:25 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/04 15:38:25 [DEBUG] Running Sweeper (aws_flow_log) in region (us-east-1)
2020/05/04 15:38:25 [INFO] Building AWS auth structure
2020/05/04 15:38:25 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/04 15:38:26 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/04 15:38:26 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/04 15:38:26 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 15:38:27 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 15:38:27 Sweeper Tests ran successfully:
	- aws_flow_log
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.839s
```
