### PR TITLE
r/aws_ses_domain_identity & r/aws_ses_email_identity: Add test sweepers

### DIFF
--- a/aws/resource_aws_ses_domain_identity_test.go
+++ b/aws/resource_aws_ses_domain_identity_test.go
@@ -2,16 +2,69 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_ses_domain_identity", &resource.Sweeper{
+		Name: "aws_ses_domain_identity",
+		F:    func(region string) error { return testSweepSesIdentities(region, ses.IdentityTypeDomain) },
+	})
+}
+
+func testSweepSesIdentities(region, identityType string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).sesconn
+	input := &ses.ListIdentitiesInput{
+		IdentityType: aws.String(identityType),
+	}
+	var sweeperErrs *multierror.Error
+
+	err = conn.ListIdentitiesPages(input, func(page *ses.ListIdentitiesOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, identity := range page.Identities {
+			identity := aws.StringValue(identity)
+
+			log.Printf("[INFO] Deleting SES Identity: %s", identity)
+			_, err = conn.DeleteIdentity(&ses.DeleteIdentityInput{
+				Identity: aws.String(identity),
+			})
+			if err != nil {
+				sweeperErr := fmt.Errorf("error deleting SES Identity (%s): %w", identity, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping SES Identities sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving SES Identities: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSSESDomainIdentity_basic(t *testing.T) {
 	domain := fmt.Sprintf(

--- a/aws/resource_aws_ses_email_identity_test.go
+++ b/aws/resource_aws_ses_email_identity_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
+func init() {
+	resource.AddTestSweepers("aws_ses_email_identity", &resource.Sweeper{
+		Name: "aws_ses_email_identity",
+		F:    func(region string) error { return testSweepSesIdentities(region, ses.IdentityTypeEmailAddress) },
+	})
+}
+
 func TestAccAWSSESEmailIdentity_basic(t *testing.T) {
 	email := fmt.Sprintf(
 		"%s@terraformtesting.com",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12658.
Relates #13167.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_ses_domain_identity make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_ses_domain_identity -timeout 60m
2020/05/07 15:12:15 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/07 15:12:15 [DEBUG] Running Sweeper (aws_ses_domain_identity) in region (us-west-2)
2020/05/07 15:12:15 [INFO] Building AWS auth structure
2020/05/07 15:12:15 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 15:12:16 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 15:12:16 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 15:12:16 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 15:12:16 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 15:12:17 [INFO] Deleting SES Identity: test002.org.uk
2020/05/07 15:12:18 [INFO] Deleting SES Identity: test001.dev
2020/05/07 15:12:18 Sweeper Tests ran successfully:
	- aws_ses_domain_identity
2020/05/07 15:12:18 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/07 15:12:18 [DEBUG] Running Sweeper (aws_ses_domain_identity) in region (us-east-1)
2020/05/07 15:12:18 [INFO] Building AWS auth structure
2020/05/07 15:12:18 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 15:12:20 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 15:12:20 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 15:12:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 15:12:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 15:12:20 Sweeper Tests ran successfully:
	- aws_ses_domain_identity
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.726s
$ TEST=./aws SWEEP=us-west-2,us-east-1 SWEEPARGS=-sweep-run=aws_ses_email_identity make sweep
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_ses_email_identity -timeout 60m
2020/05/07 15:12:43 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/07 15:12:43 [DEBUG] Running Sweeper (aws_ses_email_identity) in region (us-west-2)
2020/05/07 15:12:43 [INFO] Building AWS auth structure
2020/05/07 15:12:43 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 15:12:44 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 15:12:44 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 15:12:44 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 15:12:45 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 15:12:45 [INFO] Deleting SES Identity: test001@aol.com
2020/05/07 15:12:46 [INFO] Deleting SES Identity: kit_ewbank@hotmail.com
2020/05/07 15:12:46 Sweeper Tests ran successfully:
	- aws_ses_email_identity
2020/05/07 15:12:46 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/07 15:12:46 [DEBUG] Running Sweeper (aws_ses_email_identity) in region (us-east-1)
2020/05/07 15:12:46 [INFO] Building AWS auth structure
2020/05/07 15:12:46 [INFO] Setting AWS metadata API timeout to 100ms
2020/05/07 15:12:48 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2020/05/07 15:12:48 [INFO] AWS Auth provider used: "EnvProvider"
2020/05/07 15:12:48 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 15:12:48 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/05/07 15:12:48 [INFO] Deleting SES Identity: test@example.com
2020/05/07 15:12:48 Sweeper Tests ran successfully:
	- aws_ses_email_identity
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.608s
```
