### PR TITLE
r/aws_apigatewayv2_integration: Suppress integration_method diff for AWS Lambda integrations

### DIFF
--- a/aws/resource_aws_apigatewayv2_integration.go
+++ b/aws/resource_aws_apigatewayv2_integration.go
@@ -64,7 +64,7 @@ func resourceAwsApiGatewayV2Integration() *schema.Resource {
 				ValidateFunc: validateHTTPMethod(),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// Default HTTP method for Lambda integration is POST.
-					if v := d.Get("integration_type").(string); (v == apigatewayv2.IntegrationTypeAws || v == apigatewayv2.IntegrationTypeAwsProxy) && old == "POST" && new == "" {
+					if v := d.Get("integration_type").(string); d.Id() != "" && (v == apigatewayv2.IntegrationTypeAws || v == apigatewayv2.IntegrationTypeAwsProxy) && old == "POST" && new == "" {
 						return true
 					}
 

--- a/aws/resource_aws_apigatewayv2_integration.go
+++ b/aws/resource_aws_apigatewayv2_integration.go
@@ -62,6 +62,14 @@ func resourceAwsApiGatewayV2Integration() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateHTTPMethod(),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Default HTTP method for Lambda integration is POST.
+					if v := d.Get("integration_type").(string); (v == apigatewayv2.IntegrationTypeAws || v == apigatewayv2.IntegrationTypeAwsProxy) && old == "POST" && new == "" {
+						return true
+					}
+
+					return false
+				},
 			},
 			"integration_response_selection_expression": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_apigatewayv2_integration.go
+++ b/aws/resource_aws_apigatewayv2_integration.go
@@ -64,7 +64,7 @@ func resourceAwsApiGatewayV2Integration() *schema.Resource {
 				ValidateFunc: validateHTTPMethod(),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// Default HTTP method for Lambda integration is POST.
-					if v := d.Get("integration_type").(string); d.Id() != "" && (v == apigatewayv2.IntegrationTypeAws || v == apigatewayv2.IntegrationTypeAwsProxy) && old == "POST" && new == "" {
+					if v := d.Get("integration_type").(string); (v == apigatewayv2.IntegrationTypeAws || v == apigatewayv2.IntegrationTypeAwsProxy) && old == "POST" && new == "" {
 						return true
 					}
 

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -189,7 +189,7 @@ func TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp(t *testing.T) {
 	})
 }
 
-func TestAccAWSAPIGatewayV2Integration_Lambda(t *testing.T) {
+func TestAccAWSAPIGatewayV2Integration_LambdaWebSocket(t *testing.T) {
 	var apiId string
 	var v apigatewayv2.GetIntegrationOutput
 	resourceName := "aws_apigatewayv2_integration.test"
@@ -203,7 +203,7 @@ func TestAccAWSAPIGatewayV2Integration_Lambda(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayV2IntegrationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayV2IntegrationConfig_lambda(rName),
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_lambdaWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
@@ -216,6 +216,50 @@ func TestAccAWSAPIGatewayV2Integration_Lambda(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "integration_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
+					resource.TestCheckResourceAttr(resourceName, "tls_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2IntegrationImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Integration_LambdaHttp(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetIntegrationOutput
+	resourceName := "aws_apigatewayv2_integration.test"
+	callerIdentityDatasourceName := "data.aws_caller_identity.current"
+	lambdaResourceName := "aws_lambda_function.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2IntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2IntegrationConfig_lambdaHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2IntegrationExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "INTERNET"),
+					resource.TestCheckResourceAttr(resourceName, "content_handling_strategy", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "credentials_arn", callerIdentityDatasourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test Lambda"),
+					resource.TestCheckResourceAttr(resourceName, "integration_method", "POST"),
+					resource.TestCheckResourceAttr(resourceName, "integration_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "integration_type", "AWS_PROXY"),
+					resource.TestCheckResourceAttrPair(resourceName, "integration_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", ""),
+					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "2.0"),
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
@@ -556,8 +600,11 @@ resource "aws_apigatewayv2_integration" "test" {
 `
 }
 
-func testAccAWSAPIGatewayV2IntegrationConfig_lambda(rName string) string {
-	return testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName) + baseAccAWSLambdaConfig(rName, rName, rName) + fmt.Sprintf(`
+func testAccAWSAPIGatewayV2IntegrationConfig_lambdaWebSocket(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName),
+		baseAccAWSLambdaConfig(rName, rName, rName),
+		fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 resource "aws_lambda_function" "test" {
@@ -579,7 +626,36 @@ resource "aws_apigatewayv2_integration" "test" {
   integration_uri           = "${aws_lambda_function.test.invoke_arn}"
   passthrough_behavior      = "WHEN_NO_MATCH"
 }
-`, rName)
+`, rName))
+}
+
+func testAccAWSAPIGatewayV2IntegrationConfig_lambdaHttp(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName),
+		baseAccAWSLambdaConfig(rName, rName, rName),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  handler       = "index.handler"
+  runtime       = "nodejs10.x"
+}
+
+resource "aws_apigatewayv2_integration" "test" {
+  api_id           = "${aws_apigatewayv2_api.test.id}"
+  integration_type = "AWS_PROXY"
+
+  connection_type  = "INTERNET"
+  credentials_arn  = "${data.aws_caller_identity.current.arn}"
+  description      = "Test Lambda"
+  integration_uri  = "${aws_lambda_function.test.invoke_arn}"
+
+  payload_format_version = "2.0"
+}
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2IntegrationConfig_httpProxy(rName string) string {

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -572,13 +572,12 @@ resource "aws_apigatewayv2_integration" "test" {
   api_id           = "${aws_apigatewayv2_api.test.id}"
   integration_type = "AWS"
 
-  connection_type               = "INTERNET"
-  content_handling_strategy     = "CONVERT_TO_TEXT"
-  credentials_arn               = "${data.aws_caller_identity.current.arn}"
-  description                   = "Test Lambda"
-  integration_method            = "POST"
-  integration_uri               = "${aws_lambda_function.test.invoke_arn}"
-  passthrough_behavior          = "WHEN_NO_MATCH"
+  connection_type           = "INTERNET"
+  content_handling_strategy = "CONVERT_TO_TEXT"
+  credentials_arn           = "${data.aws_caller_identity.current.arn}"
+  description               = "Test Lambda"
+  integration_uri           = "${aws_lambda_function.test.invoke_arn}"
+  passthrough_behavior      = "WHEN_NO_MATCH"
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13261.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_integration: Correctly handle the `integration_method` attribute for AWS Lambda integrations
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Integration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Integration_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Integration_basic
=== PAUSE TestAccAWSAPIGatewayV2Integration_basic
=== RUN   TestAccAWSAPIGatewayV2Integration_disappears
=== PAUSE TestAccAWSAPIGatewayV2Integration_disappears
=== RUN   TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_Lambda
=== PAUSE TestAccAWSAPIGatewayV2Integration_Lambda
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLink
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLink
=== CONT  TestAccAWSAPIGatewayV2Integration_basic
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLink
=== CONT  TestAccAWSAPIGatewayV2Integration_Lambda
=== CONT  TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_disappears
--- PASS: TestAccAWSAPIGatewayV2Integration_disappears (24.40s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basic (28.62s)
--- PASS: TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp (44.79s)
--- PASS: TestAccAWSAPIGatewayV2Integration_Lambda (60.46s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLink (721.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	721.831s
```

Without the fix:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Integration_Lambda'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Integration_Lambda -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Integration_Lambda
=== PAUSE TestAccAWSAPIGatewayV2Integration_Lambda
=== CONT  TestAccAWSAPIGatewayV2Integration_Lambda
--- FAIL: TestAccAWSAPIGatewayV2Integration_Lambda (40.09s)
    testing.go:683: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_apigatewayv2_integration.test
          api_id:                                    "60w0poref8" => "60w0poref8"
          connection_id:                             "" => ""
          connection_type:                           "INTERNET" => "INTERNET"
          content_handling_strategy:                 "CONVERT_TO_TEXT" => "CONVERT_TO_TEXT"
          credentials_arn:                           "arn:aws:iam::123456789012:user/kit" => "arn:aws:iam::123456789012:user/kit"
          description:                               "Test Lambda" => "Test Lambda"
          id:                                        "9fisag7" => "9fisag7"
          integration_method:                        "POST" => ""
          integration_response_selection_expression: "${integration.response.body.errorMessage}" => "${integration.response.body.errorMessage}"
          integration_type:                          "AWS" => "AWS"
          integration_uri:                           "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:tf-acc-test-8699519484167888654/invocations" => "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:123456789012:function:tf-acc-test-8699519484167888654/invocations"
          passthrough_behavior:                      "WHEN_NO_MATCH" => "WHEN_NO_MATCH"
          payload_format_version:                    "1.0" => "1.0"
          template_selection_expression:             "" => ""
          timeout_milliseconds:                      "29000" => "29000"
```