### PR TITLE
r/key_pair: add arn attribute + minor refactor

### DIFF
--- a/aws/resource_aws_key_pair.go
+++ b/aws/resource_aws_key_pair.go
@@ -2,9 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -63,6 +65,10 @@ func resourceAwsKeyPair() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchema(),
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -92,7 +98,7 @@ func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error import KeyPair: %s", err)
 	}
 
-	d.SetId(*resp.KeyName)
+	d.SetId(aws.StringValue(resp.KeyName))
 
 	return resourceAwsKeyPairRead(d, meta)
 }
@@ -107,25 +113,43 @@ func resourceAwsKeyPairRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := conn.DescribeKeyPairs(req)
 	if err != nil {
 		if isAWSErr(err, "InvalidKeyPair.NotFound", "") {
+			log.Printf("[WARN] Key Pair (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("Error retrieving KeyPair: %s", err)
 	}
 
-	for _, keyPair := range resp.KeyPairs {
-		if *keyPair.KeyName == d.Id() {
-			d.Set("key_name", keyPair.KeyName)
-			d.Set("fingerprint", keyPair.KeyFingerprint)
-			d.Set("key_pair_id", keyPair.KeyPairId)
-			if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(keyPair.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-				return fmt.Errorf("error setting tags: %s", err)
-			}
-			return nil
-		}
+	if len(resp.KeyPairs) == 0 {
+		log.Printf("[WARN] Key Pair (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	return fmt.Errorf("Unable to find key pair within: %#v", resp.KeyPairs)
+	kp := resp.KeyPairs[0]
+
+	if aws.StringValue(kp.KeyName) != d.Id() {
+		return fmt.Errorf("Unable to find key pair within: %#v", resp.KeyPairs)
+	}
+
+	d.Set("key_name", kp.KeyName)
+	d.Set("fingerprint", kp.KeyFingerprint)
+	d.Set("key_pair_id", kp.KeyPairId)
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(kp.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ec2",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("key-pair/%s", d.Id()),
+	}.String()
+
+	d.Set("arn", arn)
+
+	return nil
 }
 
 func resourceAwsKeyPairUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -266,6 +266,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   - [`aws_glue_trigger` resource](/docs/providers/aws/r/glue_trigger.html)
   - [`aws_instance` data source](/docs/providers/aws/d/instance.html)
   - [`aws_instance` resource](/docs/providers/aws/r/instance.html)
+  - [`aws_key_pair` resource](/docs/providers/aws/r/key_pair.html)  
   - [`aws_launch_template` data source](/docs/providers/aws/d/launch_template.html)
   - [`aws_launch_template` resource](/docs/providers/aws/r/launch_template.html)
   - [`aws_redshift_cluster` resource](/docs/providers/aws/r/redshift_cluster.html)

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - The key pair name.
+* `arn` - The key pair ARN.
 * `key_name` - The key pair name.
 * `key_pair_id` - The key pair ID.
 * `fingerprint` - The MD5 public key fingerprint as specified in section 4 of RFC 4716.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624, #13527

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_key_pair: add arn attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSKeyPair_'
--- PASS: TestAccAWSKeyPair_basic (45.24s)
--- PASS: TestAccAWSKeyPair_tags (101.47s)
--- PASS: TestAccAWSKeyPair_generatedName (44.91s)
--- PASS: TestAccAWSKeyPair_namePrefix (47.57s)
--- PASS: TestAccAWSKeyPair_disappears (35.94s)
```
