### PR TITLE
resource/aws_eks_node_group: Add force_update_version argument

### DIFF
--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -58,6 +58,10 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"force_update_version": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"instance_types": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -374,7 +378,7 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 		input := &eks.UpdateNodegroupVersionInput{
 			ClientRequestToken: aws.String(resource.UniqueId()),
 			ClusterName:        aws.String(clusterName),
-			Force:              aws.Bool(false),
+			Force:              aws.Bool(d.Get("force_update_version").(bool)),
 			NodegroupName:      aws.String(nodeGroupName),
 		}
 

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -125,6 +125,7 @@ The following arguments are optional:
 
 * `ami_type` - (Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided.
 * `disk_size` - (Optional) Disk size in GiB for worker nodes. Defaults to `20`. Terraform will only perform drift detection if a configuration value is provided.
+* `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
 * `instance_types` - (Optional) Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
 * `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13296
Reference: https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateNodegroupVersion.html#AmazonEKS-UpdateNodegroupVersion-request-force

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_eks_node_group: Add `force_update_version` argument
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes (1567.59s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (1568.65s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1578.04s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1613.79s)
--- PASS: TestAccAWSEksNodeGroup_disappears (1618.86s)
--- PASS: TestAccAWSEksNodeGroup_basic (1620.08s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1627.14s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1633.79s)
--- PASS: TestAccAWSEksNodeGroup_Version (1641.90s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1648.59s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1675.80s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1683.37s)
--- PASS: TestAccAWSEksNodeGroup_AmiType (1730.12s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1768.14s)
--- PASS: TestAccAWSEksNodeGroup_ForceUpdateVersion (4839.40s)
```
