### PR TITLE
resource/aws_autoscaling_group: Ignore ordering differences for `tags` argument

### DIFF
--- a/aws/autoscaling_tags.go
+++ b/aws/autoscaling_tags.go
@@ -80,12 +80,12 @@ func setAutoscalingTags(conn *autoscaling.AutoScaling, d *schema.ResourceData) e
 		removeTags = append(removeTags, r...)
 
 		oraw, nraw = d.GetChange("tags")
-		old, err = autoscalingTagsFromList(oraw.([]interface{}), resourceID)
+		old, err = autoscalingTagsFromList(oraw.(*schema.Set).List(), resourceID)
 		if err != nil {
 			return err
 		}
 
-		new, err = autoscalingTagsFromList(nraw.([]interface{}), resourceID)
+		new, err = autoscalingTagsFromList(nraw.(*schema.Set).List(), resourceID)
 		if err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func autoscalingTagsFromList(vs []interface{}, resourceID string) ([]*autoscalin
 	result := make([]*autoscaling.Tag, 0, len(vs))
 	for _, tag := range vs {
 		attr, ok := tag.(map[string]interface{})
-		if !ok {
+		if !ok || len(attr) == 0 {
 			continue
 		}
 

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -396,7 +396,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			"tag": autoscalingTagSchema(),
 
 			"tags": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeMap,
@@ -548,7 +548,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
-		tags, err := autoscalingTagsFromList(v.([]interface{}), resourceID)
+		tags, err := autoscalingTagsFromList(v.(*schema.Set).List(), resourceID)
 		if err != nil {
 			return err
 		}
@@ -734,7 +734,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 
 	if v, tagsOk = d.GetOk("tags"); tagsOk {
 		tags := map[string]struct{}{}
-		for _, tag := range v.([]interface{}) {
+		for _, tag := range v.(*schema.Set).List() {
 			attr, ok := tag.(map[string]interface{})
 			if !ok {
 				continue

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -2276,13 +2276,13 @@ resource "aws_autoscaling_group" "bar" {
       propagate_at_launch = true
     },
     {
-      key                 = "FromTags2"
-      value               = "value2"
+      key                 = "FromTags3"
+      value               = "value3"
       propagate_at_launch = true
     },
     {
-      key                 = "FromTags3"
-      value               = "value3"
+      key                 = "FromTags2"
+      value               = "value2"
       propagate_at_launch = true
     },
   ]

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -197,8 +197,8 @@ The following arguments are supported:
 * `termination_policies` (Optional) A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `OldestLaunchTemplate`, `AllocationStrategy`, `Default`.
 * `suspended_processes` - (Optional) A list of processes to suspend for the AutoScaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`.
 Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your autoscaling group from functioning properly.
-* `tag` (Optional) A list of tag blocks. Tags documented below.
-* `tags` (Optional) A list of tag blocks (maps). Tags documented below.
+* `tag` (Optional) Configuration block(s) containing resource tags. Conflicts with `tags`. Documented below.
+* `tags` (Optional) Set of maps containing resource tags. Conflicts with `tag`. Documented below.
 * `placement_group` (Optional) The name of the placement group into which you'll launch your instances, if any.
 * `metrics_granularity` - (Optional) The granularity to associate with the metrics to collect. The only valid value is `1Minute`. Default is `1Minute`.
 * `enabled_metrics` - (Optional) A list of metrics to collect. The allowed values are `GroupDesiredCapacity`, `GroupInServiceCapacity`, `GroupPendingCapacity`, `GroupMinSize`, `GroupMaxSize`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupStandbyCapacity`, `GroupTerminatingCapacity`, `GroupTerminatingInstances`, `GroupTotalCapacity`, `GroupTotalInstances`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13469

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_autoscaling_group: Ignore ordering differences for `tags` argument
```

Now that we are properly setting this attribute into the Terraform state, it highlighted ordering issues, which was not previously caught by the acceptance testing for the resource.

Previously (after test configuration adjustment):

```
--- FAIL: TestAccAWSAutoScalingGroup_basic (147.82s)
    TestAccAWSAutoScalingGroup_basic: testing.go:684: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_autoscaling_group.bar
...
          tags.#:                     "3" => "3"
          tags.0.key:                 "FromTags1" => "FromTags1"
          tags.0.propagate_at_launch: "true" => "true"
          tags.0.value:               "value1" => "value1"
          tags.1.key:                 "FromTags2" => "FromTags3"
          tags.1.propagate_at_launch: "true" => "true"
          tags.1.value:               "value2" => "value3"
          tags.2.key:                 "FromTags3" => "FromTags2"
          tags.2.propagate_at_launch: "true" => "true"
          tags.2.value:               "value3" => "value2"
...
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (187.12s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (342.93s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (79.14s)
--- PASS: TestAccAWSAutoScalingGroup_basic (267.48s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (78.67s)
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (91.64s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (207.54s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (304.85s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (87.94s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (99.20s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (175.02s)
--- PASS: TestAccAWSAutoScalingGroup_launchTempPartitionNum (90.52s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (569.76s)
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (87.50s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (83.65s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (56.61s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (160.95s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (83.85s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (116.76s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (112.29s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (160.14s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (88.11s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (116.78s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (123.93s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (168.12s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (78.08s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (53.32s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (242.59s)
--- PASS: TestAccAWSAutoScalingGroup_tags (287.70s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (316.34s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (154.29s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (175.10s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (423.35s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (428.41s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (114.18s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (175.16s)
```
