### PR TITLE
export RemoteAdministrationEndpoint attribute for aws_fsx_windows_file_system

### DIFF
--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -91,6 +91,7 @@ func TestAccAWSFsxWindowsFileSystem_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "dns_name", regexp.MustCompile(`fs-.+\..+`)),
 					resource.TestMatchResourceAttr(resourceName, "kms_key_id", regexp.MustCompile(`^arn:`)),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "windows_configuration.#", 1),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "self_managed_active_directory.#", "0"),

--- a/website/docs/r/fsx_windows_file_system.html.markdown
+++ b/website/docs/r/fsx_windows_file_system.html.markdown
@@ -87,7 +87,8 @@ In addition to all arguments above, the following attributes are exported:
 * `network_interface_ids` - Set of Elastic Network Interface identifiers from which the file system is accessible.
 * `owner_id` - AWS account identifier that created the file system.
 * `vpc_id` - Identifier of the Virtual Private Cloud for the file system.
-
+* `windows_configuration`
+  * `remote_administration_endpoint` -  The DNS endpoint of the file system
 ## Timeouts
 
 `aws_fsx_windows_file_system` provides the following [Timeouts](/docs/configuration/resources.html#timeouts)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13616

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Exports remote administration endpoint attribute on resource creation

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSFsxWindowsFileSystem_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSFsxWindowsFileSystem_basic -timeout 120m
=== RUN   TestAccAWSFsxWindowsFileSystem_basic
=== PAUSE TestAccAWSFsxWindowsFileSystem_basic
=== CONT  TestAccAWSFsxWindowsFileSystem_basic
--- PASS: TestAccAWSFsxWindowsFileSystem_basic (2982.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2982.370s

...
```
