### PR TITLE
service/directoryservice: Fix schema error on `connect_ips`

### DIFF
--- a/aws/data_source_aws_directory_service_directory.go
+++ b/aws/data_source_aws_directory_service_directory.go
@@ -64,15 +64,15 @@ func dataSourceAwsDirectoryServiceDirectory() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"customer_username": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"connect_ips": {
 							Type:     schema.TypeSet,
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
+						},
+						"customer_username": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"customer_dns_ips": {
 							Type:     schema.TypeSet,

--- a/aws/data_source_aws_directory_service_directory.go
+++ b/aws/data_source_aws_directory_service_directory.go
@@ -68,6 +68,12 @@ func dataSourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"connect_ips": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
 						"customer_dns_ips": {
 							Type:     schema.TypeSet,
 							Computed: true,

--- a/aws/data_source_aws_directory_service_directory_test.go
+++ b/aws/data_source_aws_directory_service_directory_test.go
@@ -71,6 +71,28 @@ func TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAWSDirectoryServiceDirectory_connector(t *testing.T) {
+	resourceName := "aws_directory_service_directory.connector"
+	dataSourceName := "data.aws_directory_service_directory.test-ad-connector"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSDirectoryService(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDirectoryServiceDirectoryConfig_connector,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "connect_settings.0.connect_ips", resourceName, "connect_settings.0.connect_ips"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites(adType string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
@@ -160,3 +182,67 @@ data "aws_directory_service_directory" "test-microsoft-ad" {
 }
 `, alias)
 }
+
+const testAccDataSourceDirectoryServiceDirectoryConfig_connector = `
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_directory_service_directory" "test" {
+  name = "corp.notexample.com"
+  password = "SuperSecretPassw0rd"
+  size = "Small"
+
+  vpc_settings {
+    vpc_id = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+  }
+}
+
+resource "aws_directory_service_directory" "connector" {
+  name = "corp.notexample.com"
+  password = "SuperSecretPassw0rd"
+  size = "Small"
+  type = "ADConnector"
+
+  connect_settings {
+    customer_dns_ips = aws_directory_service_directory.test.dns_ip_addresses
+    customer_username = "Administrator"
+    vpc_id = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.test.id}"]
+  }
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+	tags = {
+		Name = "terraform-testacc-directory-service-directory-connector"
+	}
+}
+
+resource "aws_subnet" "foo" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block = "10.0.1.0/24"
+  tags = {
+    Name = "tf-acc-directory-service-directory-connector-foo"
+  }
+}
+resource "aws_subnet" "test" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  cidr_block = "10.0.2.0/24"
+  tags = {
+    Name = "tf-acc-directory-service-directory-connector-test"
+  }
+}
+
+data "aws_directory_service_directory" "test-ad-connector" {
+	directory_id = "${aws_directory_service_directory.connector.id}"
+}
+`

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -92,6 +92,12 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"connect_ips": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
 						"customer_username": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -115,12 +121,6 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-						},
-						"connect_ips": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
 						},
 					},
 				},

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -116,6 +116,12 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"connect_ips": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
 					},
 				},
 			},

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -224,6 +224,7 @@ func TestAccAWSDirectoryServiceDirectory_connector(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.connector"),
 					resource.TestCheckResourceAttrSet("aws_directory_service_directory.connector", "security_group_id"),
+					resource.TestCheckResourceAttrSet("aws_directory_service_directory.connector", "connect_settings.0.connect_ips.#"),
 				),
 			},
 			{

--- a/website/docs/d/directory_service_directory.html.markdown
+++ b/website/docs/d/directory_service_directory.html.markdown
@@ -46,6 +46,7 @@ data "aws_directory_service_directory" "example" {
 `connect_settings` (for `ADConnector`) is also exported with the following attributes:
  
  * `customer_username` - The username corresponding to the password provided.
+ * `connect_ips` - The IP addresses of the AD Connector servers.
  * `customer_dns_ips` - The DNS IP addresses of the domain to connect to.
  * `subnet_ids` - The identifiers of the subnets for the connector servers (2 subnets in 2 different AZs).
  * `vpc_id` - The ID of the VPC that the connector is in.

--- a/website/docs/d/directory_service_directory.html.markdown
+++ b/website/docs/d/directory_service_directory.html.markdown
@@ -45,8 +45,8 @@ data "aws_directory_service_directory" "example" {
  
 `connect_settings` (for `ADConnector`) is also exported with the following attributes:
  
- * `customer_username` - The username corresponding to the password provided.
  * `connect_ips` - The IP addresses of the AD Connector servers.
+ * `customer_username` - The username corresponding to the password provided.
  * `customer_dns_ips` - The DNS IP addresses of the domain to connect to.
  * `subnet_ids` - The identifiers of the subnets for the connector servers (2 subnets in 2 different AZs).
  * `vpc_id` - The ID of the VPC that the connector is in.

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -158,9 +158,9 @@ In addition to all arguments above, the following attributes are exported:
 * `dns_ip_addresses` - A list of IP addresses of the DNS servers for the directory or connector.
 * `security_group_id` - The ID of the security group created by the directory.
 
-**connect_settings** exports the following:
+`connect_settings` (for `ADConnector`) is also exported with the following attributes:
 
-* `connect_ips` - The IP addresses of the AD Connector servers.
+ * `connect_ips` - The IP addresses of the AD Connector servers.
 
 ## Import
 

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -158,6 +158,9 @@ In addition to all arguments above, the following attributes are exported:
 * `dns_ip_addresses` - A list of IP addresses of the DNS servers for the directory or connector.
 * `security_group_id` - The ID of the security group created by the directory.
 
+**connect_settings** exports the following:
+
+* `connect_ips` - The IP addresses of the AD Connector servers.
 
 ## Import
 


### PR DESCRIPTION
Define `connect_ips` attribute in schema to prevent error. Add documentation and tests.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13312 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* d/aws_directory_service_directory: `connect_settings` `connect_ips` attribute now set.
* r/aws_directory_service_directory: `connect_settings` `connect_ips` attribute now set.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDirectoryServiceDirectory_connector'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDirectoryServiceDirectory_connector -timeout 120m
=== RUN   TestAccAWSDirectoryServiceDirectory_connector
=== PAUSE TestAccAWSDirectoryServiceDirectory_connector
=== CONT  TestAccAWSDirectoryServiceDirectory_connector
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (692.94s)
PASS


❯ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSDirectoryServiceDirectory_connector'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSDirectoryServiceDirectory_connector -timeout 120m
=== RUN   TestAccDataSourceAWSDirectoryServiceDirectory_connector
=== PAUSE TestAccDataSourceAWSDirectoryServiceDirectory_connector
=== CONT  TestAccDataSourceAWSDirectoryServiceDirectory_connector
--- PASS: TestAccDataSourceAWSDirectoryServiceDirectory_connector (980.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	987.013s
```
