### PR TITLE
New Data Source: aws_workspaces_directory

### DIFF
--- a/aws/data_source_aws_workspaces_bundle.go
+++ b/aws/data_source_aws_workspaces_bundle.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func dataSourceAwsWorkspaceBundle() *schema.Resource {
+func dataSourceAwsWorkspacesBundle() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAwsWorkspaceBundleRead,
 

--- a/aws/data_source_aws_workspaces_directory.go
+++ b/aws/data_source_aws_workspaces_directory.go
@@ -1,0 +1,144 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/workspaces/waiter"
+)
+
+func dataSourceAwsWorkspacesDirectory() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsWorkspacesDirectoryRead,
+
+		Schema: map[string]*schema.Schema{
+			"directory_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"self_service_permissions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"change_compute_type": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"increase_volume_size": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"rebuild_workspace": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"restart_workspace": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"switch_running_mode": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"workspace_security_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iam_role_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"registration_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"directory_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"directory_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"customer_user_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_group_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dns_ip_addresses": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func dataSourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).workspacesconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	rawOutput, state, err := waiter.DirectoryState(conn, d.Id())()
+	if err != nil {
+		return fmt.Errorf("error getting WorkSpaces Directory (%s): %s", d.Id(), err)
+	}
+	if state == workspaces.WorkspaceDirectoryStateDeregistered {
+		return fmt.Errorf("WorkSpaces directory %s was not found", d.Id())
+	}
+
+	directory := rawOutput.(*workspaces.WorkspaceDirectory)
+	d.Set("directory_id", directory.DirectoryId)
+	d.Set("workspace_security_group_id", directory.WorkspaceSecurityGroupId)
+	d.Set("iam_role_id", directory.IamRoleId)
+	d.Set("registration_code", directory.RegistrationCode)
+	d.Set("directory_name", directory.DirectoryName)
+	d.Set("directory_type", directory.DirectoryType)
+	d.Set("alias", directory.Alias)
+
+	if err := d.Set("subnet_ids", flattenStringSet(directory.SubnetIds)); err != nil {
+		return fmt.Errorf("error setting subnet_ids: %s", err)
+	}
+
+	if err := d.Set("self_service_permissions", flattenSelfServicePermissions(directory.SelfservicePermissions)); err != nil {
+		return fmt.Errorf("error setting self_service_permissions: %s", err)
+	}
+
+	if err := d.Set("ip_group_ids", flattenStringSet(directory.IpGroupIds)); err != nil {
+		return fmt.Errorf("error setting ip_group_ids: %s", err)
+	}
+
+	if err := d.Set("dns_ip_addresses", flattenStringSet(directory.DnsIpAddresses)); err != nil {
+		return fmt.Errorf("error setting dns_ip_addresses: %s", err)
+	}
+
+	tags, err := keyvaluetags.WorkspacesListTags(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error listing tags: %s", err)
+	}
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_workspaces_directory.go
+++ b/aws/data_source_aws_workspaces_directory.go
@@ -99,13 +99,17 @@ func dataSourceAwsWorkspacesDirectoryRead(d *schema.ResourceData, meta interface
 	conn := meta.(*AWSClient).workspacesconn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
-	rawOutput, state, err := waiter.DirectoryState(conn, d.Id())()
+	directoryID := d.Get("directory_id").(string)
+
+	rawOutput, state, err := waiter.DirectoryState(conn, directoryID)()
 	if err != nil {
-		return fmt.Errorf("error getting WorkSpaces Directory (%s): %s", d.Id(), err)
+		return fmt.Errorf("error getting WorkSpaces Directory (%s): %s", directoryID, err)
 	}
 	if state == workspaces.WorkspaceDirectoryStateDeregistered {
-		return fmt.Errorf("WorkSpaces directory %s was not found", d.Id())
+		return fmt.Errorf("WorkSpaces directory %s was not found", directoryID)
 	}
+
+	d.SetId(directoryID)
 
 	directory := rawOutput.(*workspaces.WorkspaceDirectory)
 	d.Set("directory_id", directory.DirectoryId)

--- a/aws/data_source_aws_workspaces_directory_test.go
+++ b/aws/data_source_aws_workspaces_directory_test.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsWorkspacesDirectory_basic(t *testing.T) {
+	rName := acctest.RandString(8)
+
+	iamRoleDataSourceName := "data.aws_iam_role.workspaces-default"
+	directoryResourceName := "aws_directory_service_directory.main"
+	dataSourceName := "data.aws_workspaces_directory.main"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsWorkspacesDirectoryConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.change_compute_type", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.increase_volume_size", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.rebuild_workspace", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.restart_workspace", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.switch_running_mode", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "dns_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "directory_type", "SIMPLE_AD"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "directory_name", directoryResourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "alias", directoryResourceName, "alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "directory_id", directoryResourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "iam_role_id", iamRoleDataSourceName, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "workspace_security_group_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "registration_code"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsWorkspacesDirectoryConfig(rName string) string {
+	return testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName) + fmt.Sprintf(`
+resource "aws_workspaces_directory" "main" {
+  directory_id = "${aws_directory_service_directory.main.id}"
+
+  self_service_permissions {
+    change_compute_type  = false
+    increase_volume_size = true
+    rebuild_workspace    = true
+    restart_workspace    = false
+    switch_running_mode  = true
+  }
+}
+
+data "aws_workspaces_directory" "main" {
+  directory_id = "${aws_directory_service_directory.main.id}"
+}
+
+data "aws_iam_role" "workspaces-default" {
+  name = "workspaces_DefaultRole"
+}
+`)
+}

--- a/aws/data_source_aws_workspaces_directory_test.go
+++ b/aws/data_source_aws_workspaces_directory_test.go
@@ -11,9 +11,8 @@ import (
 func TestAccDataSourceAwsWorkspacesDirectory_basic(t *testing.T) {
 	rName := acctest.RandString(8)
 
-	iamRoleDataSourceName := "data.aws_iam_role.workspaces-default"
-	directoryResourceName := "aws_directory_service_directory.main"
-	dataSourceName := "data.aws_workspaces_directory.main"
+	resourceName := "aws_workspaces_directory.test"
+	dataSourceName := "data.aws_workspaces_directory.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
@@ -22,22 +21,22 @@ func TestAccDataSourceAwsWorkspacesDirectory_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsWorkspacesDirectoryConfig(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "subnet_ids.#", "2"),
-					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.change_compute_type", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.increase_volume_size", "true"),
-					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.rebuild_workspace", "true"),
-					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.restart_workspace", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "self_service_permissions.0.switch_running_mode", "true"),
-					resource.TestCheckResourceAttr(dataSourceName, "dns_ip_addresses.#", "2"),
-					resource.TestCheckResourceAttr(dataSourceName, "directory_type", "SIMPLE_AD"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "directory_name", directoryResourceName, "name"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "alias", directoryResourceName, "alias"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "directory_id", directoryResourceName, "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "iam_role_id", iamRoleDataSourceName, "arn"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "workspace_security_group_id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "registration_code"),
-					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_ids.#", resourceName, "subnet_ids.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "self_service_permissions.#", resourceName, "self_service_permissions.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "self_service_permissions.0.change_compute_type", resourceName, "self_service_permissions.0.change_compute_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "self_service_permissions.0.increase_volume_size", resourceName, "self_service_permissions.0.increase_volume_size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "self_service_permissions.0.rebuild_workspace", resourceName, "self_service_permissions.0.rebuild_workspace"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "self_service_permissions.0.restart_workspace", resourceName, "self_service_permissions.0.restart_workspace"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "self_service_permissions.0.switch_running_mode", resourceName, "self_service_permissions.0.switch_running_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dns_ip_addresses.#", resourceName, "dns_ip_addresses.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "directory_type", resourceName, "directory_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "directory_name", resourceName, "directory_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "alias", resourceName, "alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "directory_id", resourceName, "directory_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "iam_role_id", resourceName, "iam_role_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "workspace_security_group_id", resourceName, "workspace_security_group_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "registration_code", resourceName, "registration_code"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
 				),
 			},
 		},
@@ -46,7 +45,7 @@ func TestAccDataSourceAwsWorkspacesDirectory_basic(t *testing.T) {
 
 func testAccDataSourceAwsWorkspacesDirectoryConfig(rName string) string {
 	return testAccAwsWorkspacesDirectoryConfig_Prerequisites(rName) + fmt.Sprintf(`
-resource "aws_workspaces_directory" "main" {
+resource "aws_workspaces_directory" "test" {
   directory_id = "${aws_directory_service_directory.main.id}"
 
   self_service_permissions {
@@ -58,8 +57,8 @@ resource "aws_workspaces_directory" "main" {
   }
 }
 
-data "aws_workspaces_directory" "main" {
-  directory_id = "${aws_directory_service_directory.main.id}"
+data "aws_workspaces_directory" "test" {
+  directory_id = "${aws_workspaces_directory.test.id}"
 }
 
 data "aws_iam_role" "workspaces-default" {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -353,6 +353,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafv2_rule_group":                           dataSourceAwsWafv2RuleGroup(),
 			"aws_wafv2_web_acl":                              dataSourceAwsWafv2WebACL(),
 			"aws_workspaces_bundle":                          dataSourceAwsWorkspaceBundle(),
+			"aws_workspaces_directory":                       dataSourceAwsWorkspacesDirectory(),
 
 			// Adding the Aliases for the ALB -> LB Rename
 			"aws_lb":               dataSourceAwsLb(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -352,7 +352,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_wafv2_regex_pattern_set":                    dataSourceAwsWafv2RegexPatternSet(),
 			"aws_wafv2_rule_group":                           dataSourceAwsWafv2RuleGroup(),
 			"aws_wafv2_web_acl":                              dataSourceAwsWafv2WebACL(),
-			"aws_workspaces_bundle":                          dataSourceAwsWorkspaceBundle(),
+			"aws_workspaces_bundle":                          dataSourceAwsWorkspacesBundle(),
 			"aws_workspaces_directory":                       dataSourceAwsWorkspacesDirectory(),
 
 			// Adding the Aliases for the ALB -> LB Rename

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -3694,6 +3694,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/d/workspaces_bundle.html">aws_workspaces_bundle</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/workspaces_directory.html">aws_workspaces_directory</a>
+                                </li>
                             </ul>
                         </li>
                         <li>

--- a/website/docs/d/workspaces_bundle.html.markdown
+++ b/website/docs/d/workspaces_bundle.html.markdown
@@ -3,12 +3,12 @@ subcategory: "WorkSpaces"
 layout: "aws"
 page_title: "AWS: aws_workspaces_bundle"
 description: |-
-  Get information on a WorkSpaces Bundle.
+  Retrieve information about an AWS WorkSpaces bundle.
 ---
 
 # Data Source: aws_workspaces_bundle
 
-Use this data source to get information about a WorkSpaces Bundle.
+Retrieve information about an AWS WorkSpaces bundle.
 
 ## Example Usage
 
@@ -32,8 +32,6 @@ The following arguments are supported:
 * `name` – (Optional) The name of the bundle. You cannot combine this parameter with `bundle_id`.
 
 ## Attributes Reference
-
-The following attributes are exported:
 
 * `description` – The description of the bundle.
 * `bundle_id` – The ID of the bundle.

--- a/website/docs/d/workspaces_directory.html.markdown
+++ b/website/docs/d/workspaces_directory.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "WorkSpaces"
+layout: "aws"
+page_title: "AWS: aws_workspaces_directory"
+description: |-
+  Retrieve information about an AWS WorkSpaces directory.
+---
+
+# Data Source: aws_workspaces_directory
+
+Retrieve information about an AWS WorkSpaces directory.
+
+## Example Usage
+
+```hcl
+data "aws_workspaces_directory" "example" {
+  directory_id = "d-9067783251"
+}
+```
+
+## Argument Reference
+
+* `directory_id` - (Required) The directory identifier for registration in WorkSpaces service.
+
+## Attributes Reference
+
+* `id` - The WorkSpaces directory identifier.
+* `subnet_ids` - The identifiers of the subnets where the directory resides.
+* `tags` – A map of tags assigned to the WorkSpaces directory.
+* `workspace_security_group_id` - The identifier of the security group that is assigned to new WorkSpaces.
+* `iam_role_id` - The identifier of the IAM role. This is the role that allows Amazon WorkSpaces to make calls to other services, such as Amazon EC2, on your behalf.
+* `registration_code` - The registration code for the directory. This is the code that users enter in their Amazon WorkSpaces client application to connect to the directory.
+* `directory_name` - The name of the directory.
+* `directory_type` - The directory type.
+* `customer_user_name` - The user name for the service account.
+* `alias` - The directory alias.
+* `ip_group_ids` - The identifiers of the IP access control groups associated with the directory.
+* `dns_ip_addresses` - The IP addresses of the DNS servers for the directory.
+* `self_service_permissions` – The permissions to enable or disable self-service capabilities.
+    * `change_compute_type` – Whether WorkSpaces directory users can change the compute type (bundle) for their workspace.
+    * `increase_volume_size` – Whether WorkSpaces directory users can increase the volume size of the drives on their workspace.
+    * `rebuild_workspace` – Whether WorkSpaces directory users can rebuild the operating system of a workspace to its original state.
+    * `restart_workspace` – Whether WorkSpaces directory users can restart their workspace.
+    * `switch_running_mode` – Whether WorkSpaces directory users can switch the running mode of their workspace.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
New Data Source: aws_workspaces_directory (#13529)
```

### Example

```hcl
data "aws_workspaces_directory" "example" {
  directory_id = "d-9067783251"
}
```

### Acceptance Tests

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsWorkspacesDirectory_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWorkspacesDirectory_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWorkspacesDirectory_basic
=== PAUSE TestAccDataSourceAwsWorkspacesDirectory_basic
=== CONT  TestAccDataSourceAwsWorkspacesDirectory_basic
--- PASS: TestAccDataSourceAwsWorkspacesDirectory_basic (638.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	645.726s
```

### References

- [AWS DescribeWorkspaceDirectories API Action](https://docs.aws.amazon.com/workspaces/latest/api/API_DescribeWorkspaceDirectories.html)