### PR TITLE
service/sns: Fix schema error

### DIFF
--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -233,7 +234,13 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
 		attrmap := attributeOutput.Attributes
 		for terraformAttrName, snsAttrName := range SNSAttributeMap {
-			d.Set(terraformAttrName, attrmap[snsAttrName])
+			v, err := strconv.ParseInt(aws.StringValue(attrmap[snsAttrName], 10, 64))
+			// if the attribute is an integer the schema is probably an integer
+			if err == nil {
+				d.Set(terraformAttrName, v)
+			} else {
+				d.Set(terraformAttrName, aws.StringValue(attrmap[snsAttrName]))
+			}
 		}
 	} else {
 		for terraformAttrName := range SNSAttributeMap {

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -15,27 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
-// Mutable attributes
-var SNSAttributeMap = map[string]string{
-	"application_failure_feedback_role_arn":    "ApplicationFailureFeedbackRoleArn",
-	"application_success_feedback_role_arn":    "ApplicationSuccessFeedbackRoleArn",
-	"application_success_feedback_sample_rate": "ApplicationSuccessFeedbackSampleRate",
-	"arn":                                 "TopicArn",
-	"delivery_policy":                     "DeliveryPolicy",
-	"display_name":                        "DisplayName",
-	"http_failure_feedback_role_arn":      "HTTPFailureFeedbackRoleArn",
-	"http_success_feedback_role_arn":      "HTTPSuccessFeedbackRoleArn",
-	"http_success_feedback_sample_rate":   "HTTPSuccessFeedbackSampleRate",
-	"kms_master_key_id":                   "KmsMasterKeyId",
-	"lambda_failure_feedback_role_arn":    "LambdaFailureFeedbackRoleArn",
-	"lambda_success_feedback_role_arn":    "LambdaSuccessFeedbackRoleArn",
-	"lambda_success_feedback_sample_rate": "LambdaSuccessFeedbackSampleRate",
-	"policy":                              "Policy",
-	"sqs_failure_feedback_role_arn":       "SQSFailureFeedbackRoleArn",
-	"sqs_success_feedback_role_arn":       "SQSSuccessFeedbackRoleArn",
-	"sqs_success_feedback_sample_rate":    "SQSSuccessFeedbackSampleRate",
-}
-
 func resourceAwsSnsTopic() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsSnsTopicCreate,
@@ -177,13 +156,107 @@ func resourceAwsSnsTopicCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(*output.TopicArn)
 
-	for terraformAttrName, snsAttrName := range SNSAttributeMap {
-		if d.HasChange(terraformAttrName) {
-			_, terraformAttrValue := d.GetChange(terraformAttrName)
-			err := updateAwsSnsTopicAttribute(d.Id(), snsAttrName, terraformAttrValue, snsconn)
-			if err != nil {
-				return err
-			}
+	// update mutable attributes
+	if d.HasChange("application_failure_feedback_role_arn") {
+		_, v := d.GetChange("application_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "ApplicationFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("application_success_feedback_role_arn") {
+		_, v := d.GetChange("application_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "ApplicationSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("arn") {
+		_, v := d.GetChange("arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "TopicArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("delivery_policy") {
+		_, v := d.GetChange("delivery_policy")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "DeliveryPolicy", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("display_name") {
+		_, v := d.GetChange("display_name")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "DisplayName", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("http_failure_feedback_role_arn") {
+		_, v := d.GetChange("http_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "HTTPFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("http_success_feedback_role_arn") {
+		_, v := d.GetChange("http_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "HTTPSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("kms_master_key_id") {
+		_, v := d.GetChange("kms_master_key_id")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "KmsMasterKeyId", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("lambda_failure_feedback_role_arn") {
+		_, v := d.GetChange("lambda_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "LambdaFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("lambda_success_feedback_role_arn") {
+		_, v := d.GetChange("lambda_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "LambdaSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("policy") {
+		_, v := d.GetChange("policy")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "Policy", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("sqs_failure_feedback_role_arn") {
+		_, v := d.GetChange("sqs_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "SQSFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("sqs_success_feedback_role_arn") {
+		_, v := d.GetChange("sqs_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "SQSSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("application_success_feedback_sample_rate") {
+		_, v := d.GetChange("application_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "ApplicationSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("http_success_feedback_sample_rate") {
+		_, v := d.GetChange("http_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "HTTPSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("lambda_success_feedback_sample_rate") {
+		_, v := d.GetChange("lambda_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "LambdaSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("sqs_success_feedback_sample_rate") {
+		_, v := d.GetChange("sqs_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "SQSSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
 		}
 	}
 
@@ -191,21 +264,115 @@ func resourceAwsSnsTopicCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).snsconn
+	snsconn := meta.(*AWSClient).snsconn
 
-	for terraformAttrName, snsAttrName := range SNSAttributeMap {
-		if d.HasChange(terraformAttrName) {
-			_, terraformAttrValue := d.GetChange(terraformAttrName)
-			err := updateAwsSnsTopicAttribute(d.Id(), snsAttrName, terraformAttrValue, conn)
-			if err != nil {
-				return err
-			}
+	// update mutable attributes
+	if d.HasChange("application_failure_feedback_role_arn") {
+		_, v := d.GetChange("application_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "ApplicationFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("application_success_feedback_role_arn") {
+		_, v := d.GetChange("application_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "ApplicationSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("arn") {
+		_, v := d.GetChange("arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "TopicArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("delivery_policy") {
+		_, v := d.GetChange("delivery_policy")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "DeliveryPolicy", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("display_name") {
+		_, v := d.GetChange("display_name")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "DisplayName", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("http_failure_feedback_role_arn") {
+		_, v := d.GetChange("http_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "HTTPFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("http_success_feedback_role_arn") {
+		_, v := d.GetChange("http_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "HTTPSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("kms_master_key_id") {
+		_, v := d.GetChange("kms_master_key_id")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "KmsMasterKeyId", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("lambda_failure_feedback_role_arn") {
+		_, v := d.GetChange("lambda_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "LambdaFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("lambda_success_feedback_role_arn") {
+		_, v := d.GetChange("lambda_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "LambdaSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("policy") {
+		_, v := d.GetChange("policy")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "Policy", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("sqs_failure_feedback_role_arn") {
+		_, v := d.GetChange("sqs_failure_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "SQSFailureFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("sqs_success_feedback_role_arn") {
+		_, v := d.GetChange("sqs_success_feedback_role_arn")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "SQSSuccessFeedbackRoleArn", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("application_success_feedback_sample_rate") {
+		_, v := d.GetChange("application_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "ApplicationSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("http_success_feedback_sample_rate") {
+		_, v := d.GetChange("http_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "HTTPSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("lambda_success_feedback_sample_rate") {
+		_, v := d.GetChange("lambda_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "LambdaSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
+		}
+	}
+	if d.HasChange("sqs_success_feedback_sample_rate") {
+		_, v := d.GetChange("sqs_success_feedback_sample_rate")
+		if err := updateAwsSnsTopicAttribute(d.Id(), "SQSSuccessFeedbackSampleRate", v, snsconn); err != nil {
+			return err
 		}
 	}
 
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
-		if err := keyvaluetags.SnsUpdateTags(conn, d.Id(), o, n); err != nil {
+		if err := keyvaluetags.SnsUpdateTags(snsconn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)
 		}
 	}
@@ -231,20 +398,62 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// set the mutable attributes
 	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
-		attrmap := attributeOutput.Attributes
-		for terraformAttrName, snsAttrName := range SNSAttributeMap {
-			v, err := strconv.ParseInt(aws.StringValue(attrmap[snsAttrName]), 10, 64)
-			// if the attribute is an integer the schema is probably an integer
-			if err == nil {
-				d.Set(terraformAttrName, v)
-			} else {
-				d.Set(terraformAttrName, aws.StringValue(attrmap[snsAttrName]))
+		// set the string values
+		d.Set("application_failure_feedback_role_arn", aws.StringValue(attributeOutput.Attributes["ApplicationFailureFeedbackRoleArn"]))
+		d.Set("application_success_feedback_role_arn", aws.StringValue(attributeOutput.Attributes["ApplicationSuccessFeedbackRoleArn"]))
+		d.Set("arn", aws.StringValue(attributeOutput.Attributes["TopicArn"]))
+		d.Set("delivery_policy", aws.StringValue(attributeOutput.Attributes["DeliveryPolicy"]))
+		d.Set("display_name", aws.StringValue(attributeOutput.Attributes["DisplayName"]))
+		d.Set("http_failure_feedback_role_arn", aws.StringValue(attributeOutput.Attributes["HTTPFailureFeedbackRoleArn"]))
+		d.Set("http_success_feedback_role_arn", aws.StringValue(attributeOutput.Attributes["HTTPSuccessFeedbackRoleArn"]))
+		d.Set("kms_master_key_id", aws.StringValue(attributeOutput.Attributes["KmsMasterKeyId"]))
+		d.Set("lambda_failure_feedback_role_arn", aws.StringValue(attributeOutput.Attributes["LambdaFailureFeedbackRoleArn"]))
+		d.Set("lambda_success_feedback_role_arn", aws.StringValue(attributeOutput.Attributes["LambdaSuccessFeedbackRoleArn"]))
+		d.Set("policy", aws.StringValue(attributeOutput.Attributes["Policy"]))
+		d.Set("sqs_failure_feedback_role_arn", aws.StringValue(attributeOutput.Attributes["SQSFailureFeedbackRoleArn"]))
+		d.Set("sqs_success_feedback_role_arn", aws.StringValue(attributeOutput.Attributes["SQSSuccessFeedbackRoleArn"]))
+
+		// set the number values
+		var vStr string
+		var v int64
+		var err error
+
+		vStr = aws.StringValue(attributeOutput.Attributes["ApplicationSuccessFeedbackSampleRate"])
+		if vStr != "" {
+			v, err = strconv.ParseInt(vStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing integer attribute 'ApplicationSuccessFeedbackSampleRate': %s", err)
 			}
+			d.Set("application_success_feedback_sample_rate", v)
 		}
-	} else {
-		for terraformAttrName := range SNSAttributeMap {
-			d.Set(terraformAttrName, "")
+
+		vStr = aws.StringValue(attributeOutput.Attributes["HTTPSuccessFeedbackSampleRate"])
+		if vStr != "" {
+			v, err = strconv.ParseInt(vStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing integer attribute 'HTTPSuccessFeedbackSampleRate': %s", err)
+			}
+			d.Set("http_success_feedback_sample_rate", v)
+		}
+
+		vStr = aws.StringValue(attributeOutput.Attributes["LambdaSuccessFeedbackSampleRate"])
+		if vStr != "" {
+			v, err = strconv.ParseInt(vStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing integer attribute 'LambdaSuccessFeedbackSampleRate': %s", err)
+			}
+			d.Set("lambda_success_feedback_sample_rate", v)
+		}
+
+		vStr = aws.StringValue(attributeOutput.Attributes["SQSSuccessFeedbackSampleRate"])
+		if vStr != "" {
+			v, err = strconv.ParseInt(vStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing integer attribute 'SQSSuccessFeedbackSampleRate': %s", err)
+			}
+			d.Set("sqs_success_feedback_sample_rate", v)
 		}
 	}
 

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -234,7 +234,7 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
 		attrmap := attributeOutput.Attributes
 		for terraformAttrName, snsAttrName := range SNSAttributeMap {
-			v, err := strconv.ParseInt(aws.StringValue(attrmap[snsAttrName], 10, 64))
+			v, err := strconv.ParseInt(aws.StringValue(attrmap[snsAttrName]), 10, 64)
 			// if the attribute is an integer the schema is probably an integer
 			if err == nil {
 				d.Set(terraformAttrName, v)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13312 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_sns_topic: Attributes of type `schema.TypeInt` are now correctly set.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
❯ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSNSTopic_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSNSTopic_ -timeout 120m
=== RUN   TestAccAWSSNSTopic_basic
=== PAUSE TestAccAWSSNSTopic_basic
=== RUN   TestAccAWSSNSTopic_name
=== PAUSE TestAccAWSSNSTopic_name
=== RUN   TestAccAWSSNSTopic_namePrefix
=== PAUSE TestAccAWSSNSTopic_namePrefix
=== RUN   TestAccAWSSNSTopic_policy
=== PAUSE TestAccAWSSNSTopic_policy
=== RUN   TestAccAWSSNSTopic_withIAMRole
=== PAUSE TestAccAWSSNSTopic_withIAMRole
=== RUN   TestAccAWSSNSTopic_withFakeIAMRole
=== PAUSE TestAccAWSSNSTopic_withFakeIAMRole
=== RUN   TestAccAWSSNSTopic_withDeliveryPolicy
=== PAUSE TestAccAWSSNSTopic_withDeliveryPolicy
=== RUN   TestAccAWSSNSTopic_deliveryStatus
=== PAUSE TestAccAWSSNSTopic_deliveryStatus
=== RUN   TestAccAWSSNSTopic_encryption
=== PAUSE TestAccAWSSNSTopic_encryption
=== RUN   TestAccAWSSNSTopic_tags
=== PAUSE TestAccAWSSNSTopic_tags
=== CONT  TestAccAWSSNSTopic_basic
=== CONT  TestAccAWSSNSTopic_withDeliveryPolicy
=== CONT  TestAccAWSSNSTopic_encryption
=== CONT  TestAccAWSSNSTopic_tags
=== CONT  TestAccAWSSNSTopic_policy
=== CONT  TestAccAWSSNSTopic_withFakeIAMRole
=== CONT  TestAccAWSSNSTopic_withIAMRole
=== CONT  TestAccAWSSNSTopic_namePrefix
=== CONT  TestAccAWSSNSTopic_name
=== CONT  TestAccAWSSNSTopic_deliveryStatus
--- PASS: TestAccAWSSNSTopic_name (22.79s)
--- PASS: TestAccAWSSNSTopic_namePrefix (23.10s)
--- PASS: TestAccAWSSNSTopic_basic (23.38s)
--- PASS: TestAccAWSSNSTopic_policy (24.50s)
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (24.50s)
--- PASS: TestAccAWSSNSTopic_withIAMRole (33.89s)
--- PASS: TestAccAWSSNSTopic_encryption (37.90s)
--- PASS: TestAccAWSSNSTopic_deliveryStatus (39.78s)
--- PASS: TestAccAWSSNSTopic_tags (50.92s)
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (135.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	136.958s
```
