### PR TITLE
r/aws_kinesis_firehose_delivery_stream: Set 'kinesis_source_configuration' in Read function

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -571,6 +571,19 @@ func flattenProcessingConfiguration(pc *firehose.ProcessingConfiguration, roleAr
 	return processingConfiguration
 }
 
+func flattenFirehoseKinesisSourceConfiguration(desc *firehose.KinesisStreamSourceDescription) []interface{} {
+	if desc == nil {
+		return []interface{}{}
+	}
+
+	mDesc := map[string]interface{}{
+		"kinesis_stream_arn": aws.StringValue(desc.KinesisStreamARN),
+		"role_arn":           aws.StringValue(desc.RoleARN),
+	}
+
+	return []interface{}{mDesc}
+}
+
 func flattenKinesisFirehoseDeliveryStream(d *schema.ResourceData, s *firehose.DeliveryStreamDescription) error {
 	d.Set("version_id", s.VersionId)
 	d.Set("arn", s.DeliveryStreamARN)
@@ -584,6 +597,12 @@ func flattenKinesisFirehoseDeliveryStream(d *schema.ResourceData, s *firehose.De
 	}
 	if err := d.Set("server_side_encryption", []map[string]interface{}{sseOptions}); err != nil {
 		return fmt.Errorf("error setting server_side_encryption: %s", err)
+	}
+
+	if s.Source != nil {
+		if err := d.Set("kinesis_source_configuration", flattenFirehoseKinesisSourceConfiguration(s.Source.KinesisStreamSourceDescription)); err != nil {
+			return fmt.Errorf("error setting kinesis_source_configuration: %s", err)
+		}
 	}
 
 	if len(s.Destinations) > 0 {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -74,7 +74,7 @@ func s3ConfigurationSchema() *schema.Schema {
 				"compression_format": {
 					Type:     schema.TypeString,
 					Optional: true,
-					Default:  "UNCOMPRESSED",
+					Default:  firehose.CompressionFormatUncompressed,
 				},
 
 				"kms_key_arn": {
@@ -124,26 +124,18 @@ func processingConfigurationSchema() *schema.Schema {
 										"parameter_name": {
 											Type:     schema.TypeString,
 											Required: true,
-											ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-												value := v.(string)
-												if value != "LambdaArn" && value != "NumberOfRetries" && value != "RoleArn" && value != "BufferSizeInMBs" && value != "BufferIntervalInSeconds" {
-													errors = append(errors, fmt.Errorf(
-														"%q must be one of 'LambdaArn', 'NumberOfRetries', 'RoleArn', 'BufferSizeInMBs', 'BufferIntervalInSeconds'", k))
-												}
-												return
-											},
+											ValidateFunc: validation.StringInSlice([]string{
+												firehose.ProcessorParameterNameLambdaArn,
+												firehose.ProcessorParameterNameNumberOfRetries,
+												firehose.ProcessorParameterNameRoleArn,
+												firehose.ProcessorParameterNameBufferSizeInMbs,
+												firehose.ProcessorParameterNameBufferIntervalInSeconds,
+											}, false),
 										},
 										"parameter_value": {
-											Type:     schema.TypeString,
-											Required: true,
-											ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-												value := v.(string)
-												if len(value) < 1 || len(value) > 512 {
-													errors = append(errors, fmt.Errorf(
-														"%q must be at least one character long and at most 512 characters long", k))
-												}
-												return
-											},
+											Type:         schema.TypeString,
+											Required:     true,
+											ValidateFunc: validation.StringLenBetween(1, 512),
 										},
 									},
 								},
@@ -151,14 +143,9 @@ func processingConfigurationSchema() *schema.Schema {
 							"type": {
 								Type:     schema.TypeString,
 								Required: true,
-								ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-									value := v.(string)
-									if value != "Lambda" {
-										errors = append(errors, fmt.Errorf(
-											"%q must be 'Lambda'", k))
-									}
-									return
-								},
+								ValidateFunc: validation.StringInSlice([]string{
+									firehose.ProcessorTypeLambda,
+								}, false),
 							},
 						},
 					},
@@ -639,6 +626,7 @@ func flattenKinesisFirehoseDeliveryStream(d *schema.ResourceData, s *firehose.De
 		}
 		d.Set("destination_id", destination.DestinationId)
 	}
+
 	return nil
 }
 
@@ -669,17 +657,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 		MigrateState:  resourceAwsKinesisFirehoseMigrateState,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if len(value) > 64 {
-						errors = append(errors, fmt.Errorf(
-							"%q cannot be longer than 64 characters", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
 			},
 
 			"tags": tagsSchema(),
@@ -734,14 +715,13 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 					value := v.(string)
 					return strings.ToLower(value)
 				},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if value != "s3" && value != "extended_s3" && value != "redshift" && value != "elasticsearch" && value != "splunk" {
-						errors = append(errors, fmt.Errorf(
-							"%q must be one of 's3', 'extended_s3', 'redshift', 'elasticsearch', 'splunk'", k))
-					}
-					return
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"elasticsearch",
+					"extended_s3",
+					"redshift",
+					"s3",
+					"splunk",
+				}, false),
 			},
 
 			"s3_configuration": s3ConfigurationSchema(),
@@ -773,7 +753,7 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						"compression_format": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "UNCOMPRESSED",
+							Default:  firehose.CompressionFormatUncompressed,
 						},
 
 						"data_format_conversion_configuration": {
@@ -1058,15 +1038,11 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						"s3_backup_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "Disabled",
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != "Disabled" && value != "Enabled" {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of 'Disabled', 'Enabled'", k))
-								}
-								return
-							},
+							Default:  firehose.S3BackupModeDisabled,
+							ValidateFunc: validation.StringInSlice([]string{
+								firehose.S3BackupModeDisabled,
+								firehose.S3BackupModeEnabled,
+							}, false),
 						},
 
 						"s3_backup_configuration": s3ConfigurationSchema(),
@@ -1110,15 +1086,11 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						"s3_backup_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "Disabled",
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != "Disabled" && value != "Enabled" {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of 'Disabled', 'Enabled'", k))
-								}
-								return
-							},
+							Default:  firehose.S3BackupModeDisabled,
+							ValidateFunc: validation.StringInSlice([]string{
+								firehose.S3BackupModeDisabled,
+								firehose.S3BackupModeEnabled,
+							}, false),
 						},
 
 						"s3_backup_configuration": s3ConfigurationSchema(),
@@ -1204,15 +1176,14 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						"index_rotation_period": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "OneDay",
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != "NoRotation" && value != "OneHour" && value != "OneDay" && value != "OneWeek" && value != "OneMonth" {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of 'NoRotation', 'OneHour', 'OneDay', 'OneWeek', 'OneMonth'", k))
-								}
-								return
-							},
+							Default:  firehose.ElasticsearchIndexRotationPeriodOneDay,
+							ValidateFunc: validation.StringInSlice([]string{
+								firehose.ElasticsearchIndexRotationPeriodNoRotation,
+								firehose.ElasticsearchIndexRotationPeriodOneHour,
+								firehose.ElasticsearchIndexRotationPeriodOneDay,
+								firehose.ElasticsearchIndexRotationPeriodOneWeek,
+								firehose.ElasticsearchIndexRotationPeriodOneMonth,
+							}, false),
 						},
 
 						"retry_duration": {
@@ -1238,15 +1209,11 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							Type:     schema.TypeString,
 							ForceNew: true,
 							Optional: true,
-							Default:  "FailedDocumentsOnly",
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != "FailedDocumentsOnly" && value != "AllDocuments" {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of 'FailedDocumentsOnly', 'AllDocuments'", k))
-								}
-								return
-							},
+							Default:  firehose.ElasticsearchS3BackupModeFailedDocumentsOnly,
+							ValidateFunc: validation.StringInSlice([]string{
+								firehose.ElasticsearchS3BackupModeFailedDocumentsOnly,
+								firehose.ElasticsearchS3BackupModeAllDocuments,
+							}, false),
 						},
 
 						"type_name": {
@@ -1291,14 +1258,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  firehose.HECEndpointTypeRaw,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != firehose.HECEndpointTypeRaw && value != firehose.HECEndpointTypeEvent {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of 'Raw', 'Event'", k))
-								}
-								return
-							},
+							ValidateFunc: validation.StringInSlice([]string{
+								firehose.HECEndpointTypeRaw,
+								firehose.HECEndpointTypeEvent,
+							}, false),
 						},
 
 						"hec_token": {
@@ -1310,14 +1273,10 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  firehose.SplunkS3BackupModeFailedEventsOnly,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != firehose.SplunkS3BackupModeFailedEventsOnly && value != firehose.SplunkS3BackupModeAllEvents {
-									errors = append(errors, fmt.Errorf(
-										"%q must be one of 'FailedEventsOnly', 'AllEvents'", k))
-								}
-								return
-							},
+							ValidateFunc: validation.StringInSlice([]string{
+								firehose.SplunkS3BackupModeFailedEventsOnly,
+								firehose.SplunkS3BackupModeAllEvents,
+							}, false),
 						},
 
 						"retry_duration": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13530.

Also:
* Refactored to use SDK-defined constant strings
* Added a `_disappears` acceptance test

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_kinesis_firehose_delivery_stream: `kinesis_source_configuration` is now correctly set during import
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSKinesisFirehoseDeliveryStream_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSKinesisFirehoseDeliveryStream_ -timeout 120m
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_basic
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_basic
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_disappears
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_disappears
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basic
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3basic
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_KinesisStreamSource
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_KinesisStreamSource
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
=== RUN   TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
=== PAUSE TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_basic
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_KinesisStreamSource
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (32.85s)
    testing.go:684: Step 0 error: errors during apply:
        
        Error: InvalidVPCNetworkStateFault: Cannot create a publicly accessible cluster because customer VPC vpc-b6fbb6cf has no internet gateway attached.
        	status code: 400, request id: 160e2744-9762-4284-be7c-caa991e3df3d
        
          on /tmp/tf-test787880588/main.tf line 74:
          (source code not available)
        
        
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_KinesisStreamSource (117.35s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty (135.94s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (141.89s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (143.15s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_s3basic
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (145.42s)
=== CONT  TestAccAWSKinesisFirehoseDeliveryStream_disappears
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (145.72s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_basic (146.48s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (152.85s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (154.51s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (155.72s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (161.03s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (165.37s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate (167.92s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (169.97s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (139.57s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (173.16s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (191.12s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (205.08s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (111.79s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (99.85s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (247.44s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_disappears (123.66s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (183.28s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE (288.73s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (891.78s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	891.871s
FAIL
GNUmakefile:26: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

The failure is not related to this change - My default VPC has no attached IGW.
I'll open a tech-debt issue to add an acceptance test `PreCheck` for that - https://github.com/terraform-providers/terraform-provider-aws/issues/13537.