### PR TITLE
service/elb: Fix schema errors

### DIFF
--- a/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -129,7 +130,11 @@ func resourceAwsLBCookieStickinessPolicyRead(d *schema.ResourceData, meta interf
 	if *cookieAttr.AttributeName != "CookieExpirationPeriod" {
 		return fmt.Errorf("Unable to find cookie expiration period.")
 	}
-	d.Set("cookie_expiration_period", cookieAttr.AttributeValue)
+	cookieVal, err := strconv.Atoi(aws.IntValue(cookieAttr.AttributeValue))
+	if err != nil {
+		return fmt.Errorf("Error parsing cookie expiration period: %s", err)
+	}
+	d.Set("cookie_expiration_period", cookieVal)
 
 	d.Set("name", policyName)
 	d.Set("load_balancer", lbName)

--- a/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -130,7 +130,7 @@ func resourceAwsLBCookieStickinessPolicyRead(d *schema.ResourceData, meta interf
 	if *cookieAttr.AttributeName != "CookieExpirationPeriod" {
 		return fmt.Errorf("Unable to find cookie expiration period.")
 	}
-	cookieVal, err := strconv.Atoi(aws.IntValue(cookieAttr.AttributeValue))
+	cookieVal, err := strconv.Atoi(aws.StringValue(cookieAttr.AttributeValue))
 	if err != nil {
 		return fmt.Errorf("Error parsing cookie expiration period: %s", err)
 	}

--- a/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -146,7 +146,20 @@ func resourceAwsLBSSLNegotiationPolicyRead(d *schema.ResourceData, meta interfac
 	// We can get away with this because there's only one policy returned
 	policyDesc := getResp.PolicyDescriptions[0]
 	attributes := flattenPolicyAttributes(policyDesc.PolicyAttributeDescriptions)
-	return d.Set("attribute", attributes)
+
+	// This was previously erroneously setting "attributes", however this cannot
+	// be changed without introducing problematic side effects. The ELB service
+	// automatically expands the results to include all SSL attributes
+	// (unordered, so we'd need to switch to TypeSet anyways), which we would be
+	// quite impractical to force practitioners to write out and potentially
+	// update each time the API updates since there is nearly 100 attributes.
+
+	// TODO: fix attribute
+	// if err := d.Set("attribute", attributes); err != nil {
+	// 	return fmt.Errorf("error setting attribute: %s", err)
+	// }
+
+	return nil
 }
 
 func resourceAwsLBSSLNegotiationPolicyDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -143,10 +143,7 @@ func resourceAwsLBSSLNegotiationPolicyRead(d *schema.ResourceData, meta interfac
 	d.Set("load_balancer", lbName)
 	d.Set("lb_port", lbPort)
 
-	// We can get away with this because there's only one policy returned
-	policyDesc := getResp.PolicyDescriptions[0]
-	attributes := flattenPolicyAttributes(policyDesc.PolicyAttributeDescriptions)
-
+	// TODO: fix attribute
 	// This was previously erroneously setting "attributes", however this cannot
 	// be changed without introducing problematic side effects. The ELB service
 	// automatically expands the results to include all SSL attributes
@@ -154,7 +151,9 @@ func resourceAwsLBSSLNegotiationPolicyRead(d *schema.ResourceData, meta interfac
 	// quite impractical to force practitioners to write out and potentially
 	// update each time the API updates since there is nearly 100 attributes.
 
-	// TODO: fix attribute
+	// We can get away with this because there's only one policy returned
+	// policyDesc := getResp.PolicyDescriptions[0]
+	// attributes := flattenPolicyAttributes(policyDesc.PolicyAttributeDescriptions)
 	// if err := d.Set("attribute", attributes); err != nil {
 	// 	return fmt.Errorf("error setting attribute: %s", err)
 	// }

--- a/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -142,7 +142,7 @@ func resourceAwsLBSSLNegotiationPolicyRead(d *schema.ResourceData, meta interfac
 	// We can get away with this because there's only one policy returned
 	policyDesc := getResp.PolicyDescriptions[0]
 	attributes := flattenPolicyAttributes(policyDesc.PolicyAttributeDescriptions)
-	d.Set("attributes", attributes)
+	d.Set("attribute", attributes)
 
 	d.Set("name", policyName)
 	d.Set("load_balancer", lbName)

--- a/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -139,16 +139,14 @@ func resourceAwsLBSSLNegotiationPolicyRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Unable to find policy %#v", getResp.PolicyDescriptions)
 	}
 
-	// We can get away with this because there's only one policy returned
-	policyDesc := getResp.PolicyDescriptions[0]
-	attributes := flattenPolicyAttributes(policyDesc.PolicyAttributeDescriptions)
-	d.Set("attribute", attributes)
-
 	d.Set("name", policyName)
 	d.Set("load_balancer", lbName)
 	d.Set("lb_port", lbPort)
 
-	return nil
+	// We can get away with this because there's only one policy returned
+	policyDesc := getResp.PolicyDescriptions[0]
+	attributes := flattenPolicyAttributes(policyDesc.PolicyAttributeDescriptions)
+	return d.Set("attribute", attributes)
 }
 
 func resourceAwsLBSSLNegotiationPolicyDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_load_balancer_backend_server_policy.go
+++ b/aws/resource_aws_load_balancer_backend_server_policy.go
@@ -100,7 +100,11 @@ func resourceAwsLoadBalancerBackendServerPoliciesRead(d *schema.ResourceData, me
 	}
 
 	d.Set("load_balancer_name", loadBalancerName)
-	d.Set("instance_port", instancePort)
+	instancePortVal, err := strconv.ParseInt(instancePort, 10, 64)
+	if err != nil {
+		return fmt.Errorf("error parsing instance port: %s", err)
+	}
+	d.Set("instance_port", instancePortVal)
 	d.Set("policy_names", flattenStringList(policyNames))
 
 	return nil

--- a/aws/resource_aws_load_balancer_listener_policy.go
+++ b/aws/resource_aws_load_balancer_listener_policy.go
@@ -100,7 +100,11 @@ func resourceAwsLoadBalancerListenerPoliciesRead(d *schema.ResourceData, meta in
 	}
 
 	d.Set("load_balancer_name", loadBalancerName)
-	d.Set("load_balancer_port", loadBalancerPort)
+	loadBalancerPortVal, err := strconv.ParseInt(loadBalancerPort, 10, 64)
+	if err != nil {
+		return fmt.Errorf("error parsing load balancer port: %s", err)
+	}
+	d.Set("load_balancer_port", loadBalancerPortVal)
 	d.Set("policy_names", flattenStringList(policyNames))
 
 	return nil


### PR DESCRIPTION
Fixed string to int type mismatches. Noticed attr name typo `attributes` --> `attribute`.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13312 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_lb_cookie_stickiness_policy: `cookie_expiration_policy` now properly set
* resource/aws_load_balancer_backend_server_policy: `instance_port` now properly set
* resource/aws_load_balancer_listener_policy: `load_balancer_port` now properly set
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
