### PR TITLE
resource/ses_template: update Read method error messaging and acctest

### DIFF
--- a/aws/resource_aws_ses_template.go
+++ b/aws/resource_aws_ses_template.go
@@ -89,12 +89,12 @@ func resourceAwsSesTemplateRead(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Reading SES template: %#v", input)
 	gto, err := conn.GetTemplate(&input)
 	if err != nil {
-		if isAWSErr(err, "TemplateDoesNotExist", "") {
+		if isAWSErr(err, ses.ErrCodeTemplateDoesNotExistException, "") {
 			log.Printf("[WARN] SES template %q not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Reading SES template '%s' failed: %s", *input.TemplateName, err.Error())
+		return fmt.Errorf("Reading SES template '%s' failed: %s", aws.StringValue(input.TemplateName), err.Error())
 	}
 
 	d.Set("html", gto.Template.HtmlPart)

--- a/aws/resource_aws_ses_template_test.go
+++ b/aws/resource_aws_ses_template_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccAWSSesTemplate_Basic(t *testing.T) {
 	resourceName := "aws_ses_template.test"
-	name := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	var template ses.Template
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,10 +25,10 @@ func TestAccAWSSesTemplate_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckSesTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSesTemplateResourceConfigBasic1(name),
+				Config: testAccCheckAwsSesTemplateResourceConfigBasic1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSesTemplate(resourceName, &template),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					testAccCheckSesTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "html", "html"),
 					resource.TestCheckResourceAttr(resourceName, "subject", "subject"),
 					resource.TestCheckResourceAttr(resourceName, "text", ""),
@@ -45,9 +45,9 @@ func TestAccAWSSesTemplate_Basic(t *testing.T) {
 
 func TestAccAWSSesTemplate_Update(t *testing.T) {
 	t.Skipf("Skip due to SES.UpdateTemplate eventual consistency issues")
-	name := acctest.RandString(5)
-	var template ses.Template
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_template.test"
+	var template ses.Template
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
@@ -55,10 +55,10 @@ func TestAccAWSSesTemplate_Update(t *testing.T) {
 		CheckDestroy: testAccCheckSesTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsSesTemplateResourceConfigBasic1(name),
+				Config: testAccCheckAwsSesTemplateResourceConfigBasic1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSesTemplate(resourceName, &template),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					testAccCheckSesTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "html", "html"),
 					resource.TestCheckResourceAttr(resourceName, "subject", "subject"),
 					resource.TestCheckResourceAttr(resourceName, "text", ""),
@@ -70,20 +70,20 @@ func TestAccAWSSesTemplate_Update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckAwsSesTemplateResourceConfigBasic2(name),
+				Config: testAccCheckAwsSesTemplateResourceConfigBasic2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSesTemplate(resourceName, &template),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					testAccCheckSesTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "html", "html"),
 					resource.TestCheckResourceAttr(resourceName, "subject", "subject"),
 					resource.TestCheckResourceAttr(resourceName, "text", "text"),
 				),
 			},
 			{
-				Config: testAccCheckAwsSesTemplateResourceConfigBasic3(name),
+				Config: testAccCheckAwsSesTemplateResourceConfigBasic3(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSesTemplate(resourceName, &template),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					testAccCheckSesTemplateExists(resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "html", "html update"),
 					resource.TestCheckResourceAttr(resourceName, "subject", "subject"),
 					resource.TestCheckResourceAttr(resourceName, "text", ""),
@@ -93,7 +93,29 @@ func TestAccAWSSesTemplate_Update(t *testing.T) {
 	})
 }
 
-func testAccCheckSesTemplate(pr string, template *ses.Template) resource.TestCheckFunc {
+func TestAccAWSSesTemplate_disappears(t *testing.T) {
+	resourceName := "aws_ses_template.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	var template ses.Template
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSesTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsSesTemplateResourceConfigBasic1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSesTemplateExists(resourceName, &template),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesTemplate(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckSesTemplateExists(pr string, template *ses.Template) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).sesconn
 		rs, ok := s.RootModule().Resources[pr]
@@ -109,8 +131,18 @@ func testAccCheckSesTemplate(pr string, template *ses.Template) resource.TestChe
 			TemplateName: aws.String(rs.Primary.ID),
 		}
 
-		_, err := conn.GetTemplate(&input)
-		return err
+		templateOutput, err := conn.GetTemplate(&input)
+		if err != nil {
+			return err
+		}
+
+		if templateOutput == nil || templateOutput.Template == nil {
+			return fmt.Errorf("SES Template (%s) not found", rs.Primary.ID)
+		}
+
+		*template = *templateOutput.Template
+
+		return nil
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/ses_template: update Read method error messaging and acctest
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- SKIP: TestAccAWSSesTemplate_Update (0.00s)
    resource_aws_ses_template_test.go:47: Skip due to SES.UpdateTemplate eventual consistency issues
--- PASS: TestAccAWSSesTemplate_disappears (6.40s)
--- PASS: TestAccAWSSesTemplate_Basic (8.66s)
```
