### PR TITLE
resource/instance: fix non-empty plan after refresh 

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -655,21 +655,21 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	instance := runResp.Instances[0]
-	log.Printf("[INFO] Instance ID: %s", *instance.InstanceId)
+	log.Printf("[INFO] Instance ID: %s", aws.StringValue(instance.InstanceId))
 
 	// Store the resulting ID so we can look this up later
-	d.SetId(*instance.InstanceId)
+	d.SetId(aws.StringValue(instance.InstanceId))
 
 	// Wait for the instance to become running so we can get some attributes
 	// that aren't available until later.
 	log.Printf(
 		"[DEBUG] Waiting for instance (%s) to become running",
-		*instance.InstanceId)
+		aws.StringValue(instance.InstanceId))
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     []string{"running"},
-		Refresh:    InstanceStateRefreshFunc(conn, *instance.InstanceId, []string{"terminated", "shutting-down"}),
+		Refresh:    InstanceStateRefreshFunc(conn, aws.StringValue(instance.InstanceId), []string{"terminated", "shutting-down"}),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -679,7 +679,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf(
 			"Error waiting for instance (%s) to become ready: %s",
-			*instance.InstanceId, err)
+			aws.StringValue(instance.InstanceId), err)
 	}
 
 	instance = instanceRaw.(*ec2.Instance)
@@ -688,12 +688,12 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	if instance.PublicIpAddress != nil {
 		d.SetConnInfo(map[string]string{
 			"type": "ssh",
-			"host": *instance.PublicIpAddress,
+			"host": aws.StringValue(instance.PublicIpAddress),
 		})
 	} else if instance.PrivateIpAddress != nil {
 		d.SetConnInfo(map[string]string{
 			"type": "ssh",
-			"host": *instance.PrivateIpAddress,
+			"host": aws.StringValue(instance.PrivateIpAddress),
 		})
 	}
 
@@ -726,7 +726,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	if instance.State != nil {
 		// If the instance is terminated, then it is gone
-		if *instance.State.Name == "terminated" {
+		if aws.StringValue(instance.State.Name) == "terminated" {
 			d.SetId("")
 			return nil
 		}
@@ -789,16 +789,16 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		var networkInterfaces []map[string]interface{}
 		for _, iNi := range instance.NetworkInterfaces {
 			ni := make(map[string]interface{})
-			if *iNi.Attachment.DeviceIndex == 0 {
+			if aws.Int64Value(iNi.Attachment.DeviceIndex) == 0 {
 				primaryNetworkInterface = *iNi
 			}
 			// If the attached network device is inside our configuration, refresh state with values found.
 			// Otherwise, assume the network device was attached via an outside resource.
 			for _, index := range configuredDeviceIndexes {
-				if index == int(*iNi.Attachment.DeviceIndex) {
-					ni["device_index"] = *iNi.Attachment.DeviceIndex
-					ni["network_interface_id"] = *iNi.NetworkInterfaceId
-					ni["delete_on_termination"] = *iNi.Attachment.DeleteOnTermination
+				if index == int(aws.Int64Value(iNi.Attachment.DeviceIndex)) {
+					ni["device_index"] = aws.Int64Value(iNi.Attachment.DeviceIndex)
+					ni["network_interface_id"] = aws.StringValue(iNi.NetworkInterfaceId)
+					ni["delete_on_termination"] = aws.BoolValue(iNi.Attachment.DeleteOnTermination)
 				}
 			}
 			// Don't add empty network interfaces to schema
@@ -828,7 +828,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("associate_public_ip_address", primaryNetworkInterface.Association != nil)
 
 		for _, address := range primaryNetworkInterface.Ipv6Addresses {
-			ipv6Addresses = append(ipv6Addresses, *address.Ipv6Address)
+			ipv6Addresses = append(ipv6Addresses, aws.StringValue(address.Ipv6Address))
 		}
 
 	} else {
@@ -843,12 +843,12 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("ebs_optimized", instance.EbsOptimized)
-	if instance.SubnetId != nil && *instance.SubnetId != "" {
+	if instance.SubnetId != nil && aws.StringValue(instance.SubnetId) != "" {
 		d.Set("source_dest_check", instance.SourceDestCheck)
 	}
 
 	if instance.Monitoring != nil && instance.Monitoring.State != nil {
-		monitoringState := *instance.Monitoring.State
+		monitoringState := aws.StringValue(instance.Monitoring.State)
 		d.Set("monitoring", monitoringState == "enabled" || monitoringState == "pending")
 	}
 
@@ -915,7 +915,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			if b64 {
 				d.Set("user_data_base64", attr.UserData.Value)
 			} else {
-				d.Set("user_data", userDataHashSum(*attr.UserData.Value))
+				d.Set("user_data", userDataHashSum(aws.StringValue(attr.UserData.Value)))
 			}
 		}
 	}
@@ -937,7 +937,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.Get("get_password_data").(bool) {
-		passwordData, err := getAwsEc2InstancePasswordData(*instance.InstanceId, conn)
+		passwordData, err := getAwsEc2InstancePasswordData(aws.StringValue(instance.InstanceId), conn)
 		if err != nil {
 			return err
 		}
@@ -1110,7 +1110,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		var primaryInterface ec2.InstanceNetworkInterface
 		for _, ni := range instance.NetworkInterfaces {
-			if *ni.Attachment.DeviceIndex == 0 {
+			if aws.Int64Value(ni.Attachment.DeviceIndex) == 0 {
 				primaryInterface = *ni
 			}
 		}
@@ -1411,10 +1411,10 @@ func VolumeStateRefreshFunc(conn *ec2.EC2, volumeID, failState string) resource.
 
 func stringifyStateReason(sr *ec2.StateReason) string {
 	if sr.Message != nil {
-		return *sr.Message
+		return aws.StringValue(sr.Message)
 	}
 	if sr.Code != nil {
-		return *sr.Code
+		return aws.StringValue(sr.Code)
 	}
 
 	return sr.String()
@@ -1492,7 +1492,7 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 	instanceBlockDevices := make(map[string]*ec2.InstanceBlockDeviceMapping)
 	for _, bd := range instance.BlockDeviceMappings {
 		if bd.Ebs != nil {
-			instanceBlockDevices[*bd.Ebs.VolumeId] = bd
+			instanceBlockDevices[aws.StringValue(bd.Ebs.VolumeId)] = bd
 		}
 	}
 
@@ -1515,7 +1515,7 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 	}
 
 	for _, vol := range volResp.Volumes {
-		instanceBd := instanceBlockDevices[*vol.VolumeId]
+		instanceBd := instanceBlockDevices[aws.StringValue(vol.VolumeId)]
 		bd := make(map[string]interface{})
 
 		bd["volume_id"] = aws.StringValue(vol.VolumeId)
@@ -1544,19 +1544,24 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 
 		if blockDeviceIsRoot(instanceBd, instance) {
 			blockDevices["root"] = bd
-		}
-
-		// Represent the ebs block device as it's own object (cloned from bd)
-		if aws.StringValue(instance.RootDeviceType) == "ebs" {
-			ebs := make(map[string]interface{})
-			for k, v := range bd {
-				ebs[k] = v
-			}
+		} else {
 			if vol.SnapshotId != nil {
-				ebs["snapshot_id"] = aws.StringValue(vol.SnapshotId)
+				bd["snapshot_id"] = aws.StringValue(vol.SnapshotId)
 			}
-			blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), ebs)
+
+			blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)
 		}
+	}
+	// If the root device is the only block device mapping in the instance,
+	// explicitly set the ebs_block_device as a clone of the root device
+	// with the snapshot_id populated iff available
+	if blockDevices["root"] != nil && len(blockDevices["ebs"].([]map[string]interface{})) == 0 {
+		ebs := make(map[string]interface{})
+		for k, v := range blockDevices["root"].(map[string]interface{}) {
+			ebs[k] = v
+		}
+		ebs["snapshot_id"] = volResp.Volumes[0].SnapshotId
+		blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), ebs)
 	}
 
 	return blockDevices, nil
@@ -1565,8 +1570,7 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 func blockDeviceIsRoot(bd *ec2.InstanceBlockDeviceMapping, instance *ec2.Instance) bool {
 	return bd.DeviceName != nil &&
 		instance.RootDeviceName != nil &&
-		*bd.DeviceName == *instance.RootDeviceName
-
+		aws.StringValue(bd.DeviceName) == aws.StringValue(instance.RootDeviceName)
 }
 
 func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
@@ -1591,7 +1595,7 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 	rootDeviceName := image.RootDeviceName
 
 	// Instance store backed AMIs do not provide a root device name.
-	if *image.RootDeviceType == ec2.DeviceTypeInstanceStore {
+	if aws.StringValue(image.RootDeviceType) == ec2.DeviceTypeInstanceStore {
 		return nil, nil
 	}
 
@@ -1785,14 +1789,14 @@ func readBlockDeviceMappingsFromConfig(d *schema.ResourceData, conn *ec2.EC2) ([
 				ebs.VolumeType = aws.String(v)
 			}
 
-			if v, ok := bd["iops"].(int); ok && v > 0 && *ebs.VolumeType == "io1" {
+			if v, ok := bd["iops"].(int); ok && v > 0 && aws.StringValue(ebs.VolumeType) == "io1" {
 				// Only set the iops attribute if the volume type is io1. Setting otherwise
 				// can trigger a refresh/plan loop based on the computed value that is given
 				// from AWS, and prevent us from specifying 0 as a valid iops.
 				//   See https://github.com/hashicorp/terraform/pull/4146
 				//   See https://github.com/hashicorp/terraform/issues/7765
 				ebs.Iops = aws.Int64(int64(v))
-			} else if v, ok := bd["iops"].(int); ok && v > 0 && *ebs.VolumeType != "io1" {
+			} else if v, ok := bd["iops"].(int); ok && v > 0 && aws.StringValue(ebs.VolumeType) != "io1" {
 				// Message user about incompatibility
 				log.Print("[WARN] IOPs is only valid on IO1 storage type for EBS Volumes")
 			}
@@ -1842,22 +1846,22 @@ func readVolumeTags(conn *ec2.EC2, instanceId string) ([]*ec2.Tag, error) {
 // config determine which one to use in Plan and Apply.
 func readSecurityGroups(d *schema.ResourceData, instance *ec2.Instance, conn *ec2.EC2) error {
 	// An instance with a subnet is in a VPC; an instance without a subnet is in EC2-Classic.
-	hasSubnet := instance.SubnetId != nil && *instance.SubnetId != ""
+	hasSubnet := instance.SubnetId != nil && aws.StringValue(instance.SubnetId) != ""
 	useID, useName := hasSubnet, !hasSubnet
 
 	// If the instance is in a VPC, find out if that VPC is Default to determine
 	// whether to store names.
-	if instance.VpcId != nil && *instance.VpcId != "" {
+	if instance.VpcId != nil && aws.StringValue(instance.VpcId) != "" {
 		out, err := conn.DescribeVpcs(&ec2.DescribeVpcsInput{
 			VpcIds: []*string{instance.VpcId},
 		})
 		if err != nil {
-			log.Printf("[WARN] Unable to describe VPC %q: %s", *instance.VpcId, err)
+			log.Printf("[WARN] Unable to describe VPC %q: %s", aws.StringValue(instance.VpcId), err)
 		} else if len(out.Vpcs) == 0 {
 			// This may happen in Eucalyptus Cloud
 			log.Printf("[WARN] Unable to retrieve VPCs")
 		} else {
-			isInDefaultVpc := *out.Vpcs[0].IsDefault
+			isInDefaultVpc := aws.BoolValue(out.Vpcs[0].IsDefault)
 			useName = isInDefaultVpc
 		}
 	}
@@ -1866,7 +1870,7 @@ func readSecurityGroups(d *schema.ResourceData, instance *ec2.Instance, conn *ec
 	if useID {
 		sgs := make([]string, 0, len(instance.SecurityGroups))
 		for _, sg := range instance.SecurityGroups {
-			sgs = append(sgs, *sg.GroupId)
+			sgs = append(sgs, aws.StringValue(sg.GroupId))
 		}
 		log.Printf("[DEBUG] Setting Security Group IDs: %#v", sgs)
 		if err := d.Set("vpc_security_group_ids", sgs); err != nil {
@@ -1880,7 +1884,7 @@ func readSecurityGroups(d *schema.ResourceData, instance *ec2.Instance, conn *ec
 	if useName {
 		sgs := make([]string, 0, len(instance.SecurityGroups))
 		for _, sg := range instance.SecurityGroups {
-			sgs = append(sgs, *sg.GroupName)
+			sgs = append(sgs, aws.StringValue(sg.GroupName))
 		}
 		log.Printf("[DEBUG] Setting Security Group Names: %#v", sgs)
 		if err := d.Set("security_groups", sgs); err != nil {
@@ -1910,11 +1914,11 @@ func getAwsEc2InstancePasswordData(instanceID string, conn *ec2.EC2) (string, er
 			return resource.NonRetryableError(err)
 		}
 
-		if resp.PasswordData == nil || *resp.PasswordData == "" {
+		if resp.PasswordData == nil || aws.StringValue(resp.PasswordData) == "" {
 			return resource.RetryableError(fmt.Errorf("Password data is blank for instance ID: %s", instanceID))
 		}
 
-		passwordData = strings.TrimSpace(*resp.PasswordData)
+		passwordData = strings.TrimSpace(aws.StringValue(resp.PasswordData))
 
 		log.Printf("[INFO] Password data read for instance %s", instanceID)
 		return nil
@@ -1924,10 +1928,10 @@ func getAwsEc2InstancePasswordData(instanceID string, conn *ec2.EC2) (string, er
 		if err != nil {
 			return "", fmt.Errorf("Error getting password data: %s", err)
 		}
-		if resp.PasswordData == nil || *resp.PasswordData == "" {
+		if resp.PasswordData == nil || aws.StringValue(resp.PasswordData) == "" {
 			return "", fmt.Errorf("Password data is blank for instance ID: %s", instanceID)
 		}
-		passwordData = strings.TrimSpace(*resp.PasswordData)
+		passwordData = strings.TrimSpace(aws.StringValue(resp.PasswordData))
 	}
 	if err != nil {
 		return "", err
@@ -2089,7 +2093,7 @@ func buildAwsInstanceOpts(
 			opts.PrivateIPAddress = aws.String(v.(string))
 		}
 		if opts.SubnetID != nil &&
-			*opts.SubnetID != "" {
+			aws.StringValue(opts.SubnetID) != "" {
 			opts.SecurityGroupIDs = groups
 		} else {
 			opts.SecurityGroups = groups
@@ -2194,7 +2198,7 @@ func iamInstanceProfileArnToName(ip *ec2.IamInstanceProfile) string {
 	if ip == nil || ip.Arn == nil {
 		return ""
 	}
-	parts := strings.Split(*ip.Arn, "/")
+	parts := strings.Split(aws.StringValue(ip.Arn), "/")
 	return parts[len(parts)-1]
 }
 

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1803,7 +1803,6 @@ func TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices(t *testing.
 	var instance ec2.Instance
 
 	resourceName := "aws_instance.test"
-	dataSourceName := "data.aws_ami.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:            func() { testAccPreCheck(t) },
@@ -1815,14 +1814,25 @@ func TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices(t *testing.
 				Config: testAccAwsEc2InstanceConfigDynamicEBSBlockDevices,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.%", dataSourceName, "block_device_mappings.%"),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2432380901.delete_on_termination", "true"),
-					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.2432380901.device_name", dataSourceName, "block_device_mappings.340275815.device_name"),
-					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.2432380901.encrypted", dataSourceName, "block_device_mappings.340275815.ebs.encrypted"),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2432380901.iops", "100"),
-					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.2432380901.snapshot_id", dataSourceName, "block_device_mappings.340275815.ebs.snapshot_id"),
-					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.2432380901.volume_size", dataSourceName, "block_device_mappings.340275815.ebs.volume_size"),
-					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.2432380901.volume_type", dataSourceName, "block_device_mappings.340275815.ebs.volume_type"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.delete_on_termination", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.device_name", "/dev/sdc"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.iops", "100"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2554893574.volume_type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.delete_on_termination", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.device_name", "/dev/sdb"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.iops", "100"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.volume_type", "gp2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2613854568.delete_on_termination", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2613854568.device_name", "/dev/sda"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2613854568.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2613854568.iops", "100"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2613854568.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2613854568.volume_type", "gp2"),
 				),
 			},
 			{
@@ -4775,34 +4785,17 @@ data "aws_ec2_instance_type_offering" "available" {
 }
 
 const testAccAwsEc2InstanceConfigDynamicEBSBlockDevices = `
-data "aws_ami" "test" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-hvm-*-x86_64-gp2"]
-  }
-}
-
-data "aws_vpc" "test" {
-  default = true
-}
-
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.test.id
-  instance_type = "t2.micro"
+  ami           = "ami-55a7ea65"
+  instance_type = "m3.medium"
 
   dynamic "ebs_block_device" {
-    # for verifying attributes of a predictable number of ebs_block_devices, set to only 1 mapping
-    for_each = [tolist(data.aws_ami.test.block_device_mappings)[0]]
+    for_each = ["a", "b", "c"]
     iterator = device
     content {
-      device_name = device.value["device_name"]
-      iops        = "100"
-      snapshot_id = device.value["ebs"]["snapshot_id"]
-      volume_size = device.value["ebs"]["volume_size"]
-      volume_type = device.value["ebs"]["volume_type"]
+      device_name = format("/dev/sd%s", device.value)
+      volume_size = "10"
+      volume_type = "gp2"
     }
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13118

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/instance: set ebs_block_device from root_block_device when only 1 block device mapping in instance
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (61.17s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (68.79s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (82.66s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (83.97s)
--- PASS: TestFetchRootDevice (0.00s)
    --- PASS: TestFetchRootDevice/device_name_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/device_name_not_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/no_images (0.00s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (91.01s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (94.50s)
--- SKIP: TestAccAWSInstance_inEc2Classic (1.17s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (105.64s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (119.14s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (119.52s)
--- PASS: TestAccAWSInstanceDataSource_VPC (119.71s)
--- PASS: TestAccAWSInstanceDataSource_basic (129.03s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (130.24s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (131.20s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (144.76s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (64.02s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (156.45s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (164.53s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (181.79s)
--- SKIP: TestAccAWSInstance_outpost (0.00s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (70.20s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (90.81s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (11.30s)
--- PASS: TestAccAWSInstance_rootInstanceStore (69.94s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (114.39s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (94.99s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (227.13s)
--- PASS: TestAccAWSInstance_basic (138.84s)
--- PASS: TestAccAWSInstanceDataSource_tags (242.31s)
--- PASS: TestAccAWSInstance_vpc (87.19s)
--- PASS: TestAccAWSInstance_disableApiTermination (98.83s)
--- PASS: TestAccAWSInstancesDataSource_tags (193.99s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (79.40s)
--- PASS: TestAccAWSInstancesDataSource_basic (205.21s)
--- PASS: TestAccAWSInstance_sourceDestCheck (127.11s)
--- PASS: TestAccAWSInstancesDataSource_instance_state_names (193.39s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (78.93s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (87.32s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (84.89s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (78.91s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (317.58s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (175.81s)
--- PASS: TestAccAWSInstance_privateIP (67.28s)
--- PASS: TestAccAWSInstance_keyPairCheck (64.18s)
--- PASS: TestAccAWSInstance_multipleRegions (130.75s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (64.98s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (103.51s)
--- PASS: TestAccAWSInstance_volumeTags (113.70s)
--- PASS: TestAccAWSInstance_userDataBase64 (233.35s)
--- PASS: TestAccAWSInstance_tags (126.92s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (74.19s)
--- PASS: TestAccAWSInstance_placementGroup (181.52s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (115.88s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (113.07s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (134.05s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (291.02s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (68.55s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (113.65s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (88.19s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (107.13s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (67.50s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (81.92s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (186.98s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (88.08s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS (134.84s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (76.13s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (108.25s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (117.03s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (67.36s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (66.77s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (68.14s)
--- PASS: TestAccAWSInstance_changeInstanceType (225.72s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (73.43s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (91.18s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (104.50s)
--- PASS: TestInstanceTenancySchema (0.00s)
--- PASS: TestInstanceHostIDSchema (0.00s)
--- PASS: TestInstanceCpuCoreCountSchema (0.00s)
--- PASS: TestInstanceCpuThreadsPerCoreSchema (0.00s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (193.30s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (145.50s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (106.55s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (102.13s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (110.36s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (150.46s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (140.46s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (92.93s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (132.31s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (128.91s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (96.42s)
--- PASS: TestAccAWSInstance_disappears (244.65s)
--- PASS: TestAccAWSInstance_hibernation (214.54s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (310.76s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (308.87s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (310.23s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (390.69s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (400.28s)
```
 Failing in TC:
```
--- FAIL: TestAccAWSInstance_blockDevices (54.66s)
--- FAIL: TestAccAWSInstance_metadataOptions (281.46s)
--- FAIL: TestAccAWSInstance_EbsRootDevice_ModifyAll (122.22s)
--- FAIL: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (92.74s)
--- FAIL: TestAccAWSInstance_instanceProfileChange (130.77s)
--- FAIL: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (100.62s)
```
But passing locally:
```
--- PASS: TestAccAWSInstance_blockDevices (103.57s)
--- PASS: TestAccAWSInstance_metadataOptions (128.92s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (151.02s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (122.33s)
--- PASS: TestAccAWSInstance_instanceProfileChange (221.20s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (129.02s)

```