### PR TITLE
service/fsx: update to using typelist

### DIFF
--- a/aws/resource_aws_fsx_lustre_file_system.go
+++ b/aws/resource_aws_fsx_lustre_file_system.go
@@ -87,7 +87,7 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(1200),
 			},
 			"subnet_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				ForceNew: true,
 				MinItems: 1,
@@ -119,7 +119,7 @@ func resourceAwsFsxLustreFileSystemCreate(d *schema.ResourceData, meta interface
 		ClientRequestToken: aws.String(resource.UniqueId()),
 		FileSystemType:     aws.String(fsx.FileSystemTypeLustre),
 		StorageCapacity:    aws.Int64(int64(d.Get("storage_capacity").(int))),
-		SubnetIds:          expandStringSet(d.Get("subnet_ids").(*schema.Set)),
+		SubnetIds:          expandStringList(d.Get("subnet_ids").([]interface{})),
 	}
 
 	if v, ok := d.GetOk("export_path"); ok {

--- a/aws/resource_aws_fsx_windows_file_system.go
+++ b/aws/resource_aws_fsx_windows_file_system.go
@@ -147,7 +147,7 @@ func resourceAwsFsxWindowsFileSystem() *schema.Resource {
 				ValidateFunc: validation.IntBetween(32, 65536),
 			},
 			"subnet_ids": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
 				ForceNew: true,
 				MinItems: 1,
@@ -185,7 +185,7 @@ func resourceAwsFsxWindowsFileSystemCreate(d *schema.ResourceData, meta interfac
 		ClientRequestToken: aws.String(resource.UniqueId()),
 		FileSystemType:     aws.String(fsx.FileSystemTypeWindows),
 		StorageCapacity:    aws.Int64(int64(d.Get("storage_capacity").(int))),
-		SubnetIds:          expandStringSet(d.Get("subnet_ids").(*schema.Set)),
+		SubnetIds:          expandStringList(d.Get("subnet_ids").([]interface{})),
 		WindowsConfiguration: &fsx.CreateFileSystemWindowsConfiguration{
 			AutomaticBackupRetentionDays: aws.Int64(int64(d.Get("automatic_backup_retention_days").(int))),
 			CopyTagsToBackups:            aws.Bool(d.Get("copy_tags_to_backups").(bool)),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9956 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
service/fsx: correct typeset usage with typelist in cases where max_items is 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSFsxLustreFileSystem_disappears (468.94s)
--- PASS: TestAccAWSFsxLustreFileSystem_Tags (525.58s)
--- PASS: TestAccAWSFsxLustreFileSystem_basic (559.45s)
--- PASS: TestAccAWSFsxLustreFileSystem_WeeklyMaintenanceStartTime (559.79s)
--- PASS: TestAccAWSFsxLustreFileSystem_StorageCapacity (1088.68s)
--- PASS: TestAccAWSFsxLustreFileSystem_SecurityGroupIds (1115.36s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportedFileChunkSize (1308.67s)
--- PASS: TestAccAWSFsxLustreFileSystem_ImportPath (1699.45s)
--- PASS: TestAccAWSFsxLustreFileSystem_ExportPath (1739.32s)
--- PASS: TestAccAWSFsxWindowsFileSystem_SelfManagedActiveDirectory (2775.20s)
--- PASS: TestAccAWSFsxWindowsFileSystem_basic (2894.81s)
--- PASS: TestAccAWSFsxWindowsFileSystem_Tags (2898.81s)
--- PASS: TestAccAWSFsxWindowsFileSystem_AutomaticBackupRetentionDays (2902.59s)
--- PASS: TestAccAWSFsxWindowsFileSystem_DailyAutomaticBackupStartTime (2950.88s)
--- PASS: TestAccAWSFsxWindowsFileSystem_disappears (3031.25s)
--- PASS: TestAccAWSFsxWindowsFileSystem_WeeklyMaintenanceStartTime (2920.21s)
--- PASS: TestAccAWSFsxWindowsFileSystem_SelfManagedActiveDirectory_Username (3970.18s)
--- PASS: TestAccAWSFsxWindowsFileSystem_StorageCapacity (4159.27s)
--- PASS: TestAccAWSFsxWindowsFileSystem_SecurityGroupIds (4164.24s)
--- PASS: TestAccAWSFsxWindowsFileSystem_CopyTagsToBackups (4281.11s)
--- PASS: TestAccAWSFsxWindowsFileSystem_KmsKeyId (4401.74s)
--- PASS: TestAccAWSFsxWindowsFileSystem_ThroughputCapacity (4048.96s)
```
