### PR TITLE
fixes the link to "common review items"

### DIFF
--- a/docs/contributing/contribution-checklists.md
+++ b/docs/contributing/contribution-checklists.md
@@ -39,7 +39,7 @@ contributor because you can work within existing code and tests to get a feel
 for what to do.
 
 In addition to the below checklist, please see the [Common Review
-Items](#common-review-items) sections for more specific coding and testing
+Items](pullrequest-submission-and-lifecycle.md#common-review-items) sections for more specific coding and testing
 guidelines.
 
  - [ ] __Acceptance test coverage of new behavior__: Existing resources each
@@ -72,7 +72,7 @@ Adding import support for Terraform resources will allow existing infrastructure
 
 Comprehensive code examples and information about resource import support can be found in the [Extending Terraform documentation](https://www.terraform.io/docs/extend/resources/import.html).
 
-In addition to the below checklist and the items noted in the Extending Terraform documentation, please see the [Common Review Items](#common-review-items) sections for more specific coding and testing guidelines.
+In addition to the below checklist and the items noted in the Extending Terraform documentation, please see the [Common Review Items](pullrequest-submission-and-lifecycle.md#common-review-items) sections for more specific coding and testing guidelines.
 
 - [ ] _Resource Code Implementation_: In the resource code (e.g. `aws/resource_aws_service_thing.go`), implementation of `Importer` `State` function
 - [ ] _Resource Acceptance Testing Implementation_: In the resource acceptance testing (e.g. `aws/resource_aws_service_thing_test.go`), implementation of `TestStep`s with `ImportState: true`
@@ -446,7 +446,7 @@ interacts with upstream APIs. There are plenty of examples to draw from in the
 existing resources, but you still get to implement something completely new.
 
 In addition to the below checklist, please see the [Common Review
-Items](#common-review-items) sections for more specific coding and testing
+Items](pullrequest-submission-and-lifecycle.md#common-review-items) sections for more specific coding and testing
 guidelines.
 
  - [ ] __Minimal LOC__: It's difficult for both the reviewer and author to go


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Fixes the broken link of `common review items` in the contribution checklist page after docs refactor #13227