### PR TITLE
resources/aws_route53_record: Fix set_identifier with underscore

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -946,15 +946,16 @@ func parseRecordId(id string) [4]string {
 	parts := strings.SplitN(id, "_", 2)
 	if len(parts) == 2 {
 		recZone = parts[0]
-		lastUnderscore := strings.LastIndex(parts[1], "_")
-		if lastUnderscore != -1 {
-			recName, recType = parts[1][0:lastUnderscore], parts[1][lastUnderscore+1:]
-			if !r53ValidRecordTypes.MatchString(recType) {
-				recSet, recType = recType, ""
-				lastUnderscore = strings.LastIndex(recName, "_")
-				if lastUnderscore != -1 {
-					recName, recType = recName[0:lastUnderscore], recName[lastUnderscore+1:]
-				}
+		firstUnderscore := strings.Index(parts[1][:], "_")
+		// Handles the case of having a DNS name that starts with _
+		if firstUnderscore == 0 {
+			firstUnderscore = strings.Index(parts[1][1:], "_") + 1
+		}
+		recName, recType = parts[1][0:firstUnderscore], parts[1][firstUnderscore+1:]
+		if !r53ValidRecordTypes.MatchString(recType) {
+			firstUnderscore = strings.Index(recType, "_")
+			if firstUnderscore != -1 {
+				recType, recSet = recType[0:firstUnderscore], recType[firstUnderscore+1:]
 			}
 		}
 	}

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -86,6 +86,8 @@ func TestParseRecordId(t *testing.T) {
 		{"ABCDEF_test.notexample.com_A_set1", "ABCDEF", "test.notexample.com", "A", "set1"},
 		{"ABCDEF__underscore.notexample.com_A", "ABCDEF", "_underscore.notexample.com", "A", ""},
 		{"ABCDEF__underscore.notexample.com_A_set1", "ABCDEF", "_underscore.notexample.com", "A", "set1"},
+		{"ABCDEF__underscore.notexample.com_A_set_with1", "ABCDEF", "_underscore.notexample.com", "A", "set_with1"},
+		{"ABCDEF__underscore.notexample.com_A_set_with_1", "ABCDEF", "_underscore.notexample.com", "A", "set_with_1"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
As mentioned in detail in https://github.com/terraform-providers/terraform-provider-aws/issues/11677
& https://github.com/terraform-providers/terraform-provider-aws/issues/6298
there was a bug if we supplied a `set_identifier` which should contain an
underscore in.
This fix changes the logic by searching the first occurrences of underscores
to calculate the correct values for each field and as a result for the
`set_identifier` as well.
The tests included proves that the change doesn't break something and also
fixes the aforementioned bug.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
