### PR TITLE
service/ram: Fix schema error

### DIFF
--- a/aws/data_source_aws_ram_resource_share.go
+++ b/aws/data_source_aws_ram_resource_share.go
@@ -52,12 +52,12 @@ func dataSourceAwsRamResourceShare() *schema.Resource {
 				Computed: true,
 			},
 
-			"tags": tagsSchemaComputed(),
-
-			"id": {
+			"owning_account_id": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
+			}
+
+			"tags": tagsSchemaComputed(),
 
 			"status": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_ram_resource_share.go
+++ b/aws/data_source_aws_ram_resource_share.go
@@ -55,7 +55,7 @@ func dataSourceAwsRamResourceShare() *schema.Resource {
 			"owning_account_id": {
 				Type:     schema.TypeString,
 				Computed: true,
-			}
+			},
 
 			"tags": tagsSchemaComputed(),
 

--- a/aws/data_source_aws_ram_resource_share_test.go
+++ b/aws/data_source_aws_ram_resource_share_test.go
@@ -27,6 +27,7 @@ func TestAccDataSourceAwsRamResourceShare_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "owning_account_id"),
 				),
 			},
 		},

--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -51,4 +51,5 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The Amazon Resource Name (ARN) of the resource share.
 * `id` - The Amazon Resource Name (ARN) of the resource share.
 * `status` - The Status of the RAM share.
+* `owning_account_id` - The ID of the AWS account that owns the resource share.
 * `tags` - The Tags attached to the RAM share


### PR DESCRIPTION
Export `owning_account_id`, check value is set in tests, add attr to docs. Also removed superfluous `id` from schema

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13312 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_ram_resource_share: Export `owning_account_id`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
