### PR TITLE
data-source/aws_lambda_invocation: Deprecate result_map attribute

### DIFF
--- a/aws/data_source_aws_lambda_invocation.go
+++ b/aws/data_source_aws_lambda_invocation.go
@@ -40,8 +40,9 @@ func dataSourceAwsLambdaInvocation() *schema.Resource {
 			},
 
 			"result_map": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Type:       schema.TypeMap,
+				Computed:   true,
+				Deprecated: "use `result` attribute with jsondecode() function",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/website/docs/d/lambda_invocation.html.markdown
+++ b/website/docs/d/lambda_invocation.html.markdown
@@ -54,4 +54,4 @@ output "result_entry_tf012" {
 ## Attributes Reference
 
  * `result` - String result of the lambda function invocation.
- * `result_map` - This field is set only if result is a map of primitive types, where the map is string keys and string values. In Terraform 0.12 and later, use the [`jsondecode()` function](/docs/configuration/functions/jsondecode.html) with the `result` attribute instead to convert the result to all supported native Terraform types.
+ * `result_map` - (**DEPRECATED**) This field is set only if result is a map of primitive types, where the map is string keys and string values. In Terraform 0.12 and later, use the [`jsondecode()` function](/docs/configuration/functions/jsondecode.html) with the `result` attribute instead to convert the result to all supported native Terraform types.

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -19,6 +19,7 @@ Upgrade topics:
 <!-- TOC depthFrom:2 depthTo:2 -->
 
 - [Provider Version Configuration](#provider-version-configuration)
+- [Data Source: aws_lambda_invocation](#data-source-aws_lambda_invocation)
 - [Resource: aws_emr_cluster](#resource-aws_emr_cluster)
 
 <!-- /TOC -->
@@ -48,6 +49,32 @@ provider "aws" {
   # ... other configuration ...
 
   version = "~> 3.0"
+}
+```
+
+## Data Source: aws_lambda_invocation
+
+### result_map Attribute Removal
+
+Switch your Terraform configuration to the `result` attribute with the [`jsondecode()` function](https://www.terraform.io/docs/configuration/functions/jsondecode.html) instead.
+
+For example, given this previous configuration:
+
+```hcl
+# In Terraform 0.11 and earlier, the result_map attribute can be used
+# to convert a result JSON string to a map of string keys to string values.
+output "lambda_result" {
+  value = "${data.aws_lambda_invocation.example.result_map["key1"]}"
+}
+```
+
+An updated configuration:
+
+```hcl
+# In Terraform 0.12 and later, the jsondecode() function can be used
+# to convert a result JSON string to native Terraform types.
+output "lambda_result" {
+  value = jsondecode(data.aws_lambda_invocation.example.result)["key1"]
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9184
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/9190
Closes #9189
Closes #13439
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/344
Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/451

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* data-source/aws_lambda_invocation: The `result_map` attribute has been deprecated in favor of the `result` attribute and `jsondecode()` function in Terraform 0.12 and later. The old attribute used functionality that is not compatible with the next major version of the Terraform Plugin SDK. As a reminder, the next major version of the Terraform AWS Provider will only support Terraform 0.12 and later.
```

The `result_map` attribute was created as a workaround for Terraform 0.11 and earlier not having native JSON decoding abilities. This attribute came with the caveat that it only worked when the JSON was only a flat map of strings, where we otherwise ignore the `(helper/schema.ResourceData).Set()` error and instead return a warning log. In Terraform Plugin SDK v2, this error will now panic in the acceptance testing as these errors are generally indicative of resource bugs, which is unavoidable in this case.

Practitioners should instead opt for the Terraform 0.12 and later `jsondecode()` function against the `result` attribute, which can handle much more arbitrary JSON structures. This has been documented in the `aws_lambda_invocation` data source for awhile now. For JSON structures not compliant with Terraform's JSON decoding, the `result` attribute's string value can still be passed to other processing logic, such as calling the `jq` tool.

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsLambdaInvocation_complex (40.22s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_basic (45.02s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_qualifier (52.58s)
```