### PR TITLE
s3_bucket- add plan time validations

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -69,9 +69,16 @@ func resourceAwsS3Bucket() *schema.Resource {
 			},
 
 			"acl": {
-				Type:          schema.TypeString,
-				Default:       "private",
-				Optional:      true,
+				Type:     schema.TypeString,
+				Default:  s3.BucketCannedACLPrivate,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					s3.BucketCannedACLPrivate,
+					s3.BucketCannedACLAuthenticatedRead,
+					s3.BucketCannedACLPublicRead,
+					s3.BucketCannedACLPublicReadWrite,
+					"log-delivery-write",
+				}, false),
 				ConflictsWith: []string{"grant"},
 			},
 
@@ -91,6 +98,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								s3.TypeCanonicalUser,
+								s3.TypeAmazonCustomerByEmail,
 								s3.TypeGroup,
 							}, false),
 						},
@@ -102,7 +110,6 @@ func resourceAwsS3Bucket() *schema.Resource {
 						"permissions": {
 							Type:     schema.TypeSet,
 							Required: true,
-							Set:      schema.HashString,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{
@@ -407,8 +414,9 @@ func resourceAwsS3Bucket() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"role": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
 						},
 						"rules": {
 							Type:     schema.TypeSet,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_s3_bucket: add plan time validation `replication_configuration.role` and `acl`
add support for `TypeAmazonCustomerByEmail` grant type
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
