### PR TITLE
service/apigateway: Fix schema set errors

### DIFF
--- a/aws/resource_aws_api_gateway_method_settings.go
+++ b/aws/resource_aws_api_gateway_method_settings.go
@@ -42,42 +42,52 @@ func resourceAwsApiGatewayMethodSettings() *schema.Resource {
 						"metrics_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"logging_level": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"data_trace_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"throttling_burst_limit": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 						"throttling_rate_limit": {
 							Type:     schema.TypeFloat,
 							Optional: true,
+							Computed: true,
 						},
 						"caching_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"cache_ttl_in_seconds": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 						"cache_data_encrypted": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"require_authorization_for_cache_control": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"unauthorized_cache_control_header_strategy": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -113,7 +123,7 @@ func resourceAwsApiGatewayMethodSettingsRead(d *schema.ResourceData, meta interf
 		return nil
 	}
 
-	return d.Set("settings", []interface{}{map[string]interface{}{
+	if err := d.Set("settings", []interface{}{map[string]interface{}{
 		"metrics_enabled":                            settings.MetricsEnabled,
 		"logging_level":                              settings.LoggingLevel,
 		"data_trace_enabled":                         settings.DataTraceEnabled,
@@ -124,7 +134,11 @@ func resourceAwsApiGatewayMethodSettingsRead(d *schema.ResourceData, meta interf
 		"cache_data_encrypted":                       settings.CacheDataEncrypted,
 		"require_authorization_for_cache_control":    settings.RequireAuthorizationForCacheControl,
 		"unauthorized_cache_control_header_strategy": settings.UnauthorizedCacheControlHeaderStrategy,
-	}})
+	}}); err != nil {
+		return fmt.Errorf("error setting settings: %s", err)
+	}
+
+	return nil
 }
 
 func resourceAwsApiGatewayMethodSettingsUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_api_gateway_method_settings.go
+++ b/aws/resource_aws_api_gateway_method_settings.go
@@ -113,18 +113,18 @@ func resourceAwsApiGatewayMethodSettingsRead(d *schema.ResourceData, meta interf
 		return nil
 	}
 
-	d.Set("settings.0.metrics_enabled", settings.MetricsEnabled)
-	d.Set("settings.0.logging_level", settings.LoggingLevel)
-	d.Set("settings.0.data_trace_enabled", settings.DataTraceEnabled)
-	d.Set("settings.0.throttling_burst_limit", settings.ThrottlingBurstLimit)
-	d.Set("settings.0.throttling_rate_limit", settings.ThrottlingRateLimit)
-	d.Set("settings.0.caching_enabled", settings.CachingEnabled)
-	d.Set("settings.0.cache_ttl_in_seconds", settings.CacheTtlInSeconds)
-	d.Set("settings.0.cache_data_encrypted", settings.CacheDataEncrypted)
-	d.Set("settings.0.require_authorization_for_cache_control", settings.RequireAuthorizationForCacheControl)
-	d.Set("settings.0.unauthorized_cache_control_header_strategy", settings.UnauthorizedCacheControlHeaderStrategy)
-
-	return nil
+	return d.Set("settings", []interface{}{map[string]interface{}{
+		"metrics_enabled":                            settings.MetricsEnabled,
+		"logging_level":                              settings.LoggingLevel,
+		"data_trace_enabled":                         settings.DataTraceEnabled,
+		"throttling_burst_limit":                     settings.ThrottlingBurstLimit,
+		"throttling_rate_limit":                      settings.ThrottlingRateLimit,
+		"caching_enabled":                            settings.CachingEnabled,
+		"cache_ttl_in_seconds":                       settings.CacheTtlInSeconds,
+		"cache_data_encrypted":                       settings.CacheDataEncrypted,
+		"require_authorization_for_cache_control":    settings.RequireAuthorizationForCacheControl,
+		"unauthorized_cache_control_header_strategy": settings.UnauthorizedCacheControlHeaderStrategy,
+	}})
 }
 
 func resourceAwsApiGatewayMethodSettingsUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_api_gateway_method_settings.go
+++ b/aws/resource_aws_api_gateway_method_settings.go
@@ -96,6 +96,23 @@ func resourceAwsApiGatewayMethodSettings() *schema.Resource {
 	}
 }
 
+func flattenAwsApiGatewayMethodSettings(settings *apigateway.MethodSetting) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"metrics_enabled":                            settings.MetricsEnabled,
+			"logging_level":                              settings.LoggingLevel,
+			"data_trace_enabled":                         settings.DataTraceEnabled,
+			"throttling_burst_limit":                     settings.ThrottlingBurstLimit,
+			"throttling_rate_limit":                      settings.ThrottlingRateLimit,
+			"caching_enabled":                            settings.CachingEnabled,
+			"cache_ttl_in_seconds":                       settings.CacheTtlInSeconds,
+			"cache_data_encrypted":                       settings.CacheDataEncrypted,
+			"require_authorization_for_cache_control":    settings.RequireAuthorizationForCacheControl,
+			"unauthorized_cache_control_header_strategy": settings.UnauthorizedCacheControlHeaderStrategy,
+		},
+	}
+}
+
 func resourceAwsApiGatewayMethodSettingsRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigatewayconn
 
@@ -123,18 +140,7 @@ func resourceAwsApiGatewayMethodSettingsRead(d *schema.ResourceData, meta interf
 		return nil
 	}
 
-	if err := d.Set("settings", []interface{}{map[string]interface{}{
-		"metrics_enabled":                            settings.MetricsEnabled,
-		"logging_level":                              settings.LoggingLevel,
-		"data_trace_enabled":                         settings.DataTraceEnabled,
-		"throttling_burst_limit":                     settings.ThrottlingBurstLimit,
-		"throttling_rate_limit":                      settings.ThrottlingRateLimit,
-		"caching_enabled":                            settings.CachingEnabled,
-		"cache_ttl_in_seconds":                       settings.CacheTtlInSeconds,
-		"cache_data_encrypted":                       settings.CacheDataEncrypted,
-		"require_authorization_for_cache_control":    settings.RequireAuthorizationForCacheControl,
-		"unauthorized_cache_control_header_strategy": settings.UnauthorizedCacheControlHeaderStrategy,
-	}}); err != nil {
+	if err := d.Set("settings", flattenAwsApiGatewayMethodSettings(settings)); err != nil {
 		return fmt.Errorf("error setting settings: %s", err)
 	}
 

--- a/aws/resource_aws_api_gateway_request_validator.go
+++ b/aws/resource_aws_api_gateway_request_validator.go
@@ -25,7 +25,6 @@ func resourceAwsApiGatewayRequestValidator() *schema.Resource {
 				}
 				restApiID := idParts[0]
 				requestValidatorID := idParts[1]
-				d.Set("request_validator_id", requestValidatorID)
 				d.Set("rest_api_id", restApiID)
 				d.SetId(requestValidatorID)
 				return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
Removed undefined and unneeded `request_validator_id` from request validator import.
Set `settings` properly and return error, this required making the fields optional + computed. The acceptance tests would have never caught this error since the fields are user configurable, the config would be the defacto state.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13312 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_api_gateway_method_settings: `settings` now properly set
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayMethodSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayMethodSettings -timeout 120m
=== RUN   TestAccAWSAPIGatewayMethodSettings_basic
=== PAUSE TestAccAWSAPIGatewayMethodSettings_basic
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_Multiple
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_Multiple
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit
=== RUN   TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy
=== PAUSE TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy
=== CONT  TestAccAWSAPIGatewayMethodSettings_basic
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_Multiple
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled (54.34s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds (54.57s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit (116.15s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_Multiple (149.83s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit (181.82s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_basic (251.95s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled (265.11s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy (279.81s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted (383.68s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl (476.06s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled (535.43s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel (536.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	539.755s
```
