### PR TITLE
r/aws_ses_receipt_rule_set: Add test sweeper

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -678,6 +678,10 @@ func testSweepSkipSweepError(err error) bool {
 	if isAWSErr(err, "InvalidAction", "is not valid") {
 		return true
 	}
+	// For example from GovCloud SES.SetActiveReceiptRuleSet.
+	if isAWSErr(err, "InvalidAction", "Unavailable Operation") {
+		return true
+	}
 	return false
 }
 

--- a/aws/resource_aws_ses_receipt_rule_set_test.go
+++ b/aws/resource_aws_ses_receipt_rule_set_test.go
@@ -2,14 +2,83 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_ses_receipt_rule_set", &resource.Sweeper{
+		Name: "aws_ses_receipt_rule_set",
+		F:    testSweepSesReceiptRuleSets,
+	})
+}
+
+func testSweepSesReceiptRuleSets(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).sesconn
+
+	// You cannot delete the receipt rule set that is currently active.
+	// Setting the name of the receipt rule set to make active to null disables all email receiving.
+	log.Printf("[INFO] Disabling any currently active SES Receipt Rule Set")
+	_, err = conn.SetActiveReceiptRuleSet(&ses.SetActiveReceiptRuleSetInput{})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping SES Receipt Rule Sets sweep for %s: %s", region, err)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error disabling any currently active SES Receipt Rule Set: %w", err)
+	}
+
+	input := &ses.ListReceiptRuleSetsInput{}
+	var sweeperErrs *multierror.Error
+
+	for {
+		output, err := conn.ListReceiptRuleSets(input)
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping SES Receipt Rule Sets sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		}
+		if err != nil {
+			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving SES Receipt Rule Sets: %w", err))
+			return sweeperErrs
+		}
+
+		for _, ruleSet := range output.RuleSets {
+			name := aws.StringValue(ruleSet.Name)
+
+			log.Printf("[INFO] Deleting SES Receipt Rule Set: %s", name)
+			_, err := conn.DeleteReceiptRuleSet(&ses.DeleteReceiptRuleSetInput{
+				RuleSetName: aws.String(name),
+			})
+			if isAWSErr(err, ses.ErrCodeRuleSetDoesNotExistException, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting SES Receipt Rule Set (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSSESReceiptRuleSet_basic(t *testing.T) {
 	resourceName := "aws_ses_receipt_rule_set.test"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12658.
Relates #13167.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_ses_receipt_rule_set make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_ses_receipt_rule_set -timeout 60m
2020/05/05 14:39:55 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/05 14:39:55 [DEBUG] Running Sweeper (aws_ses_receipt_rule_set) in region (us-west-2)
2020/05/05 14:39:55 [INFO] Building AWS auth structure
2020/05/05 14:39:55 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/05 14:39:56 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/05 14:39:56 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/05 14:39:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/05 14:39:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/05 14:39:57 [INFO] Disabling any currently active SES Receipt Rule Set
2020/05/05 14:39:58 [INFO] Deleting SES Receipt Rule Set: default-rule-set
2020/05/05 14:39:58 [INFO] Deleting SES Receipt Rule Set: ruleset2
2020/05/05 14:39:59 Sweeper Tests ran successfully:
	- aws_ses_receipt_rule_set
2020/05/05 14:39:59 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/05 14:39:59 [DEBUG] Running Sweeper (aws_ses_receipt_rule_set) in region (us-east-1)
2020/05/05 14:39:59 [INFO] Building AWS auth structure
2020/05/05 14:39:59 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/05 14:40:00 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/05 14:40:00 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/05 14:40:00 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/05 14:40:00 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/05 14:40:00 [INFO] Disabling any currently active SES Receipt Rule Set
2020/05/05 14:40:01 Sweeper Tests ran successfully:
	- aws_ses_receipt_rule_set
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.062s
```
