### PR TITLE
service/secretsmanager: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_secretsmanager_secret_version_test.go
+++ b/aws/resource_aws_secretsmanager_secret_version_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -16,6 +15,7 @@ func TestAccAwsSecretsManagerSecretVersion_BasicString(t *testing.T) {
 	var version secretsmanager.GetSecretValueOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_secretsmanager_secret_version.test"
+	secretResourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
@@ -30,8 +30,7 @@ func TestAccAwsSecretsManagerSecretVersion_BasicString(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.3070137", "AWSCURRENT"),
-					resource.TestMatchResourceAttr(resourceName, "arn",
-						regexp.MustCompile(`^arn:[\w-]+:secretsmanager:[^:]+:\d{12}:secret:.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", secretResourceName, "arn"),
 				),
 			},
 			{
@@ -47,6 +46,7 @@ func TestAccAwsSecretsManagerSecretVersion_Base64Binary(t *testing.T) {
 	var version secretsmanager.GetSecretValueOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_secretsmanager_secret_version.test"
+	secretResourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
@@ -61,8 +61,7 @@ func TestAccAwsSecretsManagerSecretVersion_Base64Binary(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.3070137", "AWSCURRENT"),
-					resource.TestMatchResourceAttr(resourceName, "arn",
-						regexp.MustCompile(`^arn:[\w-]+:secretsmanager:[^:]+:\d{12}:secret:.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", secretResourceName, "arn"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_secretsmanager_secret_test.go:81:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_secretsmanager_secret_test.go:116:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_secretsmanager_secret_test.go:249:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_secretsmanager_secret_version_test.go:33:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_secretsmanager_secret_version_test.go:64:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsSecretsManagerSecret_policy (17.47s)
--- PASS: TestAccAwsSecretsManagerSecret_Basic (19.59s)
--- PASS: TestAccAwsSecretsManagerSecret_withNamePrefix (20.10s)
--- PASS: TestAccAwsSecretsManagerSecret_Description (31.28s)
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (35.90s)
--- PASS: TestAccAwsSecretsManagerSecret_Tags (55.29s)
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (57.99s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (60.14s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (66.59s)
```

```
--- PASS: TestAccAwsSecretsManagerSecretVersion_Base64Binary (18.69s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_BasicString (20.54s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_VersionStages (44.35s)
```
