### PR TITLE
r/xray_encryption_config - new resource

### DIFF
--- a/aws/internal/service/xray/waiter/status.go
+++ b/aws/internal/service/xray/waiter/status.go
@@ -3,7 +3,7 @@ package waiter
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // EncryptionConfigStatus fetches the Encryption Config and its Status

--- a/aws/internal/service/xray/waiter/status.go
+++ b/aws/internal/service/xray/waiter/status.go
@@ -12,6 +12,10 @@ func EncryptionConfigStatus(conn *xray.XRay) resource.StateRefreshFunc {
 
 		output, _ := conn.GetEncryptionConfig(&xray.GetEncryptionConfigInput{})
 
+		if output == nil || output.EncryptionConfig == nil {
+			return output, EncryptionConfigStatusUnknown, nil
+		}
+		
 		return output, aws.StringValue(output.EncryptionConfig.Status), nil
 	}
 }

--- a/aws/internal/service/xray/waiter/status.go
+++ b/aws/internal/service/xray/waiter/status.go
@@ -1,9 +1,8 @@
 package waiter
 
 import (
-	"github.com/aws/aws-sdk-go/service/xray"
-
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/xray"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 

--- a/aws/internal/service/xray/waiter/status.go
+++ b/aws/internal/service/xray/waiter/status.go
@@ -6,6 +6,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+const (
+	EncryptionConfigStatusUnknown = "Unknown"
+)
+
 // EncryptionConfigStatus fetches the Encryption Config and its Status
 func EncryptionConfigStatus(conn *xray.XRay) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
@@ -15,7 +19,7 @@ func EncryptionConfigStatus(conn *xray.XRay) resource.StateRefreshFunc {
 		if output == nil || output.EncryptionConfig == nil {
 			return output, EncryptionConfigStatusUnknown, nil
 		}
-		
+
 		return output, aws.StringValue(output.EncryptionConfig.Status), nil
 	}
 }

--- a/aws/internal/service/xray/waiter/status.go
+++ b/aws/internal/service/xray/waiter/status.go
@@ -1,0 +1,18 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/service/xray"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// EncryptionConfigStatus fetches the Encryption Config and its Status
+func EncryptionConfigStatus(conn *xray.XRay) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+
+		output, _ := conn.GetEncryptionConfig(&xray.GetEncryptionConfigInput{})
+
+		return output, aws.StringValue(output.EncryptionConfig.Status), nil
+	}
+}

--- a/aws/internal/service/xray/waiter/waiter.go
+++ b/aws/internal/service/xray/waiter/waiter.go
@@ -7,13 +7,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+const (
+	EncryptionConfigAvailableTimeout = 15 * time.Minute
+)
+
 // EncryptionConfigAvailable waits for a EncryptionConfig to return Available
 func EncryptionConfigAvailable(conn *xray.XRay) (*xray.EncryptionConfig, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{xray.EncryptionStatusUpdating},
 		Target:  []string{xray.EncryptionStatusActive},
 		Refresh: EncryptionConfigStatus(conn),
-		Timeout: 15 * time.Minute,
+		Timeout: EncryptionConfigAvailableTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/internal/service/xray/waiter/waiter.go
+++ b/aws/internal/service/xray/waiter/waiter.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/xray"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // EncryptionConfigAvailable waits for a EncryptionConfig to return Available

--- a/aws/internal/service/xray/waiter/waiter.go
+++ b/aws/internal/service/xray/waiter/waiter.go
@@ -1,0 +1,26 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/service/xray"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// EncryptionConfigAvailable waits for a EncryptionConfig to return Available
+func EncryptionConfigAvailable(conn *xray.XRay) (*xray.EncryptionConfig, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{xray.EncryptionStatusUpdating},
+		Target:  []string{xray.EncryptionStatusActive},
+		Refresh: EncryptionConfigStatus(conn),
+		Timeout: 15 * time.Minute,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*xray.EncryptionConfig); ok {
+		return v, err
+	}
+
+	return nil, err
+}

--- a/aws/internal/service/xray/waiter/waiter.go
+++ b/aws/internal/service/xray/waiter/waiter.go
@@ -1,9 +1,9 @@
 package waiter
 
 import (
-	"github.com/aws/aws-sdk-go/service/xray"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/xray"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -937,6 +937,7 @@ func Provider() *schema.Provider {
 			"aws_pinpoint_event_stream":                               resourceAwsPinpointEventStream(),
 			"aws_pinpoint_gcm_channel":                                resourceAwsPinpointGCMChannel(),
 			"aws_pinpoint_sms_channel":                                resourceAwsPinpointSMSChannel(),
+			"aws_xray_encryption_config":                              resourceAwsXrayEncryptionConfig(),
 			"aws_xray_group":                                          resourceAwsXrayGroup(),
 			"aws_xray_sampling_rule":                                  resourceAwsXraySamplingRule(),
 			"aws_workspaces_ip_group":                                 resourceAwsWorkspacesIpGroup(),

--- a/aws/resource_aws_xray_encryption_config.go
+++ b/aws/resource_aws_xray_encryption_config.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/xray/waiter"
 )
 

--- a/aws/resource_aws_xray_encryption_config.go
+++ b/aws/resource_aws_xray_encryption_config.go
@@ -46,7 +46,7 @@ func resourceAwsXrayEncryptionConfigPut(d *schema.ResourceData, meta interface{}
 		Type: aws.String(d.Get("type").(string)),
 	}
 
-	if v, ok := d.GetOk("key_id"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("key_id"); ok {
 		input.KeyId = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_xray_encryption_config.go
+++ b/aws/resource_aws_xray_encryption_config.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/xray/waiter"
@@ -52,7 +51,7 @@ func resourceAwsXrayEncryptionConfigPut(d *schema.ResourceData, meta interface{}
 
 	_, err := conn.PutEncryptionConfig(input)
 	if err != nil {
-		return fmt.Errorf("error creating XRay Encryption Config: %s", err)
+		return fmt.Errorf("error creating XRay Encryption Config: %w", err)
 	}
 
 	d.SetId(meta.(*AWSClient).region)
@@ -70,7 +69,7 @@ func resourceAwsXrayEncryptionConfigRead(d *schema.ResourceData, meta interface{
 	config, err := conn.GetEncryptionConfig(&xray.GetEncryptionConfigInput{})
 
 	if err != nil {
-		return fmt.Errorf("error reading XRay Encryption Config: %s", err)
+		return fmt.Errorf("error reading XRay Encryption Config: %w", err)
 	}
 
 	d.Set("key_id", config.EncryptionConfig.KeyId)

--- a/aws/resource_aws_xray_encryption_config.go
+++ b/aws/resource_aws_xray_encryption_config.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/xray/waiter"
+)
+
+func resourceAwsXrayEncryptionConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsXrayEncryptionConfigPut,
+		Read:   resourceAwsXrayEncryptionConfigRead,
+		Update: resourceAwsXrayEncryptionConfigPut,
+		Delete: schema.Noop,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					xray.EncryptionTypeKms,
+					xray.EncryptionTypeNone,
+				}, false),
+			},
+		},
+	}
+}
+
+func resourceAwsXrayEncryptionConfigPut(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).xrayconn
+
+	input := &xray.PutEncryptionConfigInput{
+		Type: aws.String(d.Get("type").(string)),
+	}
+
+	if v, ok := d.GetOk("key_id"); ok && v.(string) != "" {
+		input.KeyId = aws.String(v.(string))
+	}
+
+	_, err := conn.PutEncryptionConfig(input)
+	if err != nil {
+		return fmt.Errorf("error creating XRay Encryption Config: %s", err)
+	}
+
+	d.SetId(resource.UniqueId())
+
+	if _, err := waiter.EncryptionConfigAvailable(conn); err != nil {
+		return fmt.Errorf("error waiting for Xray Encryption Config (%s) to Available: %w", d.Id(), err)
+	}
+
+	return resourceAwsXrayEncryptionConfigRead(d, meta)
+}
+
+func resourceAwsXrayEncryptionConfigRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).xrayconn
+
+	config, err := conn.GetEncryptionConfig(&xray.GetEncryptionConfigInput{})
+
+	if err != nil {
+		return fmt.Errorf("error reading XRay Encryption Config: %s", err)
+	}
+
+	d.Set("key_id", config.EncryptionConfig.KeyId)
+	d.Set("type", config.EncryptionConfig.Type)
+
+	return nil
+}

--- a/aws/resource_aws_xray_encryption_config.go
+++ b/aws/resource_aws_xray_encryption_config.go
@@ -55,7 +55,7 @@ func resourceAwsXrayEncryptionConfigPut(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("error creating XRay Encryption Config: %s", err)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(meta.(*AWSClient).region)
 
 	if _, err := waiter.EncryptionConfigAvailable(conn); err != nil {
 		return fmt.Errorf("error waiting for Xray Encryption Config (%s) to Available: %w", d.Id(), err)

--- a/aws/resource_aws_xray_encryption_config.go
+++ b/aws/resource_aws_xray_encryption_config.go
@@ -23,8 +23,9 @@ func resourceAwsXrayEncryptionConfig() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"key_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
 			},
 			"type": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_xray_encryption_config_test.go
+++ b/aws/resource_aws_xray_encryption_config_test.go
@@ -110,7 +110,7 @@ POLICY
 
 resource "aws_xray_encryption_config" "test" {
   type   = "KMS"
-  key_id = "${aws_kms_key.test.arn}" 
+  key_id = "${aws_kms_key.test.arn}"
 }
 `, acctest.RandString(8))
 }

--- a/aws/resource_aws_xray_encryption_config_test.go
+++ b/aws/resource_aws_xray_encryption_config_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/xray"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSXrayEncryptionConfig_basic(t *testing.T) {
@@ -110,7 +110,7 @@ POLICY
 
 resource "aws_xray_encryption_config" "test" {
   type   = "KMS"
-  key_id = "${aws_kms_key.test.arn}"
+  key_id = aws_kms_key.test.arn
 }
 `, acctest.RandString(8))
 }

--- a/aws/resource_aws_xray_encryption_config_test.go
+++ b/aws/resource_aws_xray_encryption_config_test.go
@@ -1,0 +1,116 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSXrayEncryptionConfig_basic(t *testing.T) {
+	var EncryptionConfig xray.EncryptionConfig
+	resourceName := "aws_xray_encryption_config.test"
+	keyResourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSXrayEncryptionConfigBasicConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXrayEncryptionConfigExists(resourceName, &EncryptionConfig),
+					resource.TestCheckResourceAttr(resourceName, "type", "NONE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSXrayEncryptionConfigWithKeyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXrayEncryptionConfigExists(resourceName, &EncryptionConfig),
+					resource.TestCheckResourceAttr(resourceName, "type", "KMS"),
+					resource.TestCheckResourceAttrPair(resourceName, "key_id", keyResourceName, "arn"),
+				),
+			},
+			{
+				Config: testAccAWSXrayEncryptionConfigBasicConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXrayEncryptionConfigExists(resourceName, &EncryptionConfig),
+					resource.TestCheckResourceAttr(resourceName, "type", "NONE"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckXrayEncryptionConfigExists(n string, EncryptionConfig *xray.EncryptionConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No XRay Sampling Rule ID is set")
+		}
+		conn := testAccProvider.Meta().(*AWSClient).xrayconn
+
+		config, err := conn.GetEncryptionConfig(&xray.GetEncryptionConfigInput{})
+
+		if err != nil {
+			return err
+		}
+
+		*EncryptionConfig = *config.EncryptionConfig
+
+		return nil
+	}
+}
+
+func testAccAWSXrayEncryptionConfigBasicConfig() string {
+	return fmt.Sprintf(`
+resource "aws_xray_encryption_config" "test" {
+  type = "NONE"
+}
+`)
+}
+
+func testAccAWSXrayEncryptionConfigWithKeyConfig() string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = "Terraform acc test %s"
+  deletion_window_in_days = 7
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_xray_encryption_config" "test" {
+  type   = "KMS"
+  key_id = "${aws_kms_key.test.arn}" 
+}
+`, acctest.RandString(8))
+}

--- a/aws/resource_aws_xray_encryption_config_test.go
+++ b/aws/resource_aws_xray_encryption_config_test.go
@@ -59,7 +59,7 @@ func testAccCheckXrayEncryptionConfigExists(n string, EncryptionConfig *xray.Enc
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No XRay Sampling Rule ID is set")
+			return fmt.Errorf("No XRay Encryption Config ID is set")
 		}
 		conn := testAccProvider.Meta().(*AWSClient).xrayconn
 

--- a/website/docs/r/xray_encryption_config.html.markdown
+++ b/website/docs/r/xray_encryption_config.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Creates and manages an AWS XRay Encryption Config.
 
+~> **NOTE:** Removing this resource from Terraform has no effect to the encryption configuration within X-Ray.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/xray_encryption_config.html.markdown
+++ b/website/docs/r/xray_encryption_config.html.markdown
@@ -63,8 +63,8 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Import
 
-XRay Encryption Config can be imported using any value as there is a single one per region, e.g.
+XRay Encryption Config can be imported using the region name, e.g.
 
 ```
-$ terraform import aws_xray_encryption_config.example example
+$ terraform import aws_xray_encryption_config.example us-west-2
 ```

--- a/website/docs/r/xray_encryption_config.html.markdown
+++ b/website/docs/r/xray_encryption_config.html.markdown
@@ -55,7 +55,7 @@ resource "aws_xray_encryption_config" "example" {
 ## Argument Reference
 
 * `type` - (Required) The type of encryption. Set to `KMS` to use your own key for encryption. Set to `NONE` for default encryption.
-* `key_id` - (Optional) An AWS KMS customer master key (CMK). can be the Key ID, Key ARN or Alias. 
+* `key_id` - (Optional) An AWS KMS customer master key (CMK) ARN. 
 
 ## Attributes Reference
 

--- a/website/docs/r/xray_encryption_config.html.markdown
+++ b/website/docs/r/xray_encryption_config.html.markdown
@@ -46,7 +46,7 @@ POLICY
 
 resource "aws_xray_encryption_config" "example" {
   type   = "KMS"
-  key_id = "${aws_kms_key.example.arn}" 
+  key_id = "${aws_kms_key.example.arn}"
 }
 ```
 

--- a/website/docs/r/xray_encryption_config.html.markdown
+++ b/website/docs/r/xray_encryption_config.html.markdown
@@ -1,0 +1,70 @@
+---
+subcategory: "XRay"
+layout: "aws"
+page_title: "AWS: aws_xray_encryption_config"
+description: |-
+    Creates and manages an AWS XRay Encryption Config.
+---
+
+# Resource: aws_xray_encryption_config
+
+Creates and manages an AWS XRay Encryption Config.
+
+## Example Usage
+
+```hcl
+resource "aws_xray_encryption_config" "example" {
+  type = "NONE"
+}
+```
+
+## Example Usage with KMS Key
+
+```hcl
+resource "aws_kms_key" "example" {
+  description             = "Some Key"
+  deletion_window_in_days = 7
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_xray_encryption_config" "example" {
+  type   = "KMS"
+  key_id = "${aws_kms_key.example.arn}" 
+}
+```
+
+## Argument Reference
+
+* `type` - (Required) The type of encryption. Set to `KMS` to use your own key for encryption. Set to `NONE` for default encryption.
+* `key_id` - (Optional) An AWS KMS customer master key (CMK). can be the Key ID, Key ARN or Alias. 
+
+## Attributes Reference
+
+In addition to the arguments above, the following attributes are exported:
+
+* `id` - unique id for the resource.
+
+## Import
+
+XRay Encryption Config can be imported using any value as there is a single one per region, e.g.
+
+```
+$ terraform import aws_xray_encryption_config.example example
+```

--- a/website/docs/r/xray_encryption_config.html.markdown
+++ b/website/docs/r/xray_encryption_config.html.markdown
@@ -59,7 +59,7 @@ resource "aws_xray_encryption_config" "example" {
 
 In addition to the arguments above, the following attributes are exported:
 
-* `id` - unique id for the resource.
+* `id` - Region name.
 
 ## Import
 

--- a/website/docs/r/xray_encryption_config.html.markdown
+++ b/website/docs/r/xray_encryption_config.html.markdown
@@ -46,7 +46,7 @@ POLICY
 
 resource "aws_xray_encryption_config" "example" {
   type   = "KMS"
-  key_id = "${aws_kms_key.example.arn}"
+  key_id = aws_kms_key.example.arn
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8749

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_xray_encyption_config - new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSXrayEncryptionConfig_basic'
--- PASS: TestAccAWSXrayEncryptionConfig_basic (1026.62s)
```
