### PR TITLE
tests/provider: Small sweeper fixes

### DIFF
--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -38,6 +38,11 @@ func testSweepCloudTrails(region string) error {
 		for _, trail := range page.Trails {
 			name := aws.StringValue(trail.Name)
 
+			if name == "AWSMacieTrail-DO-NOT-EDIT" {
+				log.Printf("[INFO] Skipping AWSMacieTrail-DO-NOT-EDIT for Macie Classic, which is not automatically recreated by the service")
+				continue
+			}
+
 			output, err := conn.DescribeTrails(&cloudtrail.DescribeTrailsInput{
 				TrailNameList: aws.StringSlice([]string{name}),
 			})

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -53,7 +53,7 @@ func testSweepIamRoles(region string) error {
 	prefixes := []string{
 		"ecs_instance_role",
 		"ecs_tf",
-		"EMR_AutoScaling_DefaultRole",
+		"EMR_AutoScaling_DefaultRole_",
 		"iam_emr",
 		"terraform-",
 		"test",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-iam-role-automatic-scaling.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A (trivial sweeper adjustments)

Macie Classic requires this trail:

```
--- FAIL: TestAccAWSMacieS3BucketAssociation_basic (3.10s)
    TestAccAWSMacieS3BucketAssociation_basic: resource_aws_macie_s3_bucket_association_test.go:156: unexpected PreCheck error: InvalidInputException: The request was rejected. The CloudTrail AWSMacieTrail-DO-NOT-EDIT does not exist for this AWS account 123456789012 in this AWS region.
```

EMR acceptance test configurations use this naming scheme with an underscore and random integer suffix. Keep the default role, otherwise our Terraform configurations ensuring its existence repeatedly trigger recreation:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_iam_role.EMR_AutoScaling_DefaultRole will be created
  + resource "aws_iam_role" "EMR_AutoScaling_DefaultRole" {
...
```