### PR TITLE
tests/service/efs: Fix infinite looping of sweepers

### DIFF
--- a/aws/resource_aws_efs_access_point_test.go
+++ b/aws/resource_aws_efs_access_point_test.go
@@ -45,12 +45,12 @@ func testSweepEfsAccessPoints(region string) error {
 				out, err := conn.DescribeAccessPoints(input)
 				if err != nil {
 					errors = multierror.Append(errors, fmt.Errorf("error retrieving EFS access points on File System %q: %w", id, err))
-					continue
+					break
 				}
 
 				if out == nil || len(out.AccessPoints) == 0 {
 					log.Printf("[INFO] No EFS access points to sweep on File System %q", id)
-					continue
+					break
 				}
 
 				for _, AccessPoint := range out.AccessPoints {

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -46,12 +46,12 @@ func testSweepEfsMountTargets(region string) error {
 				out, err := conn.DescribeMountTargets(input)
 				if err != nil {
 					errors = multierror.Append(errors, fmt.Errorf("error retrieving EFS Mount Targets on File System %q: %w", id, err))
-					continue
+					break
 				}
 
 				if out == nil || len(out.MountTargets) == 0 {
 					log.Printf("[INFO] No EFS Mount Targets to sweep on File System %q", id)
-					continue
+					break
 				}
 
 				for _, mounttarget := range out.MountTargets {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously the sweeper could get stuck in an infinite loop when an EFS File System was present, but EFS Mount Targets or EFS Access Points were not:

```
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [INFO] No EFS Mount Targets to sweep on File System "fs-a3e9c509"
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [DEBUG] [aws-sdk-go] DEBUG: Request elasticfilesystem/DescribeMountTargets Details:
...
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [DEBUG] [aws-sdk-go] DEBUG: Response elasticfilesystem/DescribeMountTargets Details:
...
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [DEBUG] [aws-sdk-go] {"Marker":null,"MountTargets":[],"NextMarker":null}
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [INFO] No EFS Mount Targets to sweep on File System "fs-a3e9c509"
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [DEBUG] [aws-sdk-go] DEBUG: Request elasticfilesystem/DescribeMountTargets Details:
...
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [DEBUG] [aws-sdk-go] DEBUG: Response elasticfilesystem/DescribeMountTargets Details:
...
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [DEBUG] [aws-sdk-go] {"Marker":null,"MountTargets":[],"NextMarker":null}
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [INFO] No EFS Mount Targets to sweep on File System "fs-a3e9c509"
[19:46:35] :	 [Step 5/5] 2020/05/19 19:46:35 [DEBUG] [aws-sdk-go] DEBUG: Request elasticfilesystem/DescribeMountTargets Details:
```

Output from sweeper in AWS Commercial:

```
2020/05/19 21:54:17 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/19 21:54:17 [DEBUG] Running Sweeper (aws_efs_mount_target) in region (us-west-2)
...
2020/05/19 21:54:20 [INFO] Deleting Mount Targets for EFS File System: fs-a3e9c509
2020/05/19 21:54:21 [INFO] No EFS Mount Targets to sweep on File System "fs-a3e9c509"
2020/05/19 21:54:21 [INFO] Deleting Mount Targets for EFS File System: fs-afe9c505
2020/05/19 21:54:21 [INFO] No EFS Mount Targets to sweep on File System "fs-afe9c505"
2020/05/19 21:54:21 [INFO] Deleting Mount Targets for EFS File System: fs-aee9c504
2020/05/19 21:54:21 [INFO] No EFS Mount Targets to sweep on File System "fs-aee9c504"
2020/05/19 21:54:21 [INFO] Deleting Mount Targets for EFS File System: fs-abe9c501
2020/05/19 21:54:22 [INFO] No EFS Mount Targets to sweep on File System "fs-abe9c501"
2020/05/19 21:54:22 [INFO] Deleting Mount Targets for EFS File System: fs-aae9c500
2020/05/19 21:54:22 [INFO] No EFS Mount Targets to sweep on File System "fs-aae9c500"
2020/05/19 21:54:22 [INFO] Deleting Mount Targets for EFS File System: fs-a9e9c503
2020/05/19 21:54:22 [INFO] No EFS Mount Targets to sweep on File System "fs-a9e9c503"
2020/05/19 21:54:22 [INFO] Deleting Mount Targets for EFS File System: fs-a8e9c502
2020/05/19 21:54:23 [INFO] No EFS Mount Targets to sweep on File System "fs-a8e9c502"
2020/05/19 21:54:23 [INFO] Deleting Mount Targets for EFS File System: fs-57e8c4fd
2020/05/19 21:54:23 [INFO] No EFS Mount Targets to sweep on File System "fs-57e8c4fd"
2020/05/19 21:54:23 [INFO] Deleting Mount Targets for EFS File System: fs-56e8c4fc
2020/05/19 21:54:24 [INFO] No EFS Mount Targets to sweep on File System "fs-56e8c4fc"
2020/05/19 21:54:24 [INFO] Deleting Mount Targets for EFS File System: fs-55e8c4ff
2020/05/19 21:54:24 [INFO] No EFS Mount Targets to sweep on File System "fs-55e8c4ff"
2020/05/19 21:54:24 [INFO] Deleting Mount Targets for EFS File System: fs-54e8c4fe
2020/05/19 21:54:24 [INFO] No EFS Mount Targets to sweep on File System "fs-54e8c4fe"
2020/05/19 21:54:24 [INFO] Deleting Mount Targets for EFS File System: fs-1ad8f5b0
2020/05/19 21:54:25 [INFO] No EFS Mount Targets to sweep on File System "fs-1ad8f5b0"
2020/05/19 21:54:25 [DEBUG] Running Sweeper (aws_efs_access_point) in region (us-west-2)
2020/05/19 21:54:25 [INFO] Deleting access points for EFS File System: fs-a3e9c509
2020/05/19 21:54:26 [INFO] No EFS access points to sweep on File System "fs-a3e9c509"
2020/05/19 21:54:26 [INFO] Deleting access points for EFS File System: fs-afe9c505
2020/05/19 21:54:26 [INFO] No EFS access points to sweep on File System "fs-afe9c505"
2020/05/19 21:54:26 [INFO] Deleting access points for EFS File System: fs-aee9c504
2020/05/19 21:54:26 [INFO] No EFS access points to sweep on File System "fs-aee9c504"
2020/05/19 21:54:26 [INFO] Deleting access points for EFS File System: fs-abe9c501
2020/05/19 21:54:27 [INFO] No EFS access points to sweep on File System "fs-abe9c501"
2020/05/19 21:54:27 [INFO] Deleting access points for EFS File System: fs-aae9c500
2020/05/19 21:54:27 [INFO] No EFS access points to sweep on File System "fs-aae9c500"
2020/05/19 21:54:27 [INFO] Deleting access points for EFS File System: fs-a9e9c503
2020/05/19 21:54:28 [INFO] No EFS access points to sweep on File System "fs-a9e9c503"
2020/05/19 21:54:28 [INFO] Deleting access points for EFS File System: fs-a8e9c502
2020/05/19 21:54:28 [INFO] No EFS access points to sweep on File System "fs-a8e9c502"
2020/05/19 21:54:28 [INFO] Deleting access points for EFS File System: fs-57e8c4fd
2020/05/19 21:54:28 [INFO] No EFS access points to sweep on File System "fs-57e8c4fd"
2020/05/19 21:54:28 [INFO] Deleting access points for EFS File System: fs-56e8c4fc
2020/05/19 21:54:29 [INFO] No EFS access points to sweep on File System "fs-56e8c4fc"
2020/05/19 21:54:29 [INFO] Deleting access points for EFS File System: fs-55e8c4ff
2020/05/19 21:54:29 [INFO] No EFS access points to sweep on File System "fs-55e8c4ff"
2020/05/19 21:54:29 [INFO] Deleting access points for EFS File System: fs-54e8c4fe
2020/05/19 21:54:30 [INFO] No EFS access points to sweep on File System "fs-54e8c4fe"
2020/05/19 21:54:30 [INFO] Deleting access points for EFS File System: fs-1ad8f5b0
2020/05/19 21:54:30 [INFO] No EFS access points to sweep on File System "fs-1ad8f5b0"
2020/05/19 21:54:30 [DEBUG] Running Sweeper (aws_efs_file_system) in region (us-west-2)
2020/05/19 21:54:30 [INFO] Deleting EFS File System: fs-a3e9c509
2020/05/19 21:54:32 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:34 [INFO] Deleting EFS File System: fs-afe9c505
2020/05/19 21:54:35 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:37 [INFO] Deleting EFS File System: fs-aee9c504
2020/05/19 21:54:37 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:40 [INFO] Deleting EFS File System: fs-abe9c501
2020/05/19 21:54:40 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:42 [INFO] Deleting EFS File System: fs-aae9c500
2020/05/19 21:54:43 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:45 [INFO] Deleting EFS File System: fs-a9e9c503
2020/05/19 21:54:46 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:48 [INFO] Deleting EFS File System: fs-a8e9c502
2020/05/19 21:54:49 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:52 [INFO] Deleting EFS File System: fs-57e8c4fd
2020/05/19 21:54:52 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:54 [INFO] Deleting EFS File System: fs-56e8c4fc
2020/05/19 21:54:55 [DEBUG] Waiting for state to become: []
2020/05/19 21:54:57 [INFO] Deleting EFS File System: fs-55e8c4ff
2020/05/19 21:54:58 [DEBUG] Waiting for state to become: []
2020/05/19 21:55:00 [INFO] Deleting EFS File System: fs-54e8c4fe
2020/05/19 21:55:00 [DEBUG] Waiting for state to become: []
2020/05/19 21:55:03 [INFO] Deleting EFS File System: fs-1ad8f5b0
2020/05/19 21:55:03 [DEBUG] Waiting for state to become: []
2020/05/19 21:55:05 Sweeper Tests ran successfully:
	- aws_efs_mount_target
	- aws_efs_access_point
	- aws_efs_file_system
2020/05/19 21:55:05 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/19 21:55:05 [DEBUG] Running Sweeper (aws_efs_mount_target) in region (us-east-1)
...
2020/05/19 21:55:07 [DEBUG] Running Sweeper (aws_efs_access_point) in region (us-east-1)
2020/05/19 21:55:07 [DEBUG] Running Sweeper (aws_efs_file_system) in region (us-east-1)
2020/05/19 21:55:08 Sweeper Tests ran successfully:
	- aws_efs_mount_target
	- aws_efs_access_point
	- aws_efs_file_system
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.386s
```

Output from sweeper in AWS GovCloud (US):

```
2020/05/19 21:55:18 [DEBUG] Running Sweepers for region (us-gov-west-1):
2020/05/19 21:55:18 [DEBUG] Running Sweeper (aws_efs_mount_target) in region (us-gov-west-1)
...
2020/05/19 21:55:20 [DEBUG] Running Sweeper (aws_efs_access_point) in region (us-gov-west-1)
2020/05/19 21:55:21 [DEBUG] Running Sweeper (aws_efs_file_system) in region (us-gov-west-1)
2020/05/19 21:55:21 Sweeper Tests ran successfully:
	- aws_efs_file_system
	- aws_efs_mount_target
	- aws_efs_access_point
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.050s
```
