### PR TITLE
r/aws_glacier_vault: Add test sweeper

### DIFF
--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -2,15 +2,77 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/glacier"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_glacier_vault", &resource.Sweeper{
+		Name: "aws_glacier_vault",
+		F:    testSweepGlacierVaults,
+	})
+}
+
+func testSweepGlacierVaults(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).glacierconn
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListVaultsPages(&glacier.ListVaultsInput{}, func(page *glacier.ListVaultsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, vault := range page.VaultList {
+			name := aws.StringValue(vault.VaultName)
+
+			// First attempt to delete the vault's notification configuration in case the vault deletion fails.
+			log.Printf("[INFO] Deleting Glacier Vault (%s) Notifications", name)
+			_, err := conn.DeleteVaultNotifications(&glacier.DeleteVaultNotificationsInput{
+				VaultName: aws.String(name),
+			})
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Glacier Vault (%s) Notifications: %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Glacier Vault: %s", name)
+			_, err = conn.DeleteVault(&glacier.DeleteVaultInput{
+				VaultName: aws.String(name),
+			})
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Glacier Vault (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Glacier Vaults sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Glacier Vaults: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSGlacierVault_basic(t *testing.T) {
 	rInt := acctest.RandInt()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12658.
Relates #13167.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_glacier_vault make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_glacier_vault -timeout 60m
2020/05/06 09:55:00 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/06 09:55:00 [DEBUG] Running Sweeper (aws_glacier_vault) in region (us-west-2)
2020/05/06 09:55:00 [INFO] Building AWS auth structure
2020/05/06 09:55:00 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/06 09:55:01 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/06 09:55:01 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/06 09:55:01 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/06 09:55:01 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/06 09:55:03 [INFO] Deleting Glacier Vault (test1) Notifications
2020/05/06 09:55:03 [INFO] Deleting Glacier Vault: test1
2020/05/06 09:55:03 [INFO] Deleting Glacier Vault (test2) Notifications
2020/05/06 09:55:04 [INFO] Deleting Glacier Vault: test2
2020/05/06 09:55:04 Sweeper Tests ran successfully:
	- aws_glacier_vault
2020/05/06 09:55:04 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/06 09:55:04 [DEBUG] Running Sweeper (aws_glacier_vault) in region (us-east-1)
2020/05/06 09:55:04 [INFO] Building AWS auth structure
2020/05/06 09:55:04 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/06 09:55:06 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/06 09:55:06 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/06 09:55:06 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/06 09:55:06 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/06 09:55:06 Sweeper Tests ran successfully:
	- aws_glacier_vault
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.245s
```
