### PR TITLE
Correctly restore Target Group LB algorithm default

### DIFF
--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -454,6 +454,17 @@ func TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
+				// Set to non-default first
+				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "least_outstanding_requests"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "least_outstanding_requests"),
+				),
+			},
+			{
+				// Verify default is restored
 				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, false, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
@@ -463,21 +474,13 @@ func TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType(t *testing.T) {
 				),
 			},
 			{
+				// Explicitly set default
 				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "round_robin"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
 					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "round_robin"),
-				),
-			},
-			{
-				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "least_outstanding_requests"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "least_outstanding_requests"),
 				),
 			},
 		},

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -124,7 +124,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 			"load_balancing_algorithm_type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  "round_robin",
 				ValidateFunc: validation.StringInSlice([]string{
 					"round_robin",
 					"least_outstanding_requests",


### PR DESCRIPTION
Closes
https://github.com/terraform-providers/terraform-provider-aws/issues/12297

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Correctly restore target group algorithm when unsetting load_balancing_algorithm_type
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS="-run=TestAccAWSALBTargetGroup_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSALBTargetGroup_ -timeout 120m
=== RUN   TestAccAWSALBTargetGroup_basic
=== PAUSE TestAccAWSALBTargetGroup_basic
=== RUN   TestAccAWSALBTargetGroup_namePrefix
=== PAUSE TestAccAWSALBTargetGroup_namePrefix
=== RUN   TestAccAWSALBTargetGroup_generatedName
=== PAUSE TestAccAWSALBTargetGroup_generatedName
=== RUN   TestAccAWSALBTargetGroup_changeNameForceNew
=== PAUSE TestAccAWSALBTargetGroup_changeNameForceNew
=== RUN   TestAccAWSALBTargetGroup_changeProtocolForceNew
=== PAUSE TestAccAWSALBTargetGroup_changeProtocolForceNew
=== RUN   TestAccAWSALBTargetGroup_changePortForceNew
=== PAUSE TestAccAWSALBTargetGroup_changePortForceNew
=== RUN   TestAccAWSALBTargetGroup_changeVpcForceNew
=== PAUSE TestAccAWSALBTargetGroup_changeVpcForceNew
=== RUN   TestAccAWSALBTargetGroup_tags
=== PAUSE TestAccAWSALBTargetGroup_tags
=== RUN   TestAccAWSALBTargetGroup_updateHealthCheck
=== PAUSE TestAccAWSALBTargetGroup_updateHealthCheck
=== RUN   TestAccAWSALBTargetGroup_updateSticknessEnabled
=== PAUSE TestAccAWSALBTargetGroup_updateSticknessEnabled
=== RUN   TestAccAWSALBTargetGroup_setAndUpdateSlowStart
=== PAUSE TestAccAWSALBTargetGroup_setAndUpdateSlowStart
=== RUN   TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType
=== PAUSE TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType
=== RUN   TestAccAWSALBTargetGroup_lambda
=== PAUSE TestAccAWSALBTargetGroup_lambda
=== RUN   TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled
=== PAUSE TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled
=== RUN   TestAccAWSALBTargetGroup_missingPortProtocolVpc
=== PAUSE TestAccAWSALBTargetGroup_missingPortProtocolVpc
=== CONT  TestAccAWSALBTargetGroup_basic
=== CONT  TestAccAWSALBTargetGroup_updateHealthCheck
=== CONT  TestAccAWSALBTargetGroup_changePortForceNew
=== CONT  TestAccAWSALBTargetGroup_lambda
=== CONT  TestAccAWSALBTargetGroup_missingPortProtocolVpc
=== CONT  TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled
=== CONT  TestAccAWSALBTargetGroup_setAndUpdateSlowStart
=== CONT  TestAccAWSALBTargetGroup_updateSticknessEnabled
=== CONT  TestAccAWSALBTargetGroup_changeVpcForceNew
=== CONT  TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType
=== CONT  TestAccAWSALBTargetGroup_changeProtocolForceNew
=== CONT  TestAccAWSALBTargetGroup_tags
=== CONT  TestAccAWSALBTargetGroup_generatedName
=== CONT  TestAccAWSALBTargetGroup_namePrefix
=== CONT  TestAccAWSALBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSALBTargetGroup_lambda (20.61s)
--- PASS: TestAccAWSALBTargetGroup_missingPortProtocolVpc (29.12s)
--- PASS: TestAccAWSALBTargetGroup_namePrefix (33.30s)
--- PASS: TestAccAWSALBTargetGroup_basic (33.85s)
--- PASS: TestAccAWSALBTargetGroup_generatedName (35.01s)
--- PASS: TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled (47.00s)
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (57.30s)
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (57.44s)
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (57.76s)
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (60.64s)
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (61.31s)
--- PASS: TestAccAWSALBTargetGroup_tags (61.96s)
--- PASS: TestAccAWSALBTargetGroup_setAndUpdateSlowStart (62.81s)
--- PASS: TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType (75.26s)
--- PASS: TestAccAWSALBTargetGroup_updateSticknessEnabled (76.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       78.344s
```
