### PR TITLE
r/aws_kinesis_analytics_application: Add test sweeper

### DIFF
--- a/aws/internal/service/kinesisanalytics/waiter/status.go
+++ b/aws/internal/service/kinesisanalytics/waiter/status.go
@@ -1,0 +1,38 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// ApplicationStatus NotFound
+	ApplicationStatusNotFound = "NotFound"
+
+	// ApplicationStatus Unknown
+	ApplicationStatusUnknown = "Unknown"
+)
+
+// ApplicationStatus fetches the Application and its Status
+func ApplicationStatus(conn *kinesisanalytics.KinesisAnalytics, applicationName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &kinesisanalytics.DescribeApplicationInput{
+			ApplicationName: aws.String(applicationName),
+		}
+
+		output, err := conn.DescribeApplication(input)
+
+		if err != nil {
+			return nil, ApplicationStatusUnknown, err
+		}
+
+		application := output.ApplicationDetail
+
+		if application == nil {
+			return application, ApplicationStatusNotFound, nil
+		}
+
+		return application, aws.StringValue(application.ApplicationStatus), nil
+	}
+}

--- a/aws/internal/service/kinesisanalytics/waiter/waiter.go
+++ b/aws/internal/service/kinesisanalytics/waiter/waiter.go
@@ -1,0 +1,31 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for an Application to be deleted
+	ApplicationDeletedTimeout = 20 * time.Minute
+)
+
+// ApplicationDeleted waits for an Application to be deleted
+func ApplicationDeleted(conn *kinesisanalytics.KinesisAnalytics, applicationName string) (*kinesisanalytics.ApplicationSummary, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{kinesisanalytics.ApplicationStatusRunning, kinesisanalytics.ApplicationStatusDeleting},
+		Target:  []string{ApplicationStatusNotFound},
+		Refresh: ApplicationStatus(conn, applicationName),
+		Timeout: ApplicationDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*kinesisanalytics.ApplicationSummary); ok {
+		return v, err
+	}
+
+	return nil, err
+}

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -30,7 +30,7 @@ func init() {
 			"aws_elasticsearch_domain",
 			// Not currently implemented: "aws_flow_log",
 			"aws_glue_job",
-			// Not currently implemented: "aws_kinesis_analytics_application",
+			"aws_kinesis_analytics_application",
 			"aws_kinesis_firehose_delivery_stream",
 			"aws_lambda_function",
 			"aws_mq_broker",

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -2,14 +2,101 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/waiter"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_kinesis_analytics_application", &resource.Sweeper{
+		Name: "aws_kinesis_analytics_application",
+		F:    testSweepKinesisAnalyticsApplications,
+	})
+}
+
+func testSweepKinesisAnalyticsApplications(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).kinesisanalyticsconn
+	input := &kinesisanalytics.ListApplicationsInput{}
+	var sweeperErrs *multierror.Error
+
+	for {
+		output, err := conn.ListApplications(input)
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Kinesis Analytics Application sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		}
+		if err != nil {
+			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Kinesis Analytics Applications: %w", err))
+			return sweeperErrs
+		}
+
+		var name string
+		for _, applicationSummary := range output.ApplicationSummaries {
+			name = aws.StringValue(applicationSummary.ApplicationName)
+
+			output, err := conn.DescribeApplication(&kinesisanalytics.DescribeApplicationInput{
+				ApplicationName: aws.String(name),
+			})
+			if isAWSErr(err, kinesisanalytics.ErrCodeResourceNotFoundException, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error describing Kinesis Analytics Application (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			if output.ApplicationDetail == nil {
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Kinesis Analytics Application: %s", name)
+			_, err = conn.DeleteApplication(&kinesisanalytics.DeleteApplicationInput{
+				ApplicationName: aws.String(name),
+				CreateTimestamp: output.ApplicationDetail.CreateTimestamp,
+			})
+			if isAWSErr(err, kinesisanalytics.ErrCodeResourceNotFoundException, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Kinesis Analytics Application (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			_, err = waiter.ApplicationDeleted(conn, name)
+			if isAWSErr(err, kinesisanalytics.ErrCodeResourceNotFoundException, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error waiting for Kinesis Analytics Application (%s) to be deleted: %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		if !aws.BoolValue(output.HasMoreApplications) {
+			break
+		}
+		input.ExclusiveStartApplicationName = aws.String(name)
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSKinesisAnalyticsApplication_basic(t *testing.T) {
 	var application kinesisanalytics.ApplicationDetail


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13094.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_kinesis_analytics_application make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_kinesis_analytics_application -timeout 60m
2020/05/04 17:38:51 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/04 17:38:51 [DEBUG] Running Sweeper (aws_kinesis_analytics_application) in region (us-west-2)
2020/05/04 17:38:51 [INFO] Building AWS auth structure
2020/05/04 17:38:51 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/04 17:38:53 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/04 17:38:53 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/04 17:38:53 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 17:38:53 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 17:38:54 [INFO] Deleting Kinesis Analytics Application: example2
2020/05/04 17:38:55 [DEBUG] Waiting for state to become: [NotFound]
2020/05/04 17:38:55 [TRACE] Waiting 200ms before next try
2020/05/04 17:38:56 [INFO] Deleting Kinesis Analytics Application: fred
2020/05/04 17:38:57 [DEBUG] Waiting for state to become: [NotFound]
2020/05/04 17:38:57 [TRACE] Waiting 200ms before next try
2020/05/04 17:38:57 [TRACE] Waiting 400ms before next try
2020/05/04 17:38:58 [TRACE] Waiting 800ms before next try
2020/05/04 17:38:59 Sweeper Tests ran successfully:
	- aws_kinesis_analytics_application
2020/05/04 17:38:59 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/04 17:38:59 [DEBUG] Running Sweeper (aws_kinesis_analytics_application) in region (us-east-1)
2020/05/04 17:38:59 [INFO] Building AWS auth structure
2020/05/04 17:38:59 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/04 17:39:01 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/04 17:39:01 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/04 17:39:01 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 17:39:01 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/04 17:39:01 Sweeper Tests ran successfully:
	- aws_kinesis_analytics_application
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.103s```
