### PR TITLE
Fix aws_security_group_rule: description overwritten on state refresh

### DIFF
--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -851,15 +851,24 @@ func descriptionFromIPPerm(d *schema.ResourceData, rule *ec2.IpPermission) strin
 			groupId := components[1]
 
 			for _, gp := range rule.UserIdGroupPairs {
+				if *gp.GroupId != groupId || *gp.UserId != userId {
+					continue
+				}
 				if *gp.GroupId == groupId && *gp.UserId == userId {
-					return aws.StringValue(gp.Description)
+					if desc := aws.StringValue(gp.Description); desc != "" {
+						return desc
+					}
 				}
 			}
 		case 1:
 			groupId := components[0]
 			for _, gp := range rule.UserIdGroupPairs {
-				if *gp.GroupId == groupId {
-					return aws.StringValue(gp.Description)
+				if *gp.GroupId != groupId {
+					continue
+				}
+
+				if desc := aws.StringValue(gp.Description); desc != "" {
+					return desc
 				}
 			}
 		}

--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -842,6 +842,7 @@ func descriptionFromIPPerm(d *schema.ResourceData, rule *ec2.IpPermission) strin
 		}
 	}
 
+	// probe UserIdGroupPairs
 	if raw, ok := d.GetOk("source_security_group_id"); ok {
 		components := strings.Split(raw.(string), "/")
 
@@ -851,19 +852,18 @@ func descriptionFromIPPerm(d *schema.ResourceData, rule *ec2.IpPermission) strin
 			groupId := components[1]
 
 			for _, gp := range rule.UserIdGroupPairs {
-				if *gp.GroupId != groupId || *gp.UserId != userId {
+				if aws.StringValue(gp.GroupId) != groupId || aws.StringValue(gp.UserId) != userId {
 					continue
 				}
-				if *gp.GroupId == groupId && *gp.UserId == userId {
-					if desc := aws.StringValue(gp.Description); desc != "" {
-						return desc
-					}
+
+				if desc := aws.StringValue(gp.Description); desc != "" {
+					return desc
 				}
 			}
 		case 1:
 			groupId := components[0]
 			for _, gp := range rule.UserIdGroupPairs {
-				if *gp.GroupId != groupId {
+				if aws.StringValue(gp.GroupId) != groupId {
 					continue
 				}
 

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -170,8 +170,8 @@ func TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id(t *testing.T) {
 				Config: testAccAWSSecurityGroupRule_Ingress_Source_with_AccountId(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
-					resource.TestMatchResourceAttr(
-						ruleName, "security_group_id", regexp.MustCompile("^sg-[0-9a-z]{17}$")),
+					resource.TestCheckResourceAttrPair(
+						ruleName, "security_group_id", "aws_security_group.web", "id"),
 					resource.TestMatchResourceAttr(
 						ruleName, "source_security_group_id", regexp.MustCompile("^[0-9]{12}/sg-[0-9a-z]{17}$")),
 					resource.TestCheckResourceAttr(

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -2089,6 +2089,7 @@ resource "aws_security_group_rule" "allow_self" {
   from_port                = 0
   to_port                  = 0
   protocol                 = "-1"
+  description              = "some description"
   security_group_id        = "${aws_security_group.web.id}"
   source_security_group_id = "${data.aws_caller_identity.current.account_id}/${aws_security_group.web.id}"
 }

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -159,6 +159,8 @@ func TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id(t *testing.T) {
 
 	rInt := acctest.RandInt()
 
+	ruleName := "aws_security_group_rule.allow_self"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -168,6 +170,18 @@ func TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id(t *testing.T) {
 				Config: testAccAWSSecurityGroupRule_Ingress_Source_with_AccountId(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
+					resource.TestMatchResourceAttr(
+						ruleName, "security_group_id", regexp.MustCompile("^sg-[0-9a-z]{17}$")),
+					resource.TestMatchResourceAttr(
+						ruleName, "source_security_group_id", regexp.MustCompile("^[0-9]{12}/sg-[0-9a-z]{17}$")),
+					resource.TestCheckResourceAttr(
+						ruleName, "description", "some description"),
+					resource.TestCheckResourceAttr(
+						ruleName, "from_port", "0"),
+					resource.TestCheckResourceAttr(
+						ruleName, "to_port", "0"),
+					resource.TestCheckResourceAttr(
+						ruleName, "protocol", "-1"),
 				),
 			},
 		},


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Reason for change: Existing state refresh code does not set `description` field when `source_security_group_id` contains account id prefix.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_security_group_rule: Fix description field from being overwritten during state refresh when `source_security_group_id` contains account id prefix
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id -timeout 120m
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id
=== PAUSE TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id
=== CONT  TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id (34.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.394s
```
