### PR TITLE
Add support for Step Functions IoT action

### DIFF
--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -439,6 +439,30 @@ func TestAccAWSIoTTopicRule_sqs(t *testing.T) {
 	})
 }
 
+func TestAccAWSIoTTopicRule_step_functions(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_iot_topic_rule.rule"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTTopicRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTTopicRule_step_functions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTTopicRuleExists("aws_iot_topic_rule.rule"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSIoTTopicRule_iot_analytics(t *testing.T) {
 	rName := acctest.RandString(5)
 
@@ -900,6 +924,24 @@ resource "aws_iot_topic_rule" "rule" {
     queue_url = "fakedata"
     role_arn  = "${aws_iam_role.iot_role.arn}"
     use_base64 = false
+  }
+}
+`, rName)
+}
+
+func testAccAWSIoTTopicRule_step_functions(rName string) string {
+	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
+resource "aws_iot_topic_rule" "rule" {
+  name        = "test_rule_%[1]s"
+  description = "Example rule"
+  enabled     = true
+  sql         = "SELECT * FROM 'topic/test'"
+  sql_version = "2015-10-08"
+
+  step_functions {
+    execution_name_prefix = "myprefix"
+    state_machine_name = "mystatemachine"
+    role_arn = "${aws_iam_role.iot_role.arn}"
   }
 }
 `, rName)

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -163,7 +163,7 @@ The `sqs` object takes the following arguments:
 
 The `step_functions` object takes the following arguments:
 
-* `execution_name_prefix` - (Optional) The prefix used to generate, along with a UUID, the unique state machine name.
+* `execution_name_prefix` - (Optional) The prefix used to generate, along with a UUID, the unique state machine execution name.
 * `state_machine_name` - (Required) The name of the Step Functions state machine whose execution will be started.
 * `role_arn` - (Required) The ARN of the IAM role that grants access to start execution of the state machine.
 

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -161,6 +161,12 @@ The `sqs` object takes the following arguments:
 * `role_arn` - (Required) The ARN of the IAM role that grants access.
 * `use_base64` - (Required) Specifies whether to use Base64 encoding.
 
+The `step_functions` object takes the following arguments:
+
+* `execution_name_prefix` - (Optional) The prefix used to generate, along with a UUID, the unique state machine name.
+* `state_machine_name` - (Required) The name of the Step Functions state machine whose execution will be started.
+* `role_arn` - (Required) The ARN of the IAM role that grants access to start execution of the state machine.
+
 The `iot_analytics` object takes the following arguments:
 
 * `channel_name` - (Required) Name of AWS IOT Analytics channel.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for Step Functions to aws_iot_topic_rule
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIoTTopicRule_step_functions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSIoTTopicRule_step_functions -timeout 120m
=== RUN   TestAccAWSIoTTopicRule_step_functions
=== PAUSE TestAccAWSIoTTopicRule_step_functions
=== CONT  TestAccAWSIoTTopicRule_step_functions
--- PASS: TestAccAWSIoTTopicRule_step_functions (27.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.120s

...
```
