### PR TITLE
service/elastic_transcoder: update to using typelist

### DIFF
--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -35,7 +35,7 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 
 			// ContentConfig also requires ThumbnailConfig
 			"content_config": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
@@ -102,7 +102,7 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 			},
 
 			"notifications": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -144,7 +144,7 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 			},
 
 			"thumbnail_config": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
@@ -235,22 +235,22 @@ func resourceAwsElasticTranscoderPipelineCreate(d *schema.ResourceData, meta int
 }
 
 func expandETNotifications(d *schema.ResourceData) *elastictranscoder.Notifications {
-	set, ok := d.GetOk("notifications")
+	list, ok := d.GetOk("notifications")
 	if !ok {
 		return nil
 	}
 
-	s := set.(*schema.Set).List()
-	if len(s) == 0 {
+	l := list.([]interface{})
+	if len(l) == 0 {
 		return nil
 	}
 
-	if s[0] == nil {
-		log.Printf("[ERR] First element of Notifications set is nil")
+	if l[0] == nil {
+		log.Printf("[ERR] First element of Notifications list is nil")
 		return nil
 	}
 
-	rN := s[0].(map[string]interface{})
+	rN := l[0].(map[string]interface{})
 
 	return &elastictranscoder.Notifications{
 		Completed:   aws.String(rN["completed"].(string)),
@@ -290,17 +290,17 @@ func flattenETNotifications(n *elastictranscoder.Notifications) []map[string]int
 }
 
 func expandETPiplineOutputConfig(d *schema.ResourceData, key string) *elastictranscoder.PipelineOutputConfig {
-	set, ok := d.GetOk(key)
+	list, ok := d.GetOk(key)
 	if !ok {
 		return nil
 	}
 
-	s := set.(*schema.Set)
-	if s == nil || s.Len() == 0 {
+	l := list.([]interface{})
+	if len(l) == 0 {
 		return nil
 	}
 
-	cc := s.List()[0].(map[string]interface{})
+	cc := l[0].(map[string]interface{})
 
 	cfg := &elastictranscoder.PipelineOutputConfig{
 		Bucket:       aws.String(cc["bucket"].(string)),

--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -26,7 +26,7 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 			},
 
 			"audio": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				MaxItems: 1,
@@ -62,7 +62,7 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 				},
 			},
 			"audio_codec_options": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
 				ForceNew: true,
@@ -112,7 +112,7 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 			},
 
 			"thumbnails": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
 				ForceNew: true,
@@ -170,7 +170,7 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 			},
 
 			"video": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				MaxItems: 1,
@@ -355,16 +355,16 @@ func resourceAwsElasticTranscoderPresetCreate(d *schema.ResourceData, meta inter
 }
 
 func expandETThumbnails(d *schema.ResourceData) *elastictranscoder.Thumbnails {
-	set, ok := d.GetOk("thumbnails")
+	list, ok := d.GetOk("thumbnails")
 	if !ok {
 		return nil
 	}
 
-	s := set.(*schema.Set)
-	if s == nil || s.Len() == 0 {
+	l := list.([]interface{})
+	if len(l) == 0 {
 		return nil
 	}
-	t := s.List()[0].(map[string]interface{})
+	t := l[0].(map[string]interface{})
 
 	thumbnails := &elastictranscoder.Thumbnails{}
 
@@ -404,16 +404,16 @@ func expandETThumbnails(d *schema.ResourceData) *elastictranscoder.Thumbnails {
 }
 
 func expandETAudioParams(d *schema.ResourceData) *elastictranscoder.AudioParameters {
-	set, ok := d.GetOk("audio")
+	list, ok := d.GetOk("audio")
 	if !ok {
 		return nil
 	}
 
-	s := set.(*schema.Set)
-	if s == nil || s.Len() == 0 {
+	l := list.([]interface{})
+	if len(l) == 0 {
 		return nil
 	}
-	audio := s.List()[0].(map[string]interface{})
+	audio := l[0].(map[string]interface{})
 
 	return &elastictranscoder.AudioParameters{
 		AudioPackingMode: aws.String(audio["audio_packing_mode"].(string)),
@@ -426,12 +426,12 @@ func expandETAudioParams(d *schema.ResourceData) *elastictranscoder.AudioParamet
 }
 
 func expandETAudioCodecOptions(d *schema.ResourceData) *elastictranscoder.AudioCodecOptions {
-	s := d.Get("audio_codec_options").(*schema.Set)
-	if s == nil || s.Len() == 0 {
+	l := d.Get("audio_codec_options").([]interface{})
+	if len(l) == 0 {
 		return nil
 	}
 
-	codec := s.List()[0].(map[string]interface{})
+	codec := l[0].(map[string]interface{})
 
 	codecOpts := &elastictranscoder.AudioCodecOptions{}
 
@@ -455,11 +455,11 @@ func expandETAudioCodecOptions(d *schema.ResourceData) *elastictranscoder.AudioC
 }
 
 func expandETVideoParams(d *schema.ResourceData) *elastictranscoder.VideoParameters {
-	s := d.Get("video").(*schema.Set)
-	if s == nil || s.Len() == 0 {
+	l := d.Get("video").([]interface{})
+	if len(l) == 0 {
 		return nil
 	}
-	p := s.List()[0].(map[string]interface{})
+	p := l[0].(map[string]interface{})
 
 	etVideoParams := &elastictranscoder.VideoParameters{
 		Watermarks: expandETVideoWatermarks(d),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9956 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
service/elastic_transcoder: correct typeset usage with typelist in cases where max_items is 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSElasticTranscoderPreset_disappears (7.48s)
--- PASS: TestAccAWSElasticTranscoderPreset_basic (9.25s)
--- PASS: TestAccAWSElasticTranscoderPipeline_disappears (11.78s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (12.56s)
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (13.29s)
--- PASS: TestAccAWSElasticTranscoderPipeline_kmsKey (13.39s)
--- PASS: TestAccAWSElasticTranscoderPreset_Description (13.54s)
--- PASS: TestAccAWSElasticTranscoderPreset_Full (14.72s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (18.57s)
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (27.06s)
```