### PR TITLE
r/aws_batch_job_definition: Prevent diffs when no command specified in container properties

### DIFF
--- a/aws/internal/service/batch/equivalency/container_properties.go
+++ b/aws/internal/service/batch/equivalency/container_properties.go
@@ -20,6 +20,11 @@ func (cp *containerProperties) Reduce() error {
 	})
 
 	// Prevent difference of API response that adds an empty array when not configured during the request
+	if len(cp.Command) == 0 {
+		cp.Command = nil
+	}
+
+	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.Environment) == 0 {
 		cp.Environment = nil
 	}

--- a/aws/internal/service/batch/equivalency/container_properties_test.go
+++ b/aws/internal/service/batch/equivalency/container_properties_test.go
@@ -208,6 +208,38 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
+		{
+			Name: "empty command, mountPoints, resourceRequirements, ulimits, volumes",
+			ApiJson: `
+{
+	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+	"vcpus": 1,
+	"memory": 4096,
+	"command": [],
+	"jobRoleArn": "arn:aws:iam::123:role/role-test",
+	"volumes": [],
+	"environment": [{"name":"ENVIRONMENT","value":"test"}],
+	"mountPoints": [],
+	"ulimits": [],
+	"resourceRequirements": []
+}
+`,
+			ConfigurationJson: `
+{
+    "image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
+    "memory": 4096,
+    "vcpus": 1,
+    "jobRoleArn": "arn:aws:iam::123:role/role-test",
+    "environment": [
+      {
+        "name": "ENVIRONMENT",
+        "value": "test"
+      }
+   ]
+}
+`,
+			ExpectEquivalent: true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13629.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_batch_job_definition: Prevent diffs when no `command` is specified in `container_properties`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ go test ./aws/internal/service/batch/equivalency
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.005s
```

Related:
* https://github.com/terraform-providers/terraform-provider-aws/pull/12000