### PR TITLE
Non-deprecated syntax for TGW attachment example

### DIFF
--- a/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -14,9 +14,9 @@ Manages an EC2 Transit Gateway VPC Attachment. For examples of custom route tabl
 
 ```hcl
 resource "aws_ec2_transit_gateway_vpc_attachment" "example" {
-  subnet_ids         = ["${aws_subnet.example.id}"]
-  transit_gateway_id = "${aws_ec2_transit_gateway.example.id}"
-  vpc_id             = "${aws_vpc.example.id}"
+  subnet_ids         = [aws_subnet.example.id]
+  transit_gateway_id = aws_ec2_transit_gateway.example.id
+  vpc_id             = aws_vpc.example.id
 }
 ```
 


### PR DESCRIPTION
This avoids the Terraform 0.12 warnings for strings which contain only a single interpolated variable.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Update syntax in `aws_ec2_transit_gateway_vpc_attachment` example
```
