### PR TITLE
resource/instance: update logic to set ebs and root block devices

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -2348,10 +2348,9 @@ func resourceAwsInstanceFind(conn *ec2.EC2, params *ec2.DescribeInstancesInput) 
 }
 
 func suppressEBSBlockDeviceDiffs(o, n interface{}, d *schema.ResourceData) bool {
-	// In configurations where a root device is not explicitly set,
-	// either omitted or provided within the list of ebs_block_devices (e.g from an AMI's block_device_mappings),
-	// a DIFF will occur as AWS computes the root_block_device (or uses the ebs_block_device from an AMI defined as "root")
-	// and adds the computed device to the list of ebs_block_devices
+	// A DIFF will occur as AWS computes ebs_block_devices, either from the root_block_device block
+	// or from ebs_block_device blocks configured which can also include the "root" if e.g. dynamically set from
+	// an AMI's block_device_mappings attribute
 	// e.g. 1 ebs_block_device block set in a config without a root_block_device block -> 2 ebs_block_devices blocks (includes the new root) and 1 root_block_device block
 	//      1 ebs_block_device set in a config from an AMI data_source -> 1 ebs_block_device block (the root) and 1 root_block_device block
 	oldDevices := o.(*schema.Set)

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -2351,7 +2351,7 @@ func suppressEBSBlockDeviceDiffs(o, n interface{}, d *schema.ResourceData) bool 
 	// In configurations where a root device is not explicitly set,
 	// either omitted or provided within the list of ebs_block_devices (e.g from an AMI's block_device_mappings),
 	// a DIFF will occur as AWS computes the root_block_device (or uses the ebs_block_device from an AMI defined as "root")
-	// and adds the computed device to the list of ebs_block_devices as well
+	// and adds the computed device to the list of ebs_block_devices
 	// e.g. 1 ebs_block_device block set in a config without a root_block_device block -> 2 ebs_block_devices blocks (includes the new root) and 1 root_block_device block
 	//      1 ebs_block_device set in a config from an AMI data_source -> 1 ebs_block_device block (the root) and 1 root_block_device block
 	oldDevices := o.(*schema.Set)

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -2360,6 +2360,9 @@ func suppressEBSBlockDeviceDiffs(o, n interface{}, d *schema.ResourceData) bool 
 	if deviceDiff == nil || len(deviceDiff.List()) == 0 {
 		return true
 	}
+	if len(deviceDiff.List()) > 1 {
+		return false
+	}
 	device := make(map[string]interface{})
 	for k, v := range deviceDiff.List()[0].(map[string]interface{}) {
 		if k == "snapshot_id" {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -4871,19 +4871,13 @@ resource "aws_instance" "test" {
 }
 `
 
-var testAccAwsEc2InstanceConfig_SingleDynamicEBSBlockDeviceFromAmi = composeConfig(`
-data "aws_ami" "test" {
-  most_recent = true
-  owners      = ["aws-marketplace"]
-  filter {
-    name   = "product-code"
-    values = ["aw0evgkw8e5c1q413zgy5pjce"]
-  }
-}
-`, testAccAWSEc2InstanceConfig_DynamicEBSBlocks)
+var testAccAwsEc2InstanceConfig_SingleDynamicEBSBlockDeviceFromAmi = composeConfig(
+	testAccAwsEc2InstanceAmiWithEbsRootVolume,
+	testAccAWSEc2InstanceConfig_DynamicEBSBlocks,
+)
 
 var testAccAwsEc2InstanceConfig_MultipleDynamicEBSBlockDevicesFromAmi = composeConfig(`
-data "aws_ami" "test" {
+data "aws_ami" "ami" {
   most_recent = true
 
   owners = ["679593333241"] # The official CIS account
@@ -4909,11 +4903,11 @@ data "aws_ami" "test" {
 
 const testAccAWSEc2InstanceConfig_DynamicEBSBlocks = `
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.test.id
+  ami           = data.aws_ami.ami.id
   instance_type = "m3.medium"
 
   dynamic "ebs_block_device" {
-    for_each = data.aws_ami.test.block_device_mappings
+    for_each = data.aws_ami.ami.block_device_mappings
     iterator = device
     content {
       device_name = device.value["device_name"]

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1798,7 +1798,7 @@ func TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermina
 	})
 }
 
-// Test to validate fix for GH-ISSUE #1318 (dynamic ebs_block_devices forcing replacement after state refresh)
+// Test to validate fix for GH-ISSUE #13118 (dynamic ebs_block_devices forcing replacement after state refresh)
 // EBS Block Devices created dynamically (without a root device configured)
 func TestAccAWSInstance_DynamicEbsBlockDevice_Multiple(t *testing.T) {
 	var instance ec2.Instance
@@ -1858,7 +1858,7 @@ func TestAccAWSInstance_DynamicEbsBlockDevice_Multiple(t *testing.T) {
 	})
 }
 
-// Test to validate fix for GH-ISSUE #1318 (dynamic ebs_block_devices forcing replacement after state refresh)
+// Test to validate fix for GH-ISSUE #13118 (dynamic ebs_block_devices forcing replacement after state refresh)
 // EBS Block Devices created dynamically from AMI's block_device_mappings (only 1 i.e. the root device)
 func TestAccAWSInstance_DynamicEbsBlockDevice_SingleFromAmi(t *testing.T) {
 	var instance ec2.Instance
@@ -1888,7 +1888,7 @@ func TestAccAWSInstance_DynamicEbsBlockDevice_SingleFromAmi(t *testing.T) {
 	})
 }
 
-// Test to validate fix for GH-ISSUE #1318 (dynamic ebs_block_devices forcing replacement after state refresh)
+// Test to validate fix for GH-ISSUE #13118 (dynamic ebs_block_devices forcing replacement after state refresh)
 // EBS Block Devices created dynamically from AMI's block_device_mappings (more than 1 i.e. n mappings + root device)
 func TestAccAWSInstance_DynamicEbsBlockDevice_MultipleFromAmi(t *testing.T) {
 	var instance ec2.Instance

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -332,7 +332,7 @@ func TestAccAWSInstance_EbsBlockDevice_KmsKeyArn(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.device_name", "/dev/sdd"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.encrypted", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.2634515331.kms_key_id", kmsKeyResourceName, "arn"),
-					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.3568741603.device_name", resourceName,"root_block_device.0.device_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.3568741603.device_name", resourceName, "root_block_device.0.device_name"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.3568741603.encrypted", "false"),
 				),
 			},

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -328,10 +328,18 @@ func TestAccAWSInstance_EbsBlockDevice_KmsKeyArn(t *testing.T) {
 				Config: testAccInstanceConfigEbsBlockDeviceKmsKeyArn,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.device_name", "/dev/sdd"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.encrypted", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.2634515331.kms_key_id", kmsKeyResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.3568741603.device_name", resourceName,"root_block_device.0.device_name"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.3568741603.encrypted", "false"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -481,7 +489,7 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 			// Map out the block devices by name, which should be unique.
 			blockDevices := make(map[string]*ec2.InstanceBlockDeviceMapping)
 			for _, blockDevice := range v.BlockDeviceMappings {
-				blockDevices[*blockDevice.DeviceName] = blockDevice
+				blockDevices[aws.StringValue(blockDevice.DeviceName)] = blockDevice
 			}
 
 			// Check if the root block device exists.
@@ -526,7 +534,11 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "root_block_device.0.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_size", rootVolumeSize),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.0.volume_type", "gp2"),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.3568741603.device_name", "/dev/sda1"),
+					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.3568741603.volume_id", resourceName, "root_block_device.0.volume_id"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.3568741603.volume_size", rootVolumeSize),
+					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.3568741603.volume_type", "gp2"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.device_name", "/dev/sdb"),
 					resource.TestMatchResourceAttr(resourceName, "ebs_block_device.2576023345.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2576023345.volume_size", "9"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13118

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/instance: set ebs and root block devices (of ebs type) from API responses to instance/volume requests
resource/instance: suppress diffs in cases where root_block_device is not provided or set from an AMI
```

**AccTest Note:**
* `TestAccAWSInstance_DynamicEbsDeviceBlock_MultipleFromAmi`: references a marketplace AMI that needs to be subscribed to 

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
Added tests:
--- PASS: TestAccAWSInstance_DynamicEbsBlockDevice_Multiple (194.12s)
--- PASS: TestAccAWSInstance_DynamicEbsBlockDevice_SingleFromAmi (119.78s)
--- PASS: TestAccAWSInstance_DynamicEbsDeviceBlock_MultipleFromAmi (96.22s)
```
```
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (67.42s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (67.59s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (78.65s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (79.14s)
--- PASS: TestFetchRootDevice (0.00s)
    --- PASS: TestFetchRootDevice/device_name_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/device_name_not_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/no_images (0.00s)
--- PASS: TestAccAWSInstanceDataSource_VPC (93.18s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (97.08s)
--- SKIP: TestAccAWSInstance_inEc2Classic (1.05s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (100.32s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (100.82s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (101.72s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (118.23s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (119.30s)
--- PASS: TestAccAWSInstanceDataSource_tags (123.85s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (125.97s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (131.08s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (137.70s)
--- PASS: TestAccAWSInstancesDataSource_basic (82.21s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (151.41s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (73.20s)
--- SKIP: TestAccAWSInstance_outpost (0.00s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (180.88s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (69.90s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (90.90s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (10.34s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (84.11s)
--- PASS: TestAccAWSInstance_blockDevices (79.87s)
--- PASS: TestAccAWSInstance_placementGroup (58.95s)
--- PASS: TestAccAWSInstance_userDataBase64 (111.03s)
--- PASS: TestAccAWSInstance_vpc (74.60s)
--- PASS: TestAccAWSInstanceDataSource_basic (231.63s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (232.25s)
--- PASS: TestAccAWSInstance_rootInstanceStore (109.05s)
--- PASS: TestAccAWSInstance_disableApiTermination (94.03s)
--- PASS: TestAccAWSInstancesDataSource_tags (182.47s)
--- PASS: TestAccAWSInstance_sourceDestCheck (113.85s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (75.25s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (76.81s)
--- PASS: TestAccAWSInstancesDataSource_instance_state_names (192.14s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (184.27s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (282.55s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (83.90s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (77.48s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (88.82s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (174.73s)
--- PASS: TestAccAWSInstance_privateIP (74.71s)
--- PASS: TestAccAWSInstance_keyPairCheck (63.42s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (74.73s)
--- PASS: TestAccAWSInstance_basic (229.43s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (63.92s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (85.36s)
--- PASS: TestAccAWSInstance_volumeTags (111.56s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (133.61s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (103.55s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (114.37s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (112.06s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS (111.96s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (121.88s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (320.09s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (87.74s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (98.14s)
--- PASS: TestAccAWSInstance_tags (227.00s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (125.86s)
--- PASS: TestAccAWSInstance_multipleRegions (249.66s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (85.29s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (75.91s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (216.12s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (64.99s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (76.78s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (133.60s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (77.59s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (79.41s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (144.87s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (63.16s)
--- PASS: TestAccAWSInstance_changeInstanceType (241.42s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (101.00s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (91.05s)
--- PASS: TestInstanceHostIDSchema (0.00s)
--- PASS: TestInstanceCpuCoreCountSchema (0.00s)
--- PASS: TestInstanceCpuThreadsPerCoreSchema (0.00s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (103.59s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (101.79s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (99.41s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (114.72s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (118.15s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (130.09s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (113.90s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (168.57s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (123.89s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (182.76s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (89.03s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (88.31s)
--- PASS: TestAccAWSInstance_disappears (121.14s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (141.37s)
--- PASS: TestAccAWSInstance_hibernation (155.94s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (280.71s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (376.71s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (401.93s)
--- PASS: TestAccAWSInstance_instanceProfileChange (218.19s)
--- PASS: TestAccAWSInstance_metadataOptions (129.52s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (138.99s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (118.75s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (109.53s)
```