### PR TITLE
service/apigateway: update to using typelist

### DIFF
--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -55,7 +55,7 @@ func resourceAwsApiGatewayUsagePlan() *schema.Resource {
 			},
 
 			"quota_settings": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -85,7 +85,7 @@ func resourceAwsApiGatewayUsagePlan() *schema.Resource {
 			},
 
 			"throttle_settings": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -155,7 +155,7 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("quota_settings"); ok {
-		settings := v.(*schema.Set).List()
+		settings := v.([]interface{})
 		q, ok := settings[0].(map[string]interface{})
 
 		if errors := validateApiGatewayUsagePlanQuotaSettings(q); len(errors) > 0 {
@@ -184,7 +184,7 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 	}
 
 	if v, ok := d.GetOk("throttle_settings"); ok {
-		settings := v.(*schema.Set).List()
+		settings := v.([]interface{})
 		q, ok := settings[0].(map[string]interface{})
 
 		if !ok {
@@ -363,10 +363,7 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChange("throttle_settings") {
 		o, n := d.GetChange("throttle_settings")
-
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
-		diff := ns.Difference(os).List()
+		diff := n.([]interface{})
 
 		// Handle Removal
 		if len(diff) == 0 {
@@ -411,10 +408,7 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChange("quota_settings") {
 		o, n := d.GetChange("quota_settings")
-
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
-		diff := ns.Difference(os).List()
+		diff := n.([]interface{})
 
 		// Handle Removal
 		if len(diff) == 0 {

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -208,9 +208,9 @@ func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:            func() { testAccPreCheck(t) },
-		Providers:           testAccProviders,
-		CheckDestroy:        testAccCheckAWSAPIGatewayUsagePlanDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(rName),
@@ -262,9 +262,9 @@ func TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:            func() { testAccPreCheck(t) },
-		Providers:           testAccProviders,
-		CheckDestroy:        testAccCheckAWSAPIGatewayUsagePlanDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSApiGatewayUsagePlanThrottlingConfig(rName),
@@ -288,9 +288,9 @@ func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:            func() { testAccPreCheck(t) },
-		Providers:           testAccProviders,
-		CheckDestroy:        testAccCheckAWSAPIGatewayUsagePlanDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(rName),

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -231,8 +231,8 @@ func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "throttle_settings.4173790118.burst_limit", "2"),
-					resource.TestCheckResourceAttr(resourceName, "throttle_settings.4173790118.rate_limit", "5"),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.burst_limit", "2"),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.rate_limit", "5"),
 				),
 			},
 			{
@@ -240,8 +240,8 @@ func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "throttle_settings.1779463053.burst_limit", "3"),
-					resource.TestCheckResourceAttr(resourceName, "throttle_settings.1779463053.rate_limit", "6"),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.burst_limit", "3"),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.rate_limit", "6"),
 				),
 			},
 			{
@@ -272,7 +272,7 @@ func TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 				Config: testAccAWSApiGatewayUsagePlanThrottlingConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "throttle_settings.4173790118.rate_limit", "5"),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.0.rate_limit", "5"),
 				),
 			},
 			{
@@ -313,9 +313,9 @@ func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "quota_settings.1956747625.limit", "100"),
-					resource.TestCheckResourceAttr(resourceName, "quota_settings.1956747625.offset", "6"),
-					resource.TestCheckResourceAttr(resourceName, "quota_settings.1956747625.period", "WEEK"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.limit", "100"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.offset", "6"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.period", "WEEK"),
 				),
 			},
 			{
@@ -323,9 +323,9 @@ func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "quota_settings.3909168194.limit", "200"),
-					resource.TestCheckResourceAttr(resourceName, "quota_settings.3909168194.offset", "20"),
-					resource.TestCheckResourceAttr(resourceName, "quota_settings.3909168194.period", "MONTH"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.limit", "200"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.offset", "20"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.0.period", "MONTH"),
 				),
 			},
 			{

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -211,7 +211,6 @@ func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 		PreCheck:            func() { testAccPreCheck(t) },
 		Providers:           testAccProviders,
 		CheckDestroy:        testAccCheckAWSAPIGatewayUsagePlanDestroy,
-		DisableBinaryDriver: true,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(rName),
@@ -266,7 +265,6 @@ func TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 		PreCheck:            func() { testAccPreCheck(t) },
 		Providers:           testAccProviders,
 		CheckDestroy:        testAccCheckAWSAPIGatewayUsagePlanDestroy,
-		DisableBinaryDriver: true,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSApiGatewayUsagePlanThrottlingConfig(rName),
@@ -293,7 +291,6 @@ func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 		PreCheck:            func() { testAccPreCheck(t) },
 		Providers:           testAccProviders,
 		CheckDestroy:        testAccCheckAWSAPIGatewayUsagePlanDestroy,
-		DisableBinaryDriver: true,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSApiGatewayUsagePlanBasicConfig(rName),

--- a/aws/resource_aws_api_gateway_vpc_link.go
+++ b/aws/resource_aws_api_gateway_vpc_link.go
@@ -33,7 +33,7 @@ func resourceAwsApiGatewayVpcLink() *schema.Resource {
 				Optional: true,
 			},
 			"target_arns": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				MaxItems: 1,
 				Required: true,
 				ForceNew: true,
@@ -54,7 +54,7 @@ func resourceAwsApiGatewayVpcLinkCreate(d *schema.ResourceData, meta interface{}
 
 	input := &apigateway.CreateVpcLinkInput{
 		Name:       aws.String(d.Get("name").(string)),
-		TargetArns: expandStringList(d.Get("target_arns").(*schema.Set).List()),
+		TargetArns: expandStringList(d.Get("target_arns").([]interface{})),
 		Tags:       tags,
 	}
 	if v, ok := d.GetOk("description"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9956 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
service/apigateway: correct typeset usage with typelist in cases where max_items is 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (623.39s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (656.41s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_tags (690.06s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (706.87s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_basic (757.71s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (794.37s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (814.24s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (894.62s)

--- PASS: TestAccAWSAPIGatewayVpcLink_basic (692.07s)
--- PASS: TestAccAWSAPIGatewayVpcLink_tags (714.51s)
```