### PR TITLE
service/asg: Fix schema panic in ASG tags

### DIFF
--- a/aws/autoscaling_tags.go
+++ b/aws/autoscaling_tags.go
@@ -248,14 +248,21 @@ func autoscalingTagFromMap(attr map[string]interface{}, resourceID string) (*aut
 	return t, nil
 }
 
-// autoscalingTagDescriptionsToSlice turns the list of tags into a slice.
-func autoscalingTagDescriptionsToSlice(ts []*autoscaling.TagDescription) []map[string]interface{} {
+// autoscalingTagDescriptionsToSlice turns the list of tags into a slice. If
+// forceStrings is true, all values are converted to strings
+func autoscalingTagDescriptionsToSlice(ts []*autoscaling.TagDescription, forceStrings bool) []map[string]interface{} {
 	tags := make([]map[string]interface{}, 0, len(ts))
 	for _, t := range ts {
+		var propagateAtLaunch interface{}
+		if forceStrings {
+			propagateAtLaunch = strconv.FormatBool(*t.PropagateAtLaunch)
+		} else {
+			propagateAtLaunch = *t.PropagateAtLaunch
+		}
 		tags = append(tags, map[string]interface{}{
 			"key":                 *t.Key,
 			"value":               *t.Value,
-			"propagate_at_launch": *t.PropagateAtLaunch,
+			"propagate_at_launch": propagateAtLaunch,
 		})
 	}
 

--- a/aws/autoscaling_tags.go
+++ b/aws/autoscaling_tags.go
@@ -255,13 +255,13 @@ func autoscalingTagDescriptionsToSlice(ts []*autoscaling.TagDescription, forceSt
 	for _, t := range ts {
 		var propagateAtLaunch interface{}
 		if forceStrings {
-			propagateAtLaunch = strconv.FormatBool(*t.PropagateAtLaunch)
+			propagateAtLaunch = strconv.FormatBool(aws.BoolValue(t.PropagateAtLaunch))
 		} else {
-			propagateAtLaunch = *t.PropagateAtLaunch
+			propagateAtLaunch = aws.BoolValue(t.PropagateAtLaunch)
 		}
 		tags = append(tags, map[string]interface{}{
-			"key":                 *t.Key,
-			"value":               *t.Value,
+			"key":                 aws.StringValue(t.Key),
+			"value":               aws.StringValue(t.Value),
 			"propagate_at_launch": propagateAtLaunch,
 		})
 	}

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -729,7 +729,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 				tagList = append(tagList, t)
 			}
 		}
-		d.Set("tag", autoscalingTagDescriptionsToSlice(tagList))
+		d.Set("tag", autoscalingTagDescriptionsToSlice(tagList, false))
 	}
 
 	if v, tagsOk = d.GetOk("tags"); tagsOk {
@@ -754,11 +754,11 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 			}
 		}
 		//lintignore:AWSR002
-		d.Set("tags", autoscalingTagDescriptionsToSlice(tagsList))
+		d.Set("tags", autoscalingTagDescriptionsToSlice(tagsList, true))
 	}
 
 	if !tagOk && !tagsOk {
-		d.Set("tag", autoscalingTagDescriptionsToSlice(g.Tags))
+		d.Set("tag", autoscalingTagDescriptionsToSlice(g.Tags, false))
 	}
 
 	if err := d.Set("target_group_arns", flattenStringList(g.TargetGroupARNs)); err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13312 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Autoscaling groups tags 'propagate_at_launch' will now properly set 
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ TF_SCHEMA_PANIC_ON_ERROR=1 make testacc TEST=./aws TESTARGS='-run=TestAccAWSAutoScalingGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoScalingGroup -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_basic
=== PAUSE TestAccAWSAutoScalingGroup_basic
=== RUN   TestAccAWSAutoScalingGroup_namePrefix
=== PAUSE TestAccAWSAutoScalingGroup_namePrefix
=== RUN   TestAccAWSAutoScalingGroup_autoGeneratedName
=== PAUSE TestAccAWSAutoScalingGroup_autoGeneratedName
=== RUN   TestAccAWSAutoScalingGroup_terminationPolicies
=== PAUSE TestAccAWSAutoScalingGroup_terminationPolicies
=== RUN   TestAccAWSAutoScalingGroup_tags
=== PAUSE TestAccAWSAutoScalingGroup_tags
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
=== PAUSE TestAccAWSAutoScalingGroup_VpcUpdates
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
=== PAUSE TestAccAWSAutoScalingGroup_WithLoadBalancer
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
=== PAUSE TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
=== RUN   TestAccAWSAutoScalingGroup_withPlacementGroup
=== PAUSE TestAccAWSAutoScalingGroup_withPlacementGroup
=== RUN   TestAccAWSAutoScalingGroup_enablingMetrics
=== PAUSE TestAccAWSAutoScalingGroup_enablingMetrics
=== RUN   TestAccAWSAutoScalingGroup_suspendingProcesses
=== PAUSE TestAccAWSAutoScalingGroup_suspendingProcesses
=== RUN   TestAccAWSAutoScalingGroup_withMetrics
=== PAUSE TestAccAWSAutoScalingGroup_withMetrics
=== RUN   TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
=== PAUSE TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
=== RUN   TestAccAWSAutoScalingGroup_MaxInstanceLifetime
=== PAUSE TestAccAWSAutoScalingGroup_MaxInstanceLifetime
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups
=== PAUSE TestAccAWSAutoScalingGroup_ALB_TargetGroups
=== RUN   TestAccAWSAutoScalingGroup_TargetGroupArns
=== PAUSE TestAccAWSAutoScalingGroup_TargetGroupArns
=== RUN   TestAccAWSAutoScalingGroup_initialLifecycleHook
=== PAUSE TestAccAWSAutoScalingGroup_initialLifecycleHook
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
=== PAUSE TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
=== RUN   TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
=== PAUSE TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
=== RUN   TestAccAWSAutoScalingGroup_emptyAvailabilityZones
=== PAUSE TestAccAWSAutoScalingGroup_emptyAvailabilityZones
=== RUN   TestAccAWSAutoScalingGroup_launchTemplate
=== PAUSE TestAccAWSAutoScalingGroup_launchTemplate
=== RUN   TestAccAWSAutoScalingGroup_launchTemplate_update
=== PAUSE TestAccAWSAutoScalingGroup_launchTemplate_update
=== RUN   TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
=== PAUSE TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
=== RUN   TestAccAWSAutoScalingGroup_LoadBalancers
=== PAUSE TestAccAWSAutoScalingGroup_LoadBalancers
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
=== RUN   TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity
=== PAUSE TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity
=== RUN   TestAccAWSAutoScalingGroup_launchTempPartitionNum
=== PAUSE TestAccAWSAutoScalingGroup_launchTempPartitionNum
=== CONT  TestAccAWSAutoScalingGroup_basic
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType
=== CONT  TestAccAWSAutoScalingGroup_emptyAvailabilityZones
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy
=== CONT  TestAccAWSAutoScalingGroup_LoadBalancers
=== CONT  TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile
=== CONT  TestAccAWSAutoScalingGroup_launchTemplate_update
=== CONT  TestAccAWSAutoScalingGroup_launchTemplate
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version
=== CONT  TestAccAWSAutoScalingGroup_launchTempPartitionNum
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice
=== CONT  TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools
=== CONT  TestAccAWSAutoScalingGroup_suspendingProcesses
=== CONT  TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (49.52s)
=== CONT  TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
--- PASS: TestAccAWSAutoScalingGroup_launchTempPartitionNum (51.85s)
=== CONT  TestAccAWSAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (58.53s)
=== CONT  TestAccAWSAutoScalingGroup_TargetGroupArns
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (77.05s)
=== CONT  TestAccAWSAutoScalingGroup_ALB_TargetGroups
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (80.21s)
=== CONT  TestAccAWSAutoScalingGroup_MaxInstanceLifetime
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (81.89s)
=== CONT  TestAccAWSAutoScalingGroup_serviceLinkedRoleARN
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (82.57s)
=== CONT  TestAccAWSAutoScalingGroup_withMetrics
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (84.62s)
=== CONT  TestAccAWSAutoScalingGroup_VpcUpdates
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (87.64s)
=== CONT  TestAccAWSAutoScalingGroup_enablingMetrics
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (90.22s)
=== CONT  TestAccAWSAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (90.88s)
=== CONT  TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (105.32s)
=== CONT  TestAccAWSAutoScalingGroup_WithLoadBalancer
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (113.01s)
=== CONT  TestAccAWSAutoScalingGroup_terminationPolicies
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (115.10s)
=== CONT  TestAccAWSAutoScalingGroup_tags
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (121.81s)
=== CONT  TestAccAWSAutoScalingGroup_autoGeneratedName
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (68.63s)
=== CONT  TestAccAWSAutoScalingGroup_namePrefix
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (82.15s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (82.84s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (169.46s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (179.82s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (102.51s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (47.63s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (87.11s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (180.50s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (178.57s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (160.71s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (187.37s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (298.20s)
--- PASS: TestAccAWSAutoScalingGroup_basic (298.42s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (263.50s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (272.14s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (303.79s)
--- PASS: TestAccAWSAutoScalingGroup_tags (249.05s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (392.48s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (402.73s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (742.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	745.036s
```
