### PR TITLE
Documentation updates

### DIFF
--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -105,8 +105,8 @@ Supported nested arguments for the `options` configuration block:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ARN of the certificate
-* `arn` - The ARN of the certificate
+* `id` - The ID of the certificate
+* `arn` - The ARN of the certificate (same as `id`)
 * `domain_name` - The domain name for which the certificate is issued
 * `domain_validation_options` - A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if `DNS`-validation was used.
 * `validation_emails` - A list of addresses that received a validation E-Mail. Only set if `EMAIL`-validation was used.

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -105,8 +105,8 @@ Supported nested arguments for the `options` configuration block:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the certificate
-* `arn` - The ARN of the certificate (same as `id`)
+* `id` - The ARN of the certificate
+* `arn` - The ARN of the certificate
 * `domain_name` - The domain name for which the certificate is issued
 * `domain_validation_options` - A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if `DNS`-validation was used.
 * `validation_emails` - A list of addresses that received a validation E-Mail. Only set if `EMAIL`-validation was used.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -520,7 +520,7 @@ In addition to all arguments above, the following attributes are exported:
 
   * `id` - The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
 
-  * `arn` - The ARN (Amazon Resource Name) for the distribution. For example: arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5, where 123456789012 is your AWS account ID.
+  * `arn` - The ARN (Amazon Resource Name) for the distribution. For example: `arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5`, where `123456789012` is your AWS account ID.
 
   * `caller_reference` - Internal value used by CloudFront to allow future
     updates to the distribution configuration.

--- a/website/docs/r/codecommit_repository.html.markdown
+++ b/website/docs/r/codecommit_repository.html.markdown
@@ -10,10 +10,6 @@ description: |-
 
 Provides a CodeCommit Repository Resource.
 
-~> **NOTE on CodeCommit Availability**: The CodeCommit is not yet rolled out
-in all regions - available regions are listed
-[the AWS Docs](https://docs.aws.amazon.com/general/latest/gr/rande.html#codecommit_region).
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/codecommit_trigger.html.markdown
+++ b/website/docs/r/codecommit_trigger.html.markdown
@@ -10,10 +10,6 @@ description: |-
 
 Provides a CodeCommit Trigger Resource.
 
-~> **NOTE on CodeCommit**: The CodeCommit is not yet rolled out
-in all regions - available regions are listed
-[the AWS Docs](https://docs.aws.amazon.com/general/latest/gr/rande.html#codecommit_region).
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Hello maintainers! :wave:

This updates two parts in the documentation.

For the `acm_certficate` resource: the `id` and `arn` attributes are identical, but are exposed as different attributes.

For other [resources](https://www.terraform.io/docs/providers/aws/r/kinesis_video_stream.html), we indicate that they are the same (for now), so I added this identifier here, too.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
