### PR TITLE
r/aws_cloudtrail: Add test sweeper

### DIFF
--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -9,10 +9,82 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_cloudtrail", &resource.Sweeper{
+		Name: "aws_cloudtrail",
+		F:    testSweepCloudTrails,
+	})
+}
+
+func testSweepCloudTrails(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).cloudtrailconn
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListTrailsPages(&cloudtrail.ListTrailsInput{}, func(page *cloudtrail.ListTrailsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, trail := range page.Trails {
+			name := aws.StringValue(trail.Name)
+
+			output, err := conn.DescribeTrails(&cloudtrail.DescribeTrailsInput{
+				TrailNameList: aws.StringSlice([]string{name}),
+			})
+			if err != nil {
+				sweeperErr := fmt.Errorf("error describing CloudTrail (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			if len(output.TrailList) == 0 {
+				log.Printf("[INFO] CloudTrail (%s) not found, skipping", name)
+				continue
+			}
+
+			if aws.BoolValue(output.TrailList[0].IsOrganizationTrail) {
+				log.Printf("[INFO] CloudTrail (%s) is an organization trail, skipping", name)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting CloudTrail: %s", name)
+			_, err = conn.DeleteTrail(&cloudtrail.DeleteTrailInput{
+				Name: aws.String(name),
+			})
+			if isAWSErr(err, cloudtrail.ErrCodeTrailNotFoundException, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting CloudTrail (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping CloudTrail sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving CloudTrails: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSCloudTrail(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -21,7 +21,7 @@ func init() {
 		Dependencies: []string{
 			"aws_api_gateway_rest_api",
 			"aws_cloudhsm_v2_cluster",
-			// Not currently implemented: "aws_cloudtrail",
+			"aws_cloudtrail",
 			"aws_datasync_task",
 			"aws_db_instance",
 			"aws_directory_service_directory",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13092.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_cloudtrail make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_cloudtrail -timeout 60m
2020/05/04 16:05:18 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/04 16:05:18 [DEBUG] Running Sweeper (aws_cloudtrail) in region (us-west-2)
2020/05/04 16:05:18 [INFO] Building AWS auth structure
2020/05/04 16:05:18 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/04 16:05:20 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/04 16:05:20 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/04 16:05:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 16:05:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 16:05:22 [INFO] Deleting CloudTrail: AWSMacieTrail-DO-NOT-EDIT
2020/05/04 16:05:22 [INFO] CloudTrail (orgtrail) is an organization trail, skipping
2020/05/04 16:05:22 Sweeper Tests ran successfully:
	- aws_cloudtrail
2020/05/04 16:05:22 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/04 16:05:22 [DEBUG] Running Sweeper (aws_cloudtrail) in region (us-east-1)
2020/05/04 16:05:22 [INFO] Building AWS auth structure
2020/05/04 16:05:22 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/04 16:05:24 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/04 16:05:24 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/04 16:05:24 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 16:05:24 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 16:05:24 Sweeper Tests ran successfully:
	- aws_cloudtrail
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.939s
```
