### PR TITLE
docs: update aws_lambda_alias import example to use correct resource …

### DIFF
--- a/website/docs/r/lambda_alias.html.markdown
+++ b/website/docs/r/lambda_alias.html.markdown
@@ -16,8 +16,8 @@ For information about function aliases, see [CreateAlias][2] and [AliasRoutingCo
 ## Example Usage
 
 ```hcl
-resource "aws_lambda_alias" "test_alias" {
-  name             = "testalias"
+resource "aws_lambda_alias" "test_lambda_alias" {
+  name             = "my_alias"
   description      = "a sample description"
   function_name    = "${aws_lambda_function.lambda_function_test.arn}"
   function_version = "1"
@@ -56,5 +56,5 @@ For **routing_config** the following attributes are supported:
 Lambda Function Aliases can be imported using the `function_name/alias`, e.g.
 
 ```
-$ terraform import aws_lambda_function_alias.test_lambda_alias my_test_lambda_function/my_alias
+$ terraform import aws_lambda_alias.test_lambda_alias my_test_lambda_function/my_alias
 ```


### PR DESCRIPTION
Fix invalid resource name in import example for `aws_lambda_alias` (was `aws_lambda_function_alias`) and update address and id in import to match code snippet.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:
* **N/A (docs only change)**
