### PR TITLE
Update acceptance tests with ARN values

### DIFF
--- a/aws/data_source_aws_billing_service_account_test.go
+++ b/aws/data_source_aws_billing_service_account_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestAccAWSBillingServiceAccount_basic(t *testing.T) {
+	dataSourceName := "data.aws_billing_service_account.main"
+
+	billingAccountID := "386209384616"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -14,8 +18,8 @@ func TestAccAWSBillingServiceAccount_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsBillingServiceAccountConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_billing_service_account.main", "id", "386209384616"),
-					resource.TestCheckResourceAttr("data.aws_billing_service_account.main", "arn", "arn:aws:iam::386209384616:root"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", billingAccountID),
+					testAccCheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", billingAccountID, "iam", "root"),
 				),
 			},
 		},

--- a/aws/data_source_aws_cloudtrail_service_account_test.go
+++ b/aws/data_source_aws_cloudtrail_service_account_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -10,6 +9,8 @@ import (
 func TestAccAWSCloudTrailServiceAccount_basic(t *testing.T) {
 	expectedAccountID := cloudTrailServiceAccountPerRegionMap[testAccGetRegion()]
 
+	dataSourceName := "data.aws_cloudtrail_service_account.main"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -17,8 +18,8 @@ func TestAccAWSCloudTrailServiceAccount_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsCloudTrailServiceAccountConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.main", "id", expectedAccountID),
-					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.main", "arn", fmt.Sprintf("arn:%s:iam::%s:root", testAccGetPartition(), expectedAccountID)),
+					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
+					testAccCheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "root"),
 				),
 			},
 		},
@@ -28,6 +29,8 @@ func TestAccAWSCloudTrailServiceAccount_basic(t *testing.T) {
 func TestAccAWSCloudTrailServiceAccount_Region(t *testing.T) {
 	expectedAccountID := cloudTrailServiceAccountPerRegionMap[testAccGetRegion()]
 
+	dataSourceName := "data.aws_cloudtrail_service_account.regional"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -35,8 +38,8 @@ func TestAccAWSCloudTrailServiceAccount_Region(t *testing.T) {
 			{
 				Config: testAccCheckAwsCloudTrailServiceAccountConfigRegion,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.regional", "id", expectedAccountID),
-					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.regional", "arn", fmt.Sprintf("arn:%s:iam::%s:root", testAccGetPartition(), expectedAccountID)),
+					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
+					testAccCheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "root"),
 				),
 			},
 		},

--- a/aws/data_source_aws_elb_service_account_test.go
+++ b/aws/data_source_aws_elb_service_account_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestAccAWSElbServiceAccount_basic(t *testing.T) {
+	expectedAccountID := elbAccountIdPerRegionMap[testAccGetRegion()]
+
+	dataSourceName := "data.aws_elb_service_account.main"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -14,15 +18,28 @@ func TestAccAWSElbServiceAccount_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsElbServiceAccountConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elb_service_account.main", "id", "797873946194"),
-					resource.TestCheckResourceAttr("data.aws_elb_service_account.main", "arn", "arn:aws:iam::797873946194:root"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
+					testAccCheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "root"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAWSElbServiceAccount_Region(t *testing.T) {
+	expectedAccountID := elbAccountIdPerRegionMap[testAccGetRegion()]
+
+	dataSourceName := "data.aws_elb_service_account.regional"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAwsElbServiceAccountExplicitRegionConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_elb_service_account.regional", "id", "156460612806"),
-					resource.TestCheckResourceAttr("data.aws_elb_service_account.regional", "arn", "arn:aws:iam::156460612806:root"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
+					testAccCheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "root"),
 				),
 			},
 		},
@@ -34,7 +51,9 @@ data "aws_elb_service_account" "main" { }
 `
 
 const testAccCheckAwsElbServiceAccountExplicitRegionConfig = `
+data "aws_region" "current" {}
+
 data "aws_elb_service_account" "regional" {
-	region = "eu-west-1"
+	region = "${data.aws_region.current.name}"
 }
 `

--- a/aws/data_source_aws_redshift_service_account_test.go
+++ b/aws/data_source_aws_redshift_service_account_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestAccAWSRedshiftServiceAccount_basic(t *testing.T) {
+	expectedAccountID := redshiftServiceAccountPerRegionMap[testAccGetRegion()]
+
+	dataSourceName := "data.aws_redshift_service_account.main"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -14,15 +18,28 @@ func TestAccAWSRedshiftServiceAccount_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsRedshiftServiceAccountConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_redshift_service_account.main", "id", "902366379725"),
-					resource.TestCheckResourceAttr("data.aws_redshift_service_account.main", "arn", "arn:aws:iam::902366379725:user/logs"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
+					testAccCheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "user/logs"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAWSRedshiftServiceAccount_Region(t *testing.T) {
+	expectedAccountID := redshiftServiceAccountPerRegionMap[testAccGetRegion()]
+
+	dataSourceName := "data.aws_redshift_service_account.regional"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_redshift_service_account.regional", "id", "307160386991"),
-					resource.TestCheckResourceAttr("data.aws_redshift_service_account.regional", "arn", "arn:aws:iam::307160386991:user/logs"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", expectedAccountID),
+					testAccCheckResourceAttrGlobalARNAccountID(dataSourceName, "arn", expectedAccountID, "iam", "user/logs"),
 				),
 			},
 		},
@@ -34,7 +51,9 @@ data "aws_redshift_service_account" "main" { }
 `
 
 const testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig = `
+data "aws_region" "current" {}
+
 data "aws_redshift_service_account" "regional" {
-	region = "eu-west-2"
+	region = data.aws_region.current.name
 }
 `

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -114,9 +113,9 @@ func TestAccDataSourceAwsRoute53Zone_serviceDiscovery(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsRoute53ZoneConfigServiceDiscovery(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttr(dataSourceName, "linked_service_principal", "servicediscovery.amazonaws.com"),
-					resource.TestMatchResourceAttr(dataSourceName, "linked_service_description", regexp.MustCompile(`^arn:[^:]+:servicediscovery:[^:]+:[^:]+:namespace/ns-\w+$`)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "linked_service_description", resourceName, "arn"),
 				),
 			},
 		},

--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -13,12 +13,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
+const rfc1123RegexPattern = `^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$`
+
 func TestAccDataSourceAWSS3BucketObject_basic(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_basic(rInt)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_bucket_object.object"
+	dataSourceName := "data.aws_s3_bucket_object.obj"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
@@ -26,24 +30,18 @@ func TestAccDataSourceAWSS3BucketObject_basic(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceOnlyConf,
+				Config: testAccAWSDataSourceS3ObjectConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
-				),
-			},
-			{
-				Config: conf,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "11"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "binary/octet-stream"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "etag", "b10a8db164e0754105b7a99be72e3fe5"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_legal_hold_status", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_mode", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_retain_until_date", ""),
-					resource.TestCheckNoResourceAttr("data.aws_s3_bucket_object.obj", "body"),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
+					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "11"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
 				),
 			},
 		},
@@ -53,7 +51,8 @@ func TestAccDataSourceAWSS3BucketObject_basic(t *testing.T) {
 func TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint(t *testing.T) {
 	var dsObj, rObj s3.GetObjectOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	datasourceName := "data.aws_s3_bucket_object.test"
+
+	dataSourceName := "data.aws_s3_bucket_object.test"
 	resourceName := "aws_s3_bucket_object.test"
 	accessPointResourceName := "aws_s3_access_point.test"
 
@@ -64,10 +63,11 @@ func TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint(t *testing.T) {
 			{
 				Config: testAccAWSDataSourceS3ObjectConfig_basicViaAccessPoint(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists(datasourceName, &dsObj),
 					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
-					resource.TestCheckResourceAttrPair(datasourceName, "bucket", accessPointResourceName, "arn"),
-					resource.TestCheckResourceAttrPair(datasourceName, "key", resourceName, "key"),
+					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
+					resource.TestCheckResourceAttrPair(dataSourceName, "bucket", accessPointResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "key", resourceName, "key"),
 				),
 			},
 		},
@@ -76,10 +76,12 @@ func TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint(t *testing.T) {
 
 func TestAccDataSourceAWSS3BucketObject_readableBody(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_readableBody(rInt)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_bucket_object.object"
+	dataSourceName := "data.aws_s3_bucket_object.obj"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
@@ -87,24 +89,18 @@ func TestAccDataSourceAWSS3BucketObject_readableBody(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceOnlyConf,
+				Config: testAccAWSDataSourceS3ObjectConfig_readableBody(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
-				),
-			},
-			{
-				Config: conf,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "3"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "text/plain"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "etag", "a6105c0a611b41b08f1209506350279e"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_legal_hold_status", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_mode", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_retain_until_date", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "body", "yes"),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
+					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "3"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckResourceAttr(dataSourceName, "body", "yes"),
 				),
 			},
 		},
@@ -113,10 +109,12 @@ func TestAccDataSourceAWSS3BucketObject_readableBody(t *testing.T) {
 
 func TestAccDataSourceAWSS3BucketObject_kmsEncrypted(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_kmsEncrypted(rInt)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_bucket_object.object"
+	dataSourceName := "data.aws_s3_bucket_object.obj"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
@@ -124,27 +122,20 @@ func TestAccDataSourceAWSS3BucketObject_kmsEncrypted(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceOnlyConf,
+				Config: testAccAWSDataSourceS3ObjectConfig_kmsEncrypted(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
-				),
-			},
-			{
-				Config: conf,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "22"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "text/plain"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "etag", regexp.MustCompile("^[a-f0-9]{32}$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "server_side_encryption", "aws:kms"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "sse_kms_key_id",
-						regexp.MustCompile(`^arn:aws:kms:[a-z]{2}-[a-z]+-\d{1}:[0-9]{12}:key/[a-z0-9-]{36}$`)),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_legal_hold_status", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_mode", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_retain_until_date", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "body", "Keep Calm and Carry On"),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
+					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "22"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "server_side_encryption", resourceName, "server_side_encryption"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sse_kms_key_id", resourceName, "kms_key_id"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckResourceAttr(dataSourceName, "body", "Keep Calm and Carry On"),
 				),
 			},
 		},
@@ -153,10 +144,12 @@ func TestAccDataSourceAWSS3BucketObject_kmsEncrypted(t *testing.T) {
 
 func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_allParams(rInt)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_bucket_object.object"
+	dataSourceName := "data.aws_s3_bucket_object.obj"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
@@ -164,40 +157,34 @@ func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceOnlyConf,
+				Config: testAccAWSDataSourceS3ObjectConfig_allParams(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
-				),
-			},
-			{
-				Config: conf,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "21"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "application/unknown"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "etag", "723f7a6ac0c57b445790914668f98640"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "version_id", regexp.MustCompile("^.{32}$")),
-					resource.TestCheckNoResourceAttr("data.aws_s3_bucket_object.obj", "body"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "cache_control", "no-cache"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_disposition", "attachment"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_encoding", "identity"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_language", "en-GB"),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
+					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "21"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version_id", resourceName, "version_id"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cache_control", resourceName, "cache_control"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_disposition", resourceName, "content_disposition"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_encoding", resourceName, "content_encoding"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_language", resourceName, "content_language"),
 					// Encryption is off
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "server_side_encryption", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "sse_kms_key_id", ""),
+					resource.TestCheckResourceAttrPair(dataSourceName, "server_side_encryption", resourceName, "server_side_encryption"),
+					resource.TestCheckResourceAttr(dataSourceName, "sse_kms_key_id", ""),
 					// Supported, but difficult to reproduce in short testing time
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "storage_class", "STANDARD"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "expiration", ""),
+					resource.TestCheckResourceAttrPair(dataSourceName, "storage_class", resourceName, "storage_class"),
+					resource.TestCheckResourceAttr(dataSourceName, "expiration", ""),
 					// Currently unsupported in aws_s3_bucket_object resource
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "expires", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "website_redirect_location", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "metadata.%", "0"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "tags.%", "1"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_legal_hold_status", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_mode", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_retain_until_date", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "expires", ""),
+					resource.TestCheckResourceAttrPair(dataSourceName, "website_redirect_location", resourceName, "website_redirect"),
+					resource.TestCheckResourceAttr(dataSourceName, "metadata.%", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
 				),
 			},
 		},
@@ -206,10 +193,12 @@ func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 
 func TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_objectLockLegalHoldOff(rInt)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_bucket_object.object"
+	dataSourceName := "data.aws_s3_bucket_object.obj"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
@@ -217,24 +206,18 @@ func TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceOnlyConf,
+				Config: testAccAWSDataSourceS3ObjectConfig_objectLockLegalHoldOff(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
-				),
-			},
-			{
-				Config: conf,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "11"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "binary/octet-stream"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "etag", "b10a8db164e0754105b7a99be72e3fe5"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_legal_hold_status", "OFF"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_mode", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_retain_until_date", ""),
-					resource.TestCheckNoResourceAttr("data.aws_s3_bucket_object.obj", "body"),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
+					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "11"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
 				),
 			},
 		},
@@ -244,10 +227,12 @@ func TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff(t *testing.T) {
 func TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn(t *testing.T) {
 	rInt := acctest.RandInt()
 	retainUntilDate := time.Now().UTC().AddDate(0, 0, 10).Format(time.RFC3339)
-	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_objectLockLegalHoldOn(rInt, retainUntilDate)
 
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_bucket_object.object"
+	dataSourceName := "data.aws_s3_bucket_object.obj"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
@@ -255,24 +240,18 @@ func TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceOnlyConf,
+				Config: testAccAWSDataSourceS3ObjectConfig_objectLockLegalHoldOn(rInt, retainUntilDate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
-				),
-			},
-			{
-				Config: conf,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "11"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "binary/octet-stream"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "etag", "b10a8db164e0754105b7a99be72e3fe5"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_legal_hold_status", "ON"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_mode", "GOVERNANCE"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "object_lock_retain_until_date", retainUntilDate),
-					resource.TestCheckNoResourceAttr("data.aws_s3_bucket_object.obj", "body"),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
+					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "11"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
 				),
 			},
 		},
@@ -282,10 +261,12 @@ func TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn(t *testing.T) {
 func TestAccDataSourceAWSS3BucketObject_LeadingSlash(t *testing.T) {
 	var rObj s3.GetObjectOutput
 	var dsObj1, dsObj2, dsObj3 s3.GetObjectOutput
+
 	resourceName := "aws_s3_bucket_object.object"
 	dataSourceName1 := "data.aws_s3_bucket_object.obj1"
 	dataSourceName2 := "data.aws_s3_bucket_object.obj2"
 	dataSourceName3 := "data.aws_s3_bucket_object.obj3"
+
 	rInt := acctest.RandInt()
 	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_leadingSlash(rInt)
 
@@ -305,24 +286,23 @@ func TestAccDataSourceAWSS3BucketObject_LeadingSlash(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName1, &dsObj1),
 					resource.TestCheckResourceAttr(dataSourceName1, "content_length", "3"),
-					resource.TestCheckResourceAttr(dataSourceName1, "content_type", "text/plain"),
-					resource.TestCheckResourceAttr(dataSourceName1, "etag", "a6105c0a611b41b08f1209506350279e"),
-					resource.TestMatchResourceAttr(dataSourceName1, "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName1, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
 					resource.TestCheckResourceAttr(dataSourceName1, "body", "yes"),
+
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName2, &dsObj2),
 					resource.TestCheckResourceAttr(dataSourceName2, "content_length", "3"),
-					resource.TestCheckResourceAttr(dataSourceName2, "content_type", "text/plain"),
-					resource.TestCheckResourceAttr(dataSourceName2, "etag", "a6105c0a611b41b08f1209506350279e"),
-					resource.TestMatchResourceAttr(dataSourceName2, "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName2, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
 					resource.TestCheckResourceAttr(dataSourceName2, "body", "yes"),
+
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName3, &dsObj3),
 					resource.TestCheckResourceAttr(dataSourceName3, "content_length", "3"),
-					resource.TestCheckResourceAttr(dataSourceName3, "content_type", "text/plain"),
-					resource.TestCheckResourceAttr(dataSourceName3, "etag", "a6105c0a611b41b08f1209506350279e"),
-					resource.TestMatchResourceAttr(dataSourceName3, "last_modified",
-						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName3, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
 					resource.TestCheckResourceAttr(dataSourceName3, "body", "yes"),
 				),
 			},
@@ -333,11 +313,13 @@ func TestAccDataSourceAWSS3BucketObject_LeadingSlash(t *testing.T) {
 func TestAccDataSourceAWSS3BucketObject_MultipleSlashes(t *testing.T) {
 	var rObj1, rObj2 s3.GetObjectOutput
 	var dsObj1, dsObj2, dsObj3 s3.GetObjectOutput
+
 	resourceName1 := "aws_s3_bucket_object.object1"
 	resourceName2 := "aws_s3_bucket_object.object2"
 	dataSourceName1 := "data.aws_s3_bucket_object.obj1"
 	dataSourceName2 := "data.aws_s3_bucket_object.obj2"
 	dataSourceName3 := "data.aws_s3_bucket_object.obj3"
+
 	rInt := acctest.RandInt()
 	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_multipleSlashes(rInt)
 
@@ -356,17 +338,20 @@ func TestAccDataSourceAWSS3BucketObject_MultipleSlashes(t *testing.T) {
 			{
 				Config: conf,
 				Check: resource.ComposeTestCheckFunc(
+
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName1, &dsObj1),
 					resource.TestCheckResourceAttr(dataSourceName1, "content_length", "3"),
-					resource.TestCheckResourceAttr(dataSourceName1, "content_type", "text/plain"),
+					resource.TestCheckResourceAttrPair(dataSourceName1, "content_type", resourceName1, "content_type"),
 					resource.TestCheckResourceAttr(dataSourceName1, "body", "yes"),
+
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName2, &dsObj2),
 					resource.TestCheckResourceAttr(dataSourceName2, "content_length", "3"),
-					resource.TestCheckResourceAttr(dataSourceName2, "content_type", "text/plain"),
+					resource.TestCheckResourceAttrPair(dataSourceName2, "content_type", resourceName1, "content_type"),
 					resource.TestCheckResourceAttr(dataSourceName2, "body", "yes"),
+
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName3, &dsObj3),
 					resource.TestCheckResourceAttr(dataSourceName3, "content_length", "2"),
-					resource.TestCheckResourceAttr(dataSourceName3, "content_type", "text/plain"),
+					resource.TestCheckResourceAttrPair(dataSourceName3, "content_type", resourceName2, "content_type"),
 					resource.TestCheckResourceAttr(dataSourceName3, "body", "no"),
 				),
 			},
@@ -402,26 +387,23 @@ func testAccCheckAwsS3ObjectDataSourceExists(n string, obj *s3.GetObjectOutput) 
 	}
 }
 
-func testAccAWSDataSourceS3ObjectConfig_basic(randInt int) (string, string) {
-	resources := fmt.Sprintf(`
+func testAccAWSDataSourceS3ObjectConfig_basic(randInt int) string {
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
+
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "tf-testing-obj-%d"
-	content = "Hello World"
+  bucket  = aws_s3_bucket.object_bucket.bucket
+  key     = "tf-testing-obj-%[1]d"
+  content = "Hello World"
 }
-`, randInt, randInt)
 
-	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "tf-testing-obj-%d"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = aws_s3_bucket_object.object.key
 }
-`, resources, randInt, randInt)
-
-	return resources, both
+`, randInt)
 }
 
 func testAccAWSDataSourceS3ObjectConfig_basicViaAccessPoint(rName string) string {
@@ -431,114 +413,105 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 }
 
 resource "aws_s3_bucket_object" "test" {
-  bucket  = "${aws_s3_bucket.test.bucket}"
+  bucket  = aws_s3_bucket.test.bucket
   key     = %[1]q
   content = "Hello World"
 }
 
 data "aws_s3_bucket_object" "test" {
-  bucket = "${aws_s3_access_point.test.arn}"
-  key    = "${aws_s3_bucket_object.test.key}"
+  bucket = aws_s3_access_point.test.arn
+  key    = aws_s3_bucket_object.test.key
 }
 `, rName)
 }
 
-func testAccAWSDataSourceS3ObjectConfig_readableBody(randInt int) (string, string) {
-	resources := fmt.Sprintf(`
+func testAccAWSDataSourceS3ObjectConfig_readableBody(randInt int) string {
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
+
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "tf-testing-obj-%d-readable"
-	content = "yes"
-	content_type = "text/plain"
+  bucket       = "${aws_s3_bucket.object_bucket.bucket}"
+  key          = "tf-testing-obj-%[1]d-readable"
+  content      = "yes"
+  content_type = "text/plain"
 }
-`, randInt, randInt)
 
-	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "tf-testing-obj-%d-readable"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = aws_s3_bucket_object.object.key
 }
-`, resources, randInt, randInt)
-
-	return resources, both
+`, randInt)
 }
 
-func testAccAWSDataSourceS3ObjectConfig_kmsEncrypted(randInt int) (string, string) {
-	resources := fmt.Sprintf(`
+func testAccAWSDataSourceS3ObjectConfig_kmsEncrypted(randInt int) string {
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
+
 resource "aws_kms_key" "example" {
   description             = "TF Acceptance Test KMS key"
   deletion_window_in_days = 7
 }
-resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "tf-testing-obj-%d-encrypted"
-	content = "Keep Calm and Carry On"
-	content_type = "text/plain"
-	kms_key_id = "${aws_kms_key.example.arn}"
-}
-`, randInt, randInt)
 
-	both := fmt.Sprintf(`%s
+resource "aws_s3_bucket_object" "object" {
+  bucket       = aws_s3_bucket.object_bucket.bucket
+  key          = "tf-testing-obj-%[1]d-encrypted"
+  content      = "Keep Calm and Carry On"
+  content_type = "text/plain"
+  kms_key_id   = aws_kms_key.example.arn
+}
+
 data "aws_s3_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "tf-testing-obj-%d-encrypted"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = aws_s3_bucket_object.object.key
 }
-`, resources, randInt, randInt)
-
-	return resources, both
+`, randInt)
 }
 
-func testAccAWSDataSourceS3ObjectConfig_allParams(randInt int) (string, string) {
-	resources := fmt.Sprintf(`
+func testAccAWSDataSourceS3ObjectConfig_allParams(randInt int) string {
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
-	versioning {
-		enabled = true
-	}
+  bucket = "tf-object-test-bucket-%[1]d"
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "tf-testing-obj-%d-all-params"
-	content = <<CONTENT
+  bucket              = "${aws_s3_bucket.object_bucket.bucket}"
+  key                 = "tf-testing-obj-%[1]d-all-params"
+  content             = <<CONTENT
 {"msg": "Hi there!"}
 CONTENT
-	content_type = "application/unknown"
-	cache_control = "no-cache"
-	content_disposition = "attachment"
-	content_encoding = "identity"
-	content_language = "en-GB"
-	tags = {
-		Key1 = "Value 1"
-	}
+  content_type        = "application/unknown"
+  cache_control       = "no-cache"
+  content_disposition = "attachment"
+  content_encoding    = "identity"
+  content_language    = "en-GB"
+  tags = {
+    Key1 = "Value 1"
+  }
 }
-`, randInt, randInt)
 
-	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "tf-testing-obj-%d-all-params"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = aws_s3_bucket_object.object.key
 }
-`, resources, randInt, randInt)
-
-	return resources, both
+`, randInt)
 }
 
-func testAccAWSDataSourceS3ObjectConfig_objectLockLegalHoldOff(randInt int) (string, string) {
-	resources := fmt.Sprintf(`
+func testAccAWSDataSourceS3ObjectConfig_objectLockLegalHoldOff(randInt int) string {
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -548,28 +521,25 @@ resource "aws_s3_bucket" "object_bucket" {
     object_lock_enabled = "Enabled"
   }
 }
+
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "tf-testing-obj-%d"
-  content = "Hello World"
+  bucket                        = "${aws_s3_bucket.object_bucket.bucket}"
+  key                           = "tf-testing-obj-%[1]d"
+  content                       = "Hello World"
   object_lock_legal_hold_status = "OFF"
 }
-`, randInt, randInt)
 
-	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-  bucket = "tf-object-test-bucket-%d"
-  key = "tf-testing-obj-%d"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = aws_s3_bucket_object.object.key
 }
-`, resources, randInt, randInt)
-
-	return resources, both
+`, randInt)
 }
 
-func testAccAWSDataSourceS3ObjectConfig_objectLockLegalHoldOn(randInt int, retainUntilDate string) (string, string) {
-	resources := fmt.Sprintf(`
+func testAccAWSDataSourceS3ObjectConfig_objectLockLegalHoldOn(randInt int, retainUntilDate string) string {
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 
   versioning {
     enabled = true
@@ -579,54 +549,56 @@ resource "aws_s3_bucket" "object_bucket" {
     object_lock_enabled = "Enabled"
   }
 }
+
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "tf-testing-obj-%d"
-  content = "Hello World"
-  force_destroy = true
+  bucket                        = "${aws_s3_bucket.object_bucket.bucket}"
+  key                           = "tf-testing-obj-%[1]d"
+  content                       = "Hello World"
+  force_destroy                 = true
   object_lock_legal_hold_status = "ON"
-  object_lock_mode = "GOVERNANCE"
-  object_lock_retain_until_date = "%s"
+  object_lock_mode              = "GOVERNANCE"
+  object_lock_retain_until_date = "%[2]s"
 }
-`, randInt, randInt, retainUntilDate)
 
-	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-  bucket = "tf-object-test-bucket-%d"
-  key = "tf-testing-obj-%d"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = aws_s3_bucket_object.object.key
 }
-`, resources, randInt, randInt)
-
-	return resources, both
+`, randInt, retainUntilDate)
 }
 
 func testAccAWSDataSourceS3ObjectConfig_leadingSlash(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
+
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "//tf-testing-obj-%d-readable"
-  content = "yes"
+  bucket       = aws_s3_bucket.object_bucket.bucket
+  key          = "//tf-testing-obj-%[1]d-readable"
+  content      = "yes"
   content_type = "text/plain"
 }
-`, randInt, randInt)
+`, randInt)
 
-	both := fmt.Sprintf(`%s
+	both := fmt.Sprintf(`
+%[1]s
+
 data "aws_s3_bucket_object" "obj1" {
-  bucket = "tf-object-test-bucket-%d"
-  key = "tf-testing-obj-%d-readable"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "tf-testing-obj-%[2]d-readable"
 }
+
 data "aws_s3_bucket_object" "obj2" {
-  bucket = "tf-object-test-bucket-%d"
-  key = "/tf-testing-obj-%d-readable"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "/tf-testing-obj-%[2]d-readable"
 }
+
 data "aws_s3_bucket_object" "obj3" {
-  bucket = "tf-object-test-bucket-%d"
-  key = "//tf-testing-obj-%d-readable"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "//tf-testing-obj-%[2]d-readable"
 }
-`, resources, randInt, randInt, randInt, randInt, randInt, randInt)
+`, resources, randInt)
 
 	return resources, both
 }
@@ -634,37 +606,43 @@ data "aws_s3_bucket_object" "obj3" {
 func testAccAWSDataSourceS3ObjectConfig_multipleSlashes(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
+
 resource "aws_s3_bucket_object" "object1" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "first//second///third//"
-  content = "yes"
+  bucket       = "${aws_s3_bucket.object_bucket.bucket}"
+  key          = "first//second///third//"
+  content      = "yes"
   content_type = "text/plain"
 }
+
 # Without a trailing slash.
 resource "aws_s3_bucket_object" "object2" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "/first////second/third"
-  content = "no"
+  bucket       = aws_s3_bucket.object_bucket.bucket
+  key          = "/first////second/third"
+  content      = "no"
   content_type = "text/plain"
 }
 `, randInt)
 
-	both := fmt.Sprintf(`%s
+	both := fmt.Sprintf(`
+%s
+
 data "aws_s3_bucket_object" "obj1" {
-  bucket = "tf-object-test-bucket-%d"
-  key = "first/second/third/"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "first/second/third/"
 }
+
 data "aws_s3_bucket_object" "obj2" {
-  bucket = "tf-object-test-bucket-%d"
-  key = "first//second///third//"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "first//second///third//"
 }
+
 data "aws_s3_bucket_object" "obj3" {
-  bucket = "tf-object-test-bucket-%d"
-  key = "first/second/third"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "first/second/third"
 }
-`, resources, randInt, randInt, randInt)
+`, resources)
 
 	return resources, both
 }

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -242,6 +242,19 @@ func testAccCheckResourceAttrGlobalARNNoAccount(resourceName, attributeName, arn
 	}
 }
 
+// testAccCheckResourceAttrGlobalARNAccountID ensures the Terraform state exactly matches a formatted ARN without region and with specific account ID
+func testAccCheckResourceAttrGlobalARNAccountID(resourceName, attributeName, accountID, arnService, arnResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attributeValue := arn.ARN{
+			AccountID: accountID,
+			Partition: testAccGetPartition(),
+			Resource:  arnResource,
+			Service:   arnService,
+		}.String()
+		return resource.TestCheckResourceAttr(resourceName, attributeName, attributeValue)(s)
+	}
+}
+
 // testAccMatchResourceAttrGlobalARN ensures the Terraform state regexp matches a formatted ARN without region
 func testAccMatchResourceAttrGlobalARN(resourceName, attributeName, arnService string, arnResourceRegexp *regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,11 +19,10 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
 	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
 	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
-	resourceName := "aws_api_gateway_authorizer.acctest"
 
-	expectedAuthUri := regexp.MustCompile("arn:aws:apigateway:[a-z0-9-]+:lambda:path/2015-03-31/functions/" +
-		"arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:" + lambdaName + "/invocations")
-	expectedCreds := regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/" + apiGatewayName + "_auth_invocation_role")
+	resourceName := "aws_api_gateway_authorizer.acctest"
+	lambdaResourceName := "aws_lambda_function.authorizer"
+	roleResourceName := "aws_iam_role.invocation_role"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -33,19 +33,12 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerUri(&conf, expectedAuthUri),
-					resource.TestMatchResourceAttr(resourceName, "authorizer_uri", expectedAuthUri),
-					testAccCheckAWSAPIGatewayAuthorizerIdentitySource(&conf, "method.request.header.Authorization"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
-					testAccCheckAWSAPIGatewayAuthorizerName(&conf, authorizerName),
 					resource.TestCheckResourceAttr(resourceName, "name", authorizerName),
-					testAccCheckAWSAPIGatewayAuthorizerType(&conf, "TOKEN"),
 					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerCredentials(&conf, expectedCreds),
-					resource.TestMatchResourceAttr(resourceName, "authorizer_credentials", expectedCreds),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
-					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "300"),
-					testAccCheckAWSAPIGatewayAuthorizerIdentityValidationExpression(&conf, nil),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials", roleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(defaultAuthorizerTTL)),
 					resource.TestCheckResourceAttr(resourceName, "identity_validation_expression", ""),
 				),
 			},
@@ -59,19 +52,12 @@ func TestAccAWSAPIGatewayAuthorizer_basic(t *testing.T) {
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerUri(&conf, expectedAuthUri),
-					resource.TestMatchResourceAttr(resourceName, "authorizer_uri", expectedAuthUri),
-					testAccCheckAWSAPIGatewayAuthorizerIdentitySource(&conf, "method.request.header.Authorization"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "identity_source", "method.request.header.Authorization"),
-					testAccCheckAWSAPIGatewayAuthorizerName(&conf, authorizerName+"_modified"),
 					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"_modified"),
-					testAccCheckAWSAPIGatewayAuthorizerType(&conf, "TOKEN"),
 					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerCredentials(&conf, expectedCreds),
-					resource.TestMatchResourceAttr(resourceName, "authorizer_credentials", expectedCreds),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(360)),
-					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "360"),
-					testAccCheckAWSAPIGatewayAuthorizerIdentityValidationExpression(&conf, aws.String(".*")),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials", roleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(360)),
 					resource.TestCheckResourceAttr(resourceName, "identity_validation_expression", ".*"),
 				),
 			},
@@ -83,6 +69,7 @@ func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
 	apiGatewayName := acctest.RandomWithPrefix("tf-acctest-apigw")
 	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
 	cognitoName := acctest.RandomWithPrefix("tf-acctest-cognito-user-pool")
+
 	resourceName := "aws_api_gateway_authorizer.acctest"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -94,6 +81,7 @@ func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
 				Config: testAccAWSAPIGatewayAuthorizerConfig_cognito(apiGatewayName, authorizerName, cognitoName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"-cognito"),
+					resource.TestCheckResourceAttr(resourceName, "type", "COGNITO_USER_POOLS"),
 					resource.TestCheckResourceAttr(resourceName, "provider_arns.#", "2"),
 				),
 			},
@@ -107,6 +95,7 @@ func TestAccAWSAPIGatewayAuthorizer_cognito(t *testing.T) {
 				Config: testAccAWSAPIGatewayAuthorizerConfig_cognitoUpdate(apiGatewayName, authorizerName, cognitoName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"-cognito-update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "COGNITO_USER_POOLS"),
 					resource.TestCheckResourceAttr(resourceName, "provider_arns.#", "3"),
 				),
 			},
@@ -119,11 +108,10 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 	authorizerName := acctest.RandomWithPrefix("tf-acctest-igw-authorizer")
 	lambdaName := acctest.RandomWithPrefix("tf-acctest-igw-auth-lambda")
 	cognitoName := acctest.RandomWithPrefix("tf-acctest-cognito-user-pool")
-	resourceName := "aws_api_gateway_authorizer.acctest"
 
-	expectedAuthUri := regexp.MustCompile("arn:aws:apigateway:[a-z0-9-]+:lambda:path/2015-03-31/functions/" +
-		"arn:aws:lambda:[a-z0-9-]+:[0-9]{12}:function:" + lambdaName + "/invocations")
-	expectedCreds := regexp.MustCompile("arn:aws:iam::[0-9]{12}:role/" + apiGatewayName + "_auth_invocation_role")
+	resourceName := "aws_api_gateway_authorizer.acctest"
+	lambdaResourceName := "aws_lambda_function.authorizer"
+	roleResourceName := "aws_iam_role.invocation_role"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -135,8 +123,8 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", authorizerName),
 					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
-					resource.TestMatchResourceAttr(resourceName, "authorizer_uri", expectedAuthUri),
-					resource.TestMatchResourceAttr(resourceName, "authorizer_credentials", expectedCreds),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials", roleResourceName, "arn"),
 				),
 			},
 			{
@@ -158,8 +146,8 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthType(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", authorizerName+"_modified"),
 					resource.TestCheckResourceAttr(resourceName, "type", "TOKEN"),
-					resource.TestMatchResourceAttr(resourceName, "authorizer_uri", expectedAuthUri),
-					resource.TestMatchResourceAttr(resourceName, "authorizer_credentials", expectedCreds),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials", roleResourceName, "arn"),
 				),
 			},
 		},
@@ -182,8 +170,7 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
-					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(defaultAuthorizerTTL)),
 				),
 			},
 			{
@@ -196,24 +183,21 @@ func TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL(t *testing.T) {
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(360)),
-					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "360"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(360)),
 				),
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(0)),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(0)),
 				),
 			},
 			{
 				Config: testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayAuthorizerExists(resourceName, &conf),
-					testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(&conf, aws.Int64(defaultAuthorizerTTL)),
-					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", strconv.Itoa(defaultAuthorizerTTL)),
 				),
 			},
 		},
@@ -292,106 +276,6 @@ func testAccCheckAWSAPIGatewayAuthorizerDisappears(resourceName string) resource
 		_, err := conn.DeleteAuthorizer(input)
 
 		return err
-	}
-}
-
-func testAccCheckAWSAPIGatewayAuthorizerAuthorizerUri(conf *apigateway.Authorizer, expectedUri *regexp.Regexp) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if conf.AuthorizerUri == nil {
-			return fmt.Errorf("Empty AuthorizerUri, expected: %q", expectedUri)
-		}
-
-		if !expectedUri.MatchString(*conf.AuthorizerUri) {
-			return fmt.Errorf("AuthorizerUri didn't match. Expected: %q, Given: %q", expectedUri, *conf.AuthorizerUri)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSAPIGatewayAuthorizerIdentitySource(conf *apigateway.Authorizer, expectedSource string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if conf.IdentitySource == nil {
-			return fmt.Errorf("Empty IdentitySource, expected: %q", expectedSource)
-		}
-		if *conf.IdentitySource != expectedSource {
-			return fmt.Errorf("IdentitySource didn't match. Expected: %q, Given: %q", expectedSource, *conf.IdentitySource)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSAPIGatewayAuthorizerName(conf *apigateway.Authorizer, expectedName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if conf.Name == nil {
-			return fmt.Errorf("Empty Name, expected: %q", expectedName)
-		}
-		if *conf.Name != expectedName {
-			return fmt.Errorf("Name didn't match. Expected: %q, Given: %q", expectedName, *conf.Name)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSAPIGatewayAuthorizerType(conf *apigateway.Authorizer, expectedType string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if conf.Type == nil {
-			return fmt.Errorf("Empty Type, expected: %q", expectedType)
-		}
-		if *conf.Type != expectedType {
-			return fmt.Errorf("Type didn't match. Expected: %q, Given: %q", expectedType, *conf.Type)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSAPIGatewayAuthorizerAuthorizerCredentials(conf *apigateway.Authorizer, expectedCreds *regexp.Regexp) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if conf.AuthorizerCredentials == nil {
-			return fmt.Errorf("Empty AuthorizerCredentials, expected: %q", expectedCreds)
-		}
-		if !expectedCreds.MatchString(*conf.AuthorizerCredentials) {
-			return fmt.Errorf("AuthorizerCredentials didn't match. Expected: %q, Given: %q",
-				expectedCreds, *conf.AuthorizerCredentials)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSAPIGatewayAuthorizerAuthorizerResultTtlInSeconds(conf *apigateway.Authorizer, expectedTtl *int64) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if expectedTtl == conf.AuthorizerResultTtlInSeconds {
-			return nil
-		}
-		if expectedTtl == nil && conf.AuthorizerResultTtlInSeconds != nil {
-			return fmt.Errorf("Expected empty AuthorizerResultTtlInSeconds, given: %d", *conf.AuthorizerResultTtlInSeconds)
-		}
-		if conf.AuthorizerResultTtlInSeconds == nil {
-			return fmt.Errorf("Empty AuthorizerResultTtlInSeconds, expected: %d", expectedTtl)
-		}
-		if *conf.AuthorizerResultTtlInSeconds != *expectedTtl {
-			return fmt.Errorf("AuthorizerResultTtlInSeconds didn't match. Expected: %d, Given: %d",
-				*expectedTtl, *conf.AuthorizerResultTtlInSeconds)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSAPIGatewayAuthorizerIdentityValidationExpression(conf *apigateway.Authorizer, expectedExpression *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if expectedExpression == conf.IdentityValidationExpression {
-			return nil
-		}
-		if expectedExpression == nil && conf.IdentityValidationExpression != nil {
-			return fmt.Errorf("Expected empty IdentityValidationExpression, given: %q", *conf.IdentityValidationExpression)
-		}
-		if conf.IdentityValidationExpression == nil {
-			return fmt.Errorf("Empty IdentityValidationExpression, expected: %q", *expectedExpression)
-		}
-		if *conf.IdentityValidationExpression != *expectedExpression {
-			return fmt.Errorf("IdentityValidationExpression didn't match. Expected: %q, Given: %q",
-				*expectedExpression, *conf.IdentityValidationExpression)
-		}
-		return nil
 	}
 }
 
@@ -495,7 +379,7 @@ EOF
 
 resource "aws_iam_role_policy" "invocation_policy" {
   name = "default"
-  role = "${aws_iam_role.invocation_role.id}"
+  role = aws_iam_role.invocation_role.id
 
   policy = <<EOF
 {
@@ -533,9 +417,9 @@ EOF
 
 resource "aws_lambda_function" "authorizer" {
   filename         = "test-fixtures/lambdatest.zip"
-  source_code_hash = "${filebase64sha256("test-fixtures/lambdatest.zip")}"
+  source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   function_name    = "%s"
-  role             = "${aws_iam_role.iam_for_lambda.arn}"
+  role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
   runtime          = "nodejs12.x"
 }
@@ -545,10 +429,10 @@ resource "aws_lambda_function" "authorizer" {
 func testAccAWSAPIGatewayAuthorizerConfig_lambda(apiGatewayName, authorizerName, lambdaName string) string {
 	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
 resource "aws_api_gateway_authorizer" "acctest" {
-  name = "%s"
-  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
-  authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
-  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+  name                   = "%s"
+  rest_api_id            = aws_api_gateway_rest_api.acctest.id
+  authorizer_uri         = aws_lambda_function.authorizer.invoke_arn
+  authorizer_credentials = aws_iam_role.invocation_role.arn
 }
 `, authorizerName)
 }
@@ -556,12 +440,12 @@ resource "aws_api_gateway_authorizer" "acctest" {
 func testAccAWSAPIGatewayAuthorizerConfig_lambdaUpdate(apiGatewayName, authorizerName, lambdaName string) string {
 	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
 resource "aws_api_gateway_authorizer" "acctest" {
-  name = "%s_modified"
-  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
-  authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
-  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+  name                             = "%s_modified"
+  rest_api_id                      = aws_api_gateway_rest_api.acctest.id
+  authorizer_uri                   = aws_lambda_function.authorizer.invoke_arn
+  authorizer_credentials           = aws_iam_role.invocation_role.arn
   authorizer_result_ttl_in_seconds = 360
-  identity_validation_expression = ".*"
+  identity_validation_expression   = ".*"
 }
 `, authorizerName)
 }
@@ -569,12 +453,12 @@ resource "aws_api_gateway_authorizer" "acctest" {
 func testAccAWSAPIGatewayAuthorizerConfig_lambdaNoCache(apiGatewayName, authorizerName, lambdaName string) string {
 	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
 resource "aws_api_gateway_authorizer" "acctest" {
-  name = "%s_modified"
-  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
-  authorizer_uri = "${aws_lambda_function.authorizer.invoke_arn}"
-  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+  name                             = "%s_modified"
+  rest_api_id                      = aws_api_gateway_rest_api.acctest.id
+  authorizer_uri                   = aws_lambda_function.authorizer.invoke_arn
+  authorizer_credentials           = aws_iam_role.invocation_role.arn
   authorizer_result_ttl_in_seconds = 0
-  identity_validation_expression = ".*"
+  identity_validation_expression   = ".*"
 }
 `, authorizerName)
 }
@@ -593,8 +477,8 @@ resource "aws_cognito_user_pool" "acctest" {
 resource "aws_api_gateway_authorizer" "acctest" {
   name          = "%s-cognito"
   type          = "COGNITO_USER_POOLS"
-  rest_api_id   = "${aws_api_gateway_rest_api.acctest.id}"
-  provider_arns = ["${aws_cognito_user_pool.acctest.*.arn[0]}", "${aws_cognito_user_pool.acctest.*.arn[1]}"]
+  rest_api_id   = aws_api_gateway_rest_api.acctest.id
+  provider_arns = aws_cognito_user_pool.acctest[*].arn
 }
 `, apiGatewayName, cognitoName, authorizerName)
 }
@@ -613,8 +497,8 @@ resource "aws_cognito_user_pool" "acctest_update" {
 resource "aws_api_gateway_authorizer" "acctest" {
   name          = "%s-cognito-update"
   type          = "COGNITO_USER_POOLS"
-  rest_api_id   = "${aws_api_gateway_rest_api.acctest.id}"
-  provider_arns = ["${aws_cognito_user_pool.acctest_update.*.arn[0]}", "${aws_cognito_user_pool.acctest_update.*.arn[1]}", "${aws_cognito_user_pool.acctest_update.*.arn[2]}"]
+  rest_api_id   = aws_api_gateway_rest_api.acctest.id
+  provider_arns = aws_cognito_user_pool.acctest_update[*].arn
 }
 `, apiGatewayName, cognitoName, authorizerName)
 }
@@ -622,9 +506,9 @@ resource "aws_api_gateway_authorizer" "acctest" {
 func testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationDefaultToken(apiGatewayName, authorizerName, lambdaName string) string {
 	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
 resource "aws_api_gateway_authorizer" "acctest" {
-  name = "%s"
-  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
-  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+  name                   = "%s"
+  rest_api_id            = aws_api_gateway_rest_api.acctest.id
+  authorizer_credentials = aws_iam_role.invocation_role.arn
 }
 `, authorizerName)
 }
@@ -632,10 +516,10 @@ resource "aws_api_gateway_authorizer" "acctest" {
 func testAccAWSAPIGatewayAuthorizerConfig_authTypeValidationRequest(apiGatewayName, authorizerName, lambdaName string) string {
 	return testAccAWSAPIGatewayAuthorizerConfig_baseLambda(apiGatewayName, lambdaName) + fmt.Sprintf(`
 resource "aws_api_gateway_authorizer" "acctest" {
-	name = "%s"
-	type = "REQUEST"
-  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
-  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+  name                   = "%s"
+  type                   = "REQUEST"
+  rest_api_id            = aws_api_gateway_rest_api.acctest.id
+  authorizer_credentials = aws_iam_role.invocation_role.arn
 }
 `, authorizerName)
 }
@@ -654,7 +538,7 @@ resource "aws_cognito_user_pool" "acctest" {
 resource "aws_api_gateway_authorizer" "acctest" {
   name        = "%s-cognito"
   type        = "COGNITO_USER_POOLS"
-  rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
+  rest_api_id = aws_api_gateway_rest_api.acctest.id
 }
 `, apiGatewayName, cognitoName, authorizerName)
 }

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -482,7 +482,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt), // FLAG
+				Config: testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -132,7 +132,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "true"),
 					resource.TestCheckResourceAttr(resourceName, "is_organization_trail", "false"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -147,7 +147,7 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", "prefix"),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "false"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 		},
@@ -207,7 +207,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 					// Test that "enable_logging" default works.
 					testAccCheckCloudTrailLoggingEnabled(resourceName, true),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -221,7 +221,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					testAccCheckCloudTrailLoggingEnabled(resourceName, false),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -230,7 +230,7 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					testAccCheckCloudTrailLoggingEnabled(resourceName, true),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 		},
@@ -253,7 +253,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "false"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -262,7 +262,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "true"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -276,7 +276,7 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_multi_region_trail", "false"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 		},
@@ -299,7 +299,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_organization_trail", "true"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -313,7 +313,7 @@ func testAccAWSCloudTrail_is_organization(t *testing.T) {
 					testAccCheckCloudTrailExists(resourceName, &trail),
 					resource.TestCheckResourceAttr(resourceName, "is_organization_trail", "false"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 		},
@@ -337,7 +337,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "true"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, true, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -352,7 +352,7 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "true"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 		},
@@ -362,8 +362,9 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
-	keyRegex := regexp.MustCompile(`^arn:aws:([a-zA-Z0-9\-])+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:(.*)$`)
+
 	resourceName := "aws_cloudtrail.foobar"
+	kmsResourceName := "aws_kms_key.foo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -377,7 +378,7 @@ func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "s3_key_prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "include_global_service_events", "true"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					resource.TestMatchResourceAttr(resourceName, "kms_key_id", keyRegex),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsResourceName, "arn"),
 				),
 			},
 			{
@@ -410,7 +411,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Foo", "moo"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Pooh", "hi"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -428,7 +429,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Moo", "boom"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Pooh", "hi"),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 			{
@@ -438,7 +439,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					testAccCheckCloudTrailLoadTags(&trail, &trailTagsModified),
 					testAccCheckCloudTrailLogValidationEnabled(resourceName, false, &trail),
-					testAccCheckCloudTrailKmsKeyIdEquals(resourceName, "", &trail),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
 		},
@@ -481,7 +482,7 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt),
+				Config: testAccAWSCloudTrailConfig_eventSelector(cloudTrailRandInt), // FLAG
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "event_selector.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_selector.0.data_resource.#", "1"),
@@ -598,43 +599,6 @@ func testAccCheckCloudTrailLogValidationEnabled(n string, desired bool, trail *c
 		desiredInString := fmt.Sprintf("%t", desired)
 		if enabled != desiredInString {
 			return fmt.Errorf("Expected log validation status %s, saved %s", desiredInString, enabled)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckCloudTrailKmsKeyIdEquals(n string, desired string, trail *cloudtrail.Trail) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if desired != "" && trail.KmsKeyId == nil {
-			return fmt.Errorf("No KmsKeyId attribute present in trail: %s, expected %s",
-				trail, desired)
-		}
-
-		// work around string pointer
-		var kmsKeyIdInString string
-		if trail.KmsKeyId == nil {
-			kmsKeyIdInString = ""
-		} else {
-			kmsKeyIdInString = *trail.KmsKeyId
-		}
-
-		if kmsKeyIdInString != desired {
-			return fmt.Errorf("Expected KMS Key ID %q to equal %q",
-				*trail.KmsKeyId, desired)
-		}
-
-		kmsKeyId, ok := rs.Primary.Attributes["kms_key_id"]
-		if desired != "" && !ok {
-			return fmt.Errorf("No kms_key_id attribute defined for %s", n)
-		}
-		if kmsKeyId != desired {
-			return fmt.Errorf("Expected KMS Key ID %q, saved %q", desired, kmsKeyId)
 		}
 
 		return nil

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -75,7 +74,7 @@ func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.account_ids.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "account_aggregation_source.0.account_ids.0", regexp.MustCompile(`^\d{12}$`)),
+					testAccCheckResourceAttrAccountID(resourceName, "account_aggregation_source.0.account_ids.0"),
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.regions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.regions.0", "us-west-2"),
 				),

--- a/aws/resource_aws_config_configuration_recorder_test.go
+++ b/aws/resource_aws_config_configuration_recorder_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -151,22 +150,6 @@ func testAccCheckConfigConfigurationRecorderName(n string, desired string, obj *
 		if *obj.Name != desired {
 			return fmt.Errorf("Expected configuration recorder %q name to be %q, given: %q",
 				n, desired, *obj.Name)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckConfigConfigurationRecorderRoleArn(n string, desired *regexp.Regexp, obj *configservice.ConfigurationRecorder) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if !desired.MatchString(*obj.RoleARN) {
-			return fmt.Errorf("Expected configuration recorder %q role ARN to match %q, given: %q",
-				n, desired.String(), *obj.RoleARN)
 		}
 
 		return nil

--- a/aws/resource_aws_config_configuration_recorder_test.go
+++ b/aws/resource_aws_config_configuration_recorder_test.go
@@ -69,6 +69,8 @@ func testAccConfigConfigurationRecorder_basic(t *testing.T) {
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
 	expectedRoleName := fmt.Sprintf("tf-acc-test-awsconfig-%d", rInt)
 
+	resourceName := "aws_config_configuration_recorder.foo"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -77,11 +79,10 @@ func testAccConfigConfigurationRecorder_basic(t *testing.T) {
 			{
 				Config: testAccConfigConfigurationRecorderConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckConfigConfigurationRecorderExists("aws_config_configuration_recorder.foo", &cr),
-					testAccCheckConfigConfigurationRecorderName("aws_config_configuration_recorder.foo", expectedName, &cr),
-					testAccCheckConfigConfigurationRecorderRoleArn("aws_config_configuration_recorder.foo",
-						regexp.MustCompile(`arn:aws:iam::[0-9]{12}:role/`+expectedRoleName), &cr),
-					resource.TestCheckResourceAttr("aws_config_configuration_recorder.foo", "name", expectedName),
+					testAccCheckConfigConfigurationRecorderExists(resourceName, &cr),
+					testAccCheckConfigConfigurationRecorderName(resourceName, expectedName, &cr),
+					testAccCheckResourceAttrGlobalARN(resourceName, "role_arn", "iam", fmt.Sprintf("role/%s", expectedRoleName)),
+					resource.TestCheckResourceAttr(resourceName, "name", expectedName),
 				),
 			},
 		},
@@ -94,6 +95,8 @@ func testAccConfigConfigurationRecorder_allParams(t *testing.T) {
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
 	expectedRoleName := fmt.Sprintf("tf-acc-test-awsconfig-%d", rInt)
 
+	resourceName := "aws_config_configuration_recorder.foo"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -102,15 +105,14 @@ func testAccConfigConfigurationRecorder_allParams(t *testing.T) {
 			{
 				Config: testAccConfigConfigurationRecorderConfig_allParams(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckConfigConfigurationRecorderExists("aws_config_configuration_recorder.foo", &cr),
-					testAccCheckConfigConfigurationRecorderName("aws_config_configuration_recorder.foo", expectedName, &cr),
-					testAccCheckConfigConfigurationRecorderRoleArn("aws_config_configuration_recorder.foo",
-						regexp.MustCompile(`arn:aws:iam::[0-9]{12}:role/`+expectedRoleName), &cr),
-					resource.TestCheckResourceAttr("aws_config_configuration_recorder.foo", "name", expectedName),
-					resource.TestCheckResourceAttr("aws_config_configuration_recorder.foo", "recording_group.#", "1"),
-					resource.TestCheckResourceAttr("aws_config_configuration_recorder.foo", "recording_group.0.all_supported", "false"),
-					resource.TestCheckResourceAttr("aws_config_configuration_recorder.foo", "recording_group.0.include_global_resource_types", "false"),
-					resource.TestCheckResourceAttr("aws_config_configuration_recorder.foo", "recording_group.0.resource_types.#", "2"),
+					testAccCheckConfigConfigurationRecorderExists(resourceName, &cr),
+					testAccCheckConfigConfigurationRecorderName(resourceName, expectedName, &cr),
+					testAccCheckResourceAttrGlobalARN(resourceName, "role_arn", "iam", fmt.Sprintf("role/%s", expectedRoleName)),
+					resource.TestCheckResourceAttr(resourceName, "name", expectedName),
+					resource.TestCheckResourceAttr(resourceName, "recording_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "recording_group.0.all_supported", "false"),
+					resource.TestCheckResourceAttr(resourceName, "recording_group.0.include_global_resource_types", "false"),
+					resource.TestCheckResourceAttr(resourceName, "recording_group.0.resource_types.#", "2"),
 				),
 			},
 		},

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -128,9 +128,10 @@ func TestAccAWSRedshiftCluster_withFinalSnapshot(t *testing.T) {
 func TestAccAWSRedshiftCluster_kmsKey(t *testing.T) {
 	var v redshift.Cluster
 
+	resourceName := "aws_redshift_cluster.default"
+	kmsResourceName := "aws_kms_key.foo"
+
 	ri := acctest.RandInt()
-	config := testAccAWSRedshiftClusterConfig_kmsKey(ri)
-	keyRegex := regexp.MustCompile(`^arn:aws:([a-zA-Z0-9\-])+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:(.*)$`)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -138,14 +139,12 @@ func TestAccAWSRedshiftCluster_kmsKey(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccAWSRedshiftClusterConfig_kmsKey(ri),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "cluster_type", "single-node"),
-					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "publicly_accessible", "true"),
-					resource.TestMatchResourceAttr("aws_redshift_cluster.default", "kms_key_id", keyRegex),
+					testAccCheckAWSRedshiftClusterExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "single-node"),
+					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsResourceName, "arn"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

### Description

These ARN checks are not caught by AWSAT001


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #11888
Relates #13363

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAPIGatewayAuthorizer_authTypeValidation (88.28s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (208.81s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_cognito (27.43s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_disappears (117.96s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthType (57.20s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthorizerTTL (136.58s)
```

```
--- PASS: TestAccAWSBillingServiceAccount_basic (13.31s)
```

```
--- PASS: TestAccAWSCloudTrail (261.78s)
    --- PASS: TestAccAWSCloudTrail/Trail (261.78s)
        --- PASS: TestAccAWSCloudTrail/Trail/basic (33.52s)
        --- PASS: TestAccAWSCloudTrail/Trail/cloudwatch (48.59s)
        --- PASS: TestAccAWSCloudTrail/Trail/isMultiRegion (27.97s)
        --- SKIP: TestAccAWSCloudTrail/Trail/isOrganization (1.08s)
        --- PASS: TestAccAWSCloudTrail/Trail/tags (29.49s)
        --- PASS: TestAccAWSCloudTrail/Trail/eventSelector (43.62s)
        --- PASS: TestAccAWSCloudTrail/Trail/enableLogging (28.73s)
        --- PASS: TestAccAWSCloudTrail/Trail/includeGlobalServiceEvents (13.68s)
        --- PASS: TestAccAWSCloudTrail/Trail/logValidation (21.63s)
        --- PASS: TestAccAWSCloudTrail/Trail/kmsKey (13.47s)
```

```
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (13.90s)
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (13.28s)
```

```
--- PASS: TestAccAWSCodeBuildProject_ARMContainer (105.90s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_ArtifactIdentifier (46.50s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (35.13s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Location (54.85s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Name (112.07s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_NamespaceType (106.27s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_OverrideArtifactName (47.07s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Packaging (34.89s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Path (49.00s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_Type (43.24s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (20.64s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (50.83s)
--- PASS: TestAccAWSCodeBuildProject_Cache (196.62s)
--- PASS: TestAccAWSCodeBuildProject_Description (41.28s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (28.13s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (24.95s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (97.49s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (57.69s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Value (232.24s)
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (62.55s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs (52.39s)
--- PASS: TestAccAWSCodeBuildProject_LogsConfig_S3Logs (102.76s)
--- PASS: TestAccAWSCodeBuildProject_QueuedTimeout (39.09s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (25.74s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_ArtifactIdentifier (64.27s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_EncryptionDisabled (53.38s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Location (64.29s)
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts_Name (0.00s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_NamespaceType (75.21s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_OverrideArtifactName (43.53s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Packaging (70.98s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Path (65.00s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts_Type (33.79s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (31.16s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_CodeCommit (137.53s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHub (65.41s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_GitSubmodulesConfig_GitHubEnterprise (68.08s)
--- PASS: TestAccAWSCodeBuildProject_SourceVersion (27.48s)
--- FAIL: TestAccAWSCodeBuildProject_Source_Auth (7.70s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (247.28s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_CodeCommit (56.97s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHub (178.50s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitSubmodulesConfig_GitHubEnterprise (70.03s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (35.01s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (57.03s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (51.30s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (158.00s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (38.96s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (28.67s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (34.12s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (22.11s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (28.28s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (16.20s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (29.61s)
--- PASS: TestAccAWSCodeBuildProject_Tags (58.99s)
--- FAIL: TestAccAWSCodeBuildProject_VpcConfig (338.72s)
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (47.51s)
--- PASS: TestAccAWSCodeBuildProject_basic (29.69s)
```

```
--- PASS: TestAccAWSConfigConfigurationAggregator_account (9.29s)
--- SKIP: TestAccAWSConfigConfigurationAggregator_organization (1.09s)
--- SKIP: TestAccAWSConfigConfigurationAggregator_switch (1.07s)
--- PASS: TestAccAWSConfigConfigurationAggregator_tags (21.97s)
```

```
--- PASS: TestAccAWSElbServiceAccount_Region (13.76s)
--- PASS: TestAccAWSElbServiceAccount_basic (11.48s)
```

```
--- PASS: TestAccAWSProvider_AssumeRole_Empty (12.78s)
--- PASS: TestAccAWSProvider_Endpoints (10.44s)
--- PASS: TestAccAWSProvider_Endpoints_Deprecated (9.07s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (7.28s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (8.79s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (8.20s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (8.79s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (8.76s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (9.04s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (9.00s)
--- PASS: TestAccAWSProvider_Region_AwsChina (8.70s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (8.54s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (7.87s)
```

```
--- PASS: TestAccAWSRedshiftCluster_basic (359.41s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (724.91s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption1 (2191.54s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (2251.25s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (704.52s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (973.00s)
--- PASS: TestAccAWSRedshiftCluster_iamRoles (565.01s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (370.08s)
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (449.98s)
--- FAIL: TestAccAWSRedshiftCluster_publiclyAccessible (447.10s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (449.08s)
--- PASS: TestAccAWSRedshiftCluster_tags (494.93s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (2373.92s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (1981.95s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (733.64s)
```

```
--- PASS: TestAccAWSRedshiftServiceAccount_Region (11.91s)
--- PASS: TestAccAWSRedshiftServiceAccount_basic (12.91s)
```

```
--- PASS: TestAccDataSourceAWSS3BucketObject_LeadingSlash (25.48s)
--- PASS: TestAccDataSourceAWSS3BucketObject_MultipleSlashes (21.89s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff (18.01s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn (18.76s)
--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (17.99s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basic (17.55s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint (20.63s)
--- PASS: TestAccDataSourceAWSS3BucketObject_kmsEncrypted (18.29s)
--- PASS: TestAccDataSourceAWSS3BucketObject_readableBody (18.45s)
```

```
--- PASS: TestAccDataSourceAwsRoute53Zone_id (52.52s)
--- PASS: TestAccDataSourceAwsRoute53Zone_name (52.64s)
--- PASS: TestAccDataSourceAwsRoute53Zone_serviceDiscovery (116.99s)
--- PASS: TestAccDataSourceAwsRoute53Zone_tags (86.41s)
--- PASS: TestAccDataSourceAwsRoute53Zone_vpc (84.80s)
```
