### PR TITLE
service/lambda: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -125,6 +125,20 @@ func testAccCheckResourceAttrRegionalARNNoAccount(resourceName, attributeName, a
 	}
 }
 
+// testAccCheckResourceAttrRegionalARNAccountID ensures the Terraform state exactly matches a formatted ARN with region and specific account ID
+func testAccCheckResourceAttrRegionalARNAccountID(resourceName, attributeName, accountID, arnService, arnResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attributeValue := arn.ARN{
+			AccountID: accountID,
+			Partition: testAccGetPartition(),
+			Region:    testAccGetRegion(),
+			Resource:  arnResource,
+			Service:   arnService,
+		}.String()
+		return resource.TestCheckResourceAttr(resourceName, attributeName, attributeValue)(s)
+	}
+}
+
 // testAccMatchResourceAttrRegionalARN ensures the Terraform state regexp matches a formatted ARN with region
 func testAccMatchResourceAttrRegionalARN(resourceName, attributeName, arnService string, arnResourceRegexp *regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -19,6 +18,9 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 
 	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
+	functionResourceName := "aws_lambda_function.lambda_function_test_create"
+	functionResourceNameUpdated := "aws_lambda_function.lambda_function_test_update"
+	eventSourceResourceName := "aws_kinesis_stream.kinesis_stream_test"
 
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_esm_basic_%s", rString)
@@ -27,7 +29,6 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 	streamName := fmt.Sprintf("tf_acc_stream_lambda_esm_basic_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_esm_basic_%s", rString)
 	uFuncName := fmt.Sprintf("tf_acc_lambda_esm_basic_updated_%s", rString)
-	uFuncArnRe := regexp.MustCompile(":" + uFuncName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,6 +41,9 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
 					testAccCheckResourceAttrRfc3339(resourceName, "last_modified"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_arn", functionResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_source_arn", eventSourceResourceName, "arn"),
 				),
 			},
 			{
@@ -54,7 +58,9 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "batch_size", strconv.Itoa(200)),
 					resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(false)),
-					resource.TestMatchResourceAttr(resourceName, "function_arn", uFuncArnRe),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceNameUpdated, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_arn", functionResourceNameUpdated, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_source_arn", eventSourceResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "starting_position", "TRIM_HORIZON"),
 				),
 			},
@@ -114,6 +120,9 @@ func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 
 	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
+	functionResourceName := "aws_lambda_function.lambda_function_test_create"
+	functionResourceNameUpdated := "aws_lambda_function.lambda_function_test_update"
+	eventSourceResourceName := "aws_sqs_queue.sqs_queue_test"
 
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_sqs_basic_%s", rString)
@@ -122,7 +131,6 @@ func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 	streamName := fmt.Sprintf("tf_acc_stream_lambda_sqs_basic_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_sqs_basic_%s", rString)
 	uFuncName := fmt.Sprintf("tf_acc_lambda_sqs_basic_updated_%s", rString)
-	uFuncArnRe := regexp.MustCompile(":" + uFuncName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -134,9 +142,11 @@ func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_arn", functionResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_source_arn", eventSourceResourceName, "arn"),
 					testAccCheckResourceAttrRfc3339(resourceName, "last_modified"),
-					resource.TestCheckNoResourceAttr(resourceName,
-						"starting_position"),
+					resource.TestCheckNoResourceAttr(resourceName, "starting_position"),
 				),
 			},
 			{
@@ -151,7 +161,9 @@ func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "batch_size", strconv.Itoa(5)),
 					resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(false)),
-					resource.TestMatchResourceAttr(resourceName, "function_arn", uFuncArnRe),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceNameUpdated, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_arn", functionResourceNameUpdated, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_source_arn", eventSourceResourceName, "arn"),
 					resource.TestCheckNoResourceAttr(resourceName, "starting_position"),
 				),
 			},
@@ -163,6 +175,7 @@ func TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 
 	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
+	functionResourceName := "aws_lambda_function.lambda_function_test_create"
 
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_sqs_basic_%s", rString)
@@ -170,7 +183,6 @@ func TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName(t *testing.T) {
 	attName := fmt.Sprintf("tf_acc_att_lambda_sqs_basic_%s", rString)
 	streamName := fmt.Sprintf("tf_acc_stream_lambda_sqs_basic_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_sqs_basic_%s", rString)
-	funcArnRe := regexp.MustCompile(":" + funcName + "$")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -182,8 +194,8 @@ func TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
-					resource.TestMatchResourceAttr(resourceName, "function_arn", funcArnRe),
-					resource.TestMatchResourceAttr(resourceName, "function_name", funcArnRe),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_arn", functionResourceName, "arn"),
 					resource.TestCheckNoResourceAttr(resourceName, "starting_position"),
 				),
 			},
@@ -512,9 +524,11 @@ func TestAccAWSLambdaEventSourceMapping_KinesisDestinationConfig(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	rString := acctest.RandString(8)
-	resourceName := "aws_lambda_event_source_mapping.test"
 	streamName := fmt.Sprintf("tf_acc_stream_dest_config_%s", rString)
 	streamNameUpdated := fmt.Sprintf("tf_acc_stream_dest_config_updated_%s", rString)
+
+	resourceName := "aws_lambda_event_source_mapping.test"
+	sqsResourceName := "aws_sqs_queue.sqs_queue_test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -527,7 +541,7 @@ func TestAccAWSLambdaEventSourceMapping_KinesisDestinationConfig(t *testing.T) {
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "destination_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination_config.0.on_failure.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "destination_config.0.on_failure.0.destination_arn", "aws_sqs_queue.sqs_queue_test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_config.0.on_failure.0.destination_arn", sqsResourceName, "arn"),
 				),
 			},
 			{
@@ -545,7 +559,7 @@ func TestAccAWSLambdaEventSourceMapping_KinesisDestinationConfig(t *testing.T) {
 					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "destination_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination_config.0.on_failure.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "destination_config.0.on_failure.0.destination_arn", "aws_sqs_queue.sqs_queue_test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_config.0.on_failure.0.destination_arn", sqsResourceName, "arn"),
 				),
 			},
 		},

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -81,9 +81,8 @@ func TestAccAWSLambdaFunction_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "lambda", regexp.MustCompile(`function.+`)),
-					resource.TestMatchResourceAttr(resourceName, "invoke_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:apigateway:[^:]+:lambda:path/2015-03-31/functions/arn:[^:]+:lambda:[^:]+:[^:]+:function:%s/invocations$", funcName))),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
+					testAccCheckAwsLambdaFunctionInvokeArn(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "-1"),
 				),
 			},
@@ -140,7 +139,7 @@ func TestAccAWSLambdaFunction_concurrency(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "111"),
 				),
 			},
@@ -155,7 +154,7 @@ func TestAccAWSLambdaFunction_concurrency(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "222"),
 				),
 			},
@@ -183,7 +182,7 @@ func TestAccAWSLambdaFunction_concurrencyCycle(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "-1"),
 				),
 			},
@@ -198,7 +197,7 @@ func TestAccAWSLambdaFunction_concurrencyCycle(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "222"),
 				),
 			},
@@ -207,7 +206,7 @@ func TestAccAWSLambdaFunction_concurrencyCycle(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "reserved_concurrent_executions", "-1"),
 				),
 			},
@@ -294,7 +293,7 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckNoResourceAttr(resourceName, "environment"),
 				),
 			},
@@ -309,7 +308,7 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "bar"),
 				),
 			},
@@ -318,7 +317,7 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "baz"),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo1", "bar1"),
 				),
@@ -328,7 +327,7 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckNoResourceAttr(resourceName, "environment"),
 				),
 			},
@@ -357,7 +356,7 @@ func TestAccAWSLambdaFunction_encryptedEnvVariables(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "bar"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "kms_key_arn", "kms", regexp.MustCompile(`key/.+`)),
 				),
@@ -373,7 +372,7 @@ func TestAccAWSLambdaFunction_encryptedEnvVariables(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
 				),
@@ -392,6 +391,8 @@ func TestAccAWSLambdaFunction_versioned(t *testing.T) {
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_versioned_%s", rString)
 	resourceName := "aws_lambda_function.test"
 
+	version := "1"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -402,11 +403,11 @@ func TestAccAWSLambdaFunction_versioned(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestMatchResourceAttr(resourceName, "version",
-						regexp.MustCompile("^[0-9]+$")),
-					resource.TestMatchResourceAttr(resourceName, "qualified_arn",
-						regexp.MustCompile(":"+funcName+":[0-9]+$")),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
+					resource.TestMatchResourceAttr(resourceName, "version", regexp.MustCompile("^[0-9]+$")),
+					resource.TestCheckResourceAttr(resourceName, "version", version),
+					testAccMatchResourceAttrRegionalARN(resourceName, "qualified_arn", "lambda", regexp.MustCompile(fmt.Sprintf("function:%s:[0-9]+$", funcName))),
+					testAccCheckResourceAttrRegionalARN(resourceName, "qualified_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, version)),
 				),
 			},
 			{
@@ -437,6 +438,9 @@ func TestAccAWSLambdaFunction_versionedUpdate(t *testing.T) {
 
 	var timeBeforeUpdate time.Time
 
+	version := "2"
+	versionUpdated := "3"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -456,11 +460,9 @@ func TestAccAWSLambdaFunction_versionedUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestMatchResourceAttr(resourceName, "version",
-						regexp.MustCompile("^2$")),
-					resource.TestMatchResourceAttr(resourceName, "qualified_arn",
-						regexp.MustCompile(":"+funcName+":[0-9]+$")),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "qualified_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, version)),
 					func(s *terraform.State) error {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
 					},
@@ -474,11 +476,9 @@ func TestAccAWSLambdaFunction_versionedUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
-					resource.TestMatchResourceAttr(resourceName, "version",
-						regexp.MustCompile("^3$")),
-					resource.TestMatchResourceAttr(resourceName, "qualified_arn",
-						regexp.MustCompile(":"+funcName+":[0-9]+$")),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
+					resource.TestMatchResourceAttr(resourceName, "version", regexp.MustCompile("^3$")),
+					testAccCheckResourceAttrRegionalARN(resourceName, "qualified_arn", "lambda", fmt.Sprintf("function:%s:%s", funcName, versionUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "runtime", lambda.RuntimeNodejs10X),
 					func(s *terraform.State) error {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
@@ -516,7 +516,7 @@ func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					func(s *terraform.State) error {
 						if !strings.HasSuffix(*conf.Configuration.DeadLetterConfig.TargetArn, ":"+topicName) {
 							return fmt.Errorf(
@@ -635,7 +635,7 @@ func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "tracing_config.0.mode", "Active"),
 				),
 			},
@@ -650,7 +650,7 @@ func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "tracing_config.0.mode", "PassThrough"),
 				),
 			},
@@ -712,7 +712,7 @@ func TestAccAWSLambdaFunction_Layers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr(resourceName, "layers.#", "1"),
 				),
@@ -749,7 +749,7 @@ func TestAccAWSLambdaFunction_LayersUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr(resourceName, "layers.#", "1"),
 				),
@@ -765,7 +765,7 @@ func TestAccAWSLambdaFunction_LayersUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr(resourceName, "layers.#", "2"),
 				),
@@ -794,7 +794,7 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnet_ids.#", "1"),
@@ -868,7 +868,7 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnet_ids.#", "1"),
@@ -886,7 +886,7 @@ func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnet_ids.#", "2"),
@@ -1009,7 +1009,7 @@ func TestAccAWSLambdaFunction_s3(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAWSLambdaFunctionVersion(&conf, "$LATEST"),
 				),
 			},
@@ -1054,7 +1054,7 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -1075,7 +1075,7 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 					func(s *terraform.State) error {
 						return testAccCheckAttributeIsDateAfter(s, resourceName, "last_modified", timeBeforeUpdate)
@@ -1121,7 +1121,7 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -1141,7 +1141,7 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
@@ -1182,7 +1182,7 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -1203,7 +1203,7 @@ func TestAccAWSLambdaFunction_s3Update_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
@@ -1244,7 +1244,7 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -1265,7 +1265,7 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
@@ -1473,7 +1473,7 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckNoResourceAttr(resourceName, "tags"),
 				),
 			},
@@ -1488,7 +1488,7 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value One"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Description", "Very interesting"),
@@ -1499,7 +1499,7 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, funcName),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+funcName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("function:%s", funcName)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value One Changed"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value Two"),
@@ -1793,6 +1793,13 @@ func testAccCheckAwsLambdaFunctionExists(res, funcName string, function *lambda.
 	}
 }
 
+func testAccCheckAwsLambdaFunctionInvokeArn(name string, function *lambda.GetFunctionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		arn := aws.StringValue(function.Configuration.FunctionArn)
+		return testAccCheckResourceAttrRegionalARNAccountID(name, "invoke_arn", "lambda", "apigateway", fmt.Sprintf("path/2015-03-31/functions/%s/invocations", arn))(s)
+	}
+}
+
 func testAccAwsInvokeLambdaFunction(function *lambda.GetFunctionOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		f := function.Configuration
@@ -1824,17 +1831,6 @@ func testAccCheckAWSLambdaFunctionVersion(function *lambda.GetFunctionOutput, ex
 		if *c.Version != expectedVersion {
 			return fmt.Errorf("Expected version %s, got %s", expectedVersion, *c.Version)
 		}
-		return nil
-	}
-}
-
-func testAccCheckAwsLambdaFunctionArnHasSuffix(function *lambda.GetFunctionOutput, arnSuffix string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		c := function.Configuration
-		if !strings.HasSuffix(*c.FunctionArn, arnSuffix) {
-			return fmt.Errorf("Expected function ARN %s to have suffix %s", *c.FunctionArn, arnSuffix)
-		}
-
 		return nil
 	}
 }

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -385,8 +385,7 @@ func getLambdaPolicyStatement(out *lambda.GetPolicyOutput, statemendId string) (
 	return findLambdaPolicyStatementById(&policy, statemendId)
 }
 
-func findLambdaPolicyStatementById(policy *LambdaPolicy, id string) (
-	*LambdaPolicyStatement, error) {
+func findLambdaPolicyStatementById(policy *LambdaPolicy, id string) (*LambdaPolicyStatement, error) {
 
 	log.Printf("[DEBUG] Received %d statements in Lambda policy: %s", len(policy.Statement), policy.Statement)
 	for _, statement := range policy.Statement {

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -170,7 +170,9 @@ func TestAccAWSLambdaPermission_basic(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_basic_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_basic_%s", rString)
-	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
+
+	resourceName := "aws_lambda_permission.allow_cloudwatch"
+	functionResourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -180,19 +182,19 @@ func TestAccAWSLambdaPermission_basic(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig(funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.allow_cloudwatch", &statement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.allow_cloudwatch", "action", "lambda:InvokeFunction"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.allow_cloudwatch", "principal", "events.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.allow_cloudwatch", "statement_id", "AllowExecutionFromCloudWatch"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.allow_cloudwatch", "qualifier", ""),
-					resource.TestMatchResourceAttr("aws_lambda_permission.allow_cloudwatch", "function_name", funcArnRe),
-					resource.TestCheckResourceAttr("aws_lambda_permission.allow_cloudwatch", "event_source_token", "test-event-source-token"),
+					testAccCheckLambdaPermissionExists(resourceName, &statement),
+					resource.TestCheckResourceAttr(resourceName, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttr(resourceName, "principal", "events.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "statement_id", "AllowExecutionFromCloudWatch"),
+					resource.TestCheckResourceAttr(resourceName, "qualifier", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "event_source_token", "test-event-source-token"),
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.allow_cloudwatch",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.allow_cloudwatch"),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -221,7 +223,9 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_raw_fname_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_raw_fname_%s", rString)
-	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
+
+	resourceName := "aws_lambda_permission.with_raw_func_name"
+	functionResourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -231,17 +235,17 @@ func TestAccAWSLambdaPermission_withRawFunctionName(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig_withRawFunctionName(funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.with_raw_func_name", &statement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_raw_func_name", "action", "lambda:InvokeFunction"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_raw_func_name", "principal", "events.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_raw_func_name", "statement_id", "AllowExecutionWithRawFuncName"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.with_raw_func_name", "function_name", funcArnRe),
+					testAccCheckLambdaPermissionExists(resourceName, &statement),
+					resource.TestCheckResourceAttr(resourceName, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttr(resourceName, "principal", "events.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "statement_id", "AllowExecutionWithRawFuncName"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.with_raw_func_name",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_raw_func_name"),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -252,8 +256,10 @@ func TestAccAWSLambdaPermission_withStatementIdPrefix(t *testing.T) {
 	var statement LambdaPolicyStatement
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	endsWithFuncName := regexp.MustCompile(":function:lambda_function_name_perm$")
 	startsWithPrefix := regexp.MustCompile("^AllowExecutionWithStatementIdPrefix-")
+
+	resourceName := "aws_lambda_permission.with_statement_id_prefix"
+	functionResourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -263,17 +269,17 @@ func TestAccAWSLambdaPermission_withStatementIdPrefix(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig_withStatementIdPrefix(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.with_statement_id_prefix", &statement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_statement_id_prefix", "action", "lambda:InvokeFunction"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_statement_id_prefix", "principal", "events.amazonaws.com"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.with_statement_id_prefix", "statement_id", startsWithPrefix),
-					resource.TestMatchResourceAttr("aws_lambda_permission.with_statement_id_prefix", "function_name", endsWithFuncName),
+					testAccCheckLambdaPermissionExists(resourceName, &statement),
+					resource.TestCheckResourceAttr(resourceName, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttr(resourceName, "principal", "events.amazonaws.com"),
+					resource.TestMatchResourceAttr(resourceName, "statement_id", startsWithPrefix),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
 				),
 			},
 			{
-				ResourceName:            "aws_lambda_permission.with_statement_id_prefix",
+				ResourceName:            resourceName,
 				ImportState:             true,
-				ImportStateIdFunc:       testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_statement_id_prefix"),
+				ImportStateIdFunc:       testAccAWSCLambdaPermissionImportStateIdFunc(resourceName),
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"statement_id_prefix"},
 			},
@@ -288,7 +294,9 @@ func TestAccAWSLambdaPermission_withQualifier(t *testing.T) {
 	aliasName := fmt.Sprintf("tf_acc_lambda_perm_alias_w_qualifier_%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_qualifier_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_qualifier_%s", rString)
-	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
+
+	resourceName := "aws_lambda_permission.with_qualifier"
+	functionResourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -298,18 +306,18 @@ func TestAccAWSLambdaPermission_withQualifier(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig_withQualifier(aliasName, funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.with_qualifier", &statement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_qualifier", "action", "lambda:InvokeFunction"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_qualifier", "principal", "events.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_qualifier", "statement_id", "AllowExecutionWithQualifier"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.with_qualifier", "function_name", funcArnRe),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_qualifier", "qualifier", aliasName),
+					testAccCheckLambdaPermissionExists(resourceName, &statement),
+					resource.TestCheckResourceAttr(resourceName, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttr(resourceName, "principal", "events.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "statement_id", "AllowExecutionWithQualifier"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "qualifier", aliasName),
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.with_qualifier",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_qualifier"),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -323,6 +331,8 @@ func TestAccAWSLambdaPermission_disappears(t *testing.T) {
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_multi_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_multi_%s", rString)
 
+	resourceName := "aws_lambda_permission.first"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -333,7 +343,7 @@ func TestAccAWSLambdaPermission_disappears(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig_multiplePerms(funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSLambdaPermissionDisappears("aws_lambda_permission.first", &statement),
+					testAccAWSLambdaPermissionDisappears(resourceName, &statement),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -351,7 +361,12 @@ func TestAccAWSLambdaPermission_multiplePerms(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_multi_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_multi_%s", rString)
-	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
+
+	resourceNameFirst := "aws_lambda_permission.first"
+	resourceNameSecond := "aws_lambda_permission.second"
+	resourceNameSecondModified := "aws_lambda_permission.sec0nd"
+	resourceNameThird := "aws_lambda_permission.third"
+	functionResourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -362,52 +377,52 @@ func TestAccAWSLambdaPermission_multiplePerms(t *testing.T) {
 				Config: testAccAWSLambdaPermissionConfig_multiplePerms(funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					// 1st
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.first", &firstStatement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.first", "action", "lambda:InvokeFunction"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.first", "principal", "events.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.first", "statement_id", "AllowExecutionFirst"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.first", "function_name", funcArnRe),
+					testAccCheckLambdaPermissionExists(resourceNameFirst, &firstStatement),
+					resource.TestCheckResourceAttr(resourceNameFirst, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttr(resourceNameFirst, "principal", "events.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceNameFirst, "statement_id", "AllowExecutionFirst"),
+					resource.TestCheckResourceAttrPair(resourceNameFirst, "function_name", functionResourceName, "arn"),
 					// 2nd
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.second", &firstStatementModified),
-					resource.TestCheckResourceAttr("aws_lambda_permission.second", "action", "lambda:*"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.second", "principal", "events.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.second", "statement_id", "AllowExecutionSecond"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.second", "function_name", funcArnRe),
+					testAccCheckLambdaPermissionExists(resourceNameSecond, &firstStatementModified),
+					resource.TestCheckResourceAttr(resourceNameSecond, "action", "lambda:*"),
+					resource.TestCheckResourceAttr(resourceNameSecond, "principal", "events.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceNameSecond, "statement_id", "AllowExecutionSecond"),
+					resource.TestCheckResourceAttrPair(resourceNameSecond, "function_name", functionResourceName, "arn"),
 				),
 			},
 			{
 				Config: testAccAWSLambdaPermissionConfig_multiplePermsModified(funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					// 1st
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.first", &secondStatement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.first", "action", "lambda:InvokeFunction"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.first", "principal", "events.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.first", "statement_id", "AllowExecutionFirst"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.first", "function_name", funcArnRe),
+					testAccCheckLambdaPermissionExists(resourceNameFirst, &secondStatement),
+					resource.TestCheckResourceAttr(resourceNameFirst, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttr(resourceNameFirst, "principal", "events.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceNameFirst, "statement_id", "AllowExecutionFirst"),
+					resource.TestCheckResourceAttrPair(resourceNameFirst, "function_name", functionResourceName, "arn"),
 					// 2nd
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.sec0nd", &secondStatementModified),
-					resource.TestCheckResourceAttr("aws_lambda_permission.sec0nd", "action", "lambda:*"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.sec0nd", "principal", "events.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.sec0nd", "statement_id", "AllowExecutionSec0nd"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.sec0nd", "function_name", funcArnRe),
+					testAccCheckLambdaPermissionExists(resourceNameSecondModified, &secondStatementModified),
+					resource.TestCheckResourceAttr(resourceNameSecondModified, "action", "lambda:*"),
+					resource.TestCheckResourceAttr(resourceNameSecondModified, "principal", "events.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceNameSecondModified, "statement_id", "AllowExecutionSec0nd"),
+					resource.TestCheckResourceAttrPair(resourceNameSecondModified, "function_name", functionResourceName, "arn"),
 					// 3rd
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.third", &thirdStatement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.third", "action", "lambda:*"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.third", "principal", "events.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.third", "statement_id", "AllowExecutionThird"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.third", "function_name", funcArnRe),
+					testAccCheckLambdaPermissionExists(resourceNameThird, &thirdStatement),
+					resource.TestCheckResourceAttr(resourceNameThird, "action", "lambda:*"),
+					resource.TestCheckResourceAttr(resourceNameThird, "principal", "events.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceNameThird, "statement_id", "AllowExecutionThird"),
+					resource.TestCheckResourceAttrPair(resourceNameThird, "function_name", functionResourceName, "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.first",
+				ResourceName:      resourceNameFirst,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.first"),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc(resourceNameFirst),
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      "aws_lambda_permission.sec0nd",
+				ResourceName:      resourceNameSecondModified,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.sec0nd"),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc(resourceNameSecondModified),
 				ImportStateVerify: true,
 			},
 		},
@@ -421,7 +436,10 @@ func TestAccAWSLambdaPermission_withS3(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-perm-w-s3-%s", rString)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_s3_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_s3_%s", rString)
-	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
+
+	resourceName := "aws_lambda_permission.with_s3"
+	functionResourceName := "aws_lambda_function.test"
+	bucketResourceName := "aws_s3_bucket.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -431,19 +449,18 @@ func TestAccAWSLambdaPermission_withS3(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig_withS3(bucketName, funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.with_s3", &statement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_s3", "action", "lambda:InvokeFunction"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_s3", "principal", "s3.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_s3", "statement_id", "AllowExecutionFromS3"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.with_s3", "function_name", funcArnRe),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_s3", "source_arn",
-						fmt.Sprintf("arn:aws:s3:::%s", bucketName)),
+					testAccCheckLambdaPermissionExists(resourceName, &statement),
+					resource.TestCheckResourceAttr(resourceName, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttr(resourceName, "principal", "s3.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "statement_id", "AllowExecutionFromS3"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "source_arn", bucketResourceName, "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.with_s3",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_s3"),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -458,8 +475,9 @@ func TestAccAWSLambdaPermission_withSNS(t *testing.T) {
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_sns_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_sns_%s", rString)
 
-	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
-	topicArnRe := regexp.MustCompile(":" + topicName + "$")
+	resourceName := "aws_lambda_permission.with_sns"
+	functionResourceName := "aws_lambda_function.test"
+	snsTopicResourceName := "aws_sns_topic.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -469,18 +487,18 @@ func TestAccAWSLambdaPermission_withSNS(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig_withSNS(topicName, funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.with_sns", &statement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_sns", "action", "lambda:InvokeFunction"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_sns", "principal", "sns.amazonaws.com"),
-					resource.TestCheckResourceAttr("aws_lambda_permission.with_sns", "statement_id", "AllowExecutionFromSNS"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.with_sns", "function_name", funcArnRe),
-					resource.TestMatchResourceAttr("aws_lambda_permission.with_sns", "source_arn", topicArnRe),
+					testAccCheckLambdaPermissionExists(resourceName, &statement),
+					resource.TestCheckResourceAttr(resourceName, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttr(resourceName, "principal", "sns.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "statement_id", "AllowExecutionFromSNS"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "source_arn", snsTopicResourceName, "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.with_sns",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.with_sns"),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -493,8 +511,10 @@ func TestAccAWSLambdaPermission_withIAMRole(t *testing.T) {
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_w_iam_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_w_iam_%s", rString)
-	funcArnRe := regexp.MustCompile(":function:" + funcName + "$")
-	roleArnRe := regexp.MustCompile("/" + roleName + "$")
+
+	resourceName := "aws_lambda_permission.iam_role"
+	iamRoleResourceName := "aws_iam_role.test"
+	functionResourceName := "aws_lambda_function.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -504,17 +524,17 @@ func TestAccAWSLambdaPermission_withIAMRole(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig_withIAMRole(funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLambdaPermissionExists("aws_lambda_permission.iam_role", &statement),
-					resource.TestCheckResourceAttr("aws_lambda_permission.iam_role", "action", "lambda:InvokeFunction"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.iam_role", "principal", roleArnRe),
-					resource.TestCheckResourceAttr("aws_lambda_permission.iam_role", "statement_id", "AllowExecutionFromIAMRole"),
-					resource.TestMatchResourceAttr("aws_lambda_permission.iam_role", "function_name", funcArnRe),
+					testAccCheckLambdaPermissionExists(resourceName, &statement),
+					resource.TestCheckResourceAttr(resourceName, "action", "lambda:InvokeFunction"),
+					resource.TestCheckResourceAttrPair(resourceName, "principal", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "statement_id", "AllowExecutionFromIAMRole"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_lambda_permission.iam_role",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc("aws_lambda_permission.iam_role"),
+				ImportStateIdFunc: testAccAWSCLambdaPermissionImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -704,12 +724,12 @@ func testAccAWSLambdaPermissionConfig(funcName, roleName string) string {
 resource "aws_lambda_permission" "allow_cloudwatch" {
   statement_id       = "AllowExecutionFromCloudWatch"
   action             = "lambda:InvokeFunction"
-  function_name      = aws_lambda_function.test_lambda.arn
+  function_name      = aws_lambda_function.test.arn
   principal          = "events.amazonaws.com"
   event_source_token = "test-event-source-token"
 }
 
-resource "aws_lambda_function" "test_lambda" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
@@ -792,11 +812,11 @@ func testAccAWSLambdaPermissionConfig_withRawFunctionName(funcName, roleName str
 resource "aws_lambda_permission" "with_raw_func_name" {
   statement_id  = "AllowExecutionWithRawFuncName"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.test_lambda.arn
+  function_name = aws_lambda_function.test.arn
   principal     = "events.amazonaws.com"
 }
 
-resource "aws_lambda_function" "test_lambda" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
@@ -831,11 +851,11 @@ func testAccAWSLambdaPermissionConfig_withStatementIdPrefix(rName string) string
 resource "aws_lambda_permission" "with_statement_id_prefix" {
   statement_id_prefix = "AllowExecutionWithStatementIdPrefix-"
   action              = "lambda:InvokeFunction"
-  function_name       = aws_lambda_function.test_lambda.arn
+  function_name       = aws_lambda_function.test.arn
   principal           = "events.amazonaws.com"
 }
 
-resource "aws_lambda_function" "test_lambda" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "lambda_function_name_perm"
   role          = aws_iam_role.iam_for_lambda.arn
@@ -870,7 +890,7 @@ func testAccAWSLambdaPermissionConfig_withQualifier(aliasName, funcName, roleNam
 resource "aws_lambda_permission" "with_qualifier" {
   statement_id   = "AllowExecutionWithQualifier"
   action         = "lambda:InvokeFunction"
-  function_name  = aws_lambda_function.test_lambda.arn
+  function_name  = aws_lambda_function.test.arn
   principal      = "events.amazonaws.com"
   source_account = "111122223333"
   source_arn     = "arn:aws:events:eu-west-1:111122223333:rule/RunDaily"
@@ -880,11 +900,11 @@ resource "aws_lambda_permission" "with_qualifier" {
 resource "aws_lambda_alias" "test_alias" {
   name             = "%s"
   description      = "a sample description"
-  function_name    = aws_lambda_function.test_lambda.arn
+  function_name    = aws_lambda_function.test.arn
   function_version = "$LATEST"
 }
 
-resource "aws_lambda_function" "test_lambda" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
@@ -918,19 +938,19 @@ var testAccAWSLambdaPermissionConfig_multiplePerms_tpl = `
 resource "aws_lambda_permission" "first" {
     statement_id = "AllowExecutionFirst"
     action = "lambda:InvokeFunction"
-    function_name = aws_lambda_function.test_lambda.arn
+    function_name = aws_lambda_function.test.arn
     principal = "events.amazonaws.com"
 }
 
 resource "aws_lambda_permission" "%s" {
     statement_id = "%s"
     action = "lambda:*"
-    function_name = aws_lambda_function.test_lambda.arn
+    function_name = aws_lambda_function.test.arn
     principal = "events.amazonaws.com"
 }
 %s
 
-resource "aws_lambda_function" "test_lambda" {
+resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = aws_iam_role.iam_for_lambda.arn
@@ -969,7 +989,7 @@ func testAccAWSLambdaPermissionConfig_multiplePermsModified(funcName, roleName s
 resource "aws_lambda_permission" "third" {
     statement_id = "AllowExecutionThird"
     action = "lambda:*"
-    function_name = aws_lambda_function.test_lambda.arn
+    function_name = aws_lambda_function.test.arn
     principal = "events.amazonaws.com"
 }
 `, funcName, roleName)
@@ -980,7 +1000,7 @@ func testAccAWSLambdaPermissionConfig_withS3(bucketName, funcName, roleName stri
 resource "aws_lambda_permission" "with_s3" {
   statement_id  = "AllowExecutionFromS3"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.my-func.arn
+  function_name = aws_lambda_function.test.arn
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.default.arn
 }
@@ -990,15 +1010,15 @@ resource "aws_s3_bucket" "default" {
   acl    = "private"
 }
 
-resource "aws_lambda_function" "my-func" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
-  role          = aws_iam_role.police.arn
+  role          = aws_iam_role.test.arn
   handler       = "exports.handler"
   runtime       = "nodejs12.x"
 }
 
-resource "aws_iam_role" "police" {
+resource "aws_iam_role" "test" {
   name = "%s"
 
   assume_role_policy = <<EOF
@@ -1025,7 +1045,7 @@ func testAccAWSLambdaPermissionConfig_withSNS(topicName, funcName, roleName stri
 resource "aws_lambda_permission" "with_sns" {
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.my-func.arn
+  function_name = aws_lambda_function.test.arn
   principal     = "sns.amazonaws.com"
   source_arn    = aws_sns_topic.default.arn
 }
@@ -1037,18 +1057,18 @@ resource "aws_sns_topic" "default" {
 resource "aws_sns_topic_subscription" "lambda" {
   topic_arn = aws_sns_topic.default.arn
   protocol  = "lambda"
-  endpoint  = aws_lambda_function.my-func.arn
+  endpoint  = aws_lambda_function.test.arn
 }
 
-resource "aws_lambda_function" "my-func" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
-  role          = aws_iam_role.police.arn
+  role          = aws_iam_role.test.arn
   handler       = "exports.handler"
   runtime       = "nodejs12.x"
 }
 
-resource "aws_iam_role" "police" {
+resource "aws_iam_role" "test" {
   name = "%s"
 
   assume_role_policy = <<EOF
@@ -1075,19 +1095,19 @@ func testAccAWSLambdaPermissionConfig_withIAMRole(funcName, roleName string) str
 resource "aws_lambda_permission" "iam_role" {
   statement_id  = "AllowExecutionFromIAMRole"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.my-func.arn
-  principal     = aws_iam_role.police.arn
+  function_name = aws_lambda_function.test.arn
+  principal     = aws_iam_role.test.arn
 }
 
-resource "aws_lambda_function" "my-func" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
-  role          = aws_iam_role.police.arn
+  role          = aws_iam_role.test.arn
   handler       = "exports.handler"
   runtime       = "nodejs12.x"
 }
 
-resource "aws_iam_role" "police" {
+resource "aws_iam_role" "test" {
   name = "%s"
 
   assume_role_policy = <<EOF


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_lambda_alias_test.go:38:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_lambda_event_source_mapping_test.go:57:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_lambda_event_source_mapping_test.go:154:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_lambda_event_source_mapping_test.go:185:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_lambda_function_test.go:86:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_lambda_function_test.go:408:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_lambda_function_test.go:462:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_lambda_function_test.go:480:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_lambda_permission_test.go:477:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (2.71s)
--- PASS: TestAccAWSLambdaFunction_s3 (43.99s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby27 (56.12s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (60.04s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_dotnetcore31 (62.49s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (63.08s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (72.80s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x (79.24s)
--- PASS: TestAccAWSLambdaFunction_basic (85.89s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x (91.09s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python38 (95.94s)
--- PASS: TestAccAWSLambdaFunction_tags (98.99s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (103.83s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java11 (109.80s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (115.31s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (119.91s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (129.47s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (132.50s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (134.55s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (133.19s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (99.24s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (144.93s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (19.18s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (521.50s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (544.52s)
--- PASS: TestAccAWSLambdaFunction_Layers (533.74s)
--- PASS: TestAccAWSLambdaFunction_versioned (534.02s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (554.61s)
--- PASS: TestAccAWSLambdaFunction_envVariables (584.96s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (524.27s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (556.37s)
--- PASS: TestAccAWSLambdaFunction_concurrency (547.00s)
--- PASS: TestAccAWSLambdaFunction_disappears (533.36s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (565.91s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (555.44s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (560.31s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (601.44s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (1907.91s)
--- PASS: TestAccAWSLambdaFunction_VPC (1921.26s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (2425.53s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (2582.79s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (2612.86s)
```

```
--- PASS: TestAccAWSLambdaAlias_basic (55.94s)
--- PASS: TestAccAWSLambdaAlias_nameupdate (69.84s)
--- PASS: TestAccAWSLambdaAlias_routingconfig (76.84s)
```

```
--- PASS: TestAccAWSLambdaPermission_withIAMRole (36.76s)
--- PASS: TestAccAWSLambdaPermission_withRawFunctionName (42.17s)
--- PASS: TestAccAWSLambdaPermission_basic (48.05s)
--- PASS: TestAccAWSLambdaPermission_withStatementIdPrefix (54.62s)
--- PASS: TestAccAWSLambdaPermission_withQualifier (66.74s)
--- PASS: TestAccAWSLambdaPermission_withS3 (79.80s)
--- PASS: TestAccAWSLambdaPermission_withSNS (83.03s)
--- PASS: TestAccAWSLambdaPermission_multiplePerms (105.84s)
--- PASS: TestAccAWSLambdaPermission_StatementId_Duplicate (111.36s)
--- PASS: TestAccAWSLambdaPermission_disappears (129.61s)
```

```
--- PASS: TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp (63.03s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName (65.31s)
--- PASS: TestAccAWSLambdaEventSourceMapping_KinesisDestinationConfig (78.50s)
--- PASS: TestAccAWSLambdaEventSourceMapping_BatchWindow (81.72s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqsDisappears (107.56s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_basic (117.73s)
--- PASS: TestAccAWSLambdaEventSourceMapping_MaximumRecordAgeInSeconds (120.61s)
--- PASS: TestAccAWSLambdaEventSourceMapping_MaximumRetryAttempts (127.27s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_basic (137.81s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize (148.62s)
--- PASS: TestAccAWSLambdaEventSourceMapping_ParallelizationFactor (153.08s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_disappears (155.62s)
--- PASS: TestAccAWSLambdaEventSourceMapping_BisectBatch (157.76s)
--- PASS: TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected (182.63s)
```