### PR TITLE
EBS, for typo and rephrase error message on IOPS for non-IO1

### DIFF
--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -126,7 +126,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 
 	iops := d.Get("iops").(int)
 	if t != ec2.VolumeTypeIo1 && iops > 0 {
-		log.Printf("[WARN] IOPs is only valid for storate type io1 for EBS Volumes")
+		log.Printf("[WARN] IOPs is only valid on IO1 storage type for EBS Volumes")
 	} else if t == ec2.VolumeTypeIo1 {
 		// We add the iops value without validating it's size, to allow AWS to
 		// enforce a size requirement (currently 100)

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1787,7 +1787,7 @@ func readBlockDeviceMappingsFromConfig(d *schema.ResourceData, conn *ec2.EC2) ([
 				ebs.Iops = aws.Int64(int64(v))
 			} else if v, ok := bd["iops"].(int); ok && v > 0 && *ebs.VolumeType != "io1" {
 				// Message user about incompatibility
-				log.Print("[WARN] IOPs is only valid for storate type io1 for EBS Volumes")
+				log.Print("[WARN] IOPs is only valid on IO1 storage type for EBS Volumes")
 			}
 
 			if dn, err := fetchRootDeviceName(d.Get("ami").(string), conn); err == nil {


### PR DESCRIPTION
Found `storate` in log message, changed it to `storage`
Rephrase the log message to prevent double `for`

> https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests `File is missing in the GITHUB repository` removed by commit fc36c9893c54393e68a50143bfd8b5608a1043bf

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'


# Some tests are failing, I don't have AWS personal account
...
```
