### PR TITLE
service/eks: Fix testing and eks-getting-started example for EKS API change

### DIFF
--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -271,6 +271,7 @@ func TestAccAWSEksNodeGroup_Labels(t *testing.T) {
 func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
 	var nodeGroup1 eks.Nodegroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	ssmParameterDataSourceName := "data.aws_ssm_parameter.test"
 	resourceName := "aws_eks_node_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -279,10 +280,10 @@ func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.14.8-20191213"),
+				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
-					resource.TestCheckResourceAttr(resourceName, "release_version", "1.14.8-20191213"),
+					resource.TestCheckResourceAttrPair(resourceName, "release_version", ssmParameterDataSourceName, "value"),
 				),
 			},
 			{
@@ -759,9 +760,10 @@ resource "aws_security_group" "test" {
 resource "aws_subnet" "test" {
   count = 2
 
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
-  vpc_id            = aws_vpc.test.id
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.test.id
 
   tags = {
     Name                          = "tf-acc-test-eks-node-group"
@@ -936,13 +938,17 @@ resource "aws_eks_node_group" "test" {
 `, rName, labelKey1, labelValue1, labelKey2, labelValue2)
 }
 
-func testAccAWSEksNodeGroupConfigReleaseVersion(rName, releaseVersion string) string {
+func testAccAWSEksNodeGroupConfigReleaseVersion(rName string) string {
 	return testAccAWSEksNodeGroupConfigBase(rName) + fmt.Sprintf(`
+data "aws_ssm_parameter" "test" {
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.test.version}/amazon-linux-2/recommended/release_version"
+}
+
 resource "aws_eks_node_group" "test" {
   cluster_name    = aws_eks_cluster.test.name
   node_group_name = %[1]q
   node_role_arn   = aws_iam_role.node.arn
-  release_version = %[2]q
+  release_version = data.aws_ssm_parameter.test.value
   subnet_ids      = aws_subnet.test[*].id
 
   scaling_config {
@@ -957,7 +963,7 @@ resource "aws_eks_node_group" "test" {
     "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
   ]
 }
-`, rName, releaseVersion)
+`, rName)
 }
 
 func testAccAWSEksNodeGroupConfigRemoteAccessEc2SshKey(rName string) string {

--- a/examples/eks-getting-started/vpc.tf
+++ b/examples/eks-getting-started/vpc.tf
@@ -18,9 +18,10 @@ resource "aws_vpc" "demo" {
 resource "aws_subnet" "demo" {
   count = 2
 
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = "10.0.${count.index}.0/24"
-  vpc_id            = aws_vpc.demo.id
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  cidr_block              = "10.0.${count.index}.0/24"
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.demo.id
 
   tags = map(
     "Name", "terraform-eks-demo-node",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13071
Reference: https://aws.amazon.com/blogs/containers/upcoming-changes-to-ip-assignment-for-eks-managed-node-groups/
Reference: https://github.com/awslabs/amazon-eks-ami/issues/423

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This also switches the ReleaseVersion testing to use the newly available SSM Parameter, so it is no longer hardcoded and stale.

Previously:

```
--- FAIL: TestAccAWSEksNodeGroup_basic (1278.58s)
testing.go:683: Step 0 error: errors during apply:
Error: error waiting for EKS Node Group (tf-acc-test-8344543808745629148:tf-acc-test-8344543808745629148) creation: Ec2SubnetInvalidConfiguration: One or more Amazon EC2 Subnets of [subnet-09e307c552d8e2396, subnet-09b4b4c79ae9b1c5a] for node group tf-acc-test-8344543808745629148 does not automatically assign public IP addresses to instances launched into it. If you want your instances to be assigned a public IP address, then you need to enable auto-assign public IP address for the subnet. See IP addressing in VPC guide: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-ip-addressing.html#subnet-public-ip. Resource IDs: [subnet-09e307c552d8e2396 subnet-09b4b4c79ae9b1c5a]

--- FAIL: TestAccAWSEksNodeGroup_ReleaseVersion (1129.51s)
testing.go:683: Step 0 error: errors during apply:
Error: error creating EKS Node Group (tf-acc-test-395161592184105116:tf-acc-test-395161592184105116): InvalidParameterException: releaseVersion 1.14.8-20191213 is invalid
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEksNodeGroup_AmiType (1539.44s)
--- PASS: TestAccAWSEksNodeGroup_basic (1485.68s)
--- PASS: TestAccAWSEksNodeGroup_disappears (1425.45s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1551.75s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes (1545.64s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1647.48s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (1578.86s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1566.70s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1698.65s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1619.70s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1610.20s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1551.41s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1501.53s)
--- PASS: TestAccAWSEksNodeGroup_Version (1513.24s)
```
