### PR TITLE
service/ecs: update to using typelist

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -342,7 +342,7 @@ func resourceAwsEcsService() *schema.Resource {
 			},
 
 			"service_registries": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				MaxItems: 1,
@@ -486,7 +486,7 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 		input.PlacementConstraints = pc
 	}
 
-	serviceRegistries := d.Get("service_registries").(*schema.Set).List()
+	serviceRegistries := d.Get("service_registries").([]interface{})
 	if len(serviceRegistries) > 0 {
 		srs := make([]*ecs.ServiceRegistry, 0, len(serviceRegistries))
 		for _, v := range serviceRegistries {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9956 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
service/ecs: correct typeset usage with typelist in cases where max_items is 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsService_basicImport
--- PASS: TestAccAWSEcsService_withPlacementConstraints
--- PASS: TestAccAWSEcsService_disappears
--- PASS: TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
--- PASS: TestAccAWSEcsServiceDataSource_basic
--- PASS: TestAccAWSEcsService_withMultipleCapacityProviderStrategies
--- PASS: TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withFamilyAndRevision
--- PASS: TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate
--- PASS: TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
--- PASS: TestAccAWSEcsService_ManagedTags
--- PASS: TestAccAWSEcsService_Tags
--- PASS: TestAccAWSEcsService_withCapacityProviderStrategy
--- PASS: TestAccAWSEcsService_withPlacementStrategy
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withServiceRegistries
--- PASS: TestAccAWSEcsService_withServiceRegistries_container
--- PASS: TestAccAWSEcsService_withLbChanges
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
--- PASS: TestAccAWSEcsService_PropagateTags
```