### PR TITLE
service/vpc: update to using typelist

### DIFF
--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -197,8 +197,8 @@ func resourceAwsVpcPeeringConnectionModifyOptions(d *schema.ResourceData, meta i
 
 	req := &ec2.ModifyVpcPeeringConnectionOptionsInput{
 		VpcPeeringConnectionId:            aws.String(d.Id()),
-		AccepterPeeringConnectionOptions:  expandVpcPeeringConnectionOptions(d.Get("accepter").(*schema.Set).List(), crossRegionPeering),
-		RequesterPeeringConnectionOptions: expandVpcPeeringConnectionOptions(d.Get("requester").(*schema.Set).List(), crossRegionPeering),
+		AccepterPeeringConnectionOptions:  expandVpcPeeringConnectionOptions(d.Get("accepter").([]interface{}), crossRegionPeering),
+		RequesterPeeringConnectionOptions: expandVpcPeeringConnectionOptions(d.Get("requester").([]interface{}), crossRegionPeering),
 	}
 
 	log.Printf("[DEBUG] Modifying VPC Peering Connection options: %#v", req)
@@ -325,7 +325,7 @@ func vpcPeeringConnectionRefreshState(conn *ec2.EC2, id string) resource.StateRe
 
 func vpcPeeringConnectionOptionsSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: true,
 		Computed: true,
 		MaxItems: 1,

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -241,17 +241,17 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"requester.41753983.allow_remote_vpc_dns_resolution",
+						"requester.0.allow_remote_vpc_dns_resolution",
 						"false",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"requester.41753983.allow_classic_link_to_remote_vpc",
+						"requester.0.allow_classic_link_to_remote_vpc",
 						"true",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"requester.41753983.allow_vpc_to_remote_classic_link",
+						"requester.0.allow_vpc_to_remote_classic_link",
 						"true",
 					),
 					testAccCheckAWSVpcPeeringConnectionOptions(
@@ -270,17 +270,17 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.1102046665.allow_remote_vpc_dns_resolution",
+						"accepter.0.allow_remote_vpc_dns_resolution",
 						"true",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.1102046665.allow_classic_link_to_remote_vpc",
+						"accepter.0.allow_classic_link_to_remote_vpc",
 						"false",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.1102046665.allow_vpc_to_remote_classic_link",
+						"accepter.0.allow_vpc_to_remote_classic_link",
 						"false",
 					),
 					testAccCheckAWSVpcPeeringConnectionOptions(
@@ -318,17 +318,17 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"requester.41753983.allow_remote_vpc_dns_resolution",
+						"requester.0.allow_remote_vpc_dns_resolution",
 						"false",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"requester.41753983.allow_classic_link_to_remote_vpc",
+						"requester.0.allow_classic_link_to_remote_vpc",
 						"true",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"requester.41753983.allow_vpc_to_remote_classic_link",
+						"requester.0.allow_vpc_to_remote_classic_link",
 						"true",
 					),
 					testAccCheckAWSVpcPeeringConnectionOptions(
@@ -347,17 +347,17 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.1102046665.allow_remote_vpc_dns_resolution",
+						"accepter.0.allow_remote_vpc_dns_resolution",
 						"true",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.1102046665.allow_classic_link_to_remote_vpc",
+						"accepter.0.allow_classic_link_to_remote_vpc",
 						"false",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.1102046665.allow_vpc_to_remote_classic_link",
+						"accepter.0.allow_vpc_to_remote_classic_link",
 						"false",
 					),
 					testAccCheckAWSVpcPeeringConnectionOptions(

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -222,9 +222,8 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"auto_accept"},
 
-		Providers:           testAccProviders,
-		CheckDestroy:        testAccCheckAWSVpcPeeringConnectionDestroy,
-		DisableBinaryDriver: true,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcPeeringConfig_options(rName),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9956 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
service/vpc: correct typeset usage with typelist in cases where max_items is 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- FAIL: TestAccAWSVPCPeeringConnectionAccepter_sameRegionDifferentAccount (1.16s) -- unrelated error: AWS_ALTERNATE_ACCESS_KEY_ID or AWS_ALTERNATE_PROFILE must be set for acceptance tests
--- FAIL: TestAccAWSVPCPeeringConnectionAccepter_differentRegionDifferentAccount (1.20s) -- unrelated error: AWS_ALTERNATE_ACCESS_KEY_ID or AWS_ALTERNATE_PROFILE must be set for acceptance tests
--- PASS: TestAccAWSVPCPeeringConnection_failedState (11.77s)
--- PASS: TestAccAWSVPCPeeringConnection_peerRegionAutoAccept (16.21s)
--- PASS: TestAccAWSVPCPeeringConnection_plan (18.88s)
--- PASS: TestAccAWSVPCPeeringConnection_optionsNoAutoAccept (20.72s)
--- PASS: TestAccAWSVPCPeeringConnectionAccepter_sameRegionSameAccount (26.84s)
--- PASS: TestAccAWSVPCPeeringConnection_region (31.90s)
--- PASS: TestAccAWSVPCPeeringConnection_options (34.08s)
--- PASS: TestAccAWSVPCPeeringConnection_basic (35.75s)
--- PASS: TestAccAWSVPCPeeringConnectionAccepter_differentRegionSameAccount (38.00s)
--- PASS: TestAccAWSVPCPeeringConnection_accept (39.42s)
```