### PR TITLE
r/aws_appmesh_route: Correctly handle routes with 0 weights

### DIFF
--- a/aws/resource_aws_appmesh_route_test.go
+++ b/aws/resource_aws_appmesh_route_test.go
@@ -160,6 +160,29 @@ func testAccAwsAppmeshRoute_httpRoute(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAppmeshRouteConfig_httpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshRouteExists(resourceName, &r),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
+					resource.TestCheckResourceAttr(resourceName, "virtual_router_name", vrName),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.action.0.weighted_target.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.header.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.method", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.prefix", "/path"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.0.match.0.scheme", ""),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualRouter/%s/route/%s", meshName, vrName, rName)),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccAwsAppmeshRouteImportStateIdFunc(resourceName),
 				ImportState:       true,
@@ -203,6 +226,24 @@ func testAccAwsAppmeshRoute_tcpRoute(t *testing.T) {
 			},
 			{
 				Config: testAccAppmeshRouteConfig_tcpRouteUpdated(meshName, vrName, vn1Name, vn2Name, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshRouteExists(resourceName, &r),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "mesh_name", meshName),
+					resource.TestCheckResourceAttr(resourceName, "virtual_router_name", vrName),
+					resource.TestCheckResourceAttr(resourceName, "spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.http_route.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.priority", "0"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spec.0.tcp_route.0.action.0.weighted_target.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "appmesh", fmt.Sprintf("mesh/%s/virtualRouter/%s/route/%s", meshName, vrName, rName)),
+				),
+			},
+			{
+				Config: testAccAppmeshRouteConfig_tcpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppmeshRouteExists(resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -596,6 +637,36 @@ resource "aws_appmesh_route" "test" {
 `, rName)
 }
 
+func testAccAppmeshRouteConfig_httpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
+resource "aws_appmesh_route" "test" {
+  name                = %[1]q
+  mesh_name           = "${aws_appmesh_mesh.test.id}"
+  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+
+  spec {
+    http_route {
+      match {
+        prefix = "/path"
+      }
+
+      action {
+        weighted_target {
+          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          weight       = 99
+        }
+
+        weighted_target {
+          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          weight       = 0
+        }
+      }
+    }
+  }
+}
+`, rName)
+}
+
 func testAccAppmeshRouteConfig_tcpRoute(meshName, vrName, vn1Name, vn2Name, rName string) string {
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
@@ -635,6 +706,32 @@ resource "aws_appmesh_route" "test" {
         weighted_target {
           virtual_node = "${aws_appmesh_virtual_node.bar.name}"
           weight       = 10
+        }
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAppmeshRouteConfig_tcpRouteUpdatedWithZeroWeight(meshName, vrName, vn1Name, vn2Name, rName string) string {
+	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
+resource "aws_appmesh_route" "test" {
+  name                = %[1]q
+  mesh_name           = "${aws_appmesh_mesh.test.id}"
+  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+
+  spec {
+    tcp_route {
+      action {
+        weighted_target {
+          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          weight       = 99
+        }
+
+        weighted_target {
+          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          weight       = 0
         }
       }
     }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -5130,7 +5130,7 @@ func expandAppmeshRouteSpec(vSpec []interface{}) *appmesh.RouteSpec {
 					if vVirtualNode, ok := mWeightedTarget["virtual_node"].(string); ok && vVirtualNode != "" {
 						weightedTarget.VirtualNode = aws.String(vVirtualNode)
 					}
-					if vWeight, ok := mWeightedTarget["weight"].(int); ok && vWeight > 0 {
+					if vWeight, ok := mWeightedTarget["weight"].(int); ok {
 						weightedTarget.Weight = aws.Int64(int64(vWeight))
 					}
 
@@ -5234,7 +5234,7 @@ func expandAppmeshRouteSpec(vSpec []interface{}) *appmesh.RouteSpec {
 					if vVirtualNode, ok := mWeightedTarget["virtual_node"].(string); ok && vVirtualNode != "" {
 						weightedTarget.VirtualNode = aws.String(vVirtualNode)
 					}
-					if vWeight, ok := mWeightedTarget["weight"].(int); ok && vWeight > 0 {
+					if vWeight, ok := mWeightedTarget["weight"].(int); ok {
 						weightedTarget.Weight = aws.Int64(int64(vWeight))
 					}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13479.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_appmesh_route: Correctly handle routes with `weight = 0`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAppmesh/Route'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAppmesh/Route -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/Route
=== RUN   TestAccAWSAppmesh/Route/tags
=== RUN   TestAccAWSAppmesh/Route/httpHeader
=== RUN   TestAccAWSAppmesh/Route/httpRoute
=== RUN   TestAccAWSAppmesh/Route/tcpRoute
=== RUN   TestAccAWSAppmesh/Route/routePriority
=== RUN   TestAccAWSAppmesh/VirtualRouter
=== RUN   TestAccAWSAppmesh/VirtualRouter/basic
=== RUN   TestAccAWSAppmesh/VirtualRouter/tags
--- PASS: TestAccAWSAppmesh (426.83s)
    --- PASS: TestAccAWSAppmesh/Route (316.93s)
        --- PASS: TestAccAWSAppmesh/Route/tags (72.03s)
        --- PASS: TestAccAWSAppmesh/Route/httpHeader (52.14s)
        --- PASS: TestAccAWSAppmesh/Route/httpRoute (70.98s)
        --- PASS: TestAccAWSAppmesh/Route/tcpRoute (71.21s)
        --- PASS: TestAccAWSAppmesh/Route/routePriority (50.55s)
    --- PASS: TestAccAWSAppmesh/VirtualRouter (109.90s)
        --- PASS: TestAccAWSAppmesh/VirtualRouter/basic (45.47s)
        --- PASS: TestAccAWSAppmesh/VirtualRouter/tags (64.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	426.884s
```

without the fix:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAppmesh/Route/httpRoute'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAppmesh/Route/httpRoute -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/VirtualRouter
=== RUN   TestAccAWSAppmesh/Route
=== RUN   TestAccAWSAppmesh/Route/httpRoute
--- FAIL: TestAccAWSAppmesh (37.51s)
    --- PASS: TestAccAWSAppmesh/VirtualRouter (0.00s)
    --- FAIL: TestAccAWSAppmesh/Route (37.51s)
        --- FAIL: TestAccAWSAppmesh/Route/httpRoute (37.51s)
            testing.go:684: Step 2 error: errors during apply:
                
                Error: error updating App Mesh route: InvalidParameter: 1 validation error(s) found.
                - missing required field, UpdateRouteInput.Spec.HttpRoute.Action.WeightedTargets[0].Weight.
                
                
                  on /tmp/tf-test830154970/main.tf line 34:
                  (source code not available)
                
                
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	37.563s
FAIL
GNUmakefile:26: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```