### PR TITLE
Enables AWSAT001 linter for ARN attribute checks in acceptance tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -67,6 +67,7 @@ lint:
 		-AT006 \
 		-AT007 \
 		-AT008 \
+        -AWSAT001 \
 		-AWSR001 \
 		-AWSR002 \
 		-R002 \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -67,7 +67,7 @@ lint:
 		-AT006 \
 		-AT007 \
 		-AT008 \
-        -AWSAT001 \
+		-AWSAT001 \
 		-AWSR001 \
 		-AWSR002 \
 		-R002 \


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR enables the ARN attribute check linter `AWSAT001` globally to resolve #11888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
