### PR TITLE
tests/resource/aws_batch_job_definition: Filter sweeper input on ACTIVE status

### DIFF
--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -30,9 +30,12 @@ func testSweepBatchJobDefinitions(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.(*AWSClient).batchconn
+	input := &batch.DescribeJobDefinitionsInput{
+		Status: aws.String("ACTIVE"),
+	}
 	var sweeperErrs *multierror.Error
 
-	err = conn.DescribeJobDefinitionsPages(&batch.DescribeJobDefinitionsInput{}, func(page *batch.DescribeJobDefinitionsOutput, isLast bool) bool {
+	err = conn.DescribeJobDefinitionsPages(input, func(page *batch.DescribeJobDefinitionsOutput, isLast bool) bool {
 		if page == nil {
 			return !isLast
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://docs.aws.amazon.com/batch/latest/APIReference/API_DeregisterJobDefinition.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Job definitions can remain for up to 180 days after deregistering, leaving the previous logic to repeatedly call `DeregisterJobDefinition` across thousands of job definitions extraneously each run. Once in the INACTIVE status, we can ignore them for sweeping.

Output from sweeper in AWS Commercial:

```
2020/05/26 09:54:25 [DEBUG] Running Sweepers for region (us-west-2):
2020/05/26 09:54:25 [DEBUG] Running Sweeper (aws_batch_job_queue) in region (us-west-2)
...
2020/05/26 09:54:28 [DEBUG] Running Sweeper (aws_batch_job_definition) in region (us-west-2)
2020/05/26 09:54:30 Sweeper Tests ran successfully:
	- aws_batch_job_queue
	- aws_batch_job_definition
2020/05/26 09:54:30 [DEBUG] Running Sweepers for region (us-east-1):
2020/05/26 09:54:30 [DEBUG] Running Sweeper (aws_batch_job_queue) in region (us-east-1)
...
2020/05/26 09:54:32 [DEBUG] Running Sweeper (aws_batch_job_definition) in region (us-east-1)
2020/05/26 09:54:32 Sweeper Tests ran successfully:
	- aws_batch_job_queue
	- aws_batch_job_definition
ok  	github.com/terraform-providers/terraform-provider-aws/aws	9.337s
```

Output from sweeper in AWS GovCloud (US):

```
2020/05/26 09:54:42 [DEBUG] Running Sweepers for region (us-gov-west-1):
2020/05/26 09:54:42 [DEBUG] Running Sweeper (aws_batch_job_queue) in region (us-gov-west-1)
...
2020/05/26 09:54:46 [DEBUG] Running Sweeper (aws_batch_job_definition) in region (us-gov-west-1)
2020/05/26 09:54:46 Sweeper Tests ran successfully:
	- aws_batch_job_queue
	- aws_batch_job_definition
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5.092s
```
