### PR TITLE
Add deployment type to aws_fsx_lustre_file_system

### DIFF
--- a/website/docs/r/fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/fsx_lustre_file_system.html.markdown
@@ -32,6 +32,8 @@ The following arguments are supported:
 * `security_group_ids` - (Optional) A list of IDs for the security groups that apply to the specified network interfaces created for file system access. These security groups will apply to all network interfaces.
 * `tags` - (Optional) A map of tags to assign to the file system.
 * `weekly_maintenance_start_time` - (Optional) The preferred start time (in `d:HH:MM` format) to perform weekly maintenance, in the UTC time zone.
+* `deployment_type` - (Optional) - The filesystem deployment type. One of: `SCRATCH_1`, `SCRATCH_2`, `PERSISTENT_1`.
+* `per_unit_storage_throughput` - (Optional) - Describes the amount of read and write throughput for each 1 tebibyte of storage, in MB/s/TiB, required for the `PERSISTENT_1` deployment_type. For valid values, see the [AWS documentation](https://docs.aws.amazon.com/fsx/latest/APIReference/API_CreateFileSystemLustreConfiguration.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12181

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_fsx_lustre_file_system: Add `deployment_type` and `per_unit_storage_throughput`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSFsxLustreFileSystem_DeploymentType'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSFsxLustreFileSystem_DeploymentType -timeout 120m
make testacc TESTARGS='-run=TestAccAWSFsxLustreFileSystem_basic'
=== RUN   TestAccAWSFsxLustreFileSystem_DeploymentTypePersistent1
=== PAUSE TestAccAWSFsxLustreFileSystem_DeploymentTypePersistent1
=== RUN   TestAccAWSFsxLustreFileSystem_DeploymentTypeScratch2
=== PAUSE TestAccAWSFsxLustreFileSystem_DeploymentTypeScratch2
=== CONT  TestAccAWSFsxLustreFileSystem_DeploymentTypePersistent1
=== CONT  TestAccAWSFsxLustreFileSystem_DeploymentTypeScratch2
--- PASS: TestAccAWSFsxLustreFileSystem_DeploymentTypeScratch2 (434.35s)
--- PASS: TestAccAWSFsxLustreFileSystem_DeploymentTypePersistent1 (518.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	518.129s

$ make testacc TESTARGS='-run=TestAccAWSFsxLustreFileSystem_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSFsxLustreFileSystem_basic -timeout 120m
=== RUN   TestAccAWSFsxLustreFileSystem_basic
=== PAUSE TestAccAWSFsxLustreFileSystem_basic
=== CONT  TestAccAWSFsxLustreFileSystem_basic
--- PASS: TestAccAWSFsxLustreFileSystem_basic (615.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	615.195s
```
