### PR TITLE
r/aws_launch_template: metadata_options issues

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -369,7 +369,6 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 			"metadata_options": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -891,6 +891,13 @@ func TestAccAWSLaunchTemplate_metadataOptions(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAWSLaunchTemplateConfig_metadataOptions_remove(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "0"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1643,6 +1650,14 @@ resource "aws_launch_template" "test" {
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
   }
+}
+`, rName)
+}
+
+func testAccAWSLaunchTemplateConfig_metadataOptions_remove(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

---

The `metadata_options` is riddled with bugs. I started this PR to attempt to fix the specific case where you can't get rid of the metadata options by removing the block, i.e.:

1. Initial config: 
   ```hcl
   resource "aws_launch_template" "foo" {
     name = "foo"
     metadata_options {
       http_endpoint = "enabled"
       http_tokens = "required"
     }
   }
   ```
1. Apply.
1. Update config to:
   ```hcl
   resource "aws_launch_template" "foo" {
     name = "foo"
   }
   ```
1. Try to apply, but there are no changes.

So this PR will fix that specific scenario, but this thing is so broken in so many other ways. Here are a couple of scenarios:

1. Initial config: 
   ```hcl
   resource "aws_launch_template" "foo" {
     name = "foo"
     metadata_options {
       http_endpoint = "enabled"
       http_tokens = "required"
     }
   }
   ```
1. Apply.
1. Update config to:
   ```hcl
   resource "aws_launch_template" "foo" {
     name = "foo"
     metadata_options {
       http_endpoint = "enabled"
     }
   }
   ```
1. Try to apply, but there are no changes. `http_tokens` should be unset.

The same problems exist with `aws_instance`. But it's even worse there since you can't unset the values like a launch template, they really need to be set back to the default. But since the notion of `Default` values were rejected in my original PR (https://github.com/terraform-providers/terraform-provider-aws/pull/11076), I can't imagine any sane way of fixing it without bringing that back.

1. Initial config: 
   ```hcl
   resource "aws_instance" "foo" {
     instance_type="t2.small"
     ami="ami-0e0e5738da01fdef5"
     metadata_options {
       http_endpoint = "enabled"
       http_tokens = "required"
     }
   }
   ```
1. Apply.
1. Update config to:
   ```hcl
   resource "aws_instance" "foo" {
     instance_type="t2.small"
     ami="ami-0e0e5738da01fdef5"
     metadata_options {
       http_endpoint = "enabled"
     }
   }
   ```
1. Try to apply, but there are no changes. `http_tokens` should be set to `"optional"`, as if it was never specified in the first place.

I don't agree with [this comment](https://github.com/terraform-providers/terraform-provider-aws/issues/12564#issuecomment-605435622) by ewbankkit that says `The new metadata_options attribute is defined as Computed: true for backwards compatibility reasons`. If the `metadata_options` block isn't specified, then the `MetadataOptions` simply won't be set and the API call won't contain it.

This PR will fix one tiny bug, but honestly, this thing needs an overhaul. It's so broken. In my opinion, the `aws_instance` resource cannot be fixed unless we make it aware of the defaults. It is like no one fully tested the end result.


---

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
# after the first commit:
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_metadataOptions -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_metadataOptions
=== PAUSE TestAccAWSLaunchTemplate_metadataOptions
=== CONT  TestAccAWSLaunchTemplate_metadataOptions
    TestAccAWSLaunchTemplate_metadataOptions: testing.go:684: Step 1 error: Check failed: Check 2/2 error: aws_launch_template.test: Attribute 'metadata_options.#' expected "0", got "1"
--- FAIL: TestAccAWSLaunchTemplate_metadataOptions (27.76s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	29.446s
FAIL
make: *** [testacc] Error 1

# after the second commit:
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_metadataOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplate_metadataOptions -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_metadataOptions
=== PAUSE TestAccAWSLaunchTemplate_metadataOptions
=== CONT  TestAccAWSLaunchTemplate_metadataOptions
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (41.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	43.367s
```
