### PR TITLE
Acceptance tests: Check for default subnets when no subnet_id specified

### DIFF
--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -473,11 +473,7 @@ func TestAccAWSInstanceDataSource_metadataOptions(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		// No subnet_id specified requires default VPC with default subnets or EC2-Classic.
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets(t)
-		},
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -893,12 +889,13 @@ data "aws_instance" "test" {
 func testAccInstanceDataSourceConfig_metadataOptions(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html#ec2-classic-instance-types
-		testAccAvailableEc2InstanceTypeForRegion("t1.micro", "m1.small"),
+		testAccAwsInstanceVpcConfig(rName, false),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
 
   tags = {
     Name = %[1]q

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -473,10 +473,10 @@ func TestAccAWSInstanceDataSource_metadataOptions(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		// No subnet_id specified requires default VPC or EC2-Classic.
+		// No subnet_id specified requires default VPC with default subnets or EC2-Classic.
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckHasDefaultVpcOrEc2Classic(t)
+			testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -893,7 +893,8 @@ data "aws_instance" "test" {
 func testAccInstanceDataSourceConfig_metadataOptions(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html#ec2-classic-instance-types
+		testAccAvailableEc2InstanceTypeForRegion("t1.micro", "m1.small"),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1278,16 +1278,19 @@ func testAccCheckAWSProviderPartition(providers *[]*schema.Provider, expectedPar
 	}
 }
 
-// testAccPreCheckHasDefaultVpcOrEc2Classic checks that the test region has a default VPC or has the EC2-Classic platform.
+// testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets checks that the test region has either
+// - The EC2-Classic platform available, or
+// - A default VPC with default subnets.
 // This check is useful to ensure that an instance can be launched without specifying a subnet.
-func testAccPreCheckHasDefaultVpcOrEc2Classic(t *testing.T) {
+func testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets(t *testing.T) {
 	client := testAccProvider.Meta().(*AWSClient)
 
-	if !testAccHasDefaultVpc(t) && !hasEc2Classic(client.supportedplatforms) {
-		t.Skipf("skipping tests; %s does not have a default VPC or EC2-Classic", client.region)
+	if !hasEc2Classic(client.supportedplatforms) && !(testAccHasDefaultVpc(t) && testAccDefaultSubnetCount(t) > 0) {
+		t.Skipf("skipping tests; %s does not have EC2-Classic or a default VPC with default subnets", client.region)
 	}
 }
 
+// testAccHasDefaultVpc returns whether the current AWS region has a default VPC.
 func testAccHasDefaultVpc(t *testing.T) bool {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -1305,6 +1308,26 @@ func testAccHasDefaultVpc(t *testing.T) bool {
 	}
 
 	return true
+}
+
+// testAccDefaultSubnetCount returns the number of default subnets in the current region's default VPC.
+func testAccDefaultSubnetCount(t *testing.T) int {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	input := &ec2.DescribeSubnetsInput{
+		Filters: buildEC2AttributeFilterList(map[string]string{
+			"defaultForAz": "true",
+		}),
+	}
+	output, err := conn.DescribeSubnets(input)
+	if testAccPreCheckSkipError(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("error describing default subnets: %s", err)
+	}
+
+	return len(output.Subnets)
 }
 
 func testAccAWSProviderConfigEndpoints(endpoints string) string {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -2790,9 +2790,10 @@ func TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited(t *
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source_dest_check"},
 			},
 		},
 	})
@@ -3107,10 +3108,10 @@ func TestAccAWSInstance_metadataOptions(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		// No subnet_id specified requires default VPC or EC2-Classic.
+		// No subnet_id specified requires default VPC with default subnets or EC2-Classic.
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckHasDefaultVpcOrEc2Classic(t)
+			testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets(t)
 		},
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
@@ -5138,7 +5139,8 @@ resource "aws_instance" "test" {
 func testAccInstanceConfigMetadataOptions(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html#ec2-classic-instance-types
+		testAccAvailableEc2InstanceTypeForRegion("t1.micro", "m1.small"),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
@@ -5162,7 +5164,8 @@ data "aws_instance" "test" {
 func testAccInstanceConfigMetadataOptionsUpdated(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html#ec2-classic-instance-types
+		testAccAvailableEc2InstanceTypeForRegion("t1.micro", "m1.small"),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/13260.
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/11126.

Add a "PreCheck" for default subnets in a default VPC for test cases where an instance is launched without specifying a `subnet_id`.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
# Ensure no regression when metadata options tests are run with a standalone VPC:
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstanceDataSource_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstanceDataSource_metadataOptions -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_metadataOptions
=== PAUSE TestAccAWSInstanceDataSource_metadataOptions
=== CONT  TestAccAWSInstanceDataSource_metadataOptions
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (134.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	134.316s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_metadataOptions -timeout 120m
=== RUN   TestAccAWSInstance_metadataOptions
=== PAUSE TestAccAWSInstance_metadataOptions
=== CONT  TestAccAWSInstance_metadataOptions
--- PASS: TestAccAWSInstance_metadataOptions (166.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	166.193s
# EC2-Classic
$ AWS_DEFAULT_REGION=us-east-1 make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_basic -timeout 120m
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== CONT  TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (85.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.533s
# Default VPC with default subnets
$ AWS_DEFAULT_REGION=eu-central-1 make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_basic -timeout 120m
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== CONT  TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (118.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	118.551s
$ AWS_DEFAULT_REGION=eu-west-1 make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_basic'
# No default VPC
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_basic -timeout 120m
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== CONT  TestAccAWSInstance_basic
--- SKIP: TestAccAWSInstance_basic (2.87s)
    provider_test.go:1305: skipping tests; eu-west-1 does not have EC2-Classic or a default VPC with default subnets
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.908s
# Default VPC but no default subnets
$ AWS_DEFAULT_REGION=eu-west-2 make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_basic -timeout 120m
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== CONT  TestAccAWSInstance_basic
--- SKIP: TestAccAWSInstance_basic (3.10s)
    provider_test.go:1305: skipping tests; eu-west-2 does not have EC2-Classic or a default VPC with default subnets
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3.164s
```

Without the additional `PreCheck` the _Default VPC but no default subnets_ case errors out:

```console
$ AWS_DEFAULT_REGION=eu-west-2 make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSInstance_basic -timeout 120m
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== CONT  TestAccAWSInstance_basic
--- FAIL: TestAccAWSInstance_basic (12.65s)
    testing.go:684: Step 0 error: errors during apply:
        
        Error: Error launching source instance: MissingInput: No subnets found for the default VPC 'vpc-06beb66f'. Please specify a subnet.
        	status code: 400, request id: a04a29ad-831c-4b59-8ccb-881471fed238
        
          on /tmp/tf-test353589136/main.tf line 26:
          (source code not available)
        
        
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	12.679s
FAIL
GNUmakefile:26: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```