### PR TITLE
r/aws_spot_fleet_request: Fix import crash on missing 'availability_zone'

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1606,11 +1606,11 @@ func hashLaunchSpecification(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["ami"].(string)))
-	if m["availability_zone"] != "" {
-		buf.WriteString(fmt.Sprintf("%s-", m["availability_zone"].(string)))
+	if v, ok := m["availability_zone"].(string); ok && v != "" {
+		buf.WriteString(fmt.Sprintf("%s-", v))
 	}
-	if m["subnet_id"] != "" {
-		buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
+	if v, ok := m["subnet_id"].(string); ok && v != "" {
+		buf.WriteString(fmt.Sprintf("%s-", v))
 	}
 	buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["spot_price"].(string)))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13567.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_spot_fleet_request: Prevent crash on import when `availability_zone` has not been specified
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSpotFleetRequest_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 5 -run=TestAccAWSSpotFleetRequest_ -timeout 120m
=== RUN   TestAccAWSSpotFleetRequest_basic
=== PAUSE TestAccAWSSpotFleetRequest_basic
=== RUN   TestAccAWSSpotFleetRequest_tags
=== PAUSE TestAccAWSSpotFleetRequest_tags
=== RUN   TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== PAUSE TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== RUN   TestAccAWSSpotFleetRequest_launchTemplate
=== PAUSE TestAccAWSSpotFleetRequest_launchTemplate
=== RUN   TestAccAWSSpotFleetRequest_launchTemplate_multiple
=== PAUSE TestAccAWSSpotFleetRequest_launchTemplate_multiple
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateWithOverrides
=== PAUSE TestAccAWSSpotFleetRequest_launchTemplateWithOverrides
=== RUN   TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (516.75s)
=== RUN   TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (495.60s)
=== RUN   TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== PAUSE TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== RUN   TestAccAWSSpotFleetRequest_fleetType
=== PAUSE TestAccAWSSpotFleetRequest_fleetType
=== RUN   TestAccAWSSpotFleetRequest_iamInstanceProfileArn
=== PAUSE TestAccAWSSpotFleetRequest_iamInstanceProfileArn
=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== PAUSE TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== RUN   TestAccAWSSpotFleetRequest_updateTargetCapacity
=== PAUSE TestAccAWSSpotFleetRequest_updateTargetCapacity
=== RUN   TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== PAUSE TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== PAUSE TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== RUN   TestAccAWSSpotFleetRequest_withoutSpotPrice
=== PAUSE TestAccAWSSpotFleetRequest_withoutSpotPrice
=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation
=== PAUSE TestAccAWSSpotFleetRequest_diversifiedAllocation
=== RUN   TestAccAWSSpotFleetRequest_multipleInstancePools
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstancePools
=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity
=== PAUSE TestAccAWSSpotFleetRequest_withWeightedCapacity
=== RUN   TestAccAWSSpotFleetRequest_withEBSDisk
=== PAUSE TestAccAWSSpotFleetRequest_withEBSDisk
=== RUN   TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
=== PAUSE TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
=== RUN   TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
=== PAUSE TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
=== RUN   TestAccAWSSpotFleetRequest_withTags
=== PAUSE TestAccAWSSpotFleetRequest_withTags
=== RUN   TestAccAWSSpotFleetRequest_placementTenancyAndGroup
=== PAUSE TestAccAWSSpotFleetRequest_placementTenancyAndGroup
=== RUN   TestAccAWSSpotFleetRequest_WithELBs
=== PAUSE TestAccAWSSpotFleetRequest_WithELBs
=== RUN   TestAccAWSSpotFleetRequest_WithTargetGroups
=== PAUSE TestAccAWSSpotFleetRequest_WithTargetGroups
=== RUN   TestAccAWSSpotFleetRequest_WithInstanceStoreAmi
--- SKIP: TestAccAWSSpotFleetRequest_WithInstanceStoreAmi (0.00s)
    resource_aws_spot_fleet_request_test.go:1115: Test fails due to test harness constraints
=== RUN   TestAccAWSSpotFleetRequest_disappears
=== PAUSE TestAccAWSSpotFleetRequest_disappears
=== CONT  TestAccAWSSpotFleetRequest_basic
=== CONT  TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (235.57s)
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
--- PASS: TestAccAWSSpotFleetRequest_basic (277.38s)
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (300.05s)
=== CONT  TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (308.82s)
=== CONT  TestAccAWSSpotFleetRequest_updateTargetCapacity
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (309.57s)
=== CONT  TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (288.42s)
=== CONT  TestAccAWSSpotFleetRequest_iamInstanceProfileArn
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (339.86s)
=== CONT  TestAccAWSSpotFleetRequest_fleetType
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (298.09s)
=== CONT  TestAccAWSSpotFleetRequest_launchTemplateWithOverrides
--- PASS: TestAccAWSSpotFleetRequest_fleetType (278.14s)
=== CONT  TestAccAWSSpotFleetRequest_launchTemplate_multiple
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (596.60s)
=== CONT  TestAccAWSSpotFleetRequest_launchTemplate
=== CONT  TestAccAWSSpotFleetRequest_associatePublicIpAddress
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (606.98s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (226.76s)
=== CONT  TestAccAWSSpotFleetRequest_tags
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (218.75s)
=== CONT  TestAccAWSSpotFleetRequest_withTags
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (264.16s)
=== CONT  TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (267.96s)
=== CONT  TestAccAWSSpotFleetRequest_disappears
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (873.56s)
=== CONT  TestAccAWSSpotFleetRequest_WithTargetGroups
--- PASS: TestAccAWSSpotFleetRequest_tags (337.92s)
=== CONT  TestAccAWSSpotFleetRequest_WithELBs
--- PASS: TestAccAWSSpotFleetRequest_withTags (337.47s)
=== CONT  TestAccAWSSpotFleetRequest_placementTenancyAndGroup
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (287.70s)
=== CONT  TestAccAWSSpotFleetRequest_withWeightedCapacity
--- PASS: TestAccAWSSpotFleetRequest_disappears (297.20s)
=== CONT  TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (73.33s)
=== CONT  TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (128.37s)
=== CONT  TestAccAWSSpotFleetRequest_withEBSDisk
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (473.59s)
=== CONT  TestAccAWSSpotFleetRequest_diversifiedAllocation
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (133.03s)
=== CONT  TestAccAWSSpotFleetRequest_multipleInstancePools
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (279.72s)
=== CONT  TestAccAWSSpotFleetRequest_withoutSpotPrice
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (337.55s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (277.37s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (321.30s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (335.04s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (414.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3085.374s
```
