### PR TITLE
Add TODO comment for tricker schema error

### DIFF
--- a/aws/data_source_aws_lambda_invocation.go
+++ b/aws/data_source_aws_lambda_invocation.go
@@ -82,6 +82,9 @@ func dataSourceAwsLambdaInvocationRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	// TODO: schema error: result_map seems to be a deeply nested map which
+	// cannot be set. May need to change type to string, and apply json diff
+	// suppression
 	if err = d.Set("result_map", result); err != nil {
 		log.Printf("[WARN] Cannot use the result invocation as a string map: %s", err)
 	}


### PR DESCRIPTION
This is the final schema error in the codebase, it seems there is some history here as there is a warn, currently though this does not work since `result` is a deeply nested map, but the schema is defined as `TypeMap, Elem: TypeString`.

So I'm not sure the best way to fix this, I suspect switching the field to `TypeString` and saving the `json` output directly, with a diffsuppressfunc is likely the best way to save the data? Not sure if that causes a breaking change, maybe that was the purpose of the `result` attribute?

I wanted to add the TODO so we could come back to this searching `TODO: schema error`
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13312

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
