### PR TITLE
r/aws_ses_configuration_set: Add test sweeper

### DIFF
--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -2,13 +2,70 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_ses_configuration_set", &resource.Sweeper{
+		Name: "aws_ses_configuration_set",
+		F:    testSweepSesConfigurationSets,
+	})
+}
+
+func testSweepSesConfigurationSets(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).sesconn
+	input := &ses.ListConfigurationSetsInput{}
+	var sweeperErrs *multierror.Error
+
+	for {
+		output, err := conn.ListConfigurationSets(input)
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping SES Configuration Sets sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		}
+		if err != nil {
+			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving SES Configuration Sets: %w", err))
+			return sweeperErrs
+		}
+
+		for _, configurationSet := range output.ConfigurationSets {
+			name := aws.StringValue(configurationSet.Name)
+
+			log.Printf("[INFO] Deleting SES Configuration Set: %s", name)
+			_, err := conn.DeleteConfigurationSet(&ses.DeleteConfigurationSetInput{
+				ConfigurationSetName: aws.String(name),
+			})
+			if isAWSErr(err, ses.ErrCodeConfigurationSetDoesNotExistException, "") {
+				continue
+			}
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting SES Configuration Set (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12658.
Relates #13167.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_ses_configuration_set make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_ses_configuration_set -timeout 60m
2020/05/07 14:45:10 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/07 14:45:10 [DEBUG] Running Sweeper (aws_ses_configuration_set) in region (us-west-2)
2020/05/07 14:45:10 [INFO] Building AWS auth structure
2020/05/07 14:45:10 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 14:45:11 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 14:45:11 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 14:45:11 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 14:45:12 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 14:45:13 [INFO] Deleting SES Configuration Set: test001
2020/05/07 14:45:13 [INFO] Deleting SES Configuration Set: test002
2020/05/07 14:45:13 Sweeper Tests ran successfully:
	- aws_ses_configuration_set
2020/05/07 14:45:13 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/07 14:45:13 [DEBUG] Running Sweeper (aws_ses_configuration_set) in region (us-east-1)
2020/05/07 14:45:13 [INFO] Building AWS auth structure
2020/05/07 14:45:13 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 14:45:15 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 14:45:15 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 14:45:15 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 14:45:15 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 14:45:15 Sweeper Tests ran successfully:
	- aws_ses_configuration_set
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.567s
```
