### PR TITLE
r/organizations_account: tech debt: replace custom validation funcs

### DIFF
--- a/aws/resource_aws_organizations_account.go
+++ b/aws/resource_aws_organizations_account.go
@@ -54,10 +54,13 @@ func resourceAwsOrganizationsAccount() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 50),
 			},
 			"email": {
-				ForceNew:     true,
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateAwsOrganizationsAccountEmail,
+				ForceNew: true,
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(6, 64),
+					validation.StringMatch(regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`), "must be a valid email address"),
+				),
 			},
 			"iam_user_access_to_billing": {
 				ForceNew:     true,
@@ -69,7 +72,7 @@ func resourceAwsOrganizationsAccount() *schema.Resource {
 				ForceNew:     true,
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateAwsOrganizationsAccountRoleName,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\w+=,.@-]{1,64}$`), "must consist of uppercase letters, lowercase letters, digits with no spaces, and any of the following characters"),
 			},
 			"tags": tagsSchema(),
 		},
@@ -297,36 +300,6 @@ func resourceAwsOrganizationsAccountStateRefreshFunc(conn *organizations.Organiz
 		}
 		return accountStatus, *accountStatus.State, nil
 	}
-}
-
-func validateAwsOrganizationsAccountEmail(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q must be a valid email address", value))
-	}
-
-	if len(value) < 6 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be less than 6 characters", value))
-	}
-
-	if len(value) > 64 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be greater than 64 characters", value))
-	}
-
-	return
-}
-
-func validateAwsOrganizationsAccountRoleName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[\w+=,.@-]{1,64}$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q must consist of uppercase letters, lowercase letters, digits with no spaces, and any of the following characters: =,.@-", value))
-	}
-
-	return
 }
 
 func resourceAwsOrganizationsAccountGetParentId(conn *organizations.Organizations, childId string) (string, error) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11872 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
-->
Couldn't seem to run the acceptance tests for this.