### PR TITLE
r/aws_redshift_event_subscription: Add test sweeper

### DIFF
--- a/aws/resource_aws_redshift_event_subscription_test.go
+++ b/aws/resource_aws_redshift_event_subscription_test.go
@@ -2,15 +2,67 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_redshift_event_subscription", &resource.Sweeper{
+		Name: "aws_redshift_event_subscription",
+		F:    testSweepRedshiftEventSubscriptions,
+	})
+}
+
+func testSweepRedshiftEventSubscriptions(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).redshiftconn
+	var sweeperErrs *multierror.Error
+
+	err = conn.DescribeEventSubscriptionsPages(&redshift.DescribeEventSubscriptionsInput{}, func(page *redshift.DescribeEventSubscriptionsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, eventSubscription := range page.EventSubscriptionsList {
+			name := aws.StringValue(eventSubscription.CustSubscriptionId)
+
+			log.Printf("[INFO] Deleting Redshift Event Subscription: %s", name)
+			_, err = conn.DeleteEventSubscription(&redshift.DeleteEventSubscriptionInput{
+				SubscriptionName: aws.String(name),
+			})
+			if isAWSErr(err, redshift.ErrCodeSubscriptionNotFoundFault, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting Redshift Event Subscription (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Redshift Event Subscriptions sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving Redshift Event Subscriptions: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSRedshiftEventSubscription_basicUpdate(t *testing.T) {
 	var v redshift.EventSubscription
@@ -268,24 +320,17 @@ func testAccCheckAWSRedshiftEventSubscriptionDestroy(s *terraform.State) error {
 				SubscriptionName: aws.String(rs.Primary.ID),
 			})
 
-		if ae, ok := err.(awserr.Error); ok && ae.Code() == "SubscriptionNotFound" {
+		if isAWSErr(err, redshift.ErrCodeSubscriptionNotFoundFault, "") {
 			continue
 		}
 
-		if err == nil {
-			if len(resp.EventSubscriptionsList) != 0 &&
-				*resp.EventSubscriptionsList[0].CustSubscriptionId == rs.Primary.ID {
-				return fmt.Errorf("Event Subscription still exists")
-			}
+		if err != nil {
+			return err
 		}
 
-		// Verify the error
-		newerr, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-		if newerr.Code() != "SubscriptionNotFound" {
-			return err
+		if len(resp.EventSubscriptionsList) != 0 &&
+			*resp.EventSubscriptionsList[0].CustSubscriptionId == rs.Primary.ID {
+			return fmt.Errorf("Event Subscription still exists")
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12658.
Relates #13167.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_redshift_event_subscription make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_redshift_event_subscription -timeout 60m
2020/05/07 14:18:03 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/07 14:18:03 [DEBUG] Running Sweeper (aws_redshift_event_subscription) in region (us-west-2)
2020/05/07 14:18:03 [INFO] Building AWS auth structure
2020/05/07 14:18:03 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 14:18:04 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 14:18:04 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 14:18:04 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 14:18:05 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 14:18:06 [INFO] Deleting Redshift Event Subscription: test001
2020/05/07 14:18:06 [INFO] Deleting Redshift Event Subscription: test002
2020/05/07 14:18:07 Sweeper Tests ran successfully:
	- aws_redshift_event_subscription
2020/05/07 14:18:07 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/07 14:18:07 [DEBUG] Running Sweeper (aws_redshift_event_subscription) in region (us-east-1)
2020/05/07 14:18:07 [INFO] Building AWS auth structure
2020/05/07 14:18:07 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 14:18:08 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 14:18:08 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 14:18:08 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 14:18:08 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 14:18:09 Sweeper Tests ran successfully:
	- aws_redshift_event_subscription
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.652s
```
