### PR TITLE
provider: First batch of unparam linter fixes

### DIFF
--- a/aws/resource_aws_api_gateway_base_path_mapping_test.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping_test.go
@@ -80,7 +80,7 @@ func TestAccAWSAPIGatewayBasePathMapping_basic(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayBasePathConfigBasePath(name, key, certificate, "tf-acc-test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayBasePathExists("aws_api_gateway_base_path_mapping.test", name, &conf),
+					testAccCheckAWSAPIGatewayBasePathExists("aws_api_gateway_base_path_mapping.test", &conf),
 				),
 			},
 			{
@@ -109,7 +109,7 @@ func TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty(t *testing.T) {
 			{
 				Config: testAccAWSAPIGatewayBasePathConfigBasePath(name, key, certificate, ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayBasePathExists("aws_api_gateway_base_path_mapping.test", name, &conf),
+					testAccCheckAWSAPIGatewayBasePathExists("aws_api_gateway_base_path_mapping.test", &conf),
 				),
 			},
 			{
@@ -121,7 +121,7 @@ func TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSAPIGatewayBasePathExists(n string, name string, res *apigateway.BasePathMapping) resource.TestCheckFunc {
+func testAccCheckAWSAPIGatewayBasePathExists(n string, res *apigateway.BasePathMapping) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -205,7 +205,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					// AWS will create the trail with logging turned off.
 					// Test that "enable_logging" default works.
-					testAccCheckCloudTrailLoggingEnabled(resourceName, true, &trail),
+					testAccCheckCloudTrailLoggingEnabled(resourceName, true),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
 					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
 				),
@@ -219,7 +219,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 				Config: testAccAWSCloudTrailConfigModified(cloudTrailRandInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
-					testAccCheckCloudTrailLoggingEnabled(resourceName, false, &trail),
+					testAccCheckCloudTrailLoggingEnabled(resourceName, false),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
 					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
 				),
@@ -228,7 +228,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists(resourceName, &trail),
-					testAccCheckCloudTrailLoggingEnabled(resourceName, true, &trail),
+					testAccCheckCloudTrailLoggingEnabled(resourceName, true),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
 					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
 				),
@@ -549,7 +549,7 @@ func testAccCheckCloudTrailExists(n string, trail *cloudtrail.Trail) resource.Te
 	}
 }
 
-func testAccCheckCloudTrailLoggingEnabled(n string, desired bool, trail *cloudtrail.Trail) resource.TestCheckFunc {
+func testAccCheckCloudTrailLoggingEnabled(n string, desired bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -217,7 +217,6 @@ func TestAccAWSEcsCluster_CapacityProviders(t *testing.T) {
 func TestAccAWSEcsCluster_CapacityProvidersUpdate(t *testing.T) {
 	var cluster1 ecs.Cluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	providerName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ecs_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -226,7 +225,7 @@ func TestAccAWSEcsCluster_CapacityProvidersUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsClusterCapacityProvidersFargate(rName, providerName),
+				Config: testAccAWSEcsClusterCapacityProvidersFargate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 				),
@@ -238,13 +237,13 @@ func TestAccAWSEcsCluster_CapacityProvidersUpdate(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSEcsClusterCapacityProvidersFargateSpot(rName, providerName),
+				Config: testAccAWSEcsClusterCapacityProvidersFargateSpot(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 				),
 			},
 			{
-				Config: testAccAWSEcsClusterCapacityProvidersFargateBoth(rName, providerName),
+				Config: testAccAWSEcsClusterCapacityProvidersFargateBoth(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 				),
@@ -256,7 +255,6 @@ func TestAccAWSEcsCluster_CapacityProvidersUpdate(t *testing.T) {
 func TestAccAWSEcsCluster_CapacityProvidersNoStrategy(t *testing.T) {
 	var cluster1 ecs.Cluster
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	providerName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ecs_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -265,7 +263,7 @@ func TestAccAWSEcsCluster_CapacityProvidersNoStrategy(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsClusterCapacityProvidersFargateNoStrategy(rName, providerName),
+				Config: testAccAWSEcsClusterCapacityProvidersFargateNoStrategy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 				),
@@ -277,7 +275,7 @@ func TestAccAWSEcsCluster_CapacityProvidersNoStrategy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSEcsClusterCapacityProvidersFargateSpotNoStrategy(rName, providerName),
+				Config: testAccAWSEcsClusterCapacityProvidersFargateSpotNoStrategy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
 				),
@@ -491,7 +489,7 @@ resource "aws_ecs_cluster" "test" {
 `, rName)
 }
 
-func testAccAWSEcsClusterCapacityProvidersFargate(rName, providerName string) string {
+func testAccAWSEcsClusterCapacityProvidersFargate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
 	name = %[1]q
@@ -507,7 +505,7 @@ resource "aws_ecs_cluster" "test" {
 `, rName)
 }
 
-func testAccAWSEcsClusterCapacityProvidersFargateSpot(rName, providerName string) string {
+func testAccAWSEcsClusterCapacityProvidersFargateSpot(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
 	name = %[1]q
@@ -523,7 +521,7 @@ resource "aws_ecs_cluster" "test" {
 `, rName)
 }
 
-func testAccAWSEcsClusterCapacityProvidersFargateBoth(rName, providerName string) string {
+func testAccAWSEcsClusterCapacityProvidersFargateBoth(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
 	name = %[1]q
@@ -539,7 +537,7 @@ resource "aws_ecs_cluster" "test" {
 `, rName)
 }
 
-func testAccAWSEcsClusterCapacityProvidersFargateNoStrategy(rName, providerName string) string {
+func testAccAWSEcsClusterCapacityProvidersFargateNoStrategy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
 	name = %[1]q
@@ -549,7 +547,7 @@ resource "aws_ecs_cluster" "test" {
 `, rName)
 }
 
-func testAccAWSEcsClusterCapacityProvidersFargateSpotNoStrategy(rName, providerName string) string {
+func testAccAWSEcsClusterCapacityProvidersFargateSpotNoStrategy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
 	name = %[1]q

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -376,11 +376,7 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if v, ok := d.GetOk("inference_accelerator"); ok {
-		iAcc, err := expandEcsInferenceAccelerators(v.(*schema.Set).List())
-		if err != nil {
-			return err
-		}
-		input.InferenceAccelerators = iAcc
+		input.InferenceAccelerators = expandEcsInferenceAccelerators(v.(*schema.Set).List())
 	}
 
 	constraints := d.Get("placement_constraints").(*schema.Set).List()
@@ -608,7 +604,7 @@ func flattenEcsInferenceAccelerators(list []*ecs.InferenceAccelerator) []map[str
 	return result
 }
 
-func expandEcsInferenceAccelerators(configured []interface{}) ([]*ecs.InferenceAccelerator, error) {
+func expandEcsInferenceAccelerators(configured []interface{}) []*ecs.InferenceAccelerator {
 	iAccs := make([]*ecs.InferenceAccelerator, 0, len(configured))
 	for _, lRaw := range configured {
 		data := lRaw.(map[string]interface{})
@@ -619,5 +615,5 @@ func expandEcsInferenceAccelerators(configured []interface{}) ([]*ecs.InferenceA
 		iAccs = append(iAccs, l)
 	}
 
-	return iAccs, nil
+	return iAccs
 }

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -123,7 +123,7 @@ func TestAccAWSEIPAssociation_ec2Classic(t *testing.T) {
 					testAccCheckAWSEIPAssociationExists(resourceName, &a),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 					resource.TestCheckResourceAttr(resourceName, "allocation_id", ""),
-					testAccCheckAWSEIPAssociationHasIpBasedId(resourceName, &a),
+					testAccCheckAWSEIPAssociationHasIpBasedId(resourceName),
 				),
 			},
 			{
@@ -230,7 +230,7 @@ func testAccCheckAWSEIPAssociationExists(name string, res *ec2.Address) resource
 	}
 }
 
-func testAccCheckAWSEIPAssociationHasIpBasedId(name string, res *ec2.Address) resource.TestCheckFunc {
+func testAccCheckAWSEIPAssociationHasIpBasedId(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {

--- a/aws/resource_aws_inspector_resource_group_test.go
+++ b/aws/resource_aws_inspector_resource_group_test.go
@@ -34,7 +34,7 @@ func TestAccAWSInspectorResourceGroup_basic(t *testing.T) {
 					testAccCheckAWSInspectorResourceGroupExists(resourceName, &v2),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "inspector", regexp.MustCompile(`resourcegroup/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "bar"),
-					testAccCheckAWSInspectorResourceGroupRecreated(t, &v1, &v2),
+					testAccCheckAWSInspectorResourceGroupRecreated(&v1, &v2),
 				),
 			},
 		},
@@ -69,7 +69,7 @@ func testAccCheckAWSInspectorResourceGroupExists(name string, rg *inspector.Reso
 	}
 }
 
-func testAccCheckAWSInspectorResourceGroupRecreated(t *testing.T, v1, v2 *inspector.ResourceGroup) resource.TestCheckFunc {
+func testAccCheckAWSInspectorResourceGroupRecreated(v1, v2 *inspector.ResourceGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if v2.CreatedAt.Equal(*v1.CreatedAt) {
 			return fmt.Errorf("Inspector resource group not recreated when changing tags")

--- a/aws/resource_aws_instance_migrate.go
+++ b/aws/resource_aws_instance_migrate.go
@@ -105,5 +105,4 @@ func writeV1BlockDevice(
 	countAttr := fmt.Sprintf("%s.#", bdType)
 	count, _ := strconv.Atoi(is.Attributes[countAttr])
 	is.Attributes[countAttr] = strconv.Itoa(count + 1)
-	return
 }

--- a/aws/resource_aws_instance_migrate.go
+++ b/aws/resource_aws_instance_migrate.go
@@ -45,9 +45,7 @@ func migrateAwsInstanceStateV0toV1(is *terraform.InstanceState) (*terraform.Inst
 		is.Attributes["root_block_device.#"] = "0"
 	}
 	for _, oldBd := range oldBds {
-		if err := writeV1BlockDevice(is, oldBd); err != nil {
-			return is, err
-		}
+		writeV1BlockDevice(is, oldBd)
 	}
 	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
 	return is, nil
@@ -76,7 +74,7 @@ func readV0BlockDevices(is *terraform.InstanceState) (map[string]map[string]stri
 }
 
 func writeV1BlockDevice(
-	is *terraform.InstanceState, oldBd map[string]string) error {
+	is *terraform.InstanceState, oldBd map[string]string) {
 	code := hashcode.String(oldBd["device_name"])
 	bdType := "ebs_block_device"
 	if vn, ok := oldBd["virtual_name"]; ok && strings.HasPrefix(vn, "ephemeral") {
@@ -107,5 +105,5 @@ func writeV1BlockDevice(
 	countAttr := fmt.Sprintf("%s.#", bdType)
 	count, _ := strconv.Atoi(is.Attributes[countAttr])
 	is.Attributes[countAttr] = strconv.Itoa(count + 1)
-	return nil
+	return
 }

--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -704,10 +704,7 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 			CurrentApplicationVersionId: aws.Int64(int64(version)),
 		}
 
-		applicationUpdate, err := createApplicationUpdateOpts(d)
-		if err != nil {
-			return err
-		}
+		applicationUpdate := createApplicationUpdateOpts(d)
 
 		if !reflect.DeepEqual(applicationUpdate, &kinesisanalytics.ApplicationUpdate{}) {
 			updateApplicationOpts.SetApplicationUpdate(applicationUpdate)
@@ -1085,7 +1082,7 @@ func expandKinesisAnalyticsReferenceData(rd map[string]interface{}) *kinesisanal
 	return referenceData
 }
 
-func createApplicationUpdateOpts(d *schema.ResourceData) (*kinesisanalytics.ApplicationUpdate, error) {
+func createApplicationUpdateOpts(d *schema.ResourceData) *kinesisanalytics.ApplicationUpdate {
 	applicationUpdate := &kinesisanalytics.ApplicationUpdate{}
 
 	if d.HasChange("code") {
@@ -1154,7 +1151,7 @@ func createApplicationUpdateOpts(d *schema.ResourceData) (*kinesisanalytics.Appl
 		}
 	}
 
-	return applicationUpdate, nil
+	return applicationUpdate
 }
 
 func expandKinesisAnalyticsInputUpdate(vL map[string]interface{}) *kinesisanalytics.InputUpdate {

--- a/aws/resource_aws_kinesis_video_stream_test.go
+++ b/aws/resource_aws_kinesis_video_stream_test.go
@@ -156,7 +156,7 @@ func TestAccAWSKinesisVideoStream_disappears(t *testing.T) {
 				Config: testAccKinesisVideoStreamConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKinesisVideoStreamExists(resourceName, &stream),
-					testAccCheckKinesisVideoStreamDisappears(resourceName, &stream),
+					testAccCheckKinesisVideoStreamDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -164,7 +164,7 @@ func TestAccAWSKinesisVideoStream_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckKinesisVideoStreamDisappears(resourceName string, stream *kinesisvideo.StreamInfo) resource.TestCheckFunc {
+func testAccCheckKinesisVideoStreamDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).kinesisvideoconn
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -550,7 +550,6 @@ func TestAccAWSLambdaFunction_DeadLetterConfigUpdated(t *testing.T) {
 
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_func_dlcfg_upd_%s", rString)
-	uFuncName := fmt.Sprintf("tf_acc_lambda_func_dlcfg_upd_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_dlcfg_upd_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_func_dlcfg_upd_%s", rString)
 	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_dlcfg_upd_%s", rString)
@@ -567,7 +566,7 @@ func TestAccAWSLambdaFunction_DeadLetterConfigUpdated(t *testing.T) {
 				Config: testAccAWSLambdaConfigWithDeadLetterConfig(funcName, topic1Name, policyName, roleName, sgName),
 			},
 			{
-				Config: testAccAWSLambdaConfigWithDeadLetterConfigUpdated(funcName, topic1Name, topic2Name, policyName, roleName, sgName, uFuncName),
+				Config: testAccAWSLambdaConfigWithDeadLetterConfigUpdated(funcName, topic1Name, topic2Name, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists(resourceName, funcName, &conf),
 					func(s *terraform.State) error {
@@ -2373,7 +2372,7 @@ resource "aws_sns_topic" "test" {
 }
 
 func testAccAWSLambdaConfigWithDeadLetterConfigUpdated(funcName, topic1Name, topic2Name, policyName,
-	roleName, sgName, uFuncName string) string {
+	roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "test" {
     filename = "test-fixtures/lambdatest.zip"
@@ -2394,7 +2393,7 @@ resource "aws_sns_topic" "test" {
 resource "aws_sns_topic" "test_2" {
 	name = "%s"
 }
-`, uFuncName, topic1Name, topic2Name)
+`, funcName, topic1Name, topic2Name)
 }
 
 func testAccAWSLambdaConfigWithNilDeadLetterConfig(funcName, policyName, roleName, sgName string) string {

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -325,8 +325,6 @@ func TestAccAWSLambdaPermission_withQualifier(t *testing.T) {
 }
 
 func TestAccAWSLambdaPermission_disappears(t *testing.T) {
-	var statement LambdaPolicyStatement
-
 	rString := acctest.RandString(8)
 	funcName := fmt.Sprintf("tf_acc_lambda_perm_multi_%s", rString)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_perm_multi_%s", rString)
@@ -343,7 +341,7 @@ func TestAccAWSLambdaPermission_disappears(t *testing.T) {
 			{
 				Config: testAccAWSLambdaPermissionConfig_multiplePerms(funcName, roleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSLambdaPermissionDisappears(resourceName, &statement),
+					testAccAWSLambdaPermissionDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -541,7 +539,7 @@ func TestAccAWSLambdaPermission_withIAMRole(t *testing.T) {
 	})
 }
 
-func testAccAWSLambdaPermissionDisappears(n string, statement *LambdaPolicyStatement) resource.TestCheckFunc {
+func testAccAWSLambdaPermissionDisappears(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/aws/resource_aws_lightsail_key_pair_test.go
+++ b/aws/resource_aws_lightsail_key_pair_test.go
@@ -46,7 +46,7 @@ func TestAccAWSLightsailKeyPair_publicKey(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLightsailKeyPairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLightsailKeyPairConfig_imported(lightsailName, testLightsailKeyPairPubKey1),
+				Config: testAccAWSLightsailKeyPairConfig_imported(lightsailName, lightsailPubKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLightsailKeyPairExists("aws_lightsail_key_pair.lightsail_key_pair_test", &conf),
 					resource.TestCheckResourceAttrSet("aws_lightsail_key_pair.lightsail_key_pair_test", "arn"),
@@ -175,14 +175,14 @@ resource "aws_lightsail_key_pair" "lightsail_key_pair_test" {
 `, lightsailName)
 }
 
-func testAccAWSLightsailKeyPairConfig_imported(lightsailName, key string) string {
+func testAccAWSLightsailKeyPairConfig_imported(lightsailName, publicKey string) string {
 	return fmt.Sprintf(`
 resource "aws_lightsail_key_pair" "lightsail_key_pair_test" {
   name = "%s"
 
   public_key = "%s"
 }
-`, lightsailName, lightsailPubKey)
+`, lightsailName, publicKey)
 }
 
 func testAccAWSLightsailKeyPairConfig_encrypted(lightsailName, key string) string {

--- a/aws/resource_aws_main_route_table_association_test.go
+++ b/aws/resource_aws_main_route_table_association_test.go
@@ -18,21 +18,13 @@ func TestAccAWSMainRouteTableAssociation_basic(t *testing.T) {
 			{
 				Config: testAccMainRouteTableAssociationConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMainRouteTableAssociation(
-						"aws_main_route_table_association.foo",
-						"aws_vpc.foo",
-						"aws_route_table.foo",
-					),
+					testAccCheckMainRouteTableAssociation("aws_main_route_table_association.foo", "aws_vpc.foo"),
 				),
 			},
 			{
 				Config: testAccMainRouteTableAssociationConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMainRouteTableAssociation(
-						"aws_main_route_table_association.foo",
-						"aws_vpc.foo",
-						"aws_route_table.bar",
-					),
+					testAccCheckMainRouteTableAssociation("aws_main_route_table_association.foo", "aws_vpc.foo"),
 				),
 			},
 		},
@@ -67,10 +59,7 @@ func testAccCheckMainRouteTableAssociationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckMainRouteTableAssociation(
-	mainRouteTableAssociationResource string,
-	vpcResource string,
-	routeTableResource string) resource.TestCheckFunc {
+func testAccCheckMainRouteTableAssociation(mainRouteTableAssociationResource string, vpcResource string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[mainRouteTableAssociationResource]
 		if !ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13278

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
aws/resource_aws_api_gateway_base_path_mapping_test.go:124:56: `testAccCheckAWSAPIGatewayBasePathExists` - `name` is unused (unparam)
func testAccCheckAWSAPIGatewayBasePathExists(n string, name string, res *apigateway.BasePathMapping) resource.TestCheckFunc {
                                                       ^
aws/resource_aws_athena_database.go:67:126: expandAthenaResultConfiguration - result 1 (error) is always nil (unparam)
func expandAthenaResultConfiguration(bucket string, encryptionConfigurationList []interface{}) (*athena.ResultConfiguration, error) {
                                                                                                                             ^
aws/resource_aws_cloudtrail_test.go:552:67: `testAccCheckCloudTrailLoggingEnabled` - `trail` is unused (unparam)
func testAccCheckCloudTrailLoggingEnabled(n string, desired bool, trail *cloudtrail.Trail) resource.TestCheckFunc {
                                                                  ^
aws/resource_aws_ecs_cluster_test.go:494:58: `testAccAWSEcsClusterCapacityProvidersFargate` - `providerName` is unused (unparam)
func testAccAWSEcsClusterCapacityProvidersFargate(rName, providerName string) string {
                                                         ^
aws/resource_aws_ecs_cluster_test.go:510:62: `testAccAWSEcsClusterCapacityProvidersFargateSpot` - `providerName` is unused (unparam)
func testAccAWSEcsClusterCapacityProvidersFargateSpot(rName, providerName string) string {
                                                             ^
aws/resource_aws_ecs_cluster_test.go:526:62: `testAccAWSEcsClusterCapacityProvidersFargateBoth` - `providerName` is unused (unparam)
func testAccAWSEcsClusterCapacityProvidersFargateBoth(rName, providerName string) string {
                                                             ^
aws/resource_aws_ecs_cluster_test.go:542:68: `testAccAWSEcsClusterCapacityProvidersFargateNoStrategy` - `providerName` is unused (unparam)
func testAccAWSEcsClusterCapacityProvidersFargateNoStrategy(rName, providerName string) string {
                                                                   ^
aws/resource_aws_ecs_cluster_test.go:552:72: `testAccAWSEcsClusterCapacityProvidersFargateSpotNoStrategy` - `providerName` is unused (unparam)
func testAccAWSEcsClusterCapacityProvidersFargateSpotNoStrategy(rName, providerName string) string {
                                                                       ^
aws/resource_aws_ecs_task_definition.go:611:93: expandEcsInferenceAccelerators - result 1 (error) is always nil (unparam)
func expandEcsInferenceAccelerators(configured []interface{}) ([]*ecs.InferenceAccelerator, error) {
                                                                                            ^
aws/resource_aws_eip_association_test.go:233:61: `testAccCheckAWSEIPAssociationHasIpBasedId` - `res` is unused (unparam)
func testAccCheckAWSEIPAssociationHasIpBasedId(name string, res *ec2.Address) resource.TestCheckFunc {
                                                            ^
aws/resource_aws_inspector_resource_group_test.go:72:53: `testAccCheckAWSInspectorResourceGroupRecreated` - `t` is unused (unparam)
func testAccCheckAWSInspectorResourceGroupRecreated(t *testing.T, v1, v2 *inspector.ResourceGroup) resource.TestCheckFunc {
                                                    ^
aws/resource_aws_instance_migrate.go:79:56: writeV1BlockDevice - result 0 (error) is always nil (unparam)
	is *terraform.InstanceState, oldBd map[string]string) error {
	                                                      ^
aws/resource_aws_kinesis_analytics_application.go:1088:96: createApplicationUpdateOpts - result 1 (error) is always nil (unparam)
func createApplicationUpdateOpts(d *schema.ResourceData) (*kinesisanalytics.ApplicationUpdate, error) {
                                                                                               ^
aws/resource_aws_kinesis_video_stream_test.go:167:68: `testAccCheckKinesisVideoStreamDisappears` - `stream` is unused (unparam)
func testAccCheckKinesisVideoStreamDisappears(resourceName string, stream *kinesisvideo.StreamInfo) resource.TestCheckFunc {
                                                                   ^
aws/resource_aws_lambda_function_test.go:2375:56: `testAccAWSLambdaConfigWithDeadLetterConfigUpdated` - `funcName` is unused (unparam)
func testAccAWSLambdaConfigWithDeadLetterConfigUpdated(funcName, topic1Name, topic2Name, policyName,
                                                       ^
aws/resource_aws_lambda_permission_test.go:544:53: `testAccAWSLambdaPermissionDisappears` - `statement` is unused (unparam)
func testAccAWSLambdaPermissionDisappears(n string, statement *LambdaPolicyStatement) resource.TestCheckFunc {
                                                    ^
aws/resource_aws_lightsail_key_pair_test.go:178:63: `testAccAWSLightsailKeyPairConfig_imported` - `key` is unused (unparam)
func testAccAWSLightsailKeyPairConfig_imported(lightsailName, key string) string {
                                                              ^
aws/resource_aws_main_route_table_association_test.go:73:2: `testAccCheckMainRouteTableAssociation` - `routeTableResource` is unused (unparam)
	routeTableResource string) resource.TestCheckFunc {
	^
```

Output from acceptance testing:

```
(TestAccAWSAPIGatewayBasePathMapping_|TestAccAWSAthenaDatabase_|TestAccAWSCloudTrail/Trail/enableLogging|TestAccAWSEcsCluster_CapacityProviders|TestAccAWSEcsTaskDefinition_|TestAccAWSInspectorResourceGroup_basic|TestAccAWSKinesisAnalyticsApplication_|TestAccAWSKinesisVideoStream_disappears|TestAccAWSLambdaFunction_DeadLetterConfigUpdated|TestAccAWSLambdaPermission_disappears|TestAccAWSLightsailKeyPair_publicKey|TestAccAWSMainRouteTableAssociation_basic)

--- PASS: TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty (54.58s)
--- PASS: TestAccAWSAPIGatewayBasePathMapping_basic (55.48s)

--- PASS: TestAccAWSAthenaDatabase_basic (60.51s)
--- PASS: TestAccAWSAthenaDatabase_destroyFailsIfTablesExist (73.58s)
--- PASS: TestAccAWSAthenaDatabase_encryption (71.05s)
--- PASS: TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds (65.41s)
--- PASS: TestAccAWSAthenaDatabase_nameCantHaveUppercase (1.46s)
--- PASS: TestAccAWSAthenaDatabase_nameStartsWithUnderscore (61.23s)

--- PASS: TestAccAWSCloudTrail/Trail/enableLogging (105.77s)

--- PASS: TestAccAWSEcsCluster_CapacityProviders (48.45s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersNoStrategy (53.69s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersUpdate (81.22s)

--- PASS: TestAccAWSEcsTaskDefinition_arrays (16.36s)
--- PASS: TestAccAWSEcsTaskDefinition_basic (26.60s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (26.89s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (16.28s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (16.69s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (21.81s)
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (25.92s)
--- PASS: TestAccAWSEcsTaskDefinition_inferenceAccelerator (14.07s)
--- PASS: TestAccAWSEcsTaskDefinition_ProxyConfiguration (26.41s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (45.91s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (16.00s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (16.27s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (91.23s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolume (27.55s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (27.70s)
--- PASS: TestAccAWSEcsTaskDefinition_withIPCMode (16.69s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (16.85s)
--- PASS: TestAccAWSEcsTaskDefinition_withPidMode (18.24s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (15.69s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (16.75s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (16.38s)

--- PASS: TestAccAWSInspectorResourceGroup_basic (22.88s)

--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (34.01s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (18.73s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (75.84s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (103.79s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (63.12s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (120.00s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (50.36s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (39.75s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (75.76s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (62.71s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (66.35s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (123.03s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (38.35s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (69.86s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_tags (49.91s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (28.74s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (46.64s)
--- PASS: TestAccAWSKinesisVideoStream_disappears (95.02s)

--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (76.72s)

--- PASS: TestAccAWSLambdaPermission_disappears (100.98s)

--- PASS: TestAccAWSLightsailKeyPair_publicKey (29.88s)

--- PASS: TestAccAWSMainRouteTableAssociation_basic (69.00s)
```