### PR TITLE
r/aws_apigatewayv2_stage: 'deployment_id` is Computed for auto-deployments

### DIFF
--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -119,6 +119,7 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 			"deployment_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"description": {
 				Type:         schema.TypeString,

--- a/website/docs/r/apigatewayv2_stage.html.markdown
+++ b/website/docs/r/apigatewayv2_stage.html.markdown
@@ -30,11 +30,11 @@ The following arguments are supported:
 * `name` - (Required) The name of the stage.
 * `access_log_settings` - (Optional) Settings for logging access in this stage.
 Use the [`aws_api_gateway_account`](/docs/providers/aws/r/api_gateway_account.html) resource to configure [permissions for CloudWatch Logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions).
-* `auto_deploy` - (Optional) Whether updates to an API automatically trigger a new deployment. Defaults to `false`.
+* `auto_deploy` - (Optional) Whether updates to an API automatically trigger a new deployment. Defaults to `false`. Applicable for HTTP APIs.
 * `client_certificate_id` - (Optional) The identifier of a client certificate for the stage. Use the [`aws_api_gateway_client_certificate`](/docs/providers/aws/r/api_gateway_client_certificate.html) resource to configure a client certificate.
 Supported only for WebSocket APIs.
 * `default_route_settings` - (Optional) The default route settings for the stage.
-* `deployment_id` - (Optional) The deployment identifier of the stage. Use the `aws_apigatewayv2_deployment` resource to configure a deployment.
+* `deployment_id` - (Optional) The deployment identifier of the stage. Use the [`aws_apigatewayv2_deployment`](/docs/providers/aws/r/apigatewayv2_deployment.html) resource to configure a deployment.
 * `description` - (Optional) The description for the stage.
 * `route_settings` - (Optional) Route settings for the stage.
 * `stage_variables` - (Optional) A map that defines the stage variables for the stage.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13633.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_stage: Make `deployment_id` a `Computed` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Stage_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Stage_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Stage_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== PAUSE TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== RUN   TestAccAWSAPIGatewayV2Stage_autoDeployHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_autoDeployHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_disappears
=== PAUSE TestAccAWSAPIGatewayV2Stage_disappears
=== RUN   TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== PAUSE TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== RUN   TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== PAUSE TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== RUN   TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings
=== PAUSE TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings
=== RUN   TestAccAWSAPIGatewayV2Stage_Deployment
=== PAUSE TestAccAWSAPIGatewayV2Stage_Deployment
=== RUN   TestAccAWSAPIGatewayV2Stage_RouteSettings
=== PAUSE TestAccAWSAPIGatewayV2Stage_RouteSettings
=== RUN   TestAccAWSAPIGatewayV2Stage_StageVariables
=== PAUSE TestAccAWSAPIGatewayV2Stage_StageVariables
=== RUN   TestAccAWSAPIGatewayV2Stage_Tags
=== PAUSE TestAccAWSAPIGatewayV2Stage_Tags
=== CONT  TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== CONT  TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings
=== CONT  TestAccAWSAPIGatewayV2Stage_Tags
=== CONT  TestAccAWSAPIGatewayV2Stage_StageVariables
=== CONT  TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== CONT  TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== CONT  TestAccAWSAPIGatewayV2Stage_RouteSettings
=== CONT  TestAccAWSAPIGatewayV2Stage_Deployment
=== CONT  TestAccAWSAPIGatewayV2Stage_disappears
=== CONT  TestAccAWSAPIGatewayV2Stage_autoDeployHttp
=== CONT  TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== CONT  TestAccAWSAPIGatewayV2Stage_basicHttp
--- PASS: TestAccAWSAPIGatewayV2Stage_basicWebSocket (32.37s)
--- PASS: TestAccAWSAPIGatewayV2Stage_basicHttp (32.52s)
--- PASS: TestAccAWSAPIGatewayV2Stage_Deployment (39.84s)
--- PASS: TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings (50.38s)
--- PASS: TestAccAWSAPIGatewayV2Stage_Tags (51.17s)
--- PASS: TestAccAWSAPIGatewayV2Stage_disappears (55.91s)
--- PASS: TestAccAWSAPIGatewayV2Stage_StageVariables (57.27s)
--- PASS: TestAccAWSAPIGatewayV2Stage_defaultHttpStage (59.59s)
--- PASS: TestAccAWSAPIGatewayV2Stage_autoDeployHttp (60.90s)
--- PASS: TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription (76.53s)
--- PASS: TestAccAWSAPIGatewayV2Stage_RouteSettings (77.40s)
--- PASS: TestAccAWSAPIGatewayV2Stage_AccessLogSettings (79.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	79.138s
```

Includes @acburdine's fix from https://github.com/terraform-providers/terraform-provider-aws/pull/13062.