### PR TITLE
service/ec2: Add customer_owned_ipv4_pool and map_customer_owned_ip_on_launch attributes to aws_subnet data source and resource

### DIFF
--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -77,6 +77,16 @@ func dataSourceAwsSubnet() *schema.Resource {
 				Computed: true,
 			},
 
+			"customer_owned_ipv4_pool": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"map_customer_owned_ip_on_launch": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"map_public_ip_on_launch": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -180,6 +190,8 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("assign_ipv6_address_on_creation", subnet.AssignIpv6AddressOnCreation)
+	d.Set("customer_owned_ipv4_pool", subnet.CustomerOwnedIpv4Pool)
+	d.Set("map_customer_owned_ip_on_launch", subnet.MapCustomerOwnedIpOnLaunch)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIpOnLaunch)
 
 	for _, a := range subnet.Ipv6CidrBlockAssociationSet {

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -38,6 +39,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds1ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds1ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds1ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds2ResourceName, "id", snResourceName, "id"),
@@ -48,6 +51,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds2ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds2ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds2ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds2ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds3ResourceName, "id", snResourceName, "id"),
@@ -58,6 +63,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds3ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds3ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds3ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds3ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds4ResourceName, "id", snResourceName, "id"),
@@ -68,6 +75,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds4ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds4ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds4ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds4ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds5ResourceName, "id", snResourceName, "id"),
@@ -78,6 +87,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds5ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds5ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds5ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds5ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 
 					resource.TestCheckResourceAttrPair(ds6ResourceName, "id", snResourceName, "id"),
@@ -88,6 +99,8 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ds6ResourceName, "cidr_block", cidr),
 					resource.TestCheckResourceAttr(ds6ResourceName, "tags.Name", tag),
 					resource.TestCheckResourceAttrPair(ds6ResourceName, "arn", snResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "customer_owned_ipv4_pool", snResourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "map_customer_owned_ip_on_launch", snResourceName, "map_customer_owned_ip_on_launch"),
 					resource.TestCheckResourceAttrPair(ds6ResourceName, "outpost_arn", snResourceName, "outpost_arn"),
 				),
 			},
@@ -128,6 +141,45 @@ func TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock(t *testing.T) {
 				Config: testAccDataSourceAwsSubnetConfigIpv6WithDataSourceIpv6CidrBlock(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsSubnet_CustomerOwnedIpv4Pool(t *testing.T) {
+	// Hide Outposts testing behind consistent environment variable
+	outpostArn := os.Getenv("AWS_OUTPOST_ARN")
+	if outpostArn == "" {
+		t.Skip(
+			"Environment variable AWS_OUTPOST_ARN is not set. " +
+				"This environment variable must be set to the ARN of " +
+				"a deployed Outpost to enable this test.")
+	}
+
+	// Local Gateway Route Table ID filtering in DescribeCoipPools is not currently working
+	poolId := os.Getenv("AWS_COIP_POOL_ID")
+	if poolId == "" {
+		t.Skip(
+			"Environment variable AWS_COIP_POOL_ID is not set. " +
+				"This environment variable must be set to the ID of " +
+				"a deployed Coip Pool to enable this test.")
+	}
+
+	dataSourceName := "data.aws_subnet.test"
+	resourceName := "aws_subnet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSubnetConfigCustomerOwnedIpv4Pool(outpostArn, poolId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "customer_owned_ipv4_pool", dataSourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrPair(resourceName, "map_customer_owned_ip_on_launch", dataSourceName, "map_customer_owned_ip_on_launch"),
 				),
 			},
 		},
@@ -306,4 +358,48 @@ data "aws_subnet" "by_ipv6_cidr" {
   ipv6_cidr_block = "${aws_subnet.test.ipv6_cidr_block}"
 }
 `, rInt, rInt)
+}
+
+func testAccDataSourceSubnetConfigCustomerOwnedIpv4Pool(outpostArn string, customerOwnedIpv4Pool string) string {
+	return fmt.Sprintf(`
+# TODO: This should be replaced with aws_outposts_outpost data source, when available.
+data "aws_availability_zones" "current" {
+  # Exclude Availability Zones with limited Outposts functionality.
+  blacklisted_zone_ids = ["usw2-az4"]
+
+  # Exclude Local Zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+data "aws_ec2_coip_pool" "test" {
+  pool_id = %[2]q
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-subnet-customer-owned-ipv4-pool"
+  }
+}
+
+resource "aws_subnet" "test" {
+  availability_zone        = data.aws_availability_zones.current.names[0]
+  cidr_block               = "10.1.1.0/24"
+  customer_owned_ipv4_pool = data.aws_ec2_coip_pool.test.id
+  outpost_arn              = %[1]q
+  vpc_id                   = aws_vpc.test.id
+
+  tags = {
+    Name = aws_vpc.test.tags["Name"]
+  }
+}
+
+data "aws_subnet" "test" {
+  id = aws_subnet.test.id
+}
+`, outpostArn, customerOwnedIpv4Pool)
 }

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -97,5 +97,8 @@ the selected subnet.
 In addition the following attributes are exported:
 
 * `arn` - The ARN of the subnet.
+* `customer_owned_ipv4_pool` - Identifier of customer owned IPv4 address pool.
+* `map_customer_owned_ip_on_launch` - Whether customer owned IP addresses are assigned on network interface creation.
+* `map_public_ip_on_launch` - Whether public IP addresses are assigned on instance launch.
 * `owner_id` - The ID of the AWS account that owns the subnet.
 * `outpost_arn` - The Amazon Resource Name (ARN) of the Outpost.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -51,8 +51,10 @@ The following arguments are supported:
 * `availability_zone` - (Optional) The AZ for the subnet.
 * `availability_zone_id` - (Optional) The AZ ID of the subnet.
 * `cidr_block` - (Required) The CIDR block for the subnet.
+* `customer_owned_ipv4_pool` - (Optional) The customer owned IPv4 address pool. Typically used with the `map_customer_owned_ip_on_launch` argument. The `outpost_arn` argument must be specified when configured.
 * `ipv6_cidr_block` - (Optional) The IPv6 network range for the subnet,
     in CIDR notation. The subnet size must use a /64 prefix length.
+* `map_customer_owned_ip_on_launch` -  (Optional) Specify `true` to indicate that network interfaces created in the subnet should be assigned a customer owned IP address. The `customer_owned_ipv4_pool` and `outpost_arn` arguments must be specified when set to `true`. Default is `false`.
 * `map_public_ip_on_launch` -  (Optional) Specify true to indicate
     that instances launched into the subnet should be assigned
     a public IP address. Default is `false`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13170
Closes #13171

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch` attributes
* resource/aws_subnet: Add `customer_owned_ipv4_pool` and `map_customer_owned_ip_on_launch` arguments
```

Output from acceptance testing:

```
Pending us-west-2 deployment of EC2 API.
```