### PR TITLE
service/rds: Fix schema panic errors

### DIFF
--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -242,7 +242,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(d.Get("db_instance_identifier").(string))
 
 	d.Set("allocated_storage", dbInstance.AllocatedStorage)
-	d.Set("auto_minor_upgrade_enabled", dbInstance.AutoMinorVersionUpgrade)
+	d.Set("auto_minor_version_upgrade", dbInstance.AutoMinorVersionUpgrade)
 	d.Set("availability_zone", dbInstance.AvailabilityZone)
 	d.Set("backup_retention_period", dbInstance.BackupRetentionPeriod)
 	d.Set("db_cluster_identifier", dbInstance.DBClusterIdentifier)

--- a/aws/data_source_aws_db_instance_test.go
+++ b/aws/data_source_aws_db_instance_test.go
@@ -20,6 +20,7 @@ func TestAccAWSDbInstanceDataSource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "address"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "allocated_storage"),
+					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "auto_minor_version_upgrade"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "db_instance_class"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "db_name"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "db_subnet_group"),

--- a/aws/data_source_aws_rds_cluster.go
+++ b/aws/data_source_aws_rds_cluster.go
@@ -31,6 +31,11 @@ func dataSourceAwsRdsCluster() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			"backtrack_window": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
 			"backup_retention_period": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/aws/data_source_aws_rds_cluster_test.go
+++ b/aws/data_source_aws_rds_cluster_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceAWSRDSCluster_basic(t *testing.T) {
 				Config: testAccDataSourceAwsRdsClusterConfigBasic(clusterName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "backtrack_window", resourceName, "backtrack_window"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_identifier", resourceName, "cluster_identifier"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "database_name", resourceName, "database_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "db_cluster_parameter_group_name", resourceName, "db_cluster_parameter_group_name"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13312 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* d/aws_db_instance: 'auto_minor_version_upgrade' now properly set
* d/aws_rds_cluster: 'backtrack_window' attribute now available
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
