### PR TITLE
r/cognito_identity_pool_roles_attachment - add import support

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_roles_attachment.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -17,6 +16,9 @@ func resourceAwsCognitoIdentityPoolRolesAttachment() *schema.Resource {
 		Read:   resourceAwsCognitoIdentityPoolRolesAttachmentRead,
 		Update: resourceAwsCognitoIdentityPoolRolesAttachmentUpdate,
 		Delete: resourceAwsCognitoIdentityPoolRolesAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"identity_pool_id": {
@@ -141,16 +143,18 @@ func resourceAwsCognitoIdentityPoolRolesAttachmentRead(d *schema.ResourceData, m
 	log.Printf("[DEBUG] Reading Cognito Identity Pool Roles Association: %s", d.Id())
 
 	ip, err := conn.GetIdentityPoolRoles(&cognitoidentity.GetIdentityPoolRolesInput{
-		IdentityPoolId: aws.String(d.Get("identity_pool_id").(string)),
+		IdentityPoolId: aws.String(d.Id()),
 	})
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+		if isAWSErr(err, cognitoidentity.ErrCodeResourceNotFoundException, "") {
 			log.Printf("[WARN] Cognito Identity Pool Roles Association %s not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 		return err
 	}
+
+	d.Set("identity_pool_id", d.Id())
 
 	if err := d.Set("roles", flattenCognitoIdentityPoolRoles(ip.Roles)); err != nil {
 		return fmt.Errorf("Error setting roles error: %#v", err)
@@ -211,7 +215,7 @@ func resourceAwsCognitoIdentityPoolRolesAttachmentDelete(d *schema.ResourceData,
 	log.Printf("[DEBUG] Deleting Cognito Identity Pool Roles Association: %s", d.Id())
 
 	_, err := conn.SetIdentityPoolRoles(&cognitoidentity.SetIdentityPoolRolesInput{
-		IdentityPoolId: aws.String(d.Get("identity_pool_id").(string)),
+		IdentityPoolId: aws.String(d.Id()),
 		Roles:          expandCognitoIdentityPoolRoles(make(map[string]interface{})),
 		RoleMappings:   expandCognitoIdentityPoolRoleMappingsAttachment([]interface{}{}),
 	})

--- a/aws/resource_aws_cognito_identity_pool_roles_attachment.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment.go
@@ -154,7 +154,7 @@ func resourceAwsCognitoIdentityPoolRolesAttachmentRead(d *schema.ResourceData, m
 		return err
 	}
 
-	d.Set("identity_pool_id", d.Id())
+	d.Set("identity_pool_id", ip.IdentityPoolId)
 
 	if err := d.Set("roles", flattenCognitoIdentityPoolRoles(ip.Roles)); err != nil {
 		return fmt.Errorf("Error setting roles error: %#v", err)

--- a/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -15,6 +14,7 @@ import (
 )
 
 func TestAccAWSCognitoIdentityPoolRolesAttachment_basic(t *testing.T) {
+	resourceName := "aws_cognito_identity_pool_roles_attachment.test"
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	updatedName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
@@ -26,17 +26,22 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_basic(t *testing.T) {
 			{
 				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_pool_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.authenticated"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(updatedName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_pool_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.authenticated"),
 				),
 			},
 		},
@@ -44,6 +49,7 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_basic(t *testing.T) {
 }
 
 func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings(t *testing.T) {
+	resourceName := "aws_cognito_identity_pool_roles_attachment.test"
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -54,38 +60,64 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings(t *testing.T) {
 			{
 				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool_roles_attachment.main", "role_mapping.#", "0"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_pool_id"),
+					resource.TestCheckResourceAttr(resourceName, "role_mapping.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.authenticated"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappings(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool_roles_attachment.main", "role_mapping.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_pool_id"),
+					resource.TestCheckResourceAttr(resourceName, "role_mapping.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.authenticated"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsUpdated(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool_roles_attachment.main", "role_mapping.#", "1"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_pool_id"),
+					resource.TestCheckResourceAttr(resourceName, "role_mapping.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.authenticated"),
 				),
 			},
 			{
 				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
-					resource.TestCheckResourceAttr("aws_cognito_identity_pool_roles_attachment.main", "role_mapping.#", "0"),
-					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_pool_id"),
+					resource.TestCheckResourceAttr(resourceName, "role_mapping.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.authenticated"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoIdentityPoolRolesAttachment_disappears(t *testing.T) {
+	resourceName := "aws_cognito_identity_pool_roles_attachment.test"
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCognitoIdentityPoolRolesAttachment(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -173,7 +205,7 @@ func testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy(s *terraform.State
 		})
 
 		if err != nil {
-			if wserr, ok := err.(awserr.Error); ok && wserr.Code() == "ResourceNotFoundException" {
+			if isAWSErr(err, cognitoidentity.ErrCodeResourceNotFoundException, "") {
 				return nil
 			}
 			return err
@@ -301,7 +333,7 @@ EOF
 
 func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name string) string {
 	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
-resource "aws_cognito_identity_pool_roles_attachment" "main" {
+resource "aws_cognito_identity_pool_roles_attachment" "test" {
   identity_pool_id = "${aws_cognito_identity_pool.main.id}"
 
   roles = {
@@ -313,7 +345,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 
 func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappings(name string) string {
 	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
-resource "aws_cognito_identity_pool_roles_attachment" "main" {
+resource "aws_cognito_identity_pool_roles_attachment" "test" {
   identity_pool_id = "${aws_cognito_identity_pool.main.id}"
 
   role_mapping {
@@ -338,7 +370,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 
 func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsUpdated(name string) string {
 	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
-resource "aws_cognito_identity_pool_roles_attachment" "main" {
+resource "aws_cognito_identity_pool_roles_attachment" "test" {
   identity_pool_id = "${aws_cognito_identity_pool.main.id}"
 
   role_mapping {
@@ -370,7 +402,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 
 func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithAmbiguousRoleResolutionError(name string) string {
 	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
-resource "aws_cognito_identity_pool_roles_attachment" "main" {
+resource "aws_cognito_identity_pool_roles_attachment" "test" {
   identity_pool_id = "${aws_cognito_identity_pool.main.id}"
 
   role_mapping {
@@ -394,7 +426,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 
 func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithRulesTypeError(name string) string {
 	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
-resource "aws_cognito_identity_pool_roles_attachment" "main" {
+resource "aws_cognito_identity_pool_roles_attachment" "test" {
   identity_pool_id = "${aws_cognito_identity_pool.main.id}"
 
   role_mapping {
@@ -412,7 +444,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 
 func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithTokenTypeError(name string) string {
 	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig(name) + `
-resource "aws_cognito_identity_pool_roles_attachment" "main" {
+resource "aws_cognito_identity_pool_roles_attachment" "test" {
   identity_pool_id = "${aws_cognito_identity_pool.main.id}"
 
   role_mapping {

--- a/website/docs/r/cognito_identity_pool_roles_attachment.markdown
+++ b/website/docs/r/cognito_identity_pool_roles_attachment.markdown
@@ -125,3 +125,11 @@ In addition to the arguments, which are exported, the following attributes are e
 * `identity_pool_id` (Required) - An identity pool ID in the format REGION:GUID.
 * `role_mapping` (Optional) - The List of [Role Mapping](#role-mappings).
 * `roles` (Required) - The map of roles associated with this pool. For a given role, the key will be either "authenticated" or "unauthenticated" and the value will be the Role ARN.
+
+## Import
+
+Cognito Identity Pool Roles Attachment can be imported using the Identity Pool id, e.g.
+
+```
+$ terraform import aws_cognito_identity_pool_roles_attachment.example <identity-pool-id>
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_cognito_identity_pool_roles_attachment - add import support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (93.53s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (136.56s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_disappears (46.10s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (29.06s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (28.89s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (29.17s)
```
