### PR TITLE
service/opsworks: Fix schema error

### DIFF
--- a/aws/resource_aws_opsworks_application.go
+++ b/aws/resource_aws_opsworks_application.go
@@ -387,32 +387,42 @@ func resourceAwsOpsworksApplicationDelete(d *schema.ResourceData, meta interface
 	return err
 }
 
-func resourceAwsOpsworksSetApplicationEnvironmentVariable(d *schema.ResourceData, v []*opsworks.EnvironmentVariable) {
-	log.Printf("[DEBUG] envs: %s %d", v, len(v))
-	if len(v) == 0 {
+func resourceAwsOpsworksFindEnvironmentVariable(key string, vs []*opsworks.EnvironmentVariable) *opsworks.EnvironmentVariable {
+	for _, v := range vs {
+		if aws.StringValue(v.Key) == key {
+			return v
+		}
+	}
+	return nil
+}
+
+func resourceAwsOpsworksSetApplicationEnvironmentVariable(d *schema.ResourceData, vs []*opsworks.EnvironmentVariable) {
+	if len(vs) == 0 {
 		d.Set("environment", nil)
 		return
 	}
-	newValue := make([]*map[string]interface{}, len(v))
 
-	for i := 0; i < len(v); i++ {
-		config := v[i]
-		data := make(map[string]interface{})
-		newValue[i] = &data
+	// sensitive variables are returned obfuscated from the API, this creates a
+	// permadiff between the obfuscated API response and the config value. We
+	// start with the existing state so it can passthrough when the key is secure
+	values := d.Get("environment").(*schema.Set).List()
 
-		if config.Key != nil {
-			data["key"] = *config.Key
+	for i := 0; i < len(values); i++ {
+		value := values[i].(map[string]interface{})
+		if v := resourceAwsOpsworksFindEnvironmentVariable(value["key"].(string), vs); v != nil {
+			if !aws.BoolValue(v.Secure) {
+				value["secure"] = aws.BoolValue(v.Secure)
+				value["key"] = aws.StringValue(v.Key)
+				value["value"] = aws.StringValue(v.Value)
+				values[i] = value
+			}
+		} else {
+			// delete if not found in API response
+			values = append(values[:i], values[i+1:]...)
 		}
-		if config.Value != nil {
-			data["value"] = *config.Value
-		}
-		if config.Secure != nil {
-			data["secure"] = aws.BoolValue(config.Secure)
-		}
-		log.Printf("[DEBUG] v: %s", data)
 	}
 
-	d.Set("environment", newValue)
+	d.Set("environment", values)
 }
 
 func resourceAwsOpsworksApplicationEnvironmentVariable(d *schema.ResourceData) []*opsworks.EnvironmentVariable {

--- a/aws/resource_aws_opsworks_application.go
+++ b/aws/resource_aws_opsworks_application.go
@@ -407,12 +407,7 @@ func resourceAwsOpsworksSetApplicationEnvironmentVariable(d *schema.ResourceData
 			data["value"] = *config.Value
 		}
 		if config.Secure != nil {
-
-			if aws.BoolValue(config.Secure) {
-				data["secure"] = &opsworksTrueString
-			} else {
-				data["secure"] = &opsworksFalseString
-			}
+			data["secure"] = aws.BoolValue(config.Secure)
 		}
 		log.Printf("[DEBUG] v: %s", data)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13312

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_opsworks_application: `environment` `secure` now properly set
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
