### PR TITLE
r/aws_ses_event_destination: Refresh resource state in the Read method

### DIFF
--- a/aws/resource_aws_ses_event_destination.go
+++ b/aws/resource_aws_ses_event_destination.go
@@ -186,6 +186,52 @@ func resourceAwsSesEventDestinationCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceAwsSesEventDestinationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesconn
+
+	configurationSetName := d.Get("configuration_set_name").(string)
+	input := &ses.DescribeConfigurationSetInput{
+		ConfigurationSetAttributeNames: aws.StringSlice([]string{ses.ConfigurationSetAttributeEventDestinations}),
+		ConfigurationSetName:           aws.String(configurationSetName),
+	}
+
+	output, err := conn.DescribeConfigurationSet(input)
+	if isAWSErr(err, ses.ErrCodeConfigurationSetDoesNotExistException, "") {
+		log.Printf("[WARN] SES Configuration Set (%s) not found, removing from state", configurationSetName)
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading SES Configuration Set Event Destination (%s): %w", d.Id(), err)
+	}
+
+	var thisEventDestination *ses.EventDestination
+	for _, eventDestination := range output.EventDestinations {
+		if aws.StringValue(eventDestination.Name) == d.Id() {
+			thisEventDestination = eventDestination
+			break
+		}
+	}
+	if thisEventDestination == nil {
+		log.Printf("[WARN] SES Configuration Set Event Destination (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("configuration_set_name", output.ConfigurationSet.Name)
+	d.Set("enabled", thisEventDestination.Enabled)
+	d.Set("name", thisEventDestination.Name)
+	if err := d.Set("cloudwatch_destination", flattenSesCloudWatchDestination(thisEventDestination.CloudWatchDestination)); err != nil {
+		return fmt.Errorf("error setting cloudwatch_destination: %w", err)
+	}
+	if err := d.Set("kinesis_destination", flattenSesKinesisFirehoseDestination(thisEventDestination.KinesisFirehoseDestination)); err != nil {
+		return fmt.Errorf("error setting kinesis_destination: %w", err)
+	}
+	if err := d.Set("matching_types", flattenStringSet(thisEventDestination.MatchingEventTypes)); err != nil {
+		return fmt.Errorf("error setting matching_types: %w", err)
+	}
+	if err := d.Set("sns_destination", flattenSesSnsDestination(thisEventDestination.SNSDestination)); err != nil {
+		return fmt.Errorf("error setting sns_destination: %w", err)
+	}
 
 	return nil
 }
@@ -216,4 +262,49 @@ func generateCloudWatchDestination(v []interface{}) []*ses.CloudWatchDimensionCo
 	}
 
 	return b
+}
+
+func flattenSesCloudWatchDestination(destination *ses.CloudWatchDestination) []interface{} {
+	if destination == nil {
+		return []interface{}{}
+	}
+
+	vDimensionConfigurations := []interface{}{}
+
+	for _, dimensionConfiguration := range destination.DimensionConfigurations {
+		mDimensionConfiguration := map[string]interface{}{
+			"default_value":  aws.StringValue(dimensionConfiguration.DefaultDimensionValue),
+			"dimension_name": aws.StringValue(dimensionConfiguration.DimensionName),
+			"value_source":   aws.StringValue(dimensionConfiguration.DimensionValueSource),
+		}
+
+		vDimensionConfigurations = append(vDimensionConfigurations, mDimensionConfiguration)
+	}
+
+	return vDimensionConfigurations
+}
+
+func flattenSesKinesisFirehoseDestination(destination *ses.KinesisFirehoseDestination) []interface{} {
+	if destination == nil {
+		return []interface{}{}
+	}
+
+	mDestination := map[string]interface{}{
+		"role_arn":   aws.StringValue(destination.IAMRoleARN),
+		"stream_arn": aws.StringValue(destination.DeliveryStreamARN),
+	}
+
+	return []interface{}{mDestination}
+}
+
+func flattenSesSnsDestination(destination *ses.SNSDestination) []interface{} {
+	if destination == nil {
+		return []interface{}{}
+	}
+
+	mDestination := map[string]interface{}{
+		"topic_arn": aws.StringValue(destination.TopicARN),
+	}
+
+	return []interface{}{mDestination}
 }

--- a/aws/resource_aws_ses_event_destination_test.go
+++ b/aws/resource_aws_ses_event_destination_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,17 +12,13 @@ import (
 )
 
 func TestAccAWSSESEventDestination_basic(t *testing.T) {
-	rString := acctest.RandString(8)
-
-	bucketName := fmt.Sprintf("tf-acc-bucket-ses-event-dst-%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_ses_event_dst_%s", rString)
-	streamName := fmt.Sprintf("tf_acc_stream_ses_event_dst_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_ses_event_dst_%s", rString)
-	topicName := fmt.Sprintf("tf_acc_topic_ses_event_dst_%s", rString)
-	sesCfgSetName := fmt.Sprintf("tf_acc_cfg_ses_event_dst_%s", rString)
-	sesEventDstNameKinesis := fmt.Sprintf("tf_acc_event_dst_kinesis_%s", rString)
-	sesEventDstNameCw := fmt.Sprintf("tf_acc_event_dst_cloudwatch_%s", rString)
-	sesEventDstNameSns := fmt.Sprintf("tf_acc_event_dst_sns_%s", rString)
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+	rName3 := acctest.RandomWithPrefix("tf-acc-test")
+	cloudwatchDestinationResourceName := "aws_ses_event_destination.cloudwatch"
+	kinesisDestinationResourceName := "aws_ses_event_destination.kinesis"
+	snsDestinationResourceName := "aws_ses_event_destination.sns"
+	var v1, v2, v3 ses.EventDestination
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -32,17 +29,48 @@ func TestAccAWSSESEventDestination_basic(t *testing.T) {
 		CheckDestroy: testAccCheckSESEventDestinationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSESEventDestinationConfig(bucketName, roleName, streamName, policyName, topicName,
-					sesCfgSetName, sesEventDstNameKinesis, sesEventDstNameCw, sesEventDstNameSns),
+				Config: testAccAWSSESEventDestinationConfig(rName1, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESEventDestinationExists("aws_ses_configuration_set.test"),
-					resource.TestCheckResourceAttr(
-						"aws_ses_event_destination.kinesis", "name", sesEventDstNameKinesis),
-					resource.TestCheckResourceAttr(
-						"aws_ses_event_destination.cloudwatch", "name", sesEventDstNameCw),
-					resource.TestCheckResourceAttr(
-						"aws_ses_event_destination.sns", "name", sesEventDstNameSns),
+					testAccCheckAwsSESEventDestinationExists(cloudwatchDestinationResourceName, &v1),
+					testAccCheckAwsSESEventDestinationExists(kinesisDestinationResourceName, &v2),
+					testAccCheckAwsSESEventDestinationExists(snsDestinationResourceName, &v3),
+					resource.TestCheckResourceAttr(cloudwatchDestinationResourceName, "name", rName1),
+					resource.TestCheckResourceAttr(kinesisDestinationResourceName, "name", rName2),
+					resource.TestCheckResourceAttr(snsDestinationResourceName, "name", rName3),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSESEventDestination_disappears(t *testing.T) {
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+	rName3 := acctest.RandomWithPrefix("tf-acc-test")
+	cloudwatchDestinationResourceName := "aws_ses_event_destination.cloudwatch"
+	kinesisDestinationResourceName := "aws_ses_event_destination.kinesis"
+	snsDestinationResourceName := "aws_ses_event_destination.sns"
+	var v1, v2, v3 ses.EventDestination
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESEventDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSESEventDestinationConfig(rName1, rName2, rName3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEventDestinationExists(cloudwatchDestinationResourceName, &v1),
+					testAccCheckAwsSESEventDestinationExists(kinesisDestinationResourceName, &v2),
+					testAccCheckAwsSESEventDestinationExists(snsDestinationResourceName, &v3),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesEventDestination(), cloudwatchDestinationResourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesEventDestination(), kinesisDestinationResourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesEventDestination(), snsDestinationResourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -78,7 +106,7 @@ func testAccCheckSESEventDestinationDestroy(s *terraform.State) error {
 
 }
 
-func testAccCheckAwsSESEventDestinationExists(n string) resource.TestCheckFunc {
+func testAccCheckAwsSESEventDestinationExists(n string, v *ses.EventDestination) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -91,36 +119,34 @@ func testAccCheckAwsSESEventDestinationExists(n string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*AWSClient).sesconn
 
-		response, err := conn.ListConfigurationSets(&ses.ListConfigurationSetsInput{})
+		response, err := conn.DescribeConfigurationSet(&ses.DescribeConfigurationSetInput{
+			ConfigurationSetAttributeNames: aws.StringSlice([]string{ses.ConfigurationSetAttributeEventDestinations}),
+			ConfigurationSetName:           aws.String(rs.Primary.Attributes["configuration_set_name"]),
+		})
 		if err != nil {
 			return err
 		}
 
-		found := false
-		for _, element := range response.ConfigurationSets {
-			if *element.Name == rs.Primary.ID {
-				found = true
+		for _, eventDestination := range response.EventDestinations {
+			if aws.StringValue(eventDestination.Name) == rs.Primary.ID {
+				*v = *eventDestination
+				return nil
 			}
 		}
 
-		if !found {
-			return fmt.Errorf("The configuration set was not created")
-		}
-
-		return nil
+		return fmt.Errorf("The SES Configuration Set Event Destination was not found")
 	}
 }
 
-func testAccAWSSESEventDestinationConfig(bucketName, roleName, streamName, policyName, topicName,
-	sesCfgSetName, sesEventDstNameKinesis, sesEventDstNameCw, sesEventDstNameSns string) string {
+func testAccAWSSESEventDestinationConfig(rName1, rName2, rName3 string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "bucket" {
-  bucket = "%s"
+resource "aws_s3_bucket" "test" {
+  bucket = %[2]q
   acl    = "private"
 }
 
-resource "aws_iam_role" "firehose_role" {
-  name = "%s"
+resource "aws_iam_role" "test" {
+  name = %[2]q
 
   assume_role_policy = <<EOF
 {
@@ -146,23 +172,23 @@ resource "aws_iam_role" "firehose_role" {
 EOF
 }
 
-resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
-  name        = "%s"
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  name        = %[2]q
   destination = "s3"
 
   s3_configuration {
-    role_arn   = "${aws_iam_role.firehose_role.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    role_arn   = "${aws_iam_role.test.arn}"
+    bucket_arn = "${aws_s3_bucket.test.arn}"
   }
 }
 
-resource "aws_iam_role_policy" "firehose_delivery_policy" {
-  name   = "%s"
-  role   = "${aws_iam_role.firehose_role.id}"
-  policy = "${data.aws_iam_policy_document.fh_felivery_document.json}"
+resource "aws_iam_role_policy" "test" {
+  name   = %[2]q
+  role   = "${aws_iam_role.test.id}"
+  policy = "${data.aws_iam_policy_document.test.json}"
 }
 
-data "aws_iam_policy_document" "fh_felivery_document" {
+data "aws_iam_policy_document" "test" {
   statement {
     sid = "GiveSESPermissionToPutFirehose"
 
@@ -177,28 +203,28 @@ data "aws_iam_policy_document" "fh_felivery_document" {
   }
 }
 
-resource "aws_sns_topic" "ses_destination" {
-  name = "%s"
+resource "aws_sns_topic" "test" {
+  name = %[3]q
 }
 
 resource "aws_ses_configuration_set" "test" {
-  name = "%s"
+  name = %[1]q
 }
 
 resource "aws_ses_event_destination" "kinesis" {
-  name                   = "%s"
+  name                   = %[2]q
   configuration_set_name = "${aws_ses_configuration_set.test.name}"
   enabled                = true
   matching_types         = ["bounce", "send"]
 
   kinesis_destination {
-    stream_arn = "${aws_kinesis_firehose_delivery_stream.test_stream.arn}"
-    role_arn   = "${aws_iam_role.firehose_role.arn}"
+    stream_arn = "${aws_kinesis_firehose_delivery_stream.test.arn}"
+    role_arn   = "${aws_iam_role.test.arn}"
   }
 }
 
 resource "aws_ses_event_destination" "cloudwatch" {
-  name                   = "%s"
+  name                   = %[1]q
   configuration_set_name = "${aws_ses_configuration_set.test.name}"
   enabled                = true
   matching_types         = ["bounce", "send"]
@@ -217,15 +243,14 @@ resource "aws_ses_event_destination" "cloudwatch" {
 }
 
 resource "aws_ses_event_destination" "sns" {
-  name                   = "%s"
+  name                   = %[3]q
   configuration_set_name = "${aws_ses_configuration_set.test.name}"
   enabled                = true
   matching_types         = ["bounce", "send"]
 
   sns_destination {
-    topic_arn = "${aws_sns_topic.ses_destination.arn}"
+    topic_arn = "${aws_sns_topic.test.arn}"
   }
 }
-`, bucketName, roleName, streamName, policyName, topicName,
-		sesCfgSetName, sesEventDstNameKinesis, sesEventDstNameCw, sesEventDstNameSns)
+`, rName1, rName2, rName3)
 }

--- a/aws/resource_aws_ses_event_destination_test.go
+++ b/aws/resource_aws_ses_event_destination_test.go
@@ -39,6 +39,24 @@ func TestAccAWSSESEventDestination_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(snsDestinationResourceName, "name", rName3),
 				),
 			},
+			{
+				ResourceName:      cloudwatchDestinationResourceName,
+				ImportStateId:     fmt.Sprintf("%s/%s", rName1, rName1),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      kinesisDestinationResourceName,
+				ImportStateId:     fmt.Sprintf("%s/%s", rName1, rName2),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      snsDestinationResourceName,
+				ImportStateId:     fmt.Sprintf("%s/%s", rName1, rName3),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/ses_event_destination.markdown
+++ b/website/docs/r/ses_event_destination.markdown
@@ -88,3 +88,12 @@ The following arguments are supported:
 ### sns_destination Argument Reference
 
 * `topic_arn` - (Required) The ARN of the SNS topic
+
+## Import
+
+SES event destinations can be imported using `configuration_set_name` together with the event destination's `name`,
+e.g.
+
+```
+$ terraform import aws_ses_event_destination.sns some-configuration-set-test/event-destination-sns
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13464.
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/13344.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ses_event_destination: Correctly refresh resource state
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSESEventDestination_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSSESEventDestination_ -timeout 120m
=== RUN   TestAccAWSSESEventDestination_basic
=== PAUSE TestAccAWSSESEventDestination_basic
=== RUN   TestAccAWSSESEventDestination_disappears
=== PAUSE TestAccAWSSESEventDestination_disappears
=== CONT  TestAccAWSSESEventDestination_basic
=== CONT  TestAccAWSSESEventDestination_disappears
--- PASS: TestAccAWSSESEventDestination_disappears (120.14s)
--- PASS: TestAccAWSSESEventDestination_basic (122.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	122.122s
```
