### PR TITLE
.github/workflows/issues: Remove outdated GitHub Project handling

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,11 +12,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: label needs-triage
-
-    - name: Add new issue into Triage Board
-      uses: alex-page/github-project-automation-plus@v0.1.1
-      if: github.event.action == 'opened'
-      with:
-        project: AWS Provider Triage
-        column:  Needs Triage
-        repo-token: ${{ secrets.GITHUB_ACTIONS_TOKEN }}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/actions?query=workflow%3A%22Issue+triage%22+is%3Afailure

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Currently errors because that GitHub Project no longer exists.

Output from acceptance testing: N/A (GitHub Actions)