### PR TITLE
fixed aws_lambda_invocation to work with arbitratry JSON results

### DIFF
--- a/aws/data_source_aws_lambda_invocation.go
+++ b/aws/data_source_aws_lambda_invocation.go
@@ -80,11 +80,9 @@ func dataSourceAwsLambdaInvocationRead(d *schema.ResourceData, meta interface{})
 	var result map[string]interface{}
 
 	if err = json.Unmarshal(res.Payload, &result); err != nil {
-		return err
-	}
-
-	if err = d.Set("result_map", result); err != nil {
-		log.Printf("[WARN] Cannot use the result invocation as a string map: %s", err)
+		log.Printf("[WARN] Cannot unmarshal the result of invocation as a string map, result_map will be empty: %s", err)
+	} else if err = d.Set("result_map", result); err != nil {
+		log.Printf("[WARN] Cannot use the result of invocation as a string map, result_map will be empty: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s_%s_%x", functionName, qualifier, md5.Sum(input)))

--- a/website/docs/d/lambda_invocation.html.markdown
+++ b/website/docs/d/lambda_invocation.html.markdown
@@ -55,3 +55,4 @@ output "result_entry_tf012" {
 
  * `result` - String result of the lambda function invocation.
  * `result_map` - (**DEPRECATED**) This field is set only if result is a map of primitive types, where the map is string keys and string values. In Terraform 0.12 and later, use the [`jsondecode()` function](/docs/configuration/functions/jsondecode.html) with the `result` attribute instead to convert the result to all supported native Terraform types.
+ This field will be empty if lambda function responses with anything other than string key/value JSON object (`{"key": "value"}`).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9189 #4808 #9184

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data.aws_lambda_invocation will no longer fails when unmarshaling types which are not map[string]interface instead result_map will be unset
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsLambdaInvocation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsLambdaInvocation -timeout 120m
=== RUN   TestAccDataSourceAwsLambdaInvocation_basic
=== PAUSE TestAccDataSourceAwsLambdaInvocation_basic
=== RUN   TestAccDataSourceAwsLambdaInvocation_qualifier
=== PAUSE TestAccDataSourceAwsLambdaInvocation_qualifier
=== RUN   TestAccDataSourceAwsLambdaInvocation_complex
=== PAUSE TestAccDataSourceAwsLambdaInvocation_complex
=== RUN   TestAccDataSourceAwsLambdaInvocation_types_number
=== PAUSE TestAccDataSourceAwsLambdaInvocation_types_number
=== RUN   TestAccDataSourceAwsLambdaInvocation_types_string
=== PAUSE TestAccDataSourceAwsLambdaInvocation_types_string
=== RUN   TestAccDataSourceAwsLambdaInvocation_types_array
=== PAUSE TestAccDataSourceAwsLambdaInvocation_types_array
=== CONT  TestAccDataSourceAwsLambdaInvocation_basic
=== CONT  TestAccDataSourceAwsLambdaInvocation_types_string
=== CONT  TestAccDataSourceAwsLambdaInvocation_complex
=== CONT  TestAccDataSourceAwsLambdaInvocation_types_number
=== CONT  TestAccDataSourceAwsLambdaInvocation_qualifier
=== CONT  TestAccDataSourceAwsLambdaInvocation_types_array
--- PASS: TestAccDataSourceAwsLambdaInvocation_types_string (68.38s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_qualifier (75.04s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_types_number (83.51s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_complex (92.83s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_types_array (103.33s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_basic (110.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	113.312s
```
I think this will be a non-breaking change.
If lambda function was returning non-`map[string]string` it was panicing, so no use-cases was possible.