### PR TITLE
resource/ses_event_destination: add Read method logic and update importer method

### DIFF
--- a/website/docs/r/ses_event_destination.markdown
+++ b/website/docs/r/ses_event_destination.markdown
@@ -88,3 +88,11 @@ The following arguments are supported:
 ### sns_destination Argument Reference
 
 * `topic_arn` - (Required) The ARN of the SNS topic
+
+## Import
+
+SES Event Destinations can be imported using the `name` and `configuration_set_name`, e.g.
+
+```
+$ terraform import aws_ses_event_destination.example event-destination-sns/configuration-set-example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9897

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/ses_event_destination: document import support and update resource Read logic
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSESEventDestination_basic (122.24s)
--- PASS: TestAccAWSSESEventDestination_disappears (158.55s)
```
