### PR TITLE
r/xray_group - new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -937,6 +937,7 @@ func Provider() *schema.Provider {
 			"aws_pinpoint_event_stream":                               resourceAwsPinpointEventStream(),
 			"aws_pinpoint_gcm_channel":                                resourceAwsPinpointGCMChannel(),
 			"aws_pinpoint_sms_channel":                                resourceAwsPinpointSMSChannel(),
+			"aws_xray_group":                                          resourceAwsXrayGroup(),
 			"aws_xray_sampling_rule":                                  resourceAwsXraySamplingRule(),
 			"aws_workspaces_ip_group":                                 resourceAwsWorkspacesIpGroup(),
 

--- a/aws/resource_aws_xray_group.go
+++ b/aws/resource_aws_xray_group.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAwsXrayGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsXrayGroupCreate,
+		Read:   resourceAwsXrayGroupRead,
+		Update: resourceAwsXrayGroupUpdate,
+		Delete: resourceAwsXrayGroupDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"filter_expression": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsXrayGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).xrayconn
+	input := &xray.CreateGroupInput{
+		GroupName:        aws.String(d.Get("group_name").(string)),
+		FilterExpression: aws.String(d.Get("filter_expression").(string)),
+	}
+
+	out, err := conn.CreateGroup(input)
+	if err != nil {
+		return fmt.Errorf("error creating XRay Group: %s", err)
+	}
+
+	d.SetId(aws.StringValue(out.Group.GroupARN))
+
+	return resourceAwsXrayGroupRead(d, meta)
+}
+
+func resourceAwsXrayGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).xrayconn
+
+	input := &xray.GetGroupInput{
+		GroupARN: aws.String(d.Id()),
+	}
+
+	group, err := conn.GetGroup(input)
+
+	if err != nil {
+		if isAWSErr(err, xray.ErrCodeInvalidRequestException, "Group not found") {
+			log.Printf("[WARN] XRay Group (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading XRay Group (%s): %s", d.Id(), err)
+	}
+
+	d.Set("arn", group.Group.GroupARN)
+	d.Set("group_name", group.Group.GroupName)
+	d.Set("filter_expression", group.Group.FilterExpression)
+
+	return nil
+}
+
+func resourceAwsXrayGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).xrayconn
+
+	input := &xray.UpdateGroupInput{
+		GroupARN:         aws.String(d.Id()),
+		FilterExpression: aws.String(d.Get("filter_expression").(string)),
+	}
+
+	_, err := conn.UpdateGroup(input)
+	if err != nil {
+		return fmt.Errorf("error updating XRay Group (%s): %s", d.Id(), err)
+	}
+
+	return resourceAwsXrayGroupRead(d, meta)
+}
+
+func resourceAwsXrayGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).xrayconn
+
+	log.Printf("[INFO] Deleting XRay Group: %s", d.Id())
+
+	params := &xray.DeleteGroupInput{
+		GroupARN: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteGroup(params)
+	if err != nil {
+		return fmt.Errorf("error deleting XRay Group: %s", d.Id())
+	}
+
+	return nil
+}

--- a/aws/resource_aws_xray_group.go
+++ b/aws/resource_aws_xray_group.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsXrayGroup() *schema.Resource {
@@ -21,6 +22,10 @@ func resourceAwsXrayGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"group_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -30,10 +35,7 @@ func resourceAwsXrayGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -43,11 +45,12 @@ func resourceAwsXrayGroupCreate(d *schema.ResourceData, meta interface{}) error 
 	input := &xray.CreateGroupInput{
 		GroupName:        aws.String(d.Get("group_name").(string)),
 		FilterExpression: aws.String(d.Get("filter_expression").(string)),
+		Tags:             keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().XrayTags(),
 	}
 
 	out, err := conn.CreateGroup(input)
 	if err != nil {
-		return fmt.Errorf("error creating XRay Group: %s", err)
+		return fmt.Errorf("error creating XRay Group: %w", err)
 	}
 
 	d.SetId(aws.StringValue(out.Group.GroupARN))
@@ -57,6 +60,7 @@ func resourceAwsXrayGroupCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceAwsXrayGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).xrayconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	input := &xray.GetGroupInput{
 		GroupARN: aws.String(d.Id()),
@@ -70,12 +74,22 @@ func resourceAwsXrayGroupRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading XRay Group (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading XRay Group (%s): %w", d.Id(), err)
 	}
 
-	d.Set("arn", group.Group.GroupARN)
+	arn := aws.StringValue(group.Group.GroupARN)
+	d.Set("arn", arn)
 	d.Set("group_name", group.Group.GroupName)
 	d.Set("filter_expression", group.Group.FilterExpression)
+
+	tags, err := keyvaluetags.XrayListTags(conn, arn)
+	if err != nil {
+		return fmt.Errorf("error listing tags for Xray Group (%q): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
 
 	return nil
 }
@@ -83,14 +97,23 @@ func resourceAwsXrayGroupRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsXrayGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).xrayconn
 
-	input := &xray.UpdateGroupInput{
-		GroupARN:         aws.String(d.Id()),
-		FilterExpression: aws.String(d.Get("filter_expression").(string)),
+	if d.HasChange("filter_expression") {
+		input := &xray.UpdateGroupInput{
+			GroupARN:         aws.String(d.Id()),
+			FilterExpression: aws.String(d.Get("filter_expression").(string)),
+		}
+
+		_, err := conn.UpdateGroup(input)
+		if err != nil {
+			return fmt.Errorf("error updating XRay Group (%s): %w", d.Id(), err)
+		}
 	}
 
-	_, err := conn.UpdateGroup(input)
-	if err != nil {
-		return fmt.Errorf("error updating XRay Group (%s): %s", d.Id(), err)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.XrayUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %w", err)
+		}
 	}
 
 	return resourceAwsXrayGroupRead(d, meta)
@@ -106,7 +129,7 @@ func resourceAwsXrayGroupDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 	_, err := conn.DeleteGroup(params)
 	if err != nil {
-		return fmt.Errorf("error deleting XRay Group: %s", d.Id())
+		return fmt.Errorf("error deleting XRay Group (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_xray_group.go
+++ b/aws/resource_aws_xray_group.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAwsXrayGroup() *schema.Resource {

--- a/aws/resource_aws_xray_group_test.go
+++ b/aws/resource_aws_xray_group_test.go
@@ -1,0 +1,139 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSXrayGroup_basic(t *testing.T) {
+	var Group xray.Group
+	resourceName := "aws_xray_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSXrayGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSXrayGroupBasicConfig(rName, "responsetime > 5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXrayGroupExists(resourceName, &Group),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "xray", regexp.MustCompile(`group/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "filter_expression", "responsetime > 5"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSXrayGroupBasicConfig(rName, "responsetime > 10"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXrayGroupExists(resourceName, &Group),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "xray", regexp.MustCompile(`group/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "filter_expression", "responsetime > 10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSXrayGroup_disappears(t *testing.T) {
+	var Group xray.Group
+	resourceName := "aws_xray_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSXrayGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSXrayGroupBasicConfig(rName, "responsetime > 5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXrayGroupExists(resourceName, &Group),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsXrayGroup(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckXrayGroupExists(n string, Group *xray.Group) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No XRay Group ID is set")
+		}
+		conn := testAccProvider.Meta().(*AWSClient).xrayconn
+
+		input := &xray.GetGroupInput{
+			GroupARN: aws.String(rs.Primary.ID),
+		}
+
+		group, err := conn.GetGroup(input)
+
+		if err != nil {
+			return err
+		}
+
+		*Group = *group.Group
+
+		return nil
+	}
+}
+
+func testAccCheckAWSXrayGroupDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_xray_group" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).xrayconn
+
+		input := &xray.GetGroupInput{
+			GroupARN: aws.String(rs.Primary.ID),
+		}
+
+		group, err := conn.GetGroup(input)
+
+		if isAWSErr(err, xray.ErrCodeInvalidRequestException, "Group not found") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if group != nil {
+			return fmt.Errorf("Expected XRay Group to be destroyed, %s found", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSXrayGroupBasicConfig(rName, expression string) string {
+	return fmt.Sprintf(`
+resource "aws_xray_group" "test" {
+  group_name        = %[1]q
+  filter_expression = %[2]q
+}
+`, rName, expression)
+}

--- a/aws/resource_aws_xray_group_test.go
+++ b/aws/resource_aws_xray_group_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/aws/resource_aws_xray_group_test.go
+++ b/aws/resource_aws_xray_group_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSXrayGroup_basic(t *testing.T) {

--- a/website/docs/r/xray_group.html.markdown
+++ b/website/docs/r/xray_group.html.markdown
@@ -23,6 +23,7 @@ resource "aws_xray_group" "example" {
 
 * `group_name` - (Required) The name of the group.
 * `filter_expression` - (Required) The filter expression defining criteria by which to group traces. more info can be found in official [docs](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-filters.html).
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 

--- a/website/docs/r/xray_group.html.markdown
+++ b/website/docs/r/xray_group.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "XRay"
+layout: "aws"
+page_title: "AWS: aws_xray_group"
+description: |-
+    Creates and manages an AWS XRay Group.
+---
+
+# Resource: aws_xray_group
+
+Creates and manages an AWS XRay Group.
+
+## Example Usage
+
+```hcl
+resource "aws_xray_group" "example" {
+  group_name        = "example"
+  filter_expression = "responsetime > 5"
+}
+```
+
+## Argument Reference
+
+* `group_name` - (Required) The name of the group.
+* `filter_expression` - (Required) The filter expression defining criteria by which to group traces. more info can be found in official [docs](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-filters.html).
+
+## Attributes Reference
+
+In addition to the arguments above, the following attributes are exported:
+
+* `id` - The ARN of the Group.
+* `arn` - The ARN of the Group.
+
+## Import
+
+XRay Groups can be imported using the ARN, e.g.
+
+```
+$ terraform import aws_xray_group.example arn:aws:xray:us-west-2:1234567890:group/example-group/TNGX7SW5U6QY36T4ZMOUA3HVLBYCZTWDIOOXY3CJAXTHSS3YCWUA
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8749

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resoruce_aws_xray_group - add new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSXrayGroup_'
--- PASS: TestAccAWSXrayGroup_basic (65.99s)
--- PASS: TestAccAWSXrayGroup_tags (152.98s)
--- PASS: TestAccAWSXrayGroup_disappears (30.12s)
```
