### PR TITLE
Support VPC config for Amazon Kinesis Data Firehose

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1289,8 +1289,9 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 										Set:      schema.HashString,
 									},
 									"role_arn": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateArn,
 									},
 								},
 							},
@@ -1844,21 +1845,13 @@ func extractVpcConfiguration(es map[string]interface{}) *firehose.VpcConfigurati
 	if len(config) == 0 {
 		return nil
 	}
+
 	vpcConfig := config[0].(map[string]interface{})
-	s := vpcConfig["subnet_ids"].(*schema.Set).List()
-	subnets := make([]string, len(s))
-	for i, v := range s {
-		subnets[i] = fmt.Sprint(v)
-	}
-	sg := vpcConfig["security_group_ids"].(*schema.Set).List()
-	securityGroups := make([]string, len(sg))
-	for i, v := range sg {
-		securityGroups[i] = fmt.Sprint(v)
-	}
+
 	return &firehose.VpcConfiguration{
 		RoleARN:          aws.String(vpcConfig["role_arn"].(string)),
-		SubnetIds:        aws.StringSlice(subnets),
-		SecurityGroupIds: aws.StringSlice(securityGroups),
+		SubnetIds:        expandStringSet(vpcConfig["subnet_ids"].(*schema.Set)),
+		SecurityGroupIds: expandStringSet(vpcConfig["security_group_ids"].(*schema.Set)),
 	}
 }
 

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1281,14 +1281,12 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 										Required: true,
 										ForceNew: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
-										Set:      schema.HashString,
 									},
 									"security_group_ids": {
 										Type:     schema.TypeSet,
 										Required: true,
 										ForceNew: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
-										Set:      schema.HashString,
 									},
 									"role_arn": {
 										Type:         schema.TypeString,

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1279,18 +1279,21 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 									"subnet_ids": {
 										Type:     schema.TypeSet,
 										Required: true,
+										ForceNew: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 										Set:      schema.HashString,
 									},
 									"security_group_ids": {
 										Type:     schema.TypeSet,
 										Required: true,
+										ForceNew: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 										Set:      schema.HashString,
 									},
 									"role_arn": {
 										Type:         schema.TypeString,
 										Required:     true,
+										ForceNew:     true,
 										ValidateFunc: validateArn,
 									},
 								},

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -206,8 +206,8 @@ func flattenVpcConfiguration(description *firehose.VpcConfigurationDescription) 
 
 	m := map[string]interface{}{
 		"vpc_id":             aws.StringValue(description.VpcId),
-		"subnet_ids":         flattenStringList(description.SubnetIds),
-		"security_group_ids": flattenStringList(description.SecurityGroupIds),
+		"subnet_ids":         flattenStringSet(description.SubnetIds),
+		"security_group_ids": flattenStringSet(description.SecurityGroupIds),
 		"role_arn":           aws.StringValue(description.RoleARN),
 	}
 

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1103,6 +1103,72 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates(t *testi
 	})
 }
 
+func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates(t *testing.T) {
+	var stream firehose.DeliveryStreamDescription
+
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+	ri := acctest.RandInt()
+	rString := acctest.RandString(8)
+	funcName := fmt.Sprintf("aws_kinesis_firehose_delivery_stream_test_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_%s", rString)
+	preConfigWithVpc := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchVpcBasic,
+		ri, ri, ri, ri, ri)
+
+	postConfigWithVpc := testAccFirehoseAWSLambdaConfigBasic(funcName, policyName, roleName) +
+		fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchVpcUpdate,
+			ri, ri, ri, ri, ri)
+
+	updatedElasticSearchConfig := &firehose.ElasticsearchDestinationDescription{
+		BufferingHints: &firehose.ElasticsearchBufferingHints{
+			IntervalInSeconds: aws.Int64(500),
+		},
+		ProcessingConfiguration: &firehose.ProcessingConfiguration{
+			Enabled: aws.Bool(true),
+			Processors: []*firehose.Processor{
+				{
+					Type: aws.String("Lambda"),
+					Parameters: []*firehose.ProcessorParameter{
+						{
+							ParameterName:  aws.String("LambdaArn"),
+							ParameterValue: aws.String("valueNotTested"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisFirehoseDeliveryStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfigWithVpc,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test", &stream),
+					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil),
+					resource.TestMatchResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", regexp.MustCompile(`^vpc-.+$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: postConfigWithVpc,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test", &stream),
+					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, updatedElasticSearchConfig, nil),
+					resource.TestMatchResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", regexp.MustCompile(`^vpc-.+$`)),
+				),
+			},
+		},
+	})
+}
+
 // Regression test for https://github.com/terraform-providers/terraform-provider-aws/issues/1657
 func TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration(t *testing.T) {
 	var stream firehose.DeliveryStreamDescription
@@ -2452,6 +2518,113 @@ EOF
 }
 `
 
+// ElasticSearch associated with VPC
+var testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
+data "aws_availability_zones" "available" {
+  state = "available"
+  
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+  
+resource "aws_vpc" "elasticsearch_in_vpc" {
+  cidr_block = "192.168.0.0/22"
+  
+  tags = {
+    Name = "terraform-testacc-elasticsearch-domain-in-vpc"
+  }
+}
+  
+resource "aws_subnet" "first" {
+  vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "192.168.0.0/24"
+  
+  tags = {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-first"
+  }
+}
+  
+resource "aws_subnet" "second" {
+  vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  cidr_block        = "192.168.1.0/24"
+  
+  tags = {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-second"
+  }
+}
+  
+resource "aws_security_group" "first" {
+  vpc_id = "${aws_vpc.elasticsearch_in_vpc.id}"
+}
+  
+resource "aws_security_group" "second" {
+  vpc_id = "${aws_vpc.elasticsearch_in_vpc.id}"
+}
+
+resource "aws_elasticsearch_domain" "test_cluster" {
+
+  domain_name = "es-test-%d"
+
+  cluster_config {
+    instance_count         = 2
+    zone_awareness_enabled = true
+    instance_type          = "t2.small.elasticsearch"
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+
+  vpc_options {
+    security_group_ids = ["${aws_security_group.first.id}", "${aws_security_group.second.id}"]
+    subnet_ids         = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
+  }
+}
+
+resource "aws_iam_role_policy" "firehose-elasticsearch" {
+  name   = "elasticsearch"
+  role   = "${aws_iam_role.firehose.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "es:*"
+      ],
+      "Resource": [
+        "${aws_elasticsearch_domain.test_cluster.arn}",
+        "${aws_elasticsearch_domain.test_cluster.arn}/*"
+      ]
+	},
+	{
+	  "Effect": "Allow",
+	  "Action": [
+         "ec2:DescribeVpcs",
+         "ec2:DescribeVpcAttribute",
+         "ec2:DescribeSubnets",
+         "ec2:DescribeSecurityGroups",
+         "ec2:DescribeNetworkInterfaces",
+         "ec2:CreateNetworkInterface",
+         "ec2:CreateNetworkInterfacePermission",
+         "ec2:DeleteNetworkInterface"
+	  ],
+	  "Resource": [
+	    "*"
+	  ]
+	}
+  ]
+}
+EOF
+}
+`
+
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchBasic = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on = [aws_iam_role_policy.firehose-elasticsearch]
@@ -2473,6 +2646,30 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 }
 `
 
+var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchVpcBasic = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig + `
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
+
+  name = "terraform-kinesis-firehose-es-%d"
+  destination = "elasticsearch"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
+  elasticsearch_configuration {
+    domain_arn = "${aws_elasticsearch_domain.test_cluster.arn}"
+    role_arn = "${aws_iam_role.firehose.arn}"
+    index_name = "test"
+    type_name = "test"
+	
+    vpc_config {
+      subnet_ids = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
+      security_group_ids = ["${aws_security_group.first.id}", "${aws_security_group.second.id}"]
+      role_arn   = "${aws_iam_role.firehose.arn}"
+	}
+  }
+}
+`
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchUpdate = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on = [aws_iam_role_policy.firehose-elasticsearch]
@@ -2507,6 +2704,40 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   }
 }
 `
+
+var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchVpcUpdate = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig + `
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
+
+  name = "terraform-kinesis-firehose-es-%d"
+  destination = "elasticsearch"
+  s3_configuration {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
+  elasticsearch_configuration {
+    domain_arn = "${aws_elasticsearch_domain.test_cluster.arn}"
+    role_arn = "${aws_iam_role.firehose.arn}"
+    index_name = "test"
+    type_name = "test"
+    buffering_interval = 500
+    vpc_config {
+      subnet_ids = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
+      security_group_ids = ["${aws_security_group.first.id}", "${aws_security_group.second.id}"]
+      role_arn   = "${aws_iam_role.firehose.arn}"
+	}
+    processing_configuration {
+      enabled = false
+      processors {
+        type = "Lambda"
+        parameters {
+          parameter_name = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+      }
+    }
+  }
+}`
 
 func testAccKinesisFirehoseDeliveryStreamConfig_missingProcessingConfiguration(rInt int) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2666,7 +2666,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
       subnet_ids = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
       security_group_ids = ["${aws_security_group.first.id}", "${aws_security_group.second.id}"]
       role_arn   = "${aws_iam_role.firehose.arn}"
-	}
+    }
   }
 }
 `
@@ -2725,7 +2725,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
       subnet_ids = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
       security_group_ids = ["${aws_security_group.first.id}", "${aws_security_group.second.id}"]
       role_arn   = "${aws_iam_role.firehose.arn}"
-	}
+    }
     processing_configuration {
       enabled = false
       processors {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2606,11 +2606,7 @@ resource "aws_iam_role_policy" "firehose-elasticsearch" {
 	{
 	  "Effect": "Allow",
 	  "Action": [
-         "ec2:DescribeVpcs",
-         "ec2:DescribeVpcAttribute",
-         "ec2:DescribeSubnets",
-         "ec2:DescribeSecurityGroups",
-         "ec2:DescribeNetworkInterfaces",
+         "ec2:Describe*",
          "ec2:CreateNetworkInterface",
          "ec2:CreateNetworkInterfacePermission",
          "ec2:DeleteNetworkInterface"

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2527,104 +2527,103 @@ EOF
 // ElasticSearch associated with VPC
 var testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
 data "aws_availability_zones" "available" {
-  state = "available"
+	state = "available"
   
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-  
-resource "aws_vpc" "elasticsearch_in_vpc" {
-  cidr_block = "192.168.0.0/22"
-  
-  tags = {
-    Name = "terraform-testacc-elasticsearch-domain-in-vpc"
-  }
-}
-  
-resource "aws_subnet" "first" {
-  vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  cidr_block        = "192.168.0.0/24"
-  
-  tags = {
-    Name = "tf-acc-elasticsearch-domain-in-vpc-first"
-  }
-}
-  
-resource "aws_subnet" "second" {
-  vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  cidr_block        = "192.168.1.0/24"
-  
-  tags = {
-    Name = "tf-acc-elasticsearch-domain-in-vpc-second"
-  }
-}
-  
-resource "aws_security_group" "first" {
-  vpc_id = "${aws_vpc.elasticsearch_in_vpc.id}"
-}
-  
-resource "aws_security_group" "second" {
-  vpc_id = "${aws_vpc.elasticsearch_in_vpc.id}"
-}
-
-resource "aws_elasticsearch_domain" "test_cluster" {
-
-  domain_name = "es-test-%d"
-
-  cluster_config {
-    instance_count         = 2
-    zone_awareness_enabled = true
-    instance_type          = "t2.small.elasticsearch"
-  }
-
-  ebs_options {
-    ebs_enabled = true
-    volume_size = 10
-  }
-
-  vpc_options {
-    security_group_ids = ["${aws_security_group.first.id}", "${aws_security_group.second.id}"]
-    subnet_ids         = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
-  }
-}
-
-resource "aws_iam_role_policy" "firehose-elasticsearch" {
-  name   = "elasticsearch"
-  role   = "${aws_iam_role.firehose.id}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "es:*"
-      ],
-      "Resource": [
-        "${aws_elasticsearch_domain.test_cluster.arn}",
-        "${aws_elasticsearch_domain.test_cluster.arn}/*"
-      ]
-	},
-	{
-	  "Effect": "Allow",
-	  "Action": [
-         "ec2:Describe*",
-         "ec2:CreateNetworkInterface",
-         "ec2:CreateNetworkInterfacePermission",
-         "ec2:DeleteNetworkInterface"
-	  ],
-	  "Resource": [
-	    "*"
-	  ]
+	filter {
+	  name   = "opt-in-status"
+	  values = ["opt-in-not-required"]
 	}
-  ]
+  }
+  
+  resource "aws_vpc" "elasticsearch_in_vpc" {
+	cidr_block = "192.168.0.0/22"
+  
+	tags = {
+	  Name = "terraform-testacc-elasticsearch-domain-in-vpc"
+	}
+  }
+  
+  resource "aws_subnet" "first" {
+	vpc_id            = aws_vpc.elasticsearch_in_vpc.id
+	availability_zone = data.aws_availability_zones.available.names[0]
+	cidr_block        = "192.168.0.0/24"
+  
+	tags = {
+	  Name = "tf-acc-elasticsearch-domain-in-vpc-first"
+	}
+  }
+  
+  resource "aws_subnet" "second" {
+	vpc_id            = aws_vpc.elasticsearch_in_vpc.id
+	availability_zone = data.aws_availability_zones.available.names[1]
+	cidr_block        = "192.168.1.0/24"
+  
+	tags = {
+	  Name = "tf-acc-elasticsearch-domain-in-vpc-second"
+	}
+  }
+  
+  resource "aws_security_group" "first" {
+	vpc_id = aws_vpc.elasticsearch_in_vpc.id
+  }
+  
+  resource "aws_security_group" "second" {
+	vpc_id = aws_vpc.elasticsearch_in_vpc.id
+  }
+  
+  resource "aws_elasticsearch_domain" "test_cluster" {
+	domain_name = "es-test-%d"
+  
+	cluster_config {
+	  instance_count         = 2
+	  zone_awareness_enabled = true
+	  instance_type          = "t2.small.elasticsearch"
+	}
+  
+	ebs_options {
+	  ebs_enabled = true
+	  volume_size = 10
+	}
+  
+	vpc_options {
+	  security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
+	  subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
+	}
+  }
+  
+  resource "aws_iam_role_policy" "firehose-elasticsearch" {
+	name   = "elasticsearch"
+	role   = aws_iam_role.firehose.id
+	policy = <<EOF
+{
+	"Version":"2012-10-17",
+	"Statement":[
+	   {
+		  "Effect":"Allow",
+		  "Action":[
+			 "es:*"
+		  ],
+		  "Resource":[
+			"${aws_elasticsearch_domain.test_cluster.arn}",
+			"${aws_elasticsearch_domain.test_cluster.arn}/*"
+		  ]
+	   },
+	   {
+		  "Effect":"Allow",
+		  "Action":[
+			 "ec2:Describe*",
+			 "ec2:CreateNetworkInterface",
+			 "ec2:CreateNetworkInterfacePermission",
+			 "ec2:DeleteNetworkInterface"
+		  ],
+		  "Resource":[
+			 "*"
+		  ]
+	   }
+	]
 }
 EOF
-}
+  }
 `
 
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchBasic = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
@@ -2650,27 +2649,27 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchVpcBasic = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
-
-  name = "terraform-kinesis-firehose-es-%d"
-  destination = "elasticsearch"
-  s3_configuration {
-    role_arn = "${aws_iam_role.firehose.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+	depends_on = [aws_iam_role_policy.firehose-elasticsearch]
+  
+	name        = "terraform-kinesis-firehose-es-%d"
+	destination = "elasticsearch"
+	s3_configuration {
+	  role_arn   = aws_iam_role.firehose.arn
+	  bucket_arn = aws_s3_bucket.bucket.arn
+	}
+	elasticsearch_configuration {
+	  domain_arn = aws_elasticsearch_domain.test_cluster.arn
+	  role_arn   = aws_iam_role.firehose.arn
+	  index_name = "test"
+	  type_name  = "test"
+  
+	  vpc_config {
+		subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
+		security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
+		role_arn           = aws_iam_role.firehose.arn
+	  }
+	}
   }
-  elasticsearch_configuration {
-    domain_arn = "${aws_elasticsearch_domain.test_cluster.arn}"
-    role_arn = "${aws_iam_role.firehose.arn}"
-    index_name = "test"
-    type_name = "test"
-	
-    vpc_config {
-      subnet_ids = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
-      security_group_ids = ["${aws_security_group.first.id}", "${aws_security_group.second.id}"]
-      role_arn   = "${aws_iam_role.firehose.arn}"
-    }
-  }
-}
 `
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchUpdate = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
@@ -2709,37 +2708,37 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchVpcUpdate = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
-
-  name = "terraform-kinesis-firehose-es-%d"
-  destination = "elasticsearch"
-  s3_configuration {
-    role_arn = "${aws_iam_role.firehose.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
-  }
-  elasticsearch_configuration {
-    domain_arn = "${aws_elasticsearch_domain.test_cluster.arn}"
-    role_arn = "${aws_iam_role.firehose.arn}"
-    index_name = "test"
-    type_name = "test"
-    buffering_interval = 500
-    vpc_config {
-      subnet_ids = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
-      security_group_ids = ["${aws_security_group.first.id}", "${aws_security_group.second.id}"]
-      role_arn   = "${aws_iam_role.firehose.arn}"
-    }
-    processing_configuration {
-      enabled = false
-      processors {
-        type = "Lambda"
-        parameters {
-          parameter_name = "LambdaArn"
-          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-        }
-      }
-    }
-  }
-}`
+	depends_on = [aws_iam_role_policy.firehose-elasticsearch]
+  
+	name        = "terraform-kinesis-firehose-es-%d"
+	destination = "elasticsearch"
+	s3_configuration {
+	  role_arn   = aws_iam_role.firehose.arn
+	  bucket_arn = aws_s3_bucket.bucket.arn
+	}
+	elasticsearch_configuration {
+	  domain_arn         = aws_elasticsearch_domain.test_cluster.arn
+	  role_arn           = aws_iam_role.firehose.arn
+	  index_name         = "test"
+	  type_name          = "test"
+	  buffering_interval = 500
+	  vpc_config {
+		subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
+		security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
+		role_arn           = aws_iam_role.firehose.arn
+	  }
+	  processing_configuration {
+		enabled = false
+		processors {
+		  type = "Lambda"
+		  parameters {
+			parameter_name  = "LambdaArn"
+			parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+		  }
+		}
+	  }
+	}
+  }`
 
 func testAccKinesisFirehoseDeliveryStreamConfig_missingProcessingConfiguration(rInt int) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1147,9 +1147,12 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates(t
 			{
 				Config: preConfigWithVpc,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test", &stream),
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
 					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil),
-					resource.TestMatchResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", regexp.MustCompile(`^vpc-.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", "aws_vpc.elasticsearch_in_vpc", "id"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.security_group_ids.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.role_arn", "aws_iam_role.firehose", "arn"),
 				),
 			},
 			{
@@ -1160,9 +1163,12 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates(t
 			{
 				Config: postConfigWithVpc,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisFirehoseDeliveryStreamExists("aws_kinesis_firehose_delivery_stream.test", &stream),
+					testAccCheckKinesisFirehoseDeliveryStreamExists(resourceName, &stream),
 					testAccCheckAWSKinesisFirehoseDeliveryStreamAttributes(&stream, nil, nil, nil, updatedElasticSearchConfig, nil),
-					resource.TestMatchResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", regexp.MustCompile(`^vpc-.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", "aws_vpc.elasticsearch_in_vpc", "id"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.security_group_ids.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.role_arn", "aws_iam_role.firehose", "arn"),
 				),
 			},
 		},

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -237,14 +237,14 @@ resource "aws_elasticsearch_domain" "test_cluster" {
   }
 
   vpc_options {
-    security_group_ids = ["${aws_security_group.first.id}"]
-    subnet_ids         = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
+    security_group_ids = [aws_security_group.first.id]
+    subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
   }
 }
 
 resource "aws_iam_role_policy" "firehose-elasticsearch" {
   name   = "elasticsearch"
-  role   = "${aws_iam_role.firehose.id}"
+  role   = aws_iam_role.firehose.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -258,47 +258,47 @@ resource "aws_iam_role_policy" "firehose-elasticsearch" {
         "${aws_elasticsearch_domain.test_cluster.arn}",
         "${aws_elasticsearch_domain.test_cluster.arn}/*"
       ]
-	},
-	{
-	  "Effect": "Allow",
-	  "Action": [
-         "ec2:DescribeVpcs",
-         "ec2:DescribeVpcAttribute",
-         "ec2:DescribeSubnets",
-         "ec2:DescribeSecurityGroups",
-         "ec2:DescribeNetworkInterfaces",
-         "ec2:CreateNetworkInterface",
-         "ec2:CreateNetworkInterfacePermission",
-         "ec2:DeleteNetworkInterface"
-	  ],
-	  "Resource": [
-	    "*"
-	  ]
-	}
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:DescribeVpcs",
+            "ec2:DescribeVpcAttribute",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:CreateNetworkInterface",
+            "ec2:CreateNetworkInterfacePermission",
+            "ec2:DeleteNetworkInterface"
+          ],
+          "Resource": [
+            "*"
+          ]
+        }
   ]
 }
 EOF
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
+  depends_on = [aws_iam_role_policy.firehose-elasticsearch]
 
   name        = "terraform-kinesis-firehose-es"
   destination = "elasticsearch"
   s3_configuration {
-    role_arn   = "${aws_iam_role.firehose.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
   }
   elasticsearch_configuration {
-    domain_arn = "${aws_elasticsearch_domain.test_cluster.arn}"
-    role_arn   = "${aws_iam_role.firehose.arn}"
+    domain_arn = aws_elasticsearch_domain.test_cluster.arn
+    role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
     type_name  = "test"
 
     vpc_config {
-      subnet_ids         = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
-      security_group_ids = ["${aws_security_group.first.id}"]
-      role_arn           = "${aws_iam_role.firehose.arn}"
+      subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
+      security_group_ids = [aws_security_group.first.id]
+      role_arn           = aws_iam_role.firehose.arn
     }
   }
 }

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -444,7 +444,7 @@ The `vpc_config` object supports the following:
 
 * `subnet_ids` - (Required) A list of subnet IDs to associate with Kinesis Firehose.
 * `security_group_ids` - (Required) A list of security group IDs to associate with Kinesis Firehose.
-* `role_arn` - (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon EC2 configuration API and for creating network interfaces.  Make sure role has permissions of `ec2:CreateNetworkInterface`, `ec2:CreateNetworkInterfacePermission`, `ec2:Describe*` and `ec2:DeleteNetworkInterface`
+* `role_arn` - (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon EC2 configuration API and for creating network interfaces. Make sure role has necessary [IAM permissions](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-es-vpc)
 
 ### data_format_conversion_configuration
 

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -321,6 +321,7 @@ The `elasticsearch_configuration` object supports the following:
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.
 * `type_name` - (Required) The Elasticsearch type name with maximum length of 100 characters.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
+* `vpc_config` - (Optional) The VPC configuration for the delivery stream to connect to Elastic Search associated with the VPC. More details are given below
 * `processing_configuration` - (Optional) The data processing configuration.  More details are given below.
 
 The `splunk_configuration` objects supports the following:
@@ -354,6 +355,12 @@ The `parameters` array objects support the following:
 
 * `parameter_name` - (Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`
 * `parameter_value` - (Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.
+
+The `vpc_config` object supports the following:
+
+* `subnet_ids` - (Required) A list of subnet IDs to associate with Kinesis Firehose.
+* `security_group_ids` - (Required) A list of security group IDs to associate with Kinesis Firehose.
+* `role_arn` - (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon EC2 configuration API and for creating network interfaces.  Make sure role has permissions of `ec2:CreateNetworkInterface`, `ec2:CreateNetworkInterfacePermission`, `ec2:Describe*` and `ec2:DeleteNetworkInterface`
 
 ### data_format_conversion_configuration
 

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -137,7 +137,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
 
 ```hcl
 resource "aws_redshift_cluster" "test_cluster" {
-  cluster_identifier = "tf-redshift-cluster-%d"
+  cluster_identifier = "tf-redshift-cluster"
   database_name      = "test"
   master_username    = "testuser"
   master_password    = "T3stPass"
@@ -219,6 +219,90 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
 }
 ```
 
+### Elasticsearch Destination With VPC
+
+```hcl
+resource "aws_elasticsearch_domain" "test_cluster" {
+  domain_name = "es-test"
+
+  cluster_config {
+    instance_count         = 2
+    zone_awareness_enabled = true
+    instance_type          = "t2.small.elasticsearch"
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+
+  vpc_options {
+    security_group_ids = ["${aws_security_group.first.id}"]
+    subnet_ids         = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
+  }
+}
+
+resource "aws_iam_role_policy" "firehose-elasticsearch" {
+  name   = "elasticsearch"
+  role   = "${aws_iam_role.firehose.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "es:*"
+      ],
+      "Resource": [
+        "${aws_elasticsearch_domain.test_cluster.arn}",
+        "${aws_elasticsearch_domain.test_cluster.arn}/*"
+      ]
+	},
+	{
+	  "Effect": "Allow",
+	  "Action": [
+         "ec2:DescribeVpcs",
+         "ec2:DescribeVpcAttribute",
+         "ec2:DescribeSubnets",
+         "ec2:DescribeSecurityGroups",
+         "ec2:DescribeNetworkInterfaces",
+         "ec2:CreateNetworkInterface",
+         "ec2:CreateNetworkInterfacePermission",
+         "ec2:DeleteNetworkInterface"
+	  ],
+	  "Resource": [
+	    "*"
+	  ]
+	}
+  ]
+}
+EOF
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  depends_on = ["aws_iam_role_policy.firehose-elasticsearch"]
+
+  name        = "terraform-kinesis-firehose-es"
+  destination = "elasticsearch"
+  s3_configuration {
+    role_arn   = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+  }
+  elasticsearch_configuration {
+    domain_arn = "${aws_elasticsearch_domain.test_cluster.arn}"
+    role_arn   = "${aws_iam_role.firehose.arn}"
+    index_name = "test"
+    type_name  = "test"
+
+    vpc_config {
+      subnet_ids         = ["${aws_subnet.first.id}", "${aws_subnet.second.id}"]
+      security_group_ids = ["${aws_security_group.first.id}"]
+      role_arn           = "${aws_iam_role.firehose.arn}"
+    }
+  }
+}
+```
 
 ### Splunk Destination
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13015

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Amazon Kinesis Data Firehose can now deliver streaming data to an Amazon Elasticsearch Service domain in an Amazon VPC.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates -timeout 120m
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates (1677.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1677.859s

terraform-provider-aws git:(firehose-es-vpc-support) ✗ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSKinesisFirehoseDeliveryStream -timeout 120m=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_basic=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_basic
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basic
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3basic
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_basic
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3basic
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (121.13s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (123.65s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (127.99s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (140.90s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (156.63s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_basic (158.61s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty (162.78s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (163.71s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (166.46s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate (167.18s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (171.60s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (186.54s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (193.32s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (223.99s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (226.55s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (229.93s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (139.98s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (121.53s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (160.25s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (156.87s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE (302.40s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (180.29s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (557.15s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (852.34s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates (1830.37s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1830.450s
...
```
