### PR TITLE
Minor documentation wording improvement: noncurrent object versions

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -414,12 +414,12 @@ The `transition` object supports the following
 
 The `noncurrent_version_expiration` object supports the following
 
-* `days` (Required) Specifies the number of days an object is noncurrent object versions expire.
+* `days` (Required) Specifies the number of days noncurrent object versions expire.
 
 The `noncurrent_version_transition` object supports the following
 
-* `days` (Required) Specifies the number of days an object is noncurrent object versions expire.
-* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the noncurrent versions object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, `INTELLIGENT_TIERING`, `GLACIER`, or `DEEP_ARCHIVE`.
+* `days` (Required) Specifies the number of days noncurrent object versions transition.
+* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the noncurrent object versions to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, `INTELLIGENT_TIERING`, `GLACIER`, or `DEEP_ARCHIVE`.
 
 The `replication_configuration` object supports the following:
 


### PR DESCRIPTION
**Reasoning for Change**: Improve odd wording.

Relevant AWS docs: https://docs.aws.amazon.com/AmazonS3/latest/API/API_NoncurrentVersionExpiration.html

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/pull/13256):

```release-note
NONE
```