### PR TITLE
Don't send empty kms_arn in glue_security_configuration if mode is DISABLED

### DIFF
--- a/aws/resource_aws_glue_security_configuration.go
+++ b/aws/resource_aws_glue_security_configuration.go
@@ -213,10 +213,8 @@ func expandGlueCloudWatchEncryption(l []interface{}) *glue.CloudWatchEncryption 
 		CloudWatchEncryptionMode: aws.String(m["cloudwatch_encryption_mode"].(string)),
 	}
 
-	if v, ok := m["kms_key_arn"]; ok {
-		if v.(string) != "" {
-			cloudwatchEncryption.KmsKeyArn = aws.String(v.(string))
-		}
+	if v, ok := m["kms_key_arn"]; ok && v.(string) != "" {
+		cloudwatchEncryption.KmsKeyArn = aws.String(v.(string))
 	}
 
 	return cloudwatchEncryption
@@ -249,10 +247,8 @@ func expandGlueJobBookmarksEncryption(l []interface{}) *glue.JobBookmarksEncrypt
 		JobBookmarksEncryptionMode: aws.String(m["job_bookmarks_encryption_mode"].(string)),
 	}
 
-	if v, ok := m["kms_key_arn"]; ok {
-		if v.(string) != "" {
-			jobBookmarksEncryption.KmsKeyArn = aws.String(v.(string))
-		}
+	if v, ok := m["kms_key_arn"]; ok && v.(string) != "" {
+		jobBookmarksEncryption.KmsKeyArn = aws.String(v.(string))
 	}
 
 	return jobBookmarksEncryption
@@ -276,10 +272,8 @@ func expandGlueS3Encryption(m map[string]interface{}) *glue.S3Encryption {
 		S3EncryptionMode: aws.String(m["s3_encryption_mode"].(string)),
 	}
 
-	if v, ok := m["kms_key_arn"]; ok {
-		if v.(string) != "" {
-			s3Encryption.KmsKeyArn = aws.String(v.(string))
-		}
+	if v, ok := m["kms_key_arn"]; ok && v.(string) != "" {
+		s3Encryption.KmsKeyArn = aws.String(v.(string))
 	}
 
 	return s3Encryption

--- a/aws/resource_aws_glue_security_configuration.go
+++ b/aws/resource_aws_glue_security_configuration.go
@@ -214,7 +214,9 @@ func expandGlueCloudWatchEncryption(l []interface{}) *glue.CloudWatchEncryption 
 	}
 
 	if v, ok := m["kms_key_arn"]; ok {
-		cloudwatchEncryption.KmsKeyArn = aws.String(v.(string))
+		if v.(string) != "" {
+			cloudwatchEncryption.KmsKeyArn = aws.String(v.(string))
+		}
 	}
 
 	return cloudwatchEncryption
@@ -248,7 +250,9 @@ func expandGlueJobBookmarksEncryption(l []interface{}) *glue.JobBookmarksEncrypt
 	}
 
 	if v, ok := m["kms_key_arn"]; ok {
-		jobBookmarksEncryption.KmsKeyArn = aws.String(v.(string))
+		if v.(string) != "" {
+			jobBookmarksEncryption.KmsKeyArn = aws.String(v.(string))
+		}
 	}
 
 	return jobBookmarksEncryption


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13620 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueSecurityConfiguration_Basic'

...
```
