### PR TITLE
resource/aws_dynamodb_table: Perform individual replica creations/deletions

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -428,6 +428,7 @@ func testAccAlternateAccountPreCheck(t *testing.T) {
 	}
 }
 
+// Deprecated: Use testAccMultipleRegionPreCheck instead
 func testAccAlternateRegionPreCheck(t *testing.T) {
 	if testAccGetRegion() == testAccGetAlternateRegion() {
 		t.Fatal("AWS_DEFAULT_REGION and AWS_ALTERNATE_REGION must be set to different values for acceptance tests")
@@ -435,18 +436,6 @@ func testAccAlternateRegionPreCheck(t *testing.T) {
 
 	if testAccGetPartition() != testAccGetAlternateRegionPartition() {
 		t.Fatalf("AWS_ALTERNATE_REGION partition (%s) does not match AWS_DEFAULT_REGION partition (%s)", testAccGetAlternateRegionPartition(), testAccGetPartition())
-	}
-}
-
-func testAccThirdRegionPreCheck(t *testing.T) {
-	testAccAlternateRegionPreCheck(t)
-
-	if testAccGetRegion() == testAccGetThirdRegion() {
-		t.Fatal("AWS_DEFAULT_REGION and AWS_THIRD_REGION must be set to different values for acceptance tests")
-	}
-
-	if testAccGetPartition() != testAccGetThirdRegionPartition() {
-		t.Fatalf("AWS_THIRD_REGION partition (%s) does not match AWS_DEFAULT_REGION partition (%s)", testAccGetThirdRegionPartition(), testAccGetPartition())
 	}
 }
 
@@ -478,19 +467,32 @@ func testAccPartitionHasServicePreCheck(serviceId string, t *testing.T) {
 	}
 }
 
-func testAccMultipleRegionPreCheck(t *testing.T, expected int) {
-	switch expected {
-	case 2:
-		testAccAlternateRegionPreCheck(t)
-	case 3:
-		testAccThirdRegionPreCheck(t)
-	default:
-		t.Fatalf("unknown expected region: %d", expected)
+func testAccMultipleRegionPreCheck(t *testing.T, regions int) {
+	if testAccGetRegion() == testAccGetAlternateRegion() {
+		t.Fatal("AWS_DEFAULT_REGION and AWS_ALTERNATE_REGION must be set to different values for acceptance tests")
+	}
+
+	if testAccGetPartition() != testAccGetAlternateRegionPartition() {
+		t.Fatalf("AWS_ALTERNATE_REGION partition (%s) does not match AWS_DEFAULT_REGION partition (%s)", testAccGetAlternateRegionPartition(), testAccGetPartition())
+	}
+
+	if regions >= 3 {
+		if testAccGetRegion() == testAccGetThirdRegion() {
+			t.Fatal("AWS_DEFAULT_REGION and AWS_THIRD_REGION must be set to different values for acceptance tests")
+		}
+
+		if testAccGetAlternateRegion() == testAccGetThirdRegion() {
+			t.Fatal("AWS_ALTERNATE_REGION and AWS_THIRD_REGION must be set to different values for acceptance tests")
+		}
+
+		if testAccGetPartition() != testAccGetThirdRegionPartition() {
+			t.Fatalf("AWS_THIRD_REGION partition (%s) does not match AWS_DEFAULT_REGION partition (%s)", testAccGetThirdRegionPartition(), testAccGetPartition())
+		}
 	}
 
 	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), testAccGetRegion()); ok {
-		if len(partition.Regions()) < expected {
-			t.Skipf("skipping tests; partition includes %d regions, %d expected", len(partition.Regions()), expected)
+		if len(partition.Regions()) < regions {
+			t.Skipf("skipping tests; partition includes %d regions, %d expected", len(partition.Regions()), regions)
 		}
 	}
 }

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -760,9 +760,6 @@ func deleteAwsDynamoDbTable(tableName string, conn *dynamodb.DynamoDB) error {
 }
 
 func deleteDynamoDbReplicas(tableName string, tfList []interface{}, timeout time.Duration, conn *dynamodb.DynamoDB) error {
-	var ops []*dynamodb.ReplicationGroupUpdate
-	var regionNames []string
-
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]interface{})
 
@@ -780,47 +777,43 @@ func deleteDynamoDbReplicas(tableName string, tfList []interface{}, timeout time
 			continue
 		}
 
-		ops = append(ops, &dynamodb.ReplicationGroupUpdate{
-			Delete: &dynamodb.DeleteReplicationGroupMemberAction{
-				RegionName: aws.String(regionName),
+		input := &dynamodb.UpdateTableInput{
+			TableName: aws.String(tableName),
+			ReplicaUpdates: []*dynamodb.ReplicationGroupUpdate{
+				{
+					Delete: &dynamodb.DeleteReplicationGroupMemberAction{
+						RegionName: aws.String(regionName),
+					},
+				},
 			},
-		})
-		regionNames = append(regionNames, regionName)
-	}
-
-	if len(ops) == 0 {
-		return nil
-	}
-
-	input := &dynamodb.UpdateTableInput{
-		TableName:      aws.String(tableName),
-		ReplicaUpdates: ops,
-	}
-
-	err := resource.Retry(20*time.Minute, func() *resource.RetryError {
-		_, err := conn.UpdateTable(input)
-		if err != nil {
-			if isAWSErr(err, "ThrottlingException", "") {
-				return resource.RetryableError(err)
-			}
-			if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "can be created, updated, or deleted simultaneously") {
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
 		}
-		return nil
-	})
 
-	if isResourceTimeoutError(err) {
-		_, err = conn.UpdateTable(input)
-	}
+		err := resource.Retry(20*time.Minute, func() *resource.RetryError {
+			_, err := conn.UpdateTable(input)
+			if err != nil {
+				if isAWSErr(err, "ThrottlingException", "") {
+					return resource.RetryableError(err)
+				}
+				if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "can be created, updated, or deleted simultaneously") {
+					return resource.RetryableError(err)
+				}
+				if isAWSErr(err, dynamodb.ErrCodeResourceInUseException, "") {
+					return resource.RetryableError(err)
+				}
 
-	if err != nil {
-		return fmt.Errorf("error deleting DynamoDB Table (%s) replicas: %s", tableName, err)
-	}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
 
-	for _, regionName := range regionNames {
+		if isResourceTimeoutError(err) {
+			_, err = conn.UpdateTable(input)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error deleting DynamoDB Table (%s) replica (%s): %s", tableName, regionName, err)
+		}
+
 		if err := waitForDynamoDbReplicaDeleteToBeCompleted(tableName, regionName, timeout, conn); err != nil {
 			return fmt.Errorf("error waiting for DynamoDB Table (%s) replica (%s) deletion: %s", tableName, regionName, err)
 		}
@@ -947,9 +940,6 @@ func waitForDynamoDbReplicaDeleteToBeCompleted(tableName string, region string, 
 }
 
 func createDynamoDbReplicas(tableName string, tfList []interface{}, timeout time.Duration, conn *dynamodb.DynamoDB) error {
-	var ops []*dynamodb.ReplicationGroupUpdate
-	var regionNames []string
-
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]interface{})
 
@@ -967,47 +957,43 @@ func createDynamoDbReplicas(tableName string, tfList []interface{}, timeout time
 			continue
 		}
 
-		ops = append(ops, &dynamodb.ReplicationGroupUpdate{
-			Create: &dynamodb.CreateReplicationGroupMemberAction{
-				RegionName: aws.String(regionName),
+		input := &dynamodb.UpdateTableInput{
+			TableName: aws.String(tableName),
+			ReplicaUpdates: []*dynamodb.ReplicationGroupUpdate{
+				{
+					Create: &dynamodb.CreateReplicationGroupMemberAction{
+						RegionName: aws.String(regionName),
+					},
+				},
 			},
-		})
-		regionNames = append(regionNames, regionName)
-	}
-
-	if len(ops) == 0 {
-		return nil
-	}
-
-	input := &dynamodb.UpdateTableInput{
-		TableName:      aws.String(tableName),
-		ReplicaUpdates: ops,
-	}
-
-	err := resource.Retry(20*time.Minute, func() *resource.RetryError {
-		_, err := conn.UpdateTable(input)
-		if err != nil {
-			if isAWSErr(err, "ThrottlingException", "") {
-				return resource.RetryableError(err)
-			}
-			if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "can be created, updated, or deleted simultaneously") {
-				return resource.RetryableError(err)
-			}
-
-			return resource.NonRetryableError(err)
 		}
-		return nil
-	})
 
-	if isResourceTimeoutError(err) {
-		_, err = conn.UpdateTable(input)
-	}
+		err := resource.Retry(20*time.Minute, func() *resource.RetryError {
+			_, err := conn.UpdateTable(input)
+			if err != nil {
+				if isAWSErr(err, "ThrottlingException", "") {
+					return resource.RetryableError(err)
+				}
+				if isAWSErr(err, dynamodb.ErrCodeLimitExceededException, "can be created, updated, or deleted simultaneously") {
+					return resource.RetryableError(err)
+				}
+				if isAWSErr(err, dynamodb.ErrCodeResourceInUseException, "") {
+					return resource.RetryableError(err)
+				}
 
-	if err != nil {
-		return fmt.Errorf("error creating DynamoDB Table (%s) replicas: %s", tableName, err)
-	}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
 
-	for _, regionName := range regionNames {
+		if isResourceTimeoutError(err) {
+			_, err = conn.UpdateTable(input)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error creating DynamoDB Table (%s) replica (%s): %s", tableName, regionName, err)
+		}
+
 		if err := waitForDynamoDbReplicaUpdateToBeCompleted(tableName, regionName, timeout, conn); err != nil {
 			return fmt.Errorf("error waiting for DynamoDB Table (%s) replica (%s) creation: %s", tableName, regionName, err)
 		}

--- a/docs/contributing/running-and-writing-acceptance-tests.md
+++ b/docs/contributing/running-and-writing-acceptance-tests.md
@@ -126,12 +126,13 @@ export AWS_ALTERNATE_SECRET_ACCESS_KEY=...
 
 ### Running Cross-Region Tests
 
-Certain testing requires multiple AWS regions. Additional setup is not typically required because the testing defaults the alternate AWS region to `us-east-1`.
+Certain testing requires multiple AWS regions. Additional setup is not typically required because the testing defaults the second AWS region to `us-east-1` and the third AWS region to `us-east-2`.
 
-Running these acceptance tests is the same as before, but if you wish to override the alternate region:
+Running these acceptance tests is the same as before, but if you wish to override the second and third regions:
 
 ```sh
 export AWS_ALTERNATE_REGION=...
+export AWS_THIRD_REGION=...
 ```
 
 ## Writing an Acceptance Test
@@ -659,12 +660,12 @@ Searching for usage of `testAccAlternateAccountPreCheck` in the codebase will yi
 
 #### Cross-Region Acceptance Tests
 
-When testing requires AWS infrastructure in a second AWS region, the below changes to the normal setup will allow the management or reference of resources and data sources across regions:
+When testing requires AWS infrastructure in a second or third AWS region, the below changes to the normal setup will allow the management or reference of resources and data sources across regions:
 
-- In the `PreCheck` function, include `testAccMultipleRegionsPreCheck(t)` and `testAccAlternateRegionPreCheck(t)` to ensure a standardized set of information is required for cross-region testing configuration. If the infrastructure in the second AWS region is also in a second AWS account also include `testAccAlternateAccountPreCheck(t)`
+- In the `PreCheck` function, include `testAccMultipleRegionPreCheck(t, ###)` to ensure a standardized set of information is required for cross-region testing configuration. If the infrastructure in the second AWS region is also in a second AWS account also include `testAccAlternateAccountPreCheck(t)`
 - Declare a `providers` variable at the top of the test function: `var providers []*schema.Provider`
 - Switch usage of `Providers: testAccProviders` to `ProviderFactories: testAccProviderFactories(&providers)`
-- Add `testAccAlternateRegionProviderConfig()` to the test configuration and use `provider = "aws.alternate"` for cross-region resources. The resource that is the focus of the acceptance test should _not_ use the provider alias to simplify the testing setup. If the infrastructure in the second AWS region is also in a second AWS account use `testAccAlternateAccountAlternateRegionProviderConfig()` instead
+- Add `testAccMultipleRegionProviderConfig(###)` to the test configuration and use `provider = "aws.alternate"` (and/or `provider = "aws.third"`) for cross-region resources. The resource that is the focus of the acceptance test should _not_ use the provider alias to simplify the testing setup. If the infrastructure in the second AWS region is also in a second AWS account use `testAccAlternateAccountAlternateRegionProviderConfig()` instead
 - For any `TestStep` that includes `ImportState: true`, add the `Config` that matches the previous `TestStep` `Config`
 
 An example acceptance test implementation can be seen below:
@@ -677,8 +678,7 @@ func TestAccAwsExample_basic(t *testing.T) {
   resource.ParallelTest(t, resource.TestCase{
     PreCheck: func() {
       testAccPreCheck(t)
-      testAccMultipleRegionsPreCheck(t)
-      testAccAlternateRegionPreCheck(t)
+      testAccMultipleRegionPreCheck(t, 2)
     },
     ProviderFactories: testAccProviderFactories(&providers),
     CheckDestroy:      testAccCheckAwsExampleDestroy,
@@ -701,7 +701,7 @@ func TestAccAwsExample_basic(t *testing.T) {
 }
 
 func testAccAwsExampleConfig() string {
-  return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+  return testAccMultipleRegionProviderConfig(2) + fmt.Sprintf(`
 # Cross region resources should be handled by the cross region provider.
 # The standardized provider alias is aws.alternate as seen below.
 resource "aws_cross_region_example" "test" {
@@ -719,7 +719,7 @@ resource "aws_example" "test" {
 }
 ```
 
-Searching for usage of `testAccAlternateRegionPreCheck` in the codebase will yield real world examples of this setup in action.
+Searching for usage of `testAccMultipleRegionPreCheck` in the codebase will yield real world examples of this setup in action.
 
 ### Data Source Acceptance Testing
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13132

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_dynamodb_table: Prevent multiple replica creation/deletion errors
```

Also includes slight changes to the acceptance testing recommendations for cross-region testing since we now are introducing the framework to test a third region. If approved, will followup this change with refactoring of the existing testing to use the newer functions.

Previously:

```
--- FAIL: TestAccAWSDynamoDbTable_Replica_Multiple (41.02s)
    TestAccAWSDynamoDbTable_Replica_Multiple: testing.go:684: Step 0 error: errors during apply:

        Error: error creating DynamoDB Table (TerraformTestTable--8440396559818741779) replicas: error creating DynamoDB Table (TerraformTestTable--8440396559818741779) replicas: ValidationException: Update table operation with more than one create or delete replica actions not allowed
          status code: 400, request id: 5MA0CQ5LJAVOKM671RT7QTKRTJVV4KQNSO5AEMVJF66Q9ASUAAJG

          on /var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/tf-test945359260/main.tf line 20:
          (source code not available)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDynamoDbTable_attributeUpdate (756.09s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (17.31s)
--- PASS: TestAccAWSDynamoDbTable_basic (82.00s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned (135.99s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_ProvisionedToPayPerRequest (1296.50s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned (134.93s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest (934.09s)
--- PASS: TestAccAWSDynamoDbTable_disappears (59.40s)
--- PASS: TestAccAWSDynamoDbTable_disappears_PayPerRequestWithGSI (140.30s)
--- PASS: TestAccAWSDynamoDbTable_enablePitr (152.34s)
--- PASS: TestAccAWSDynamoDbTable_encryption (249.98s)
--- PASS: TestAccAWSDynamoDbTable_extended (443.38s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (144.47s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (443.69s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (757.61s)
--- PASS: TestAccAWSDynamoDbTable_Replica_Multiple (1193.16s)
--- PASS: TestAccAWSDynamoDbTable_Replica_Single (1077.60s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (148.25s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (12.21s)
--- PASS: TestAccAWSDynamoDbTable_tags (88.24s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_Disabled (116.66s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_Enabled (81.82s)
```

