### PR TITLE
r/aws_db_event_subscription: Add test sweeper

### DIFF
--- a/aws/internal/service/rds/waiter/status.go
+++ b/aws/internal/service/rds/waiter/status.go
@@ -1,0 +1,36 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// EventSubscription NotFound
+	EventSubscriptionStatusNotFound = "NotFound"
+
+	// EventSubscription Unknown
+	EventSubscriptionStatusUnknown = "Unknown"
+)
+
+// EventSubscriptionStatus fetches the EventSubscription and its Status
+func EventSubscriptionStatus(conn *rds.RDS, subscriptionName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &rds.DescribeEventSubscriptionsInput{
+			SubscriptionName: aws.String(subscriptionName),
+		}
+
+		output, err := conn.DescribeEventSubscriptions(input)
+
+		if err != nil {
+			return nil, EventSubscriptionStatusUnknown, err
+		}
+
+		if len(output.EventSubscriptionsList) == 0 {
+			return nil, EventSubscriptionStatusNotFound, nil
+		}
+
+		return output.EventSubscriptionsList[0], aws.StringValue(output.EventSubscriptionsList[0].Status), nil
+	}
+}

--- a/aws/internal/service/rds/waiter/waiter.go
+++ b/aws/internal/service/rds/waiter/waiter.go
@@ -1,0 +1,31 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for an EventSubscription to return Deleted
+	EventSubscriptionDeletedTimeout = 10 * time.Minute
+)
+
+// DeploymentDeployed waits for a EventSubscription to return Deleted
+func EventSubscriptionDeleted(conn *rds.RDS, subscriptionName string) (*rds.EventSubscription, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"deleting"},
+		Target:  []string{EventSubscriptionStatusNotFound},
+		Refresh: EventSubscriptionStatus(conn, subscriptionName),
+		Timeout: EventSubscriptionDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*rds.EventSubscription); ok {
+		return v, err
+	}
+
+	return nil, err
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12658.
Relates #13167.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_db_event_subscription make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_db_event_subscription -timeout 60m
2020/05/07 13:10:26 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/07 13:10:26 [DEBUG] Running Sweeper (aws_db_event_subscription) in region (us-west-2)
2020/05/07 13:10:26 [INFO] Building AWS auth structure
2020/05/07 13:10:26 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 13:10:28 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 13:10:28 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 13:10:28 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 13:10:28 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 13:10:29 [INFO] Deleting RDS Event Subscription: test001
2020/05/07 13:10:29 [DEBUG] Waiting for state to become: [NotFound]
2020/05/07 13:11:00 [INFO] Deleting RDS Event Subscription: test002
2020/05/07 13:11:00 [DEBUG] Waiting for state to become: [NotFound]
2020/05/07 13:11:31 Sweeper Tests ran successfully:
	- aws_db_event_subscription
2020/05/07 13:11:31 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/07 13:11:31 [DEBUG] Running Sweeper (aws_db_event_subscription) in region (us-east-1)
2020/05/07 13:11:31 [INFO] Building AWS auth structure
2020/05/07 13:11:31 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 13:11:32 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 13:11:32 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 13:11:32 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 13:11:33 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 13:11:33 Sweeper Tests ran successfully:
	- aws_db_event_subscription
ok  	github.com/terraform-providers/terraform-provider-aws/aws	67.074s
```
