### PR TITLE
Add BackupVaultNotifications resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -418,6 +418,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_backup_plan":                                         resourceAwsBackupPlan(),
 			"aws_backup_selection":                                    resourceAwsBackupSelection(),
 			"aws_backup_vault":                                        resourceAwsBackupVault(),
+			"aws_backup_vault_notifications":                          resourceAwsBackupVaultNotifications(),
 			"aws_budgets_budget":                                      resourceAwsBudgetsBudget(),
 			"aws_cloud9_environment_ec2":                              resourceAwsCloud9EnvironmentEc2(),
 			"aws_cloudformation_stack":                                resourceAwsCloudFormationStack(),

--- a/aws/resource_aws_backup_vault_notifications.go
+++ b/aws/resource_aws_backup_vault_notifications.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAwsBackupVaultNotifications() *schema.Resource {
+
+	return &schema.Resource{
+		Create: resourceAwsBackupVaultNotificationsCreate,
+		Read:   resourceAwsBackupVaultNotificationsRead,
+		Delete: resourceAwsBackupVaultNotificationsDelete,
+
+		Schema: map[string]*schema.Schema{
+			"vault_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"sns_topic_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"events": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						backup.VaultEventBackupJobStarted,
+						backup.VaultEventBackupJobCompleted,
+						backup.VaultEventBackupJobSuccessful,
+						backup.VaultEventBackupJobFailed,
+						backup.VaultEventBackupJobExpired,
+						backup.VaultEventRestoreJobStarted,
+						backup.VaultEventRestoreJobCompleted,
+						backup.VaultEventRestoreJobSuccessful,
+						backup.VaultEventRestoreJobFailed,
+						backup.VaultEventCopyJobStarted,
+						backup.VaultEventCopyJobSuccessful,
+						backup.VaultEventCopyJobFailed,
+						backup.VaultEventRecoveryPointModified,
+						backup.VaultEventBackupPlanCreated,
+						backup.VaultEventBackupPlanModified,
+					}, false),
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsBackupVaultNotificationsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	input := &backup.GetBackupVaultNotificationsInput{
+		BackupVaultName: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetBackupVaultNotifications(input)
+
+	if err != nil {
+		return fmt.Errorf("error reading Backup Vault Notifications (%s): %s", d.Id(), err)
+	}
+
+	d.Set("vault_name", resp.BackupVaultName)
+	d.Set("sns_topic_arn", resp.SNSTopicArn)
+	d.Set("events", resp.BackupVaultEvents)
+
+	return nil
+}
+
+func resourceAwsBackupVaultNotificationsCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+	input := &backup.PutBackupVaultNotificationsInput{
+		BackupVaultName: aws.String(d.Get("vault_name").(string)),
+	}
+
+	if v, ok := d.GetOk("sns_topic_arn"); ok {
+		input.SNSTopicArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("events"); ok {
+		input.BackupVaultEvents = expandStringList(v.(*schema.Set).List())
+	}
+
+	_, err := conn.PutBackupVaultNotifications(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating Backup Vault Notifications(%s): %s", d.Id(), err)
+	}
+
+	d.SetId(d.Get("vault_name").(string))
+
+	return resourceAwsBackupVaultNotificationsRead(d, meta)
+}
+
+func resourceAwsBackupVaultNotificationsDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	input := &backup.DeleteBackupVaultNotificationsInput{
+		BackupVaultName: aws.String(d.Get("vault_name").(string)),
+	}
+
+	_, err := conn.DeleteBackupVaultNotifications(input)
+
+	if err != nil {
+		return fmt.Errorf("error deleting Backup Vault Notifications (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_backup_vault_notifications_test.go
+++ b/aws/resource_aws_backup_vault_notifications_test.go
@@ -1,0 +1,117 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAwsBackupVaultNotifications_basic(t *testing.T) {
+	var notifications backup.GetBackupVaultNotificationsOutput
+
+	rInt := acctest.RandInt()
+	resourceName := "aws_backup_vault.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupVaultNotificationsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupVaultNotificationsConfigBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupVaultNotificationsExists(resourceName, &notifications),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsBackupVaultNotificationsExists(name string, notifications *backup.GetBackupVaultNotificationsOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: #{name}, #{s.RootModule(}.Resources")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).backupconn
+
+		input := &backup.GetBackupVaultNotificationsInput{
+			BackupVaultName: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetBackupVaultNotifications(input)
+
+		if err != nil {
+			return err
+		}
+
+		*notifications = *output
+		return nil
+	}
+}
+
+func testAccCheckAwsBackupVaultNotificationsDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).backupconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_backup_vault_notifications" {
+			continue
+		}
+
+		input := &backup.GetBackupVaultNotificationsInput{
+			BackupVaultName: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.GetBackupVaultNotifications(input)
+
+		if err == nil {
+			if *resp.BackupVaultName == rs.Primary.ID {
+				return fmt.Errorf("VaultNotifications '#{rs.Primary.ID}' was not deleted properly")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccBackupVaultNotificationsConfigBase(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_sns_topic" "test" {
+  name = "terraform-test-topic-%d"
+}
+resource "aws_backup_vault" "test" {
+  name = "tf_acc_test_backup_vault_%d"
+}
+`, rInt, rInt)
+}
+
+func testAccBackupVaultNotificationsConfigBasic(rInt int) string {
+	return testAccBackupVaultNotificationsConfigBase(rInt) + fmt.Sprintf(`
+resource "aws_backup_vault_notifications" "test" {
+  vault_name    = "tf_acc_test_backup_vault_%d"
+  sns_topic_arn = aws_sns_topic.test.arn
+
+  events = [
+    "BACKUP_JOB_STARTED",
+    "BACKUP_JOB_COMPLETED",
+    "BACKUP_JOB_SUCCESSFUL",
+  ]
+}
+`, rInt)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -417,6 +417,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/backup_vault.html">aws_backup_vault</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/backup_vault_notifications.html">aws_backup_vault_notifications</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "Backup"
+layout: "aws"
+page_title: "AWS: aws_backup_vault_notifications"
+description: |-
+  Provides an AWS Backup vault notifications resource.
+---
+
+# Resource: aws_backup_vault_notifications
+
+Provides an AWS Backup vault notifications resource.
+
+## Example Usage
+
+```hcl
+resource "aws_sns_topic" "topic" {
+  name = "backup-events-notification"
+}
+
+resource "aws_backup_vault" "example" {
+  name = "example_backup_vault"
+}
+
+resource "aws_backup_vault_notifications" "notify_team" {
+  vault_name    = aws_backup_vault.example.name
+  sns_topic_arn = aws_sns_topic.topic.arn
+
+  events = [
+    "BACKUP_JOB_STARTED",
+    "BACKUP_JOB_COMPLETED",
+    "BACKUP_JOB_SUCCESSFUL",
+    "BACKUP_JOB_FAILED",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vault_name`    - (Required) Name of the backup vault.
+* `sns_topic_arn` - (Required) SNS Topic ARN to which event notifications are sent.
+* `events`        - (Required) A list of events to listen to.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the vault.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_backup_vault_notifications: Add support for backup event notifications.

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAwsBackupVaultNotifications_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsBackupVaultNotifications_basic -timeout 120m
=== RUN   TestAccAwsBackupVaultNotifications_basic
=== PAUSE TestAccAwsBackupVaultNotifications_basic
=== CONT  TestAccAwsBackupVaultNotifications_basic
--- PASS: TestAccAwsBackupVaultNotifications_basic (26.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       27.998s
```
