### PR TITLE
service/iot: Update acceptance tests to use ARN testing check functions

### DIFF
--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -15,6 +15,9 @@ func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 	alias := acctest.RandomWithPrefix("RoleAlias-")
 	alias2 := acctest.RandomWithPrefix("RoleAlias2-")
 
+	resourceName := "aws_iot_role_alias.ra"
+	resourceName2 := "aws_iot_role_alias.ra2"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -23,51 +26,47 @@ func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 			{
 				Config: testAccAWSIotRoleAliasConfig(alias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra"),
-					testAccCheckResourceAttrRegionalARN("aws_iot_role_alias.ra", "arn", "iot", fmt.Sprintf("rolealias/%s", alias)),
-					resource.TestCheckResourceAttr(
-						"aws_iot_role_alias.ra", "credential_duration", "3600"),
+					testAccCheckAWSIotRoleAliasExists(resourceName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "iot", fmt.Sprintf("rolealias/%s", alias)),
+					resource.TestCheckResourceAttr(resourceName, "credential_duration", "3600"),
 				),
 			},
 			{
 				Config: testAccAWSIotRoleAliasConfigUpdate1(alias, alias2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra"),
-					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
-					testAccCheckResourceAttrRegionalARN("aws_iot_role_alias.ra", "arn", "iot", fmt.Sprintf("rolealias/%s", alias)),
-					resource.TestCheckResourceAttr(
-						"aws_iot_role_alias.ra", "credential_duration", "1800"),
+					testAccCheckAWSIotRoleAliasExists(resourceName),
+					testAccCheckAWSIotRoleAliasExists(resourceName2),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "iot", fmt.Sprintf("rolealias/%s", alias)),
+					resource.TestCheckResourceAttr(resourceName, "credential_duration", "1800"),
 				),
 			},
 			{
 				Config: testAccAWSIotRoleAliasConfigUpdate2(alias2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
-				),
+				Check:  resource.ComposeTestCheckFunc(testAccCheckAWSIotRoleAliasExists(resourceName2)),
 			},
 			{
 				Config: testAccAWSIotRoleAliasConfigUpdate3(alias2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
+					testAccCheckAWSIotRoleAliasExists(resourceName2),
 				),
 				ExpectError: regexp.MustCompile("Role alias .+? already exists for this account"),
 			},
 			{
 				Config: testAccAWSIotRoleAliasConfigUpdate4(alias2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
+					testAccCheckAWSIotRoleAliasExists(resourceName2),
 				),
 			},
 			{
 				Config: testAccAWSIotRoleAliasConfigUpdate5(alias2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
-					resource.TestMatchResourceAttr(
-						"aws_iot_role_alias.ra2", "role_arn", regexp.MustCompile(".+?bogus")),
+					testAccCheckAWSIotRoleAliasExists(resourceName2),
+					resource.TestMatchResourceAttr(resourceName2, "role_arn", regexp.MustCompile(".+?bogus")),
+					testAccMatchResourceAttrGlobalARN(resourceName2, "role_arn", "iam", regexp.MustCompile("role/rolebogus")),
 				),
 			},
 			{
-				ResourceName:      "aws_iot_role_alias.ra2",
+				ResourceName:      resourceName2,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -61,7 +61,6 @@ func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 				Config: testAccAWSIotRoleAliasConfigUpdate5(alias2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIotRoleAliasExists(resourceName2),
-					resource.TestMatchResourceAttr(resourceName2, "role_arn", regexp.MustCompile(".+?bogus")),
 					testAccMatchResourceAttrGlobalARN(resourceName2, "role_arn", "iam", regexp.MustCompile("role/rolebogus")),
 				),
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_iot_role_alias_test.go:65:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSIotRoleAlias_basic (75.55s)
```
