### PR TITLE
Documentation: Current aws_macie resources interact with Macie Classic.

### DIFF
--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -67,7 +67,7 @@ Lambda
 License Manager
 Lightsail
 MQ
-Macie
+Macie Classic
 Managed Streaming for Kafka (MSK)
 MediaConvert
 MediaPackage

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2184,7 +2184,7 @@
                     </ul>
                 </li>
                 <li>
-                    <a href="#">Macie</a>
+                    <a href="#">Macie Classic</a>
                     <ul class="nav">
                         <li>
                             <a href="#">Resources</a>

--- a/website/docs/r/macie_member_account_association.html.markdown
+++ b/website/docs/r/macie_member_account_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Macie"
+subcategory: "Macie Classic"
 layout: "aws"
 page_title: "AWS: aws_macie_member_account_association"
 description: |-
@@ -7,6 +7,8 @@ description: |-
 ---
 
 # Resource: aws_macie_member_account_association
+
+~> **NOTE:** This resource interacts with [Amazon Macie Classic](https://docs.aws.amazon.com/macie/latest/userguide/what-is-macie.html). Macie Classic cannot be activated in new accounts. See the [FAQ](https://aws.amazon.com/macie/classic-faqs/) for more details.
 
 Associates an AWS account with Amazon Macie as a member account.
 

--- a/website/docs/r/macie_s3_bucket_association.html.markdown
+++ b/website/docs/r/macie_s3_bucket_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Macie"
+subcategory: "Macie Classic"
 layout: "aws"
 page_title: "AWS: aws_macie_s3_bucket_association"
 description: |-
@@ -7,6 +7,8 @@ description: |-
 ---
 
 # Resource: aws_macie_s3_bucket_association
+
+~> **NOTE:** This resource interacts with [Amazon Macie Classic](https://docs.aws.amazon.com/macie/latest/userguide/what-is-macie.html). Macie Classic cannot be activated in new accounts. See the [FAQ](https://aws.amazon.com/macie/classic-faqs/) for more details.
 
 Associates an S3 resource with Amazon Macie for monitoring and data classification.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/13432.

Add note to the current Macie resources that Macie Classic cannot be activated in new accounts.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

resource/aws_macie_member_account_association and resource/aws_macie_s3_bucket_association: These resources interact with Amazon Macie Classic and Macie Classic cannot be activated in new accounts. See the [FAQ](https://aws.amazon.com/macie/classic-faqs/) for more details.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
