### PR TITLE
r/workspaces_ip_group - add tags test + remove from state when deleted

### DIFF
--- a/aws/resource_aws_workspaces_ip_group_test.go
+++ b/aws/resource_aws_workspaces_ip_group_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestAccAwsWorkspacesIpGroup_basic(t *testing.T) {
 	var v workspaces.IpGroup
-	ipGroupName := fmt.Sprintf("terraform-acctest-%s", acctest.RandString(10))
-	ipGroupNewName := fmt.Sprintf("terraform-acctest-new-%s", acctest.RandString(10))
+	ipGroupName := acctest.RandomWithPrefix("tf-acc-test")
+	ipGroupNewName := acctest.RandomWithPrefix("tf-acc-test-upd")
 	ipGroupDescription := fmt.Sprintf("Terraform Acceptance Test %s", strings.Title(acctest.RandString(20)))
 	resourceName := "aws_workspaces_ip_group.test"
 
@@ -31,10 +31,7 @@ func TestAccAwsWorkspacesIpGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ipGroupName),
 					resource.TestCheckResourceAttr(resourceName, "description", ipGroupDescription),
 					resource.TestCheckResourceAttr(resourceName, "rules.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "test"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Terraform", "true"),
-					resource.TestCheckResourceAttr(resourceName, "tags.IPGroup", "Home"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -49,15 +46,79 @@ func TestAccAwsWorkspacesIpGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", ipGroupNewName),
 					resource.TestCheckResourceAttr(resourceName, "description", ipGroupDescription),
 					resource.TestCheckResourceAttr(resourceName, "rules.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.IPGroup", "Home"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Purpose", "test"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesIpGroup_tags(t *testing.T) {
+	var v workspaces.IpGroup
+	resourceName := "aws_workspaces_ip_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesIpGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWorkspacesIpGroupConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesIpGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsWorkspacesIpGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesIpGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsWorkspacesIpGroupConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesIpGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsWorkspacesIpGroup_disappears(t *testing.T) {
+	var v workspaces.IpGroup
+	ipGroupName := acctest.RandomWithPrefix("tf-acc-test")
+	ipGroupDescription := fmt.Sprintf("Terraform Acceptance Test %s", strings.Title(acctest.RandString(20)))
+	resourceName := "aws_workspaces_ip_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsWorkspacesIpGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsWorkspacesIpGroupConfigA(ipGroupName, ipGroupDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAwsWorkspacesIpGroupExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsWorkspacesIpGroup(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -122,8 +183,39 @@ func testAccCheckAwsWorkspacesIpGroupExists(n string, v *workspaces.IpGroup) res
 func testAccAwsWorkspacesIpGroupConfigA(name, description string) string {
 	return fmt.Sprintf(`
 resource "aws_workspaces_ip_group" "test" {
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+  description = %[2]q
+
+  rules {
+    source = "10.0.0.0/16"
+  }
+
+  rules {
+    source      = "10.0.0.1/16"
+    description = "Home"
+  }
+}
+`, name, description)
+}
+
+func testAccAwsWorkspacesIpGroupConfigB(name, description string) string {
+	return fmt.Sprintf(`
+resource "aws_workspaces_ip_group" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  rules {
+    source      = "10.0.0.1/16"
+    description = "Home"
+  }
+}
+`, name, description)
+}
+
+func testAccAwsWorkspacesIpGroupConfigTags1(name, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_workspaces_ip_group" "test" {
+  name        = %[1]q
 
   rules {
     source = "10.0.0.0/16"
@@ -135,19 +227,20 @@ resource "aws_workspaces_ip_group" "test" {
   }
 
   tags = {
-    Name = "test"
-    Terraform = true
-    IPGroup = "Home"
+    %[2]q = %[3]q
   }
 }
-`, name, description)
+`, name, tagKey1, tagValue1)
 }
 
-func testAccAwsWorkspacesIpGroupConfigB(name, description string) string {
+func testAccAwsWorkspacesIpGroupConfigTags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_workspaces_ip_group" "test" {
-  name        = "%s"
-  description = "%s"
+  name        = %[1]q
+
+  rules {
+    source = "10.0.0.0/16"
+  }
 
   rules {
     source      = "10.0.0.1/16"
@@ -155,9 +248,9 @@ resource "aws_workspaces_ip_group" "test" {
   }
 
   tags = {
-    Purpose   = "test"
-    IPGroup = "Home"
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, name, description)
+`, name, tagKey1, tagValue1, tagKey2, tagValue2)
 }


### PR DESCRIPTION
add tags test
fix state removal when does not exist

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_workspaces_ip_group: plan time validation `rules.source`
resource_aws_workspaces_ip_group: remove from state if deleted
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsWorkspacesIpGroup_'
--- PASS: TestAccAwsWorkspacesIpGroup_basic (75.11s)
--- PASS: TestAccAwsWorkspacesIpGroup_tags (93.90s)
--- PASS: TestAccAwsWorkspacesIpGroup_disappears (28.14s)
```
