### PR TITLE
r/aws_sns_platform_application: Add test sweeper

### DIFF
--- a/aws/resource_aws_sns_platform_application_test.go
+++ b/aws/resource_aws_sns_platform_application_test.go
@@ -9,13 +9,67 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/sns"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_sns_platform_application", &resource.Sweeper{
+		Name: "aws_sns_platform_application",
+		F:    testSweepSnsPlatformApplications,
+	})
+}
+
+func testSweepSnsPlatformApplications(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).snsconn
+	input := &sns.ListPlatformApplicationsInput{}
+	var sweeperErrs *multierror.Error
+
+	for {
+		output, err := conn.ListPlatformApplications(input)
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping SNS Platform Applications sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		}
+		if err != nil {
+			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving SNS Platform Applications: %w", err))
+			return sweeperErrs
+		}
+
+		for _, platformApplication := range output.PlatformApplications {
+			arn := aws.StringValue(platformApplication.PlatformApplicationArn)
+
+			log.Printf("[INFO] Deleting SNS Platform Application: %s", arn)
+			_, err := conn.DeletePlatformApplication(&sns.DeletePlatformApplicationInput{
+				PlatformApplicationArn: aws.String(arn),
+			})
+			if isAWSErr(err, sns.ErrCodeNotFoundException, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting SNS Platform Application (%s): %w", arn, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 /**
  Before running this test, at least one of these ENV variables combinations must be set:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/12658.
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/13167.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_sns_platform_application make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_sns_platform_application -timeout 60m
2020/05/05 13:12:53 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/05 13:12:53 [DEBUG] Running Sweeper (aws_sns_platform_application) in region (us-west-2)
2020/05/05 13:12:53 [INFO] Building AWS auth structure
2020/05/05 13:12:53 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/05 13:12:54 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/05 13:12:54 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/05 13:12:54 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/05 13:12:55 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/05 13:12:56 Sweeper Tests ran successfully:
	- aws_sns_platform_application
2020/05/05 13:12:56 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/05 13:12:56 [DEBUG] Running Sweeper (aws_sns_platform_application) in region (us-east-1)
2020/05/05 13:12:56 [INFO] Building AWS auth structure
2020/05/05 13:12:56 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/05 13:12:57 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/05 13:12:57 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/05 13:12:57 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/05 13:12:57 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/05 13:12:58 Sweeper Tests ran successfully:
	- aws_sns_platform_application
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.981s
```
