### PR TITLE
aws/provider: update to using typelist + add empty condition acctest

### DIFF
--- a/aws/data_source_aws_caller_identity_test.go
+++ b/aws/data_source_aws_caller_identity_test.go
@@ -23,23 +23,6 @@ func TestAccAWSCallerIdentity_basic(t *testing.T) {
 	})
 }
 
-// Protects against a panic in the AWS Provider configuration.
-// See https://github.com/terraform-providers/terraform-provider-aws/pull/1227
-func TestAccAWSCallerIdentity_basic_panic(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAwsCallerIdentityConfig_basic_panic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsCallerIdentityAccountId("data.aws_caller_identity.current"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -70,13 +53,4 @@ func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 
 const testAccCheckAwsCallerIdentityConfig_basic = `
 data "aws_caller_identity" "current" { }
-`
-
-const testAccCheckAwsCallerIdentityConfig_basic_panic = `
-provider "aws" {
-  assume_role {
-  }
-}
-
-data "aws_caller_identity" "current" {}
 `

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1170,17 +1170,21 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 
 	assumeRoleList := d.Get("assume_role").([]interface{})
 	if len(assumeRoleList) == 1 {
-		assumeRole := assumeRoleList[0].(map[string]interface{})
-		config.AssumeRoleARN = assumeRole["role_arn"].(string)
-		config.AssumeRoleSessionName = assumeRole["session_name"].(string)
-		config.AssumeRoleExternalID = assumeRole["external_id"].(string)
+		if assumeRoleList[0] != nil {
+			assumeRole := assumeRoleList[0].(map[string]interface{})
+			config.AssumeRoleARN = assumeRole["role_arn"].(string)
+			config.AssumeRoleSessionName = assumeRole["session_name"].(string)
+			config.AssumeRoleExternalID = assumeRole["external_id"].(string)
 
-		if v := assumeRole["policy"].(string); v != "" {
-			config.AssumeRolePolicy = v
+			if v := assumeRole["policy"].(string); v != "" {
+				config.AssumeRolePolicy = v
+			}
+
+			log.Printf("[INFO] assume_role configuration set: (ARN: %q, SessionID: %q, ExternalID: %q, Policy: %q)",
+				config.AssumeRoleARN, config.AssumeRoleSessionName, config.AssumeRoleExternalID, config.AssumeRolePolicy)
+		} else {
+			log.Printf("[INFO] Empty assume_role block read from configuration")
 		}
-
-		log.Printf("[INFO] assume_role configuration set: (ARN: %q, SessionID: %q, ExternalID: %q, Policy: %q)",
-			config.AssumeRoleARN, config.AssumeRoleSessionName, config.AssumeRoleExternalID, config.AssumeRolePolicy)
 	} else {
 		log.Printf("[INFO] No assume_role block read from configuration")
 	}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1168,7 +1168,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	}
 	config.CredsFilename = credsPath
 
-	assumeRoleList := d.Get("assume_role").(*schema.Set).List()
+	assumeRoleList := d.Get("assume_role").([]interface{})
 	if len(assumeRoleList) == 1 {
 		assumeRole := assumeRoleList[0].(map[string]interface{})
 		config.AssumeRoleARN = assumeRole["role_arn"].(string)
@@ -1214,7 +1214,7 @@ var awsMutexKV = mutexkv.NewMutexKV()
 
 func assumeRoleSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -943,6 +943,21 @@ func TestAccAWSProvider_Region_AwsGovCloudUs(t *testing.T) {
 	})
 }
 
+func TestAccAWSProvider_AssumeRole_Empty(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSProviderConfigAssumeRoleEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsCallerIdentityAccountId("data.aws_caller_identity.current"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSProviderDnsSuffix(providers *[]*schema.Provider, expectedDnsSuffix string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if providers == nil {
@@ -1464,6 +1479,15 @@ provider "aws" {
 }
 `, os.Getenv("TF_ACC_ASSUME_ROLE_ARN"), policy)
 }
+
+const testAccCheckAWSProviderConfigAssumeRoleEmpty = `
+provider "aws" {
+  assume_role {
+  }
+}
+
+data "aws_caller_identity" "current" {}
+`
 
 // composeConfig can be called to concatenate multiple strings to build test configurations
 func composeConfig(config ...string) string {

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -944,9 +944,12 @@ func TestAccAWSProvider_Region_AwsGovCloudUs(t *testing.T) {
 }
 
 func TestAccAWSProvider_AssumeRole_Empty(t *testing.T) {
+	var providers []*schema.Provider
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAWSProviderConfigAssumeRoleEmpty,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9956 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws/provider: correct typeset usage with typelist in cases where max_items is 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSProvider_Region_AwsChina (3.55s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (3.55s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (3.56s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (3.74s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (3.74s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (3.74s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (3.74s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (3.74s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (3.75s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (3.76s)
--- PASS: TestAccAWSProvider_Endpoints_Deprecated (3.78s)
--- PASS: TestAccAWSProvider_Endpoints (3.83s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (19.18s)
```