### PR TITLE
service/neptune: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -21,6 +21,8 @@ const (
 	// is not currently available in the AWS sdk-for-go
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/neptune/#pkg-constants
 	CloudwatchLogsExportsAudit = "audit"
+
+	neptuneDefaultPort = 8182
 )
 
 func resourceAwsNeptuneCluster() *schema.Resource {
@@ -194,7 +196,7 @@ func resourceAwsNeptuneCluster() *schema.Resource {
 			"port": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  8182,
+				Default:  neptuneDefaultPort,
 				ForceNew: true,
 			},
 

--- a/aws/resource_aws_neptune_cluster_instance.go
+++ b/aws/resource_aws_neptune_cluster_instance.go
@@ -134,7 +134,7 @@ func resourceAwsNeptuneClusterInstance() *schema.Resource {
 			"port": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  8182,
+				Default:  neptuneDefaultPort,
 				ForceNew: true,
 			},
 

--- a/aws/resource_aws_neptune_cluster_instance_test.go
+++ b/aws/resource_aws_neptune_cluster_instance_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -15,6 +16,13 @@ import (
 
 func TestAccAWSNeptuneClusterInstance_basic(t *testing.T) {
 	var v neptune.DBInstance
+	rInt := acctest.RandInt()
+
+	resourceName := "aws_neptune_cluster_instance.cluster_instances"
+	clusterResourceName := "aws_neptune_cluster.default"
+	parameterGroupResourceName := "aws_neptune_parameter_group.test"
+
+	clusterInstanceName := fmt.Sprintf("tf-cluster-instance-%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,40 +30,38 @@ func TestAccAWSNeptuneClusterInstance_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterInstanceConfig(acctest.RandInt()),
+				Config: testAccAWSNeptuneClusterInstanceConfig(clusterInstanceName, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterInstanceExists("aws_neptune_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSNeptuneClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterInstanceAttributes(&v),
-					resource.TestCheckResourceAttrSet("aws_neptune_cluster_instance.cluster_instances", "address"),
-					resource.TestMatchResourceAttr("aws_neptune_cluster_instance.cluster_instances", "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:[^:]+:db:.+`)),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "auto_minor_version_upgrade", "true"),
-					resource.TestMatchResourceAttr("aws_neptune_cluster_instance.cluster_instances", "availability_zone", regexp.MustCompile(fmt.Sprintf("^%s", testAccGetRegion()))),
-					resource.TestCheckResourceAttrSet("aws_neptune_cluster_instance.cluster_instances", "cluster_identifier"),
-					resource.TestCheckResourceAttrSet("aws_neptune_cluster_instance.cluster_instances", "dbi_resource_id"),
-					resource.TestMatchResourceAttr("aws_neptune_cluster_instance.cluster_instances", "endpoint", regexp.MustCompile(`:8182$`)),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "engine", "neptune"),
-					resource.TestCheckResourceAttrSet("aws_neptune_cluster_instance.cluster_instances", "engine_version"),
-					resource.TestCheckResourceAttrSet("aws_neptune_cluster_instance.cluster_instances", "identifier"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "instance_class", "db.r4.large"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "kms_key_arn", ""),
-					resource.TestMatchResourceAttr("aws_neptune_cluster_instance.cluster_instances", "neptune_parameter_group_name", regexp.MustCompile(`^tf-cluster-test-group-`)),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "neptune_subnet_group_name", "default"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "port", "8182"),
-					resource.TestCheckResourceAttrSet("aws_neptune_cluster_instance.cluster_instances", "preferred_backup_window"),
-					resource.TestCheckResourceAttrSet("aws_neptune_cluster_instance.cluster_instances", "preferred_maintenance_window"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "promotion_tier", "3"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "publicly_accessible", "false"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "storage_encrypted", "false"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "tags.%", "0"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "writer", "true"),
+					testAccCheckNeptuneClusterAddress(&v, resourceName, neptuneDefaultPort),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("db:%s", clusterInstanceName)),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
+					resource.TestMatchResourceAttr(resourceName, "availability_zone", regexp.MustCompile(fmt.Sprintf("^%s[a-z]{1}$", testAccGetRegion()))),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_identifier", clusterResourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "dbi_resource_id"),
+					resource.TestCheckResourceAttr(resourceName, "engine", "neptune"),
+					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
+					resource.TestCheckResourceAttr(resourceName, "identifier", clusterInstanceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_class", "db.r4.large"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "neptune_parameter_group_name", parameterGroupResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "neptune_subnet_group_name", "default"),
+					resource.TestCheckResourceAttrSet(resourceName, "preferred_backup_window"),
+					resource.TestCheckResourceAttrSet(resourceName, "preferred_maintenance_window"),
+					resource.TestCheckResourceAttr(resourceName, "promotion_tier", "3"),
+					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
+					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "writer", "true"),
 				),
 			},
 			{
-				Config: testAccAWSNeptuneClusterInstanceConfigModified(acctest.RandInt()),
+				Config: testAccAWSNeptuneClusterInstanceConfigModified(clusterInstanceName, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterInstanceExists("aws_neptune_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSNeptuneClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterInstanceAttributes(&v),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_instance.cluster_instances", "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 				),
 			},
 		},
@@ -64,6 +70,10 @@ func TestAccAWSNeptuneClusterInstance_basic(t *testing.T) {
 
 func TestAccAWSNeptuneClusterInstance_withaz(t *testing.T) {
 	var v neptune.DBInstance
+	rInt := acctest.RandInt()
+
+	resourceName := "aws_neptune_cluster_instance.cluster_instances"
+	availabiltyZonesDataSourceName := "data.aws_availability_zones.available"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,11 +81,12 @@ func TestAccAWSNeptuneClusterInstance_withaz(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterInstanceConfig_az(acctest.RandInt()),
+				Config: testAccAWSNeptuneClusterInstanceConfig_az(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterInstanceExists("aws_neptune_cluster_instance.cluster_instances", &v),
+					testAccCheckAWSNeptuneClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterInstanceAttributes(&v),
-					resource.TestMatchResourceAttr("aws_neptune_cluster_instance.cluster_instances", "availability_zone", regexp.MustCompile("^us-west-2[a-z]{1}$")),
+					resource.TestMatchResourceAttr(resourceName, "availability_zone", regexp.MustCompile(fmt.Sprintf("^%s[a-z]{1}$", testAccGetRegion()))), // NOPE
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", availabiltyZonesDataSourceName, "names.0"),
 				),
 			},
 		},
@@ -86,18 +97,21 @@ func TestAccAWSNeptuneClusterInstance_namePrefix(t *testing.T) {
 	var v neptune.DBInstance
 	rInt := acctest.RandInt()
 
+	resourceName := "aws_neptune_cluster_instance.test"
+
+	namePrefix := "tf-cluster-instance-"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterInstanceConfig_namePrefix(rInt),
+				Config: testAccAWSNeptuneClusterInstanceConfig_namePrefix(namePrefix, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterInstanceExists("aws_neptune_cluster_instance.test", &v),
+					testAccCheckAWSNeptuneClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterInstanceAttributes(&v),
-					resource.TestMatchResourceAttr(
-						"aws_neptune_cluster_instance.test", "identifier", regexp.MustCompile("^tf-cluster-instance-")),
+					resource.TestMatchResourceAttr(resourceName, "identifier", regexp.MustCompile(fmt.Sprintf("^%s", namePrefix))),
 				),
 			},
 		},
@@ -108,6 +122,9 @@ func TestAccAWSNeptuneClusterInstance_withSubnetGroup(t *testing.T) {
 	var v neptune.DBInstance
 	rInt := acctest.RandInt()
 
+	resourceName := "aws_neptune_cluster_instance.test"
+	subnetGroupResourceName := "aws_neptune_subnet_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -116,10 +133,9 @@ func TestAccAWSNeptuneClusterInstance_withSubnetGroup(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneClusterInstanceConfig_withSubnetGroup(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterInstanceExists("aws_neptune_cluster_instance.test", &v),
+					testAccCheckAWSNeptuneClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterInstanceAttributes(&v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster_instance.test", "neptune_subnet_group_name", fmt.Sprintf("tf-test-%d", rInt)),
+					resource.TestCheckResourceAttrPair(resourceName, "neptune_subnet_group_name", subnetGroupResourceName, "name"),
 				),
 			},
 		},
@@ -128,6 +144,9 @@ func TestAccAWSNeptuneClusterInstance_withSubnetGroup(t *testing.T) {
 
 func TestAccAWSNeptuneClusterInstance_generatedName(t *testing.T) {
 	var v neptune.DBInstance
+	rInt := acctest.RandInt()
+
+	resourceName := "aws_neptune_cluster_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -135,12 +154,11 @@ func TestAccAWSNeptuneClusterInstance_generatedName(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterInstanceConfig_generatedName(acctest.RandInt()),
+				Config: testAccAWSNeptuneClusterInstanceConfig_generatedName(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterInstanceExists("aws_neptune_cluster_instance.test", &v),
+					testAccCheckAWSNeptuneClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterInstanceAttributes(&v),
-					resource.TestMatchResourceAttr(
-						"aws_neptune_cluster_instance.test", "identifier", regexp.MustCompile("^tf-")),
+					resource.TestMatchResourceAttr(resourceName, "identifier", regexp.MustCompile("^tf-")),
 				),
 			},
 		},
@@ -149,7 +167,10 @@ func TestAccAWSNeptuneClusterInstance_generatedName(t *testing.T) {
 
 func TestAccAWSNeptuneClusterInstance_kmsKey(t *testing.T) {
 	var v neptune.DBInstance
-	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+	rInt := acctest.RandInt()
+
+	resourceName := "aws_neptune_cluster_instance.cluster_instances"
+	kmsKeyResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -157,11 +178,10 @@ func TestAccAWSNeptuneClusterInstance_kmsKey(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneClusterInstanceConfigKmsKey(acctest.RandInt()),
+				Config: testAccAWSNeptuneClusterInstanceConfigKmsKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterInstanceExists("aws_neptune_cluster_instance.cluster_instances", &v),
-					resource.TestMatchResourceAttr(
-						"aws_neptune_cluster_instance.cluster_instances", "kms_key_arn", keyRegex),
+					testAccCheckAWSNeptuneClusterInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", kmsKeyResourceName, "arn"),
 				),
 			},
 		},
@@ -214,24 +234,46 @@ func testAccCheckAWSNeptuneClusterInstanceAttributes(v *neptune.DBInstance) reso
 	}
 }
 
-func testAccAWSNeptuneClusterInstanceConfig(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier  = "tf-neptune-cluster-test-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
-  skip_final_snapshot = true
+func testAccCheckNeptuneClusterAddress(v *neptune.DBInstance, resourceName string, portNumber int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		address := aws.StringValue(v.Endpoint.Address)
+		if err := resource.TestCheckResourceAttr(resourceName, "address", address)(s); err != nil {
+			return err
+		}
+
+		port := strconv.Itoa(portNumber)
+		if err := resource.TestCheckResourceAttr(resourceName, "port", port)(s); err != nil {
+			return err
+		}
+
+		if err := resource.TestCheckResourceAttr(resourceName, "endpoint", fmt.Sprintf("%s:%s", address, port))(s); err != nil {
+			return err
+		}
+
+		return nil
+	}
 }
 
+func testAccAWSNeptuneClusterInstanceConfig(instanceName string, n int) string {
+	return composeConfig(
+		testAccAWSNeptuneClusterConfigBase,
+		fmt.Sprintf(`
 resource "aws_neptune_cluster_instance" "cluster_instances" {
-  identifier                   = "tf-cluster-instance-%d"
+  identifier                   = %[1]q
   cluster_identifier           = "${aws_neptune_cluster.default.id}"
   instance_class               = "db.r4.large"
-  neptune_parameter_group_name = "${aws_neptune_parameter_group.bar.name}"
+  neptune_parameter_group_name = "${aws_neptune_parameter_group.test.name}"
   promotion_tier               = "3"
 }
 
-resource "aws_neptune_parameter_group" "bar" {
-  name   = "tf-cluster-test-group-%d"
+resource "aws_neptune_cluster" "default" {
+  cluster_identifier  = "tf-neptune-cluster-test-%[2]d"
+  availability_zones  = local.availability_zone_names
+  skip_final_snapshot = true
+}
+
+resource "aws_neptune_parameter_group" "test" {
+  name   = "tf-cluster-test-group-%[2]d"
   family = "neptune1"
 
   parameter {
@@ -240,73 +282,33 @@ resource "aws_neptune_parameter_group" "bar" {
   }
 
   tags = {
-    foo = "bar"
+    Name = "test"
   }
 }
-`, n, n, n)
+`, instanceName, n))
 }
 
-func testAccAWSNeptuneClusterInstanceConfigModified(n int) string {
-	return fmt.Sprintf(`
-resource "aws_neptune_cluster" "default" {
-  cluster_identifier  = "tf-neptune-cluster-test-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
-  skip_final_snapshot = true
-}
-
+func testAccAWSNeptuneClusterInstanceConfigModified(instanceName string, n int) string {
+	return composeConfig(
+		testAccAWSNeptuneClusterConfigBase,
+		fmt.Sprintf(`
 resource "aws_neptune_cluster_instance" "cluster_instances" {
-  identifier                   = "tf-cluster-instance-%d"
+  identifier                   = %[1]q
   cluster_identifier           = "${aws_neptune_cluster.default.id}"
   instance_class               = "db.r4.large"
-  neptune_parameter_group_name = "${aws_neptune_parameter_group.bar.name}"
+  neptune_parameter_group_name = "${aws_neptune_parameter_group.test.name}"
   auto_minor_version_upgrade   = false
   promotion_tier               = "3"
 }
 
-resource "aws_neptune_parameter_group" "bar" {
-  name   = "tf-cluster-test-group-%d"
-  family = "neptune1"
-
-  parameter {
-    name  = "neptune_query_timeout"
-    value = "25"
-  }
-
-  tags = {
-    foo = "bar"
-  }
-}
-`, n, n, n)
-}
-
-func testAccAWSNeptuneClusterInstanceConfig_az(n int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_neptune_cluster" "default" {
-  cluster_identifier  = "tf-neptune-cluster-test-%d"
-  availability_zones  = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
+  cluster_identifier  = "tf-neptune-cluster-test-%[2]d"
+  availability_zones  = local.availability_zone_names
   skip_final_snapshot = true
 }
 
-resource "aws_neptune_cluster_instance" "cluster_instances" {
-  identifier                   = "tf-cluster-instance-%d"
-  cluster_identifier           = "${aws_neptune_cluster.default.id}"
-  instance_class               = "db.r4.large"
-  neptune_parameter_group_name = "${aws_neptune_parameter_group.bar.name}"
-  promotion_tier               = "3"
-  availability_zone            = "${data.aws_availability_zones.available.names[0]}"
-}
-
-resource "aws_neptune_parameter_group" "bar" {
-  name   = "tf-cluster-test-group-%d"
+resource "aws_neptune_parameter_group" "test" {
+  name   = "tf-cluster-test-group-%[2]d"
   family = "neptune1"
 
   parameter {
@@ -315,22 +317,59 @@ resource "aws_neptune_parameter_group" "bar" {
   }
 
   tags = {
-    foo = "bar"
+    Name = "test"
   }
 }
-`, n, n, n)
+`, instanceName, n))
+}
+
+func testAccAWSNeptuneClusterInstanceConfig_az(n int) string {
+	return composeConfig(
+		testAccAWSNeptuneClusterConfigBase,
+		fmt.Sprintf(`
+resource "aws_neptune_cluster_instance" "cluster_instances" {
+  identifier                   = "tf-cluster-instance-%[1]d"
+  cluster_identifier           = "${aws_neptune_cluster.default.id}"
+  instance_class               = "db.r4.large"
+  neptune_parameter_group_name = "${aws_neptune_parameter_group.test.name}"
+  promotion_tier               = "3"
+  availability_zone            = data.aws_availability_zones.available.names[0]
+}
+
+resource "aws_neptune_cluster" "default" {
+  cluster_identifier  = "tf-neptune-cluster-test-%[1]d"
+  availability_zones  = local.availability_zone_names
+  skip_final_snapshot = true
+}
+
+resource "aws_neptune_parameter_group" "test" {
+  name   = "tf-cluster-test-group-%[1]d"
+  family = "neptune1"
+
+  parameter {
+    name  = "neptune_query_timeout"
+    value = "25"
+  }
+
+  tags = {
+    Name = "test"
+  }
+}
+`, n))
 }
 
 func testAccAWSNeptuneClusterInstanceConfig_withSubnetGroup(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSNeptuneClusterConfigBase,
+		fmt.Sprintf(`
 resource "aws_neptune_cluster_instance" "test" {
-  identifier         = "tf-cluster-instance-%d"
+  identifier         = "tf-cluster-instance-%[1]d"
   cluster_identifier = "${aws_neptune_cluster.test.id}"
   instance_class     = "db.r4.large"
 }
 
 resource "aws_neptune_cluster" "test" {
-  cluster_identifier        = "tf-neptune-cluster-%d"
+  cluster_identifier        = "tf-neptune-cluster-%[1]d"
   neptune_subnet_group_name = "${aws_neptune_subnet_group.test.name}"
   skip_final_snapshot       = true
 }
@@ -364,22 +403,24 @@ resource "aws_subnet" "b" {
 }
 
 resource "aws_neptune_subnet_group" "test" {
-  name       = "tf-test-%d"
+  name       = "tf-test-%[1]d"
   subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
 }
-`, n, n, n)
+`, n))
 }
 
-func testAccAWSNeptuneClusterInstanceConfig_namePrefix(n int) string {
-	return fmt.Sprintf(`
+func testAccAWSNeptuneClusterInstanceConfig_namePrefix(namePrefix string, n int) string {
+	return composeConfig(
+		testAccAWSNeptuneClusterConfigBase,
+		fmt.Sprintf(`
 resource "aws_neptune_cluster_instance" "test" {
-  identifier_prefix  = "tf-cluster-instance-"
+  identifier_prefix  = %[1]q
   cluster_identifier = "${aws_neptune_cluster.test.id}"
   instance_class     = "db.r4.large"
 }
 
 resource "aws_neptune_cluster" "test" {
-  cluster_identifier        = "tf-neptune-cluster-%d"
+  cluster_identifier        = "tf-neptune-cluster-%[2]d"
   neptune_subnet_group_name = "${aws_neptune_subnet_group.test.name}"
   skip_final_snapshot       = true
 }
@@ -413,21 +454,23 @@ resource "aws_subnet" "b" {
 }
 
 resource "aws_neptune_subnet_group" "test" {
-  name       = "tf-test-%d"
+  name       = "tf-test-%[2]d"
   subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
 }
-`, n, n)
+`, namePrefix, n))
 }
 
 func testAccAWSNeptuneClusterInstanceConfig_generatedName(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSNeptuneClusterConfigBase,
+		fmt.Sprintf(`
 resource "aws_neptune_cluster_instance" "test" {
   cluster_identifier = "${aws_neptune_cluster.test.id}"
   instance_class     = "db.r4.large"
 }
 
 resource "aws_neptune_cluster" "test" {
-  cluster_identifier        = "tf-neptune-cluster-%d"
+  cluster_identifier        = "tf-neptune-cluster-%[1]d"
   neptune_subnet_group_name = "${aws_neptune_subnet_group.test.name}"
   skip_final_snapshot       = true
 }
@@ -461,16 +504,18 @@ resource "aws_subnet" "b" {
 }
 
 resource "aws_neptune_subnet_group" "test" {
-  name       = "tf-test-%d"
+  name       = "tf-test-%[1]d"
   subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
 }
-`, n, n)
+`, n))
 }
 
 func testAccAWSNeptuneClusterInstanceConfigKmsKey(n int) string {
-	return fmt.Sprintf(`
-resource "aws_kms_key" "foo" {
-  description = "Terraform acc test %d"
+	return composeConfig(
+		testAccAWSNeptuneClusterConfigBase,
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = "Terraform acc test %[1]d"
 
   policy = <<POLICY
 {
@@ -492,22 +537,22 @@ POLICY
 }
 
 resource "aws_neptune_cluster" "default" {
-  cluster_identifier  = "tf-neptune-cluster-test-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier  = "tf-neptune-cluster-test-%[1]d"
+  availability_zones  = local.availability_zone_names
   skip_final_snapshot = true
   storage_encrypted   = true
-  kms_key_arn         = "${aws_kms_key.foo.arn}"
+  kms_key_arn         = "${aws_kms_key.test.arn}"
 }
 
 resource "aws_neptune_cluster_instance" "cluster_instances" {
-  identifier                   = "tf-cluster-instance-%d"
+  identifier                   = "tf-cluster-instance-%[1]d"
   cluster_identifier           = "${aws_neptune_cluster.default.id}"
   instance_class               = "db.r4.large"
-  neptune_parameter_group_name = "${aws_neptune_parameter_group.bar.name}"
+  neptune_parameter_group_name = "${aws_neptune_parameter_group.test.name}"
 }
 
-resource "aws_neptune_parameter_group" "bar" {
-  name   = "tf-cluster-test-group-%d"
+resource "aws_neptune_parameter_group" "test" {
+  name   = "tf-cluster-test-group-%[1]d"
   family = "neptune1"
 
   parameter {
@@ -516,8 +561,8 @@ resource "aws_neptune_parameter_group" "bar" {
   }
 
   tags = {
-    foo = "bar"
+    Name = "test"
   }
 }
-`, n, n, n, n)
+`, n))
 }

--- a/aws/resource_aws_neptune_cluster_parameter_group_test.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group_test.go
@@ -16,7 +16,9 @@ import (
 func TestAccAWSNeptuneClusterParameterGroup_basic(t *testing.T) {
 	var v neptune.DBClusterParameterGroup
 
-	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+	parameterGroupName := acctest.RandomWithPrefix("cluster-parameter-group-test-terraform")
+
+	resourceName := "aws_neptune_cluster_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -26,22 +28,18 @@ func TestAccAWSNeptuneClusterParameterGroup_basic(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestMatchResourceAttr(
-						"aws_neptune_cluster_parameter_group.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:cluster-pg:%s", parameterGroupName))),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster_parameter_group.bar", "name", parameterGroupName),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster_parameter_group.bar", "family", "neptune1"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_cluster_parameter_group.bar", "description", "Managed by Terraform"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.#", "0"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "tags.%", "0"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("cluster-pg:%s", parameterGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "name", parameterGroupName),
+					resource.TestCheckResourceAttr(resourceName, "family", "neptune1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster_parameter_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -52,6 +50,8 @@ func TestAccAWSNeptuneClusterParameterGroup_basic(t *testing.T) {
 func TestAccAWSNeptuneClusterParameterGroup_namePrefix(t *testing.T) {
 	var v neptune.DBClusterParameterGroup
 
+	resourceName := "aws_neptune_cluster_parameter_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -60,13 +60,12 @@ func TestAccAWSNeptuneClusterParameterGroup_namePrefix(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.test", &v),
-					resource.TestMatchResourceAttr(
-						"aws_neptune_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
+					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^tf-test-")),
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster_parameter_group.test",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"name_prefix"},
@@ -78,6 +77,8 @@ func TestAccAWSNeptuneClusterParameterGroup_namePrefix(t *testing.T) {
 func TestAccAWSNeptuneClusterParameterGroup_generatedName(t *testing.T) {
 	var v neptune.DBClusterParameterGroup
 
+	resourceName := "aws_neptune_cluster_parameter_group.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -86,11 +87,11 @@ func TestAccAWSNeptuneClusterParameterGroup_generatedName(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig_generatedName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.test", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster_parameter_group.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -101,7 +102,9 @@ func TestAccAWSNeptuneClusterParameterGroup_generatedName(t *testing.T) {
 func TestAccAWSNeptuneClusterParameterGroup_Description(t *testing.T) {
 	var v neptune.DBClusterParameterGroup
 
-	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+	resourceName := "aws_neptune_cluster_parameter_group.test"
+
+	parameterGroupName := acctest.RandomWithPrefix("cluster-parameter-group-test-terraform")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -111,13 +114,13 @@ func TestAccAWSNeptuneClusterParameterGroup_Description(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig_Description(parameterGroupName, "custom description"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "description", "custom description"),
+					resource.TestCheckResourceAttr(resourceName, "description", "custom description"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster_parameter_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -128,7 +131,9 @@ func TestAccAWSNeptuneClusterParameterGroup_Description(t *testing.T) {
 func TestAccAWSNeptuneClusterParameterGroup_Parameter(t *testing.T) {
 	var v neptune.DBClusterParameterGroup
 
-	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
+	resourceName := "aws_neptune_cluster_parameter_group.test"
+
+	parameterGroupName := acctest.RandomWithPrefix("cluster-parameter-group-test-tf")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -138,28 +143,28 @@ func TestAccAWSNeptuneClusterParameterGroup_Parameter(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig_Parameter(parameterGroupName, "neptune_enable_audit_log", "1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.#", "1"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.709171678.apply_method", "pending-reboot"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.709171678.name", "neptune_enable_audit_log"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.709171678.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.709171678.apply_method", "pending-reboot"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.709171678.name", "neptune_enable_audit_log"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.709171678.value", "1"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster_parameter_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig_Parameter(parameterGroupName, "neptune_enable_audit_log", "0"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.#", "1"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.861808799.apply_method", "pending-reboot"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.861808799.name", "neptune_enable_audit_log"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "parameter.861808799.value", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.861808799.apply_method", "pending-reboot"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.861808799.name", "neptune_enable_audit_log"),
+					resource.TestCheckResourceAttr(resourceName, "parameter.861808799.value", "0"),
 				),
 			},
 		},
@@ -169,7 +174,9 @@ func TestAccAWSNeptuneClusterParameterGroup_Parameter(t *testing.T) {
 func TestAccAWSNeptuneClusterParameterGroup_Tags(t *testing.T) {
 	var v neptune.DBClusterParameterGroup
 
-	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
+	resourceName := "aws_neptune_cluster_parameter_group.test"
+
+	parameterGroupName := acctest.RandomWithPrefix("cluster-parameter-group-test-tf")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -179,33 +186,33 @@ func TestAccAWSNeptuneClusterParameterGroup_Tags(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig_Tags(parameterGroupName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_cluster_parameter_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig_Tags(parameterGroupName, "key1", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "tags.key1", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value2"),
 				),
 			},
 			{
 				Config: testAccAWSNeptuneClusterParameterGroupConfig_Tags(parameterGroupName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneClusterParameterGroupExists("aws_neptune_cluster_parameter_group.bar", &v),
+					testAccCheckAWSNeptuneClusterParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneClusterParameterGroupAttributes(&v, parameterGroupName),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_neptune_cluster_parameter_group.bar", "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 		},
@@ -294,7 +301,7 @@ func testAccCheckAWSNeptuneClusterParameterGroupExists(n string, v *neptune.DBCl
 
 func testAccAWSNeptuneClusterParameterGroupConfig_Description(name, description string) string {
 	return fmt.Sprintf(`
-resource "aws_neptune_cluster_parameter_group" "bar" {
+resource "aws_neptune_cluster_parameter_group" "test" {
   description = "%s"
   family      = "neptune1"
   name        = "%s"
@@ -304,7 +311,7 @@ resource "aws_neptune_cluster_parameter_group" "bar" {
 
 func testAccAWSNeptuneClusterParameterGroupConfig_Parameter(name, pName, pValue string) string {
 	return fmt.Sprintf(`
-resource "aws_neptune_cluster_parameter_group" "bar" {
+resource "aws_neptune_cluster_parameter_group" "test" {
   family = "neptune1"
   name   = "%s"
 
@@ -318,7 +325,7 @@ resource "aws_neptune_cluster_parameter_group" "bar" {
 
 func testAccAWSNeptuneClusterParameterGroupConfig_Tags(name, tKey, tValue string) string {
 	return fmt.Sprintf(`
-resource "aws_neptune_cluster_parameter_group" "bar" {
+resource "aws_neptune_cluster_parameter_group" "test" {
   family = "neptune1"
   name   = "%s"
 
@@ -331,7 +338,7 @@ resource "aws_neptune_cluster_parameter_group" "bar" {
 
 func testAccAWSNeptuneClusterParameterGroupConfig(name string) string {
 	return fmt.Sprintf(`
-resource "aws_neptune_cluster_parameter_group" "bar" {
+resource "aws_neptune_cluster_parameter_group" "test" {
   family = "neptune1"
   name   = "%s"
 }

--- a/aws/resource_aws_neptune_cluster_snapshot_test.go
+++ b/aws/resource_aws_neptune_cluster_snapshot_test.go
@@ -28,7 +28,7 @@ func TestAccAWSNeptuneClusterSnapshot_basic(t *testing.T) {
 					testAccCheckNeptuneClusterSnapshotExists(resourceName, &dbClusterSnapshot),
 					resource.TestCheckResourceAttrSet(resourceName, "allocated_storage"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zones.#"),
-					resource.TestMatchResourceAttr(resourceName, "db_cluster_snapshot_arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-snapshot:.+`)),
+					testAccCheckResourceAttrRegionalARN(resourceName, "db_cluster_snapshot_arn", "rds", fmt.Sprintf("cluster-snapshot:%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "engine"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
@@ -113,13 +113,13 @@ func testAccCheckNeptuneClusterSnapshotExists(resourceName string, dbClusterSnap
 func testAccAwsNeptuneClusterSnapshotConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
-  cluster_identifier  = %q
+  cluster_identifier  = %[1]q
   skip_final_snapshot = true
 }
 
 resource "aws_neptune_cluster_snapshot" "test" {
   db_cluster_identifier          = "${aws_neptune_cluster.test.id}"
-  db_cluster_snapshot_identifier = %q
+  db_cluster_snapshot_identifier = %[1]q
 }
-`, rName, rName)
+`, rName)
 }

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -570,7 +570,7 @@ func testAccCheckAWSNeptuneClusterSnapshot(rName string) resource.TestCheckFunc 
 }
 
 var testAccAWSNeptuneClusterConfigBase = `
-data "aws_availability_zones" "test" {
+data "aws_availability_zones" "available" {
   state = "available"
 
   filter {
@@ -578,13 +578,17 @@ data "aws_availability_zones" "test" {
     values = ["opt-in-not-required"]
   }
 }
+
+locals {
+	availability_zone_names = slice(data.aws_availability_zones.available.names, 0, min(3, length(data.aws_availability_zones.available.names)))
+}
 `
 
 func testAccAWSNeptuneClusterConfig(rName string) string {
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %q
-  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
@@ -596,11 +600,11 @@ func testAccAWSNeptuneClusterConfigDeleteProtection(rName string, isProtected bo
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %q
-  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
-  deletion_protection                    = %t
+  deletion_protection                  = %t
 }
 `, rName, isProtected)
 }
@@ -620,7 +624,7 @@ func testAccAWSNeptuneClusterConfigWithFinalSnapshot(rName string) string {
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
-  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones                   = local.availability_zone_names
   neptune_cluster_parameter_group_name = "default.neptune1"
   final_snapshot_identifier            = %[1]q
 }
@@ -631,7 +635,7 @@ func testAccAWSNeptuneClusterConfigTags1(rName, tagKey1, tagValue1 string) strin
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
-  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
@@ -647,7 +651,7 @@ func testAccAWSNeptuneClusterConfigTags2(rName, tagKey1, tagValue1, tagKey2, tag
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
-  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
@@ -738,7 +742,7 @@ EOF
 
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
-  availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones                   = local.availability_zone_names
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
 
@@ -825,7 +829,7 @@ EOF
 
 resource "aws_neptune_cluster" "test" {
   cluster_identifier  = %[1]q
-  availability_zones  = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones  = local.availability_zone_names
   skip_final_snapshot = true
   iam_roles           = ["${aws_iam_role.test.arn}", "${aws_iam_role.test-2.arn}"]
 
@@ -875,7 +879,7 @@ EOF
 
 resource "aws_neptune_cluster" "test" {
   cluster_identifier  = %[1]q
-  availability_zones  = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones  = local.availability_zone_names
   skip_final_snapshot = true
   iam_roles           = ["${aws_iam_role.test.arn}"]
 
@@ -910,7 +914,7 @@ func testAccAWSNeptuneClusterConfig_kmsKey(rName string) string {
 
  resource "aws_neptune_cluster" "test" {
    cluster_identifier                   = %q
-   availability_zones                   = "${slice(data.aws_availability_zones.test.names,0,3)}"
+   availability_zones                   = local.availability_zone_names
    neptune_cluster_parameter_group_name = "default.neptune1"
    storage_encrypted                    = true
    kms_key_arn                          = "${aws_kms_key.test.arn}"
@@ -922,7 +926,7 @@ func testAccAWSNeptuneClusterConfig_encrypted(rName string) string {
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier = %q
-  availability_zones = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones = local.availability_zone_names
   storage_encrypted = true
   skip_final_snapshot = true
 }
@@ -933,7 +937,7 @@ func testAccAWSNeptuneClusterConfig_backups(rName string) string {
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier           = %q
-  availability_zones           = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones           = local.availability_zone_names
   backup_retention_period      = 5
   preferred_backup_window      = "07:00-09:00"
   preferred_maintenance_window = "tue:04:00-tue:04:30"
@@ -946,7 +950,7 @@ func testAccAWSNeptuneClusterConfig_backupsUpdate(rName string) string {
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier           = %q
-  availability_zones           = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones           = local.availability_zone_names
   backup_retention_period      = 10
   preferred_backup_window      = "03:00-09:00"
   preferred_maintenance_window = "wed:01:00-wed:01:30"
@@ -960,7 +964,7 @@ func testAccAWSNeptuneClusterConfig_iamAuth(rName string) string {
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                  = %q
-  availability_zones                  = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones                  = local.availability_zone_names
   iam_database_authentication_enabled = true
   skip_final_snapshot                 = true
 }
@@ -971,7 +975,7 @@ func testAccAWSNeptuneClusterConfig_cloudwatchLogsExports(rName string) string {
 	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %q
-  availability_zones                  = "${slice(data.aws_availability_zones.test.names,0,3)}"
+  availability_zones                  = local.availability_zone_names
   skip_final_snapshot                  = true
   enable_cloudwatch_logs_exports       = ["audit"]
 }

--- a/aws/resource_aws_neptune_event_subscription_test.go
+++ b/aws/resource_aws_neptune_event_subscription_test.go
@@ -18,35 +18,37 @@ func TestAccAWSNeptuneEventSubscription_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	rName := fmt.Sprintf("tf-acc-test-neptune-event-subs-%d", rInt)
 
+	resourceName := "aws_neptune_event_subscription.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSNeptuneEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneEventSubscriptionConfig(rInt),
+				Config: testAccAWSNeptuneEventSubscriptionConfig(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneEventSubscriptionExists("aws_neptune_event_subscription.bar", &v),
-					resource.TestMatchResourceAttr("aws_neptune_event_subscription.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:[^:]+:es:%s$", rName))),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "enabled", "true"),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "source_type", "db-instance"),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "name", rName),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "tags.Name", "tf-acc-test"),
+					testAccCheckAWSNeptuneEventSubscriptionExists(resourceName, &v),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("es:%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-acc-test"),
 				),
 			},
 			{
-				Config: testAccAWSNeptuneEventSubscriptionConfigUpdate(rInt),
+				Config: testAccAWSNeptuneEventSubscriptionConfigUpdate(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneEventSubscriptionExists("aws_neptune_event_subscription.bar", &v),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "enabled", "false"),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "source_type", "db-parameter-group"),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "tags.Name", "tf-acc-test1"),
+					testAccCheckAWSNeptuneEventSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-acc-test1"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_event_subscription.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -59,6 +61,8 @@ func TestAccAWSNeptuneEventSubscription_withPrefix(t *testing.T) {
 	rInt := acctest.RandInt()
 	startsWithPrefix := regexp.MustCompile("^tf-acc-test-neptune-event-subs-")
 
+	resourceName := "aws_neptune_event_subscription.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -67,13 +71,12 @@ func TestAccAWSNeptuneEventSubscription_withPrefix(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneEventSubscriptionConfigWithPrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneEventSubscriptionExists("aws_neptune_event_subscription.bar", &v),
-					resource.TestMatchResourceAttr(
-						"aws_neptune_event_subscription.bar", "name", startsWithPrefix),
+					testAccCheckAWSNeptuneEventSubscriptionExists(resourceName, &v),
+					resource.TestMatchResourceAttr(resourceName, "name", startsWithPrefix),
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_event_subscription.bar",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"name_prefix"},
@@ -86,6 +89,8 @@ func TestAccAWSNeptuneEventSubscription_withSourceIds(t *testing.T) {
 	var v neptune.EventSubscription
 	rInt := acctest.RandInt()
 
+	resourceName := "aws_neptune_event_subscription.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -94,25 +99,21 @@ func TestAccAWSNeptuneEventSubscription_withSourceIds(t *testing.T) {
 			{
 				Config: testAccAWSNeptuneEventSubscriptionConfigWithSourceIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneEventSubscriptionExists("aws_neptune_event_subscription.bar", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_event_subscription.bar", "source_type", "db-parameter-group"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_event_subscription.bar", "source_ids.#", "1"),
+					testAccCheckAWSNeptuneEventSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr(resourceName, "source_ids.#", "1"),
 				),
 			},
 			{
 				Config: testAccAWSNeptuneEventSubscriptionConfigUpdateSourceIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneEventSubscriptionExists("aws_neptune_event_subscription.bar", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_event_subscription.bar", "source_type", "db-parameter-group"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_event_subscription.bar", "source_ids.#", "2"),
+					testAccCheckAWSNeptuneEventSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-parameter-group"),
+					resource.TestCheckResourceAttr(resourceName, "source_ids.#", "2"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_event_subscription.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -123,6 +124,9 @@ func TestAccAWSNeptuneEventSubscription_withSourceIds(t *testing.T) {
 func TestAccAWSNeptuneEventSubscription_withCategories(t *testing.T) {
 	var v neptune.EventSubscription
 	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-acc-test-neptune-event-subs-%d", rInt)
+
+	resourceName := "aws_neptune_event_subscription.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -130,27 +134,23 @@ func TestAccAWSNeptuneEventSubscription_withCategories(t *testing.T) {
 		CheckDestroy: testAccCheckAWSNeptuneEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSNeptuneEventSubscriptionConfig(rInt),
+				Config: testAccAWSNeptuneEventSubscriptionConfig(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneEventSubscriptionExists("aws_neptune_event_subscription.bar", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_event_subscription.bar", "source_type", "db-instance"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_event_subscription.bar", "event_categories.#", "5"),
+					testAccCheckAWSNeptuneEventSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
+					resource.TestCheckResourceAttr(resourceName, "event_categories.#", "5"),
 				),
 			},
 			{
-				Config: testAccAWSNeptuneEventSubscriptionConfigUpdateCategories(rInt),
+				Config: testAccAWSNeptuneEventSubscriptionConfigUpdateCategories(rName, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNeptuneEventSubscriptionExists("aws_neptune_event_subscription.bar", &v),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_event_subscription.bar", "source_type", "db-instance"),
-					resource.TestCheckResourceAttr(
-						"aws_neptune_event_subscription.bar", "event_categories.#", "1"),
+					testAccCheckAWSNeptuneEventSubscriptionExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "db-instance"),
+					resource.TestCheckResourceAttr(resourceName, "event_categories.#", "1"),
 				),
 			},
 			{
-				ResourceName:      "aws_neptune_event_subscription.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -228,14 +228,14 @@ func testAccCheckAWSNeptuneEventSubscriptionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSNeptuneEventSubscriptionConfig(rInt int) string {
+func testAccAWSNeptuneEventSubscriptionConfig(subscriptionName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-neptune-event-subs-sns-topic-%d"
+  name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
 }
 
-resource "aws_neptune_event_subscription" "bar" {
-  name          = "tf-acc-test-neptune-event-subs-%d"
+resource "aws_neptune_event_subscription" "test" {
+  name          = %[2]q
   sns_topic_arn = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type   = "db-instance"
 
@@ -251,17 +251,17 @@ resource "aws_neptune_event_subscription" "bar" {
     Name = "tf-acc-test"
   }
 }
-`, rInt, rInt)
+`, rInt, subscriptionName)
 }
 
-func testAccAWSNeptuneEventSubscriptionConfigUpdate(rInt int) string {
+func testAccAWSNeptuneEventSubscriptionConfigUpdate(subscriptionName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-neptune-event-subs-sns-topic-%d"
+  name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
 }
 
-resource "aws_neptune_event_subscription" "bar" {
-  name          = "tf-acc-test-neptune-event-subs-%d"
+resource "aws_neptune_event_subscription" "test" {
+  name          = %[2]q
   sns_topic_arn = "${aws_sns_topic.aws_sns_topic.arn}"
   enabled       = false
   source_type   = "db-parameter-group"
@@ -274,7 +274,7 @@ resource "aws_neptune_event_subscription" "bar" {
     Name = "tf-acc-test1"
   }
 }
-`, rInt, rInt)
+`, rInt, subscriptionName)
 }
 
 func testAccAWSNeptuneEventSubscriptionConfigWithPrefix(rInt int) string {
@@ -283,7 +283,7 @@ resource "aws_sns_topic" "aws_sns_topic" {
   name = "tf-acc-test-neptune-event-subs-sns-topic-%d"
 }
 
-resource "aws_neptune_event_subscription" "bar" {
+resource "aws_neptune_event_subscription" "test" {
   name_prefix   = "tf-acc-test-neptune-event-subs-"
   sns_topic_arn = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type   = "db-instance"
@@ -306,20 +306,20 @@ resource "aws_neptune_event_subscription" "bar" {
 func testAccAWSNeptuneEventSubscriptionConfigWithSourceIds(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-neptune-event-subs-sns-topic-%d"
+  name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
 }
 
-resource "aws_neptune_parameter_group" "bar" {
-  name        = "neptune-parameter-group-event-%d"
+resource "aws_neptune_parameter_group" "test" {
+  name        = "neptune-parameter-group-event-%[1]d"
   family      = "neptune1"
   description = "Test parameter group for terraform"
 }
 
-resource "aws_neptune_event_subscription" "bar" {
-  name          = "tf-acc-test-neptune-event-subs-with-ids-%d"
+resource "aws_neptune_event_subscription" "test" {
+  name          = "tf-acc-test-neptune-event-subs-with-ids-%[1]d"
   sns_topic_arn = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type   = "db-parameter-group"
-  source_ids    = ["${aws_neptune_parameter_group.bar.id}"]
+  source_ids    = ["${aws_neptune_parameter_group.test.id}"]
 
   event_categories = [
     "configuration change",
@@ -329,32 +329,32 @@ resource "aws_neptune_event_subscription" "bar" {
     Name = "tf-acc-test"
   }
 }
-`, rInt, rInt, rInt)
+`, rInt)
 }
 
 func testAccAWSNeptuneEventSubscriptionConfigUpdateSourceIds(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-neptune-event-subs-sns-topic-%d"
+  name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
 }
 
-resource "aws_neptune_parameter_group" "bar" {
-  name        = "neptune-parameter-group-event-%d"
+resource "aws_neptune_parameter_group" "test" {
+  name        = "neptune-parameter-group-event-%[1]d"
   family      = "neptune1"
   description = "Test parameter group for terraform"
 }
 
-resource "aws_neptune_parameter_group" "foo" {
-  name        = "neptune-parameter-group-event-2-%d"
+resource "aws_neptune_parameter_group" "test_2" {
+  name        = "neptune-parameter-group-event-2-%[1]d"
   family      = "neptune1"
   description = "Test parameter group for terraform"
 }
 
-resource "aws_neptune_event_subscription" "bar" {
-  name          = "tf-acc-test-neptune-event-subs-with-ids-%d"
+resource "aws_neptune_event_subscription" "test" {
+  name          = "tf-acc-test-neptune-event-subs-with-ids-%[1]d"
   sns_topic_arn = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type   = "db-parameter-group"
-  source_ids    = ["${aws_neptune_parameter_group.bar.id}", "${aws_neptune_parameter_group.foo.id}"]
+  source_ids    = ["${aws_neptune_parameter_group.test.id}", "${aws_neptune_parameter_group.test_2.id}"]
 
   event_categories = [
     "configuration change",
@@ -364,17 +364,17 @@ resource "aws_neptune_event_subscription" "bar" {
     Name = "tf-acc-test"
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt)
 }
 
-func testAccAWSNeptuneEventSubscriptionConfigUpdateCategories(rInt int) string {
+func testAccAWSNeptuneEventSubscriptionConfigUpdateCategories(subscriptionName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-neptune-event-subs-sns-topic-%d"
+  name = "tf-acc-test-neptune-event-subs-sns-topic-%[1]d"
 }
 
-resource "aws_neptune_event_subscription" "bar" {
-  name          = "tf-acc-test-neptune-event-subs-%d"
+resource "aws_neptune_event_subscription" "test" {
+  name          = %[2]q
   sns_topic_arn = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type   = "db-instance"
 
@@ -386,5 +386,5 @@ resource "aws_neptune_event_subscription" "bar" {
     Name = "tf-acc-test"
   }
 }
-`, rInt, rInt)
+`, rInt, subscriptionName)
 }

--- a/aws/resource_aws_neptune_parameter_group_test.go
+++ b/aws/resource_aws_neptune_parameter_group_test.go
@@ -27,7 +27,7 @@ func TestAccAWSNeptuneParameterGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNeptuneParameterGroupExists(resourceName, &v),
 					testAccCheckAWSNeptuneParameterGroupAttributes(&v, rName),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:pg:%s", rName))),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("pg:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(resourceName, "family", "neptune1"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_neptune_cluster_instance_test.go:30:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_neptune_cluster_instance_test.go:163:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_neptune_cluster_parameter_group_test.go:31:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_neptune_cluster_snapshot_test.go:31:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_neptune_event_subscription_test.go:30:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_neptune_parameter_group_test.go:30:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSNeptuneClusterInstance_basic (830.67s)
--- PASS: TestAccAWSNeptuneClusterInstance_generatedName (783.68s)
--- PASS: TestAccAWSNeptuneClusterInstance_kmsKey (792.31s)
--- PASS: TestAccAWSNeptuneClusterInstance_namePrefix (744.22s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (821.74s)
--- PASS: TestAccAWSNeptuneClusterInstance_withSubnetGroup (786.20s)
```

```
--- PASS: TestAccAWSNeptuneClusterParameterGroup_basic (20.50s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Description (19.97s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_generatedName (20.18s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_namePrefix (20.15s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Parameter (33.24s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Tags (45.14s)
```

```
--- PASS: TestAccAWSNeptuneClusterSnapshot_basic (210.87s)
```

```
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (187.69s)
--- PASS: TestAccAWSNeptuneCluster_basic (125.31s)
--- PASS: TestAccAWSNeptuneCluster_deleteProtection (193.05s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (132.87s)
--- PASS: TestAccAWSNeptuneCluster_iamAuth (117.54s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (140.41s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (117.60s)
--- PASS: TestAccAWSNeptuneCluster_tags (161.39s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (146.05s)
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (188.10s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (163.91s)
```

```
--- PASS: TestAccAWSNeptuneEventSubscription_basic (123.61s)
--- PASS: TestAccAWSNeptuneEventSubscription_withCategories (124.85s)
--- PASS: TestAccAWSNeptuneEventSubscription_withPrefix (80.75s)
--- PASS: TestAccAWSNeptuneEventSubscription_withSourceIds (94.02s)
--- PASS: TestAccAWSNeptuneParameterGroup_basic (33.78s)
```

```
--- PASS: TestAccAWSNeptuneParameterGroup_Description (19.28s)
--- PASS: TestAccAWSNeptuneParameterGroup_Parameter (39.59s)
--- PASS: TestAccAWSNeptuneParameterGroup_Tags (43.44s)
```
