### PR TITLE
resource/aws_network_acl: Fix issue where updating nacl subnet assoca…

### DIFF
--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -310,7 +310,7 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 				})
 				if err != nil {
 					if isAWSErr(err, "InvalidAssociationID.NotFound", "") {
-						return nil
+						continue
 					}
 					return fmt.Errorf("Error Replacing Default Network Acl Association: %s", err)
 				}

--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -303,13 +303,16 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 					}
 					return fmt.Errorf("Failed to find acl association: acl %s with subnet %s: %s", d.Id(), r, err)
 				}
-				log.Printf("DEBUG] Replacing Network Acl Association (%s) with Default Network ACL ID (%s)", *association.NetworkAclAssociationId, *defaultAcl.NetworkAclId)
+				log.Printf("[DEBUG] Replacing Network Acl Association (%s) with Default Network ACL ID (%s)", *association.NetworkAclAssociationId, *defaultAcl.NetworkAclId)
 				_, err = conn.ReplaceNetworkAclAssociation(&ec2.ReplaceNetworkAclAssociationInput{
 					AssociationId: association.NetworkAclAssociationId,
 					NetworkAclId:  defaultAcl.NetworkAclId,
 				})
 				if err != nil {
-					return err
+					if isAWSErr(err, "InvalidAssociationID.NotFound", "") {
+						return nil
+					}
+					return fmt.Errorf("Error Replacing Default Network Acl Association: %s", err)
 				}
 			}
 		}


### PR DESCRIPTION
…tions fails with InvalidAssociationID.NotFound

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12922

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_network_acl: Fix issue where updating nacl subnet assocations fails with InvalidAssociationID.NotFound
```

### Acceptance Testing
Before code change:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSNetworkAcl_SubnetsDelete'
--- FAIL: TestAccAWSNetworkAcl_SubnetsDelete (53.98s)

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSNetworkAcl_SubnetChange'
--- FAIL: TestAccAWSNetworkAcl_SubnetChange (57.31s)

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSNetworkAcl_Subnets'
--- FAIL: TestAccAWSNetworkAcl_SubnetsDelete (54.06s)
--- PASS: TestAccAWSNetworkAcl_Subnets (71.58s)
```

All Failures have same error:
```
Error: InvalidAssociationID.NotFound: The association ID 'aclassoc-<id>' does not exist
status code: 400, request id: <id>
```

Output from code change acceptance testing:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSNetworkAcl_SubnetsDelete'
--- PASS: TestAccAWSNetworkAcl_SubnetsDelete (66.27s)

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSNetworkAcl_SubnetChange'
--- PASS: TestAccAWSNetworkAcl_SubnetChange (65.85s)

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSNetworkAcl_Subnets'
--- PASS: TestAccAWSNetworkAcl_SubnetsDelete (63.98s)
--- PASS: TestAccAWSNetworkAcl_Subnets (69.76s)
```
