### PR TITLE
tests/provider: Add misspell to CHANGELOG GitHub Action workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,12 +1,20 @@
 name: CHANGELOG Checks
 on:
+  push:
+    branches:
+      - master
   pull_request:
     paths:
       - CHANGELOG.md
 
+env:
+  GO_VERSION: "1.14"
+  GO111MODULE: on
+
 jobs:
-  PRCheck:
-    name: PR Check
+  comment:
+    if: github.event_name == 'pull_request' && !contains(fromJSON('["bflad", "breathingdust", "ewbankkit", "gdavison", "maryelizbeth"]'), github.actor)
+    name: Comment
     runs-on: ubuntu-latest
     steps:
       - name: PR Comment
@@ -22,3 +30,18 @@ jobs:
             Remove any changes to the `CHANGELOG.md` file and commit them in this pull request to prevent delays with reviewing and potentially merging this pull request.
       - name: Fail the check
         run: exit 1
+  misspell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/cache@v1
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      - run: go install github.com/client9/misspell/cmd/misspell
+      - run: misspell -error -source text CHANGELOG.md


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/13248

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Currently, TravisCI runs `make docscheck`, which contains `tfproviderdocs` and `misspell` (for the CHANGELOG.md file only). To compliment any (potential) migration from TravisCI to GitHub Actions, this adds the small piece of `misspell` testing into the existing CHANGELOG workflow. `tfproviderdocs` is handled separately in the referenced pull request since it requires the provider code to fully validate changes.

Output from acceptance testing: N/A (CI testing)