### PR TITLE
hashibot: Labeling for top level Markdown files and docs/ directories

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -529,6 +529,7 @@ behavior "pull_request_path_labeler" "service_labels" {
   label_map = {
     # label provider related changes
     "provider" = [
+      "*.md",
       ".github/**/*",
       ".gitignore",
       ".go-version",
@@ -545,6 +546,8 @@ behavior "pull_request_path_labeler" "service_labels" {
       "aws/internal/naming/*",
       "aws/provider.go",
       "aws/utils.go",
+      "docs/*.md",
+      "docs/contributing/**/*",
       "GNUmakefile",
       "infrastructure/**/*",
       "main.go",
@@ -555,7 +558,10 @@ behavior "pull_request_path_labeler" "service_labels" {
       "website/**/partition*",
       "website/**/region*"
     ]
-    # label test related changes
+    "documentation" = [
+      "docs/**/*",
+      "*.md",
+    ]
     "tests" = [
       "**/*_test.go",
       "**/testdata/**/*",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Note: The provider pattern is not just `docs/**/*` since eventually the provider documentation structure will be moved under there to match the Terraform Registry guidelines: https://www.terraform.io/docs/registry/providers/docs.html

Output from acceptance testing: N/A (Hashibot configuration)