### PR TITLE
resource/aws_eks_node_group: Only pass ReleaseVersion during UpdateNodegroupVersion if changed

### DIFF
--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -378,7 +378,7 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 			NodegroupName:      aws.String(nodeGroupName),
 		}
 
-		if v, ok := d.GetOk("release_version"); ok {
+		if v, ok := d.GetOk("release_version"); ok && d.HasChange("release_version") {
 			input.ReleaseVersion = aws.String(v.(string))
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12675

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_eks_node_group: Only pass `release_version` during `UpdateNodegroupVersion` API call if changed during update
```

It was expected to see an error similar to the issue report about the incompatible update and Terraform was previously submitting the state value for `release_version`, however the EKS API as of today was automatically fixing the incorrect value instead of returning an error. The resource change is to ensure that we will only submit correct API parameters should the API return errors for this situation in the future again.

Output from acceptance testing:

```
--- PASS: TestAccAWSEksNodeGroup_disappears (1356.93s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes (1519.46s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1540.56s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1550.40s)
--- PASS: TestAccAWSEksNodeGroup_basic (1581.83s)
--- PASS: TestAccAWSEksNodeGroup_AmiType (1591.47s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1602.60s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1632.41s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1683.52s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1712.30s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1765.19s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1767.20s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (2853.92s)
--- PASS: TestAccAWSEksNodeGroup_Version (3045.62s)
```