### PR TITLE
r/aws_route53_query_log: Add test sweeper

### DIFF
--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -36,7 +36,7 @@ func init() {
 			"aws_mq_broker",
 			"aws_msk_cluster",
 			"aws_rds_cluster",
-			// Not currently implemented: "aws_route53_query_log",
+			"aws_route53_query_log",
 			"aws_sagemaker_endpoint",
 			"aws_storagegateway_gateway",
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13095.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_route53_query_log make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_route53_query_log -timeout 60m
2020/05/04 16:33:09 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/04 16:33:09 [DEBUG] Running Sweeper (aws_route53_query_log) in region (us-west-2)
2020/05/04 16:33:09 [INFO] Building AWS auth structure
2020/05/04 16:33:09 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/04 16:33:11 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/04 16:33:11 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/04 16:33:11 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 16:33:11 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 16:33:12 Sweeper Tests ran successfully:
	- aws_route53_query_log
2020/05/04 16:33:12 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/04 16:33:12 [DEBUG] Running Sweeper (aws_route53_query_log) in region (us-east-1)
2020/05/04 16:33:12 [INFO] Building AWS auth structure
2020/05/04 16:33:12 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/04 16:33:13 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/04 16:33:13 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/04 16:33:13 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 16:33:13 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 16:33:13 Sweeper Tests ran successfully:
	- aws_route53_query_log
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.488s
```
