### PR TITLE
resource/aws_iot_topic_rule: Implement tagging support

### DIFF
--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -76,6 +76,7 @@ EOF
 * `enabled` - (Required) Specifies whether the rule is enabled.
 * `sql` - (Required) The SQL statement used to query the topic. For more information, see AWS IoT SQL Reference (http://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html#aws-iot-sql-reference) in the AWS IoT Developer Guide.
 * `sql_version` - (Required) The version of the SQL rules engine to use when evaluating the rule.
+* `tags` - (Optional) Key-value map of resource tags
 
 The `cloudwatch_alarm` object takes the following arguments:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12947

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_iot_topic_rule: Add `tags` argument
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIoTTopicRule_iot_analytics (17.78s)
--- PASS: TestAccAWSIoTTopicRule_dynamoDbv2 (17.93s)
--- PASS: TestAccAWSIoTTopicRule_iot_events (18.01s)
--- PASS: TestAccAWSIoTTopicRule_lambda (18.68s)
--- PASS: TestAccAWSIoTTopicRule_basic (18.88s)
--- PASS: TestAccAWSIoTTopicRule_firehose (19.48s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchalarm (19.57s)
--- PASS: TestAccAWSIoTTopicRule_republish_with_qos (19.76s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchmetric (19.98s)
--- PASS: TestAccAWSIoTTopicRule_kinesis (20.06s)
--- PASS: TestAccAWSIoTTopicRule_s3 (20.11s)
--- PASS: TestAccAWSIoTTopicRule_sns (20.27s)
--- PASS: TestAccAWSIoTTopicRule_republish (20.31s)
--- PASS: TestAccAWSIoTTopicRule_sqs (20.41s)
--- PASS: TestAccAWSIoTTopicRule_elasticsearch (23.39s)
--- PASS: TestAccAWSIoTTopicRule_firehose_separator (33.11s)
--- PASS: TestAccAWSIoTTopicRule_dynamodb (33.23s)
--- PASS: TestAccAWSIoTTopicRule_Tags (42.42s)
```