### PR TITLE
Remove unneccesary interpolation syntax

### DIFF
--- a/website/docs/r/api_gateway_base_path_mapping.html.markdown
+++ b/website/docs/r/api_gateway_base_path_mapping.html.markdown
@@ -17,7 +17,7 @@ custom domain name.
 ```hcl
 resource "aws_api_gateway_deployment" "example" {
   # See aws_api_gateway_rest_api docs for how to create this
-  rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
   stage_name  = "live"
 }
 
@@ -31,9 +31,9 @@ resource "aws_api_gateway_domain_name" "example" {
 }
 
 resource "aws_api_gateway_base_path_mapping" "test" {
-  api_id      = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-  stage_name  = "${aws_api_gateway_deployment.example.stage_name}"
-  domain_name = "${aws_api_gateway_domain_name.example.domain_name}"
+  api_id      = aws_api_gateway_rest_api.MyDemoAPI.id
+  stage_name  = aws_api_gateway_deployment.example.stage_name
+  domain_name = aws_api_gateway_domain_name.example.domain_name
 }
 ```
 


### PR DESCRIPTION
This syntax was deprecated post 0.11 :)

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
