### PR TITLE
aws_iam_policy_document: validate principal.type

### DIFF
--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -297,6 +297,13 @@ func dataSourceAwsIamPolicyPrincipalSchema() *schema.Schema {
 				"type": {
 					Type:     schema.TypeString,
 					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"*",
+						"AWS",
+						"Service",
+						"Federated",
+						"CanonicalUser",
+					}, false),
 				},
 				"identifiers": {
 					Type:     schema.TypeSet,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR validates the `type` attribute in `principal` blocks, helping catch typos and lowercase strings that would ultimately be rejected by a later API call, e.g. an `aws_iam_policy`. Principals are referenced from:

https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13148

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_iam_policy_document: Validate `type` attributes in `principal` blocks
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDataSourceIAMPolicyDocument'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSDataSourceIAMPolicyDocument -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_basic
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_basic
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_source
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_source
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_override
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_override
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== PAUSE TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_basic
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_duplicateSid
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_override
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge
=== CONT  TestAccAWSDataSourceIAMPolicyDocument_source
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (17.31s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (17.31s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals (17.57s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice (17.85s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (17.98s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (18.01s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (18.05s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (19.49s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (25.57s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (27.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	28.420s
```
