### PR TITLE
[WIP]r/ec2_client_vpn_endpoint - add support for VPC and Security Group arguments

### DIFF
--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 * `split_tunnel` - (Optional) Indicates whether split-tunnel is enabled on VPN endpoint. Default value is `false`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `transport_protocol` - (Optional) The transport protocol to be used by the VPN session. Default value is `udp`.
+* `vpc_id` - (Optional) The ID of the VPC to associate with the Client VPN endpoint.
+* `security_group_ids` - (Optional) The IDs of one or more security groups to apply to the target network. If a VPC is provided but with no security groups, the default VPC security group will be used.
 
 
 ### `authentication_options` Argument Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ec2_client_vpn_endpoint: add `vpc` and `security_group_ids` arguments
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsEc2ClientVpnEndpoint_basic '
--- PASS: TestAccAwsEc2ClientVpnEndpoint_basic (52.78s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_disappears (43.76s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_msAD (1835.04s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_mutualAuthAndMsAD (1874.80s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withLogGroup (87.53s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_tags (126.57s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_splitTunnel (81.85s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_vpc (134.67s)
--- PASS: TestAccAwsEc2ClientVpnEndpoint_security_groups (200.65s)
```
