### PR TITLE
rd/customer_gateway - add arn + validations

### DIFF
--- a/aws/data_source_aws_customer_gateway.go
+++ b/aws/data_source_aws_customer_gateway.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -32,6 +33,10 @@ func dataSourceAwsCustomerGateway() *schema.Resource {
 			},
 			"tags": tagsSchemaComputed(),
 			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -89,6 +94,16 @@ func dataSourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(cg.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags for EC2 Customer Gateway %q: %s", aws.StringValue(cg.CustomerGatewayId), err)
 	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ec2",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("customer-gateway/%s", d.Id()),
+	}.String()
+
+	d.Set("arn", arn)
 
 	return nil
 }

--- a/aws/data_source_aws_customer_gateway_test.go
+++ b/aws/data_source_aws_customer_gateway_test.go
@@ -12,7 +12,7 @@ func TestAccAWSCustomerGatewayDataSource_Filter(t *testing.T) {
 	dataSourceName := "data.aws_customer_gateway.test"
 	resourceName := "aws_customer_gateway.test"
 
-	asn := acctest.RandIntRange(64512, 65534)
+	asn := randIntRange(64512, 65534)
 	hostOctet := acctest.RandIntRange(1, 254)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -40,7 +40,7 @@ func TestAccAWSCustomerGatewayDataSource_ID(t *testing.T) {
 	dataSourceName := "data.aws_customer_gateway.test"
 	resourceName := "aws_customer_gateway.test"
 
-	asn := acctest.RandIntRange(64512, 65534)
+	asn := randIntRange(64512, 65534)
 	hostOctet := acctest.RandIntRange(1, 254)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/data_source_aws_customer_gateway_test.go
+++ b/aws/data_source_aws_customer_gateway_test.go
@@ -29,6 +29,7 @@ func TestAccAWSCustomerGatewayDataSource_Filter(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "ip_address", dataSourceName, "ip_address"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
 					resource.TestCheckResourceAttrPair(resourceName, "type", dataSourceName, "type"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 				),
 			},
 		},

--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -34,9 +34,9 @@ func resourceAwsCustomerGateway() *schema.Resource {
 			},
 
 			"ip_address": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 				ValidateFunc: validation.Any(
 					validation.StringIsEmpty,
 					validation.IsIPv4Address,
@@ -92,14 +92,15 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 
 	// Store the ID
 	customerGateway := resp.CustomerGateway
-	d.SetId(*customerGateway.CustomerGatewayId)
-	log.Printf("[INFO] Customer gateway ID: %s", *customerGateway.CustomerGatewayId)
+	cgId := aws.StringValue(customerGateway.CustomerGatewayId)
+	d.SetId(cgId)
+	log.Printf("[INFO] Customer gateway ID: %s", cgId)
 
 	// Wait for the CustomerGateway to be available.
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     []string{"available"},
-		Refresh:    customerGatewayRefreshFunc(conn, *customerGateway.CustomerGatewayId),
+		Refresh:    customerGatewayRefreshFunc(conn, cgId),
 		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -108,8 +109,7 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	_, stateErr := stateConf.WaitForState()
 	if stateErr != nil {
 		return fmt.Errorf(
-			"Error waiting for customer gateway (%s) to become ready: %s",
-			*customerGateway.CustomerGatewayId, err)
+			"Error waiting for customer gateway (%s) to become ready: %s", cgId, err)
 	}
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
@@ -174,7 +174,7 @@ func resourceAwsCustomerGatewayExists(vpnType, ipAddress string, bgpAsn int, con
 		return false, err
 	}
 
-	if len(resp.CustomerGateways) > 0 && *resp.CustomerGateways[0].State != "deleted" {
+	if len(resp.CustomerGateways) > 0 && aws.StringValue(resp.CustomerGateways[0].State) != "deleted" {
 		return true, nil
 	}
 
@@ -208,7 +208,7 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error finding CustomerGateway: %s", d.Id())
 	}
 
-	if *resp.CustomerGateways[0].State == "deleted" {
+	if aws.StringValue(resp.CustomerGateways[0].State) == "deleted" {
 		log.Printf("[INFO] Customer Gateway is in `deleted` state: %s", d.Id())
 		d.SetId("")
 		return nil
@@ -223,7 +223,7 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if aws.StringValue(customerGateway.BgpAsn) != "" {
-		val, err := strconv.ParseInt(*customerGateway.BgpAsn, 0, 0)
+		val, err := strconv.ParseInt(aws.StringValue(customerGateway.BgpAsn), 0, 0)
 		if err != nil {
 			return fmt.Errorf("error parsing bgp_asn: %s", err)
 		}
@@ -318,9 +318,10 @@ func checkGatewayDeleteResponse(resp *ec2.DescribeCustomerGatewaysOutput, id str
 		return fmt.Errorf("Error finding CustomerGateway for delete: %s", id)
 	}
 
-	switch *resp.CustomerGateways[0].State {
+	cgState := aws.StringValue(resp.CustomerGateways[0].State)
+	switch cgState {
 	case "pending", "available", "deleting":
-		return fmt.Errorf("Gateway (%s) in state (%s), retrying", id, *resp.CustomerGateways[0].State)
+		return fmt.Errorf("Gateway (%s) in state (%s), retrying", id, cgState)
 	case "deleted":
 		return nil
 	default:

--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -30,14 +30,17 @@ func resourceAwsCustomerGateway() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(64512, 65534),
+				ValidateFunc: validation.IntBetween(1, 65534),
 			},
 
 			"ip_address": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IsIPv4Address,
+				ValidateFunc: validation.Any(
+					validation.StringIsEmpty,
+					validation.IsIPv4Address,
+				),
 			},
 
 			"type": {

--- a/aws/resource_aws_customer_gateway_test.go
+++ b/aws/resource_aws_customer_gateway_test.go
@@ -165,7 +165,7 @@ func testAccCheckCustomerGatewayDestroy(s *terraform.State) error {
 				return fmt.Errorf("Customer gateway still exists: %v", resp.CustomerGateways)
 			}
 
-			if *resp.CustomerGateways[0].State == "deleted" {
+			if aws.StringValue(resp.CustomerGateways[0].State) == "deleted" {
 				continue
 			}
 		}

--- a/aws/resource_aws_customer_gateway_test.go
+++ b/aws/resource_aws_customer_gateway_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccAWSCustomerGateway_basic(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := 65000
+	rBgpAsn := randIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -47,7 +47,7 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 
 func TestAccAWSCustomerGateway_tags(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := 65000
+	rBgpAsn := randIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -89,7 +89,7 @@ func TestAccAWSCustomerGateway_tags(t *testing.T) {
 
 func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := 65000
+	rBgpAsn := randIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -118,7 +118,7 @@ func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 }
 
 func TestAccAWSCustomerGateway_disappears(t *testing.T) {
-	rBgpAsn := 65000
+	rBgpAsn := randIntRange(64512, 65534)
 	var gateway ec2.CustomerGateway
 	resourceName := "aws_customer_gateway.test"
 

--- a/aws/resource_aws_customer_gateway_test.go
+++ b/aws/resource_aws_customer_gateway_test.go
@@ -7,14 +7,13 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAWSCustomerGateway_basic(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	rBgpAsn := 65000
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -48,7 +47,7 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 
 func TestAccAWSCustomerGateway_tags(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	rBgpAsn := 65000
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -90,7 +89,7 @@ func TestAccAWSCustomerGateway_tags(t *testing.T) {
 
 func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	rBgpAsn := 65000
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -119,7 +118,7 @@ func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 }
 
 func TestAccAWSCustomerGateway_disappears(t *testing.T) {
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	rBgpAsn := 65000
 	var gateway ec2.CustomerGateway
 	resourceName := "aws_customer_gateway.test"
 

--- a/aws/resource_aws_customer_gateway_test.go
+++ b/aws/resource_aws_customer_gateway_test.go
@@ -2,13 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"regexp"
 	"testing"
-	"time"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -18,7 +15,6 @@ import (
 func TestAccAWSCustomerGateway_basic(t *testing.T) {
 	var gateway ec2.CustomerGateway
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
-	rInt := acctest.RandInt()
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -28,9 +24,11 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfig(rInt, rBgpAsn),
+				Config: testAccCustomerGatewayConfig(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway(resourceName, &gateway),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`customer-gateway/cgw-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -39,13 +37,7 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCustomerGatewayConfigUpdateTags(rInt, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCustomerGateway(resourceName, &gateway),
-				),
-			},
-			{
-				Config: testAccCustomerGatewayConfigForceReplace(rInt, rBgpAsn),
+				Config: testAccCustomerGatewayConfigForceReplace(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway(resourceName, &gateway),
 				),
@@ -54,9 +46,8 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
+func TestAccAWSCustomerGateway_tags(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rInt := acctest.RandInt()
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
 
@@ -67,7 +58,49 @@ func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 		CheckDestroy:  testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfig(rInt, rBgpAsn),
+				Config: testAccCustomerGatewayConfigTags1(rBgpAsn, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerGateway(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1")),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCustomerGatewayConfigTags2(rBgpAsn, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerGateway(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2")),
+			},
+			{
+				Config: testAccCustomerGatewayConfigTags1(rBgpAsn, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerGateway(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2")),
+			},
+		},
+	})
+}
+
+func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
+	var gateway ec2.CustomerGateway
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	resourceName := "aws_customer_gateway.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckCustomerGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomerGatewayConfig(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway(resourceName, &gateway),
 				),
@@ -78,7 +111,7 @@ func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:      testAccCustomerGatewayConfigIdentical(rInt, rBgpAsn),
+				Config:      testAccCustomerGatewayConfigIdentical(rBgpAsn),
 				ExpectError: regexp.MustCompile("An existing customer gateway"),
 			},
 		},
@@ -86,7 +119,6 @@ func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 }
 
 func TestAccAWSCustomerGateway_disappears(t *testing.T) {
-	rInt := acctest.RandInt()
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	var gateway ec2.CustomerGateway
 	resourceName := "aws_customer_gateway.test"
@@ -97,46 +129,15 @@ func TestAccAWSCustomerGateway_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfig(rInt, rBgpAsn),
+				Config: testAccCustomerGatewayConfig(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway(resourceName, &gateway),
-					testAccAWSCustomerGatewayDisappears(&gateway),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCustomerGateway(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
-}
-
-func testAccAWSCustomerGatewayDisappears(gateway *ec2.CustomerGateway) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		opts := &ec2.DeleteCustomerGatewayInput{
-			CustomerGatewayId: gateway.CustomerGatewayId,
-		}
-		if _, err := conn.DeleteCustomerGateway(opts); err != nil {
-			return err
-		}
-		return resource.Retry(40*time.Minute, func() *resource.RetryError {
-			opts := &ec2.DescribeCustomerGatewaysInput{
-				CustomerGatewayIds: []*string{gateway.CustomerGatewayId},
-			}
-			resp, err := conn.DescribeCustomerGateways(opts)
-			if err != nil {
-				cgw, ok := err.(awserr.Error)
-				if ok && cgw.Code() == "InvalidCustomerGatewayID.NotFound" {
-					return nil
-				}
-				return resource.NonRetryableError(
-					fmt.Errorf("Error retrieving Customer Gateway: %s", err))
-			}
-			if *resp.CustomerGateways[0].State == "deleted" {
-				return nil
-			}
-			return resource.RetryableError(fmt.Errorf(
-				"Waiting for Customer Gateway: %v", gateway.CustomerGatewayId))
-		})
-	}
 }
 
 func testAccCheckCustomerGatewayDestroy(s *terraform.State) error {
@@ -156,7 +157,7 @@ func testAccCheckCustomerGatewayDestroy(s *terraform.State) error {
 			Filters: []*ec2.Filter{gatewayFilter},
 		})
 
-		if ae, ok := err.(awserr.Error); ok && ae.Code() == "InvalidCustomerGatewayID.NotFound" {
+		if isAWSErr(err, "InvalidCustomerGatewayID.NotFound", "") {
 			continue
 		}
 
@@ -213,72 +214,68 @@ func testAccCheckCustomerGateway(gatewayResource string, cgw *ec2.CustomerGatewa
 	}
 }
 
-func testAccCustomerGatewayConfig(rInt, rBgpAsn int) string {
+func testAccCustomerGatewayConfig(rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %d
   ip_address = "172.0.0.1"
   type       = "ipsec.1"
-
-  tags = {
-    Name = "test-gateway-%d"
-  }
 }
-`, rBgpAsn, rInt)
+`, rBgpAsn)
 }
 
-func testAccCustomerGatewayConfigIdentical(randInt, rBgpAsn int) string {
+func testAccCustomerGatewayConfigTags1(rBgpAsn int, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
-  bgp_asn    = %d
+  bgp_asn    = %[1]d
   ip_address = "172.0.0.1"
   type       = "ipsec.1"
 
   tags = {
-    Name = "test-gateway-%d"
+    %[2]q = %[3]q
   }
+}
+`, rBgpAsn, tagKey1, tagValue1)
+}
+
+func testAccCustomerGatewayConfigTags2(rBgpAsn int, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_customer_gateway" "test" {
+  bgp_asn    = %[1]d
+  ip_address = "172.0.0.1"
+  type       = "ipsec.1"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rBgpAsn, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccCustomerGatewayConfigIdentical(rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_customer_gateway" "test" {
+  bgp_asn    = %[1]d
+  ip_address = "172.0.0.1"
+  type       = "ipsec.1"
 }
 
 resource "aws_customer_gateway" "identical" {
-  bgp_asn    = %d
+  bgp_asn    = %[1]d
   ip_address = "172.0.0.1"
   type       = "ipsec.1"
-
-  tags = {
-    Name = "test-gateway-identical-%d"
-  }
 }
-`, rBgpAsn, randInt, rBgpAsn, randInt)
-}
-
-// Add the Another: "tag" tag.
-func testAccCustomerGatewayConfigUpdateTags(rInt, rBgpAsn int) string {
-	return fmt.Sprintf(`
-resource "aws_customer_gateway" "test" {
-  bgp_asn    = %d
-  ip_address = "172.0.0.1"
-  type       = "ipsec.1"
-
-  tags = {
-    Name    = "test-gateway-%d"
-    Another = "tag"
-  }
-}
-`, rBgpAsn, rInt)
+`, rBgpAsn)
 }
 
 // Change the ip_address.
-func testAccCustomerGatewayConfigForceReplace(rInt, rBgpAsn int) string {
+func testAccCustomerGatewayConfigForceReplace(rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %d
   ip_address = "172.10.10.1"
   type       = "ipsec.1"
-
-  tags = {
-    Name    = "test-gateway-%d"
-    Another = "tag"
-  }
 }
-`, rBgpAsn, rInt)
+`, rBgpAsn)
 }

--- a/website/docs/d/customer_gateway.html.markdown
+++ b/website/docs/d/customer_gateway.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 
 In addition to the arguments above, the following attributes are exported:
 
+* `arn` - The ARN ID of the customer gateway.
 * `bgp_asn` - (Optional) The gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).
 * `ip_address` - (Optional) The IP address of the gateway's Internet-routable external interface.
 * `tags` - Map of key-value pairs assigned to the gateway.

--- a/website/docs/d/customer_gateway.html.markdown
+++ b/website/docs/d/customer_gateway.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 In addition to the arguments above, the following attributes are exported:
 
-* `arn` - The ARN ID of the customer gateway.
+* `arn` - The ARN of the customer gateway.
 * `bgp_asn` - (Optional) The gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).
 * `ip_address` - (Optional) The IP address of the gateway's Internet-routable external interface.
 * `tags` - Map of key-value pairs assigned to the gateway.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -249,6 +249,8 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   - [`aws_ecs_capacity_provider` resource (import)](/docs/providers/aws/r/ecs_capacity_provider.html)
   - [`aws_ecs_cluster` resource (import)](/docs/providers/aws/r/ecs_cluster.html)
   - [`aws_ecs_service` resource (import)](/docs/providers/aws/r/ecs_service.html)
+  - [`aws_customer_gateway` data source](/docs/providers/aws/d/customer_gateway.html)
+  - [`aws_customer_gateway` resource](/docs/providers/aws/r/customer_gateway.html)  
   - [`aws_efs_access_point` data source](/docs/providers/aws/d/efs_access_point.html)
   - [`aws_efs_access_point` resource](/docs/providers/aws/r/efs_access_point.html)
   - [`aws_efs_file_system` data source](/docs/providers/aws/d/efs_file_system.html)

--- a/website/docs/r/customer_gateway.html.markdown
+++ b/website/docs/r/customer_gateway.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The amazon-assigned ID of the gateway.
+* `arn` - The ARN ID of the customer gateway.
 * `bgp_asn` - The gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).
 * `ip_address` - The IP address of the gateway's Internet-routable external interface.
 * `type` - The type of customer gateway.

--- a/website/docs/r/customer_gateway.html.markdown
+++ b/website/docs/r/customer_gateway.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The amazon-assigned ID of the gateway.
-* `arn` - The ARN ID of the customer gateway.
+* `arn` - The ARN of the customer gateway.
 * `bgp_asn` - The gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).
 * `ip_address` - The IP address of the gateway's Internet-routable external interface.
 * `type` - The type of customer gateway.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624, #13527

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_customer_gateway : add arn attribute
resource_aws_customer_gateway : add validation to `bgp_asn`, `ip_address` and `type`
data_source_aws_customer_gateway : add arn attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCustomerGateway_'
--- PASS: TestAccAWSCustomerGatewayDataSource_Filter (57.20s)
--- PASS: TestAccAWSCustomerGatewayDataSource_ID (54.76s)
--- PASS: TestAccAWSCustomerGateway_basic (92.61s)
--- PASS: TestAccAWSCustomerGateway_tags (103.05s)
--- PASS: TestAccAWSCustomerGateway_similarAlreadyExists (63.14s)
--- PASS: TestAccAWSCustomerGateway_disappears (42.18s)
```
