### PR TITLE
service/organizations: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -28,7 +28,6 @@ func testAccAwsOrganizationsPolicy_basic(t *testing.T) {
 				Config: testAccAwsOrganizationsPolicyConfig_Required(rName, content1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsPolicyExists(resourceName, &policy),
-					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:organizations::[^:]+:policy/o-.+/service_control_policy/p-.+$`)),
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "organizations", regexp.MustCompile("policy/o-.+/service_control_policy/p-.+$")),
 					resource.TestCheckResourceAttr(resourceName, "content", content1),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),

--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -29,6 +29,7 @@ func testAccAwsOrganizationsPolicy_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsPolicyExists(resourceName, &policy),
 					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:organizations::[^:]+:policy/o-.+/service_control_policy/p-.+$`)),
+					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "organizations", regexp.MustCompile("policy/o-.+/service_control_policy/p-.+$")),
 					resource.TestCheckResourceAttr(resourceName, "content", content1),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_organizations_policy_test.go:31:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSOrganizations (32.68s)
    --- PASS: TestAccAWSOrganizations/PolicyAttachment (7.66s)
        --- SKIP: TestAccAWSOrganizations/PolicyAttachment/Account (3.13s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/PolicyAttachment/OrganizationalUnit (2.63s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/PolicyAttachment/Root (1.90s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
    --- PASS: TestAccAWSOrganizations/Organization (9.63s)
        --- SKIP: TestAccAWSOrganizations/Organization/basic (1.97s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/Organization/AwsServiceAccessPrincipals (1.87s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/Organization/EnabledPolicyTypes (1.92s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/Organization/FeatureSet (1.92s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/Organization/DataSource (1.95s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
    --- PASS: TestAccAWSOrganizations/Account (0.00s)
        --- SKIP: TestAccAWSOrganizations/Account/basic (0.00s)
            resource_aws_organizations_account_test.go:15: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
        --- SKIP: TestAccAWSOrganizations/Account/ParentId (0.00s)
            resource_aws_organizations_account_test.go:58: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
        --- SKIP: TestAccAWSOrganizations/Account/Tags (0.00s)
            resource_aws_organizations_account_test.go:104: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
    --- PASS: TestAccAWSOrganizations/OrganizationalUnit (3.98s)
        --- SKIP: TestAccAWSOrganizations/OrganizationalUnit/basic (2.00s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/OrganizationalUnit/Name (1.98s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
    --- PASS: TestAccAWSOrganizations/OrganizationalUnits (0.00s)
        --- SKIP: TestAccAWSOrganizations/OrganizationalUnits/DataSource (1.83s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
    --- PASS: TestAccAWSOrganizations/Policy (9.58s)
        --- SKIP: TestAccAWSOrganizations/Policy/concurrent (2.03s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/Policy/Description (2.84s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/Policy/Type (2.78s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- SKIP: TestAccAWSOrganizations/Policy/basic (1.94s)
            provider_test.go:450: skipping tests; this AWS account must not be an existing member of an AWS Organization
```

These tests are expected to be skipped