### PR TITLE
rd/efs_mount_target - add az specific dns name + attributes

### DIFF
--- a/aws/data_source_aws_efs_mount_target.go
+++ b/aws/data_source_aws_efs_mount_target.go
@@ -34,7 +34,6 @@ func dataSourceAwsEfsMountTarget() *schema.Resource {
 			"security_groups": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 				Computed: true,
 			},
 			"subnet_id": {
@@ -49,19 +48,35 @@ func dataSourceAwsEfsMountTarget() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"mount_target_dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) error {
-	efsconn := meta.(*AWSClient).efsconn
+	conn := meta.(*AWSClient).efsconn
 
 	describeEfsOpts := &efs.DescribeMountTargetsInput{
 		MountTargetId: aws.String(d.Get("mount_target_id").(string)),
 	}
 
 	log.Printf("[DEBUG] Reading EFS Mount Target: %s", describeEfsOpts)
-	resp, err := efsconn.DescribeMountTargets(describeEfsOpts)
+	resp, err := conn.DescribeMountTargets(describeEfsOpts)
 	if err != nil {
 		return fmt.Errorf("Error retrieving EFS Mount Target: %s", err)
 	}
@@ -73,7 +88,7 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Found EFS mount target: %#v", mt)
 
-	d.SetId(*mt.MountTargetId)
+	d.SetId(aws.StringValue(mt.MountTargetId))
 
 	fsARN := arn.ARN{
 		AccountID: meta.(*AWSClient).accountid,
@@ -88,19 +103,23 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("ip_address", mt.IpAddress)
 	d.Set("subnet_id", mt.SubnetId)
 	d.Set("network_interface_id", mt.NetworkInterfaceId)
+	d.Set("availability_zone_name", mt.AvailabilityZoneName)
+	d.Set("availability_zone_id", mt.AvailabilityZoneId)
+	d.Set("owner_id", mt.OwnerId)
 
-	sgResp, err := efsconn.DescribeMountTargetSecurityGroups(&efs.DescribeMountTargetSecurityGroupsInput{
+	sgResp, err := conn.DescribeMountTargetSecurityGroups(&efs.DescribeMountTargetSecurityGroupsInput{
 		MountTargetId: aws.String(d.Id()),
 	})
 	if err != nil {
 		return err
 	}
-	err = d.Set("security_groups", schema.NewSet(schema.HashString, flattenStringList(sgResp.SecurityGroups)))
+	err = d.Set("security_groups", flattenStringSet(sgResp.SecurityGroups))
 	if err != nil {
 		return err
 	}
 
 	d.Set("dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.efs", aws.StringValue(mt.FileSystemId))))
+	d.Set("mount_target_dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.%s.efs", aws.StringValue(mt.AvailabilityZoneName), aws.StringValue(mt.FileSystemId))))
 
 	return nil
 }

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestAccDataSourceAwsEfsMountTargetByMountTargetId(t *testing.T) {
 	rName := acctest.RandString(10)
+	dataSourceName := "data.aws_efs_mount_target.test"
+	resourceName := "aws_efs_mount_target.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -17,12 +19,17 @@ func TestAccDataSourceAwsEfsMountTargetByMountTargetId(t *testing.T) {
 			{
 				Config: testAccAwsEfsMountTargetConfigByMountTargetId(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("data.aws_efs_mount_target.by_mount_target_id", "file_system_arn", "aws_efs_mount_target.alpha", "file_system_arn"),
-					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "file_system_id"),
-					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "ip_address"),
-					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "subnet_id"),
-					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "network_interface_id"),
-					resource.TestCheckResourceAttrSet("data.aws_efs_mount_target.by_mount_target_id", "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_id", resourceName, "file_system_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ip_address", resourceName, "ip_address"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_id", resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interface_id", resourceName, "network_interface_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mount_target_dns_name", resourceName, "mount_target_dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_name", resourceName, "availability_zone_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_id", resourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups", resourceName, "security_groups"),
 				),
 			},
 		},
@@ -31,35 +38,48 @@ func TestAccDataSourceAwsEfsMountTargetByMountTargetId(t *testing.T) {
 
 func testAccAwsEfsMountTargetConfigByMountTargetId(ct string) string {
 	return fmt.Sprintf(`
-resource "aws_efs_file_system" "foo" {
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_efs_file_system" "test" {
   creation_token = "%s"
+
+  tags = {
+    Name = "tf-acc-efs-mount-target-test"
+  }
 }
 
-resource "aws_efs_mount_target" "alpha" {
-  file_system_id = "${aws_efs_file_system.foo.id}"
-  subnet_id      = "${aws_subnet.alpha.id}"
+resource "aws_efs_mount_target" "test" {
+  file_system_id = "${aws_efs_file_system.test.id}"
+  subnet_id      = "${aws_subnet.test.id}"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-efs-mount-target"
+    Name = "tf-acc-efs-mount-target-test"
   }
 }
 
-resource "aws_subnet" "alpha" {
-  vpc_id            = "${aws_vpc.foo.id}"
-  availability_zone = "us-west-2a"
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "10.0.1.0/24"
 
   tags = {
-    Name = "tf-acc-efs-mount-target"
+    Name = "tf-acc-efs-mount-target-test"
   }
 }
 
-data "aws_efs_mount_target" "by_mount_target_id" {
-  mount_target_id = "${aws_efs_mount_target.alpha.id}"
+data "aws_efs_mount_target" "test" {
+  mount_target_id = "${aws_efs_mount_target.test.id}"
 }
 `, ct)
 }

--- a/aws/resource_aws_efs_mount_target.go
+++ b/aws/resource_aws_efs_mount_target.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAwsEfsMountTarget() *schema.Resource {
@@ -37,16 +37,16 @@ func resourceAwsEfsMountTarget() *schema.Resource {
 			},
 
 			"ip_address": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsIPv4Address,
 			},
 
 			"security_groups": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 				Computed: true,
 				Optional: true,
 			},
@@ -62,6 +62,22 @@ func resourceAwsEfsMountTarget() *schema.Resource {
 				Computed: true,
 			},
 			"dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mount_target_dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -96,7 +112,7 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 		input.IpAddress = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("security_groups"); ok {
-		input.SecurityGroups = expandStringList(v.(*schema.Set).List())
+		input.SecurityGroups = expandStringSet(v.(*schema.Set))
 	}
 
 	log.Printf("[DEBUG] Creating EFS mount target: %#v", input)
@@ -106,12 +122,12 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	d.SetId(*mt.MountTargetId)
+	d.SetId(aws.StringValue(mt.MountTargetId))
 	log.Printf("[INFO] EFS mount target ID: %s", d.Id())
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"creating"},
-		Target:  []string{"available"},
+		Pending: []string{efs.LifeCycleStateCreating},
+		Target:  []string{efs.LifeCycleStateAvailable},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeMountTargets(&efs.DescribeMountTargetsInput{
 				MountTargetId: aws.String(d.Id()),
@@ -126,7 +142,7 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 
 			mt := resp.MountTargets[0]
 
-			log.Printf("[DEBUG] Current status of %q: %q", *mt.MountTargetId, *mt.LifeCycleState)
+			log.Printf("[DEBUG] Current status of %q: %q", aws.StringValue(mt.MountTargetId), aws.StringValue(mt.LifeCycleState))
 			return mt, *mt.LifeCycleState, nil
 		},
 		Timeout:    10 * time.Minute,
@@ -136,10 +152,10 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for EFS mount target (%s) to create: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for EFS mount target (%s) to create: %s", d.Id(), err)
 	}
 
-	log.Printf("[DEBUG] EFS mount target created: %s", *mt.MountTargetId)
+	log.Printf("[DEBUG] EFS mount target created: %s", aws.StringValue(mt.MountTargetId))
 
 	return resourceAwsEfsMountTargetRead(d, meta)
 }
@@ -150,7 +166,7 @@ func resourceAwsEfsMountTargetUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("security_groups") {
 		input := efs.ModifyMountTargetSecurityGroupsInput{
 			MountTargetId:  aws.String(d.Id()),
-			SecurityGroups: expandStringList(d.Get("security_groups").(*schema.Set).List()),
+			SecurityGroups: expandStringSet(d.Get("security_groups").(*schema.Set)),
 		}
 		_, err := conn.ModifyMountTargetSecurityGroups(&input)
 		if err != nil {
@@ -167,7 +183,7 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 		MountTargetId: aws.String(d.Id()),
 	})
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "MountTargetNotFound" {
+		if isAWSErr(err, efs.ErrCodeMountTargetNotFound, "") {
 			// The EFS mount target could not be found,
 			// which would indicate that it might be
 			// already deleted.
@@ -186,8 +202,6 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Found EFS mount target: %#v", mt)
 
-	d.SetId(*mt.MountTargetId)
-
 	fsARN := arn.ARN{
 		AccountID: meta.(*AWSClient).accountid,
 		Partition: meta.(*AWSClient).partition,
@@ -201,6 +215,9 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("ip_address", mt.IpAddress)
 	d.Set("subnet_id", mt.SubnetId)
 	d.Set("network_interface_id", mt.NetworkInterfaceId)
+	d.Set("availability_zone_name", mt.AvailabilityZoneName)
+	d.Set("availability_zone_id", mt.AvailabilityZoneId)
+	d.Set("owner_id", mt.OwnerId)
 
 	sgResp, err := conn.DescribeMountTargetSecurityGroups(&efs.DescribeMountTargetSecurityGroupsInput{
 		MountTargetId: aws.String(d.Id()),
@@ -209,18 +226,19 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	err = d.Set("security_groups", schema.NewSet(schema.HashString, flattenStringList(sgResp.SecurityGroups)))
+	err = d.Set("security_groups", flattenStringSet(sgResp.SecurityGroups))
 	if err != nil {
 		return err
 	}
 
 	// DNS name per http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html
-	_, err = getAzFromSubnetId(*mt.SubnetId, meta.(*AWSClient).ec2conn)
+	_, err = getAzFromSubnetId(aws.StringValue(mt.SubnetId), meta.(*AWSClient).ec2conn)
 	if err != nil {
 		return fmt.Errorf("Failed getting Availability Zone from subnet ID (%s): %s", *mt.SubnetId, err)
 	}
 
 	d.Set("dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.efs", aws.StringValue(mt.FileSystemId))))
+	d.Set("mount_target_dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.%s.efs", aws.StringValue(mt.AvailabilityZoneName), aws.StringValue(mt.FileSystemId))))
 
 	return nil
 }
@@ -238,7 +256,7 @@ func getAzFromSubnetId(subnetId string, conn *ec2.EC2) (string, error) {
 		return "", fmt.Errorf("Expected exactly 1 subnet returned for %q, got: %d", subnetId, l)
 	}
 
-	return *out.Subnets[0].AvailabilityZone, nil
+	return aws.StringValue(out.Subnets[0].AvailabilityZone), nil
 }
 
 func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) error {
@@ -264,23 +282,18 @@ func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) e
 
 func waitForDeleteEfsMountTarget(conn *efs.EFS, id string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"available", "deleting", "deleted"},
+		Pending: []string{efs.LifeCycleStateAvailable, efs.LifeCycleStateDeleting, efs.LifeCycleStateDeleted},
 		Target:  []string{},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := conn.DescribeMountTargets(&efs.DescribeMountTargetsInput{
 				MountTargetId: aws.String(id),
 			})
 			if err != nil {
-				awsErr, ok := err.(awserr.Error)
-				if !ok {
-					return nil, "error", err
-				}
-
-				if awsErr.Code() == "MountTargetNotFound" {
+				if isAWSErr(err, efs.ErrCodeMountTargetNotFound, "") {
 					return nil, "", nil
 				}
 
-				return nil, "error", awsErr
+				return nil, "error", err
 			}
 
 			if hasEmptyMountTargets(resp) {
@@ -289,8 +302,8 @@ func waitForDeleteEfsMountTarget(conn *efs.EFS, id string, timeout time.Duration
 
 			mt := resp.MountTargets[0]
 
-			log.Printf("[DEBUG] Current status of %q: %q", *mt.MountTargetId, *mt.LifeCycleState)
-			return mt, *mt.LifeCycleState, nil
+			log.Printf("[DEBUG] Current status of %q: %q", aws.StringValue(mt.MountTargetId), aws.StringValue(mt.LifeCycleState))
+			return mt, aws.StringValue(mt.LifeCycleState), nil
 		},
 		Timeout:    timeout,
 		Delay:      2 * time.Second,

--- a/aws/resource_aws_efs_mount_target.go
+++ b/aws/resource_aws_efs_mount_target.go
@@ -143,7 +143,7 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 			mt := resp.MountTargets[0]
 
 			log.Printf("[DEBUG] Current status of %q: %q", aws.StringValue(mt.MountTargetId), aws.StringValue(mt.LifeCycleState))
-			return mt, *mt.LifeCycleState, nil
+			return mt, aws.StringValue(mt.LifeCycleState), nil
 		},
 		Timeout:    10 * time.Minute,
 		Delay:      2 * time.Second,
@@ -229,12 +229,6 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 	err = d.Set("security_groups", flattenStringSet(sgResp.SecurityGroups))
 	if err != nil {
 		return err
-	}
-
-	// DNS name per http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html
-	_, err = getAzFromSubnetId(aws.StringValue(mt.SubnetId), meta.(*AWSClient).ec2conn)
-	if err != nil {
-		return fmt.Errorf("Failed getting Availability Zone from subnet ID (%s): %s", *mt.SubnetId, err)
 	}
 
 	d.Set("dns_name", meta.(*AWSClient).RegionalHostname(fmt.Sprintf("%s.efs", aws.StringValue(mt.FileSystemId))))

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/efs"
 
 	multierror "github.com/hashicorp/go-multierror"
@@ -105,6 +104,11 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 					testAccCheckEfsMountTarget(resourceName, &mount),
 					testAccMatchResourceAttrRegionalHostname(resourceName, "dns_name", "efs", regexp.MustCompile(`fs-[^.]+`)),
 					testAccMatchResourceAttrRegionalARN(resourceName, "file_system_arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "mount_target_dns_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
 			{
@@ -138,11 +142,8 @@ func TestAccAWSEFSMountTarget_disappears(t *testing.T) {
 			{
 				Config: testAccAWSEFSMountTargetConfig(ct),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEfsMountTarget(
-						resourceName,
-						&mount,
-					),
-					testAccAWSEFSMountTargetDisappears(&mount),
+					testAccCheckEfsMountTarget(resourceName, &mount),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEfsMountTarget(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -181,7 +182,7 @@ func testAccCheckEfsMountTargetDestroy(s *terraform.State) error {
 			MountTargetId: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
-			if efsErr, ok := err.(awserr.Error); ok && efsErr.Code() == "MountTargetNotFound" {
+			if isAWSErr(err, efs.ErrCodeMountTargetNotFound, "") {
 				// gone
 				return nil
 			}
@@ -219,7 +220,7 @@ func testAccCheckEfsMountTarget(resourceID string, mount *efs.MountTargetDescrip
 			return err
 		}
 
-		if *mt.MountTargets[0].MountTargetId != fs.Primary.ID {
+		if aws.StringValue(mt.MountTargets[0].MountTargetId) != fs.Primary.ID {
 			return fmt.Errorf("Mount target ID mismatch: %q != %q",
 				*mt.MountTargets[0].MountTargetId, fs.Primary.ID)
 		}
@@ -230,67 +231,41 @@ func testAccCheckEfsMountTarget(resourceID string, mount *efs.MountTargetDescrip
 	}
 }
 
-func testAccAWSEFSMountTargetDisappears(mount *efs.MountTargetDescription) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).efsconn
-
-		_, err := conn.DeleteMountTarget(&efs.DeleteMountTargetInput{
-			MountTargetId: mount.MountTargetId,
-		})
-
-		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "MountTargetNotFound" {
-				return nil
-			}
-			return err
-		}
-
-		return resource.Retry(3*time.Minute, func() *resource.RetryError {
-			resp, err := conn.DescribeMountTargets(&efs.DescribeMountTargetsInput{
-				MountTargetId: mount.MountTargetId,
-			})
-			if err != nil {
-				if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "MountTargetNotFound" {
-					return nil
-				}
-				return resource.NonRetryableError(
-					fmt.Errorf("Error reading EFS mount target: %s", err))
-			}
-			if resp.MountTargets == nil || len(resp.MountTargets) < 1 {
-				return nil
-			}
-			if *resp.MountTargets[0].LifeCycleState == "deleted" {
-				return nil
-			}
-			return resource.RetryableError(fmt.Errorf(
-				"Waiting for EFS mount target: %s", *mount.MountTargetId))
-		})
-	}
-
-}
-
 func testAccAWSEFSMountTargetConfig(ct string) string {
 	return fmt.Sprintf(`
-resource "aws_efs_file_system" "foo" {
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_efs_file_system" "test" {
   creation_token = "%s"
+
+  tags = {
+    Name = "tf-acc-efs-mount-target-test"
+  }
 }
 
 resource "aws_efs_mount_target" "test" {
-  file_system_id = "${aws_efs_file_system.foo.id}"
+  file_system_id = "${aws_efs_file_system.test.id}"
   subnet_id      = "${aws_subnet.test.id}"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-efs-mount-target"
+    Name = "tf-acc-efs-mount-target-test"
   }
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.foo.id}"
-  availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "10.0.1.0/24"
 
   tags = {
@@ -302,31 +277,44 @@ resource "aws_subnet" "test" {
 
 func testAccAWSEFSMountTargetConfigModified(ct string) string {
 	return fmt.Sprintf(`
-resource "aws_efs_file_system" "foo" {
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_efs_file_system" "test" {
   creation_token = "%s"
+
+  tags = {
+    Name = "tf-acc-efs-mount-target-test"
+  }
 }
 
 resource "aws_efs_mount_target" "test" {
-  file_system_id = "${aws_efs_file_system.foo.id}"
+  file_system_id = "${aws_efs_file_system.test.id}"
   subnet_id      = "${aws_subnet.test.id}"
 }
 
 resource "aws_efs_mount_target" "test2" {
-  file_system_id = "${aws_efs_file_system.foo.id}"
+  file_system_id = "${aws_efs_file_system.test.id}"
   subnet_id      = "${aws_subnet.test2.id}"
 }
 
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-efs-mount-target-modified"
+    Name = "tf-acc-efs-mount-target-test"
   }
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.foo.id}"
-  availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "10.0.1.0/24"
 
   tags = {
@@ -335,8 +323,8 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_subnet" "test2" {
-  vpc_id            = "${aws_vpc.foo.id}"
-  availability_zone = "us-west-2b"
+  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "10.0.2.0/24"
 
   tags = {

--- a/website/docs/d/efs_mount_target.html.markdown
+++ b/website/docs/d/efs_mount_target.html.markdown
@@ -38,6 +38,9 @@ In addition to all arguments above, the following attributes are exported:
 * `subnet_id` - ID of the mount target's subnet.
 * `ip_address` - Address at which the file system may be mounted via the mount target.
 * `security_groups` - List of VPC security group IDs attached to the mount target.
-* `dns_name` - The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).
+* `dns_name` - The DNS name for the EFS file system.
+* `mount_target_dns_name` - The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).
 * `network_interface_id` - The ID of the network interface that Amazon EFS created when it created the mount target.
-
+* `availability_zone_name` - The name of the Availability Zone (AZ) that the mount target resides in.
+* `availability_zone_id` - The unique and consistent identifier of the Availability Zone (AZ) that the mount target resides in.
+* `owner_id` - AWS account ID that owns the resource.

--- a/website/docs/r/efs_mount_target.html.markdown
+++ b/website/docs/r/efs_mount_target.html.markdown
@@ -48,7 +48,6 @@ and [VPC resource](https://www.terraform.io/docs/providers/aws/r/vpc.html#enable
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - The ARN of the mount target.
 * `id` - The ID of the mount target.
 * `dns_name` - The DNS name for the EFS file system.
 * `mount_target_dns_name` - The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).

--- a/website/docs/r/efs_mount_target.html.markdown
+++ b/website/docs/r/efs_mount_target.html.markdown
@@ -42,16 +42,21 @@ be for the same VPC as subnet specified) in effect for the mount target.
 
 ## Attributes Reference
 
-~> **Note:** The `dns_name` attribute is only useful if the mount target is in a VPC that has
+~> **Note:** The `dns_name` and `mount_target_dns_name` attributes are only useful if the mount target is in a VPC that has
 support for DNS hostnames enabled. See [Using DNS with Your VPC](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html)
 and [VPC resource](https://www.terraform.io/docs/providers/aws/r/vpc.html#enable_dns_hostnames) in Terraform for more information.
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the mount target.
 * `id` - The ID of the mount target.
-* `dns_name` - The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).
+* `dns_name` - The DNS name for the EFS file system.
+* `mount_target_dns_name` - The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).
 * `file_system_arn` - Amazon Resource Name of the file system.
 * `network_interface_id` - The ID of the network interface that Amazon EFS created when it created the mount target.
+* `availability_zone_name` - The name of the Availability Zone (AZ) that the mount target resides in.
+* `availability_zone_id` - The unique and consistent identifier of the Availability Zone (AZ) that the mount target resides in.
+* `owner_id` - AWS account ID that owns the resource.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13527
Closes #13645

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_efs_mount_target: add `mount_target_dns_name`, `availability_zone_name`, `availability_zone_id` and `owner_id` attributes.

data_source_aws_efs_mount_target: add `mount_target_dns_name`, `availability_zone_name`, `availability_zone_id` and `owner_id` attributes.

resource_aws_efs_mount_target: add plan time validation for `ip_address`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEFSMountTarget_'
--- PASS: TestAccAWSEFSMountTarget_basic (363.86s)
--- PASS: TestAccAWSEFSMountTarget_disappears (195.87s)

--- PASS: TestAccDataSourceAwsEfsMountTargetByMountTargetId (220.47s)
```
