### PR TITLE
tech-debt/structure: remove always nil error param from expandEcsVolumes func

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -369,10 +369,7 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if v, ok := d.GetOk("volume"); ok {
-		volumes, err := expandEcsVolumes(v.(*schema.Set).List())
-		if err != nil {
-			return err
-		}
+		volumes := expandEcsVolumes(v.(*schema.Set).List())
 		input.Volumes = volumes
 	}
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -100,7 +100,7 @@ func expandListeners(configured []interface{}) ([]*elb.Listener, error) {
 
 // Takes the result of flatmap. Expand for an array of listeners and
 // returns ECS Volume compatible objects
-func expandEcsVolumes(configured []interface{}) ([]*ecs.Volume, error) {
+func expandEcsVolumes(configured []interface{}) []*ecs.Volume {
 	volumes := make([]*ecs.Volume, 0, len(configured))
 
 	// Loop over our configured volumes and create
@@ -165,7 +165,7 @@ func expandEcsVolumes(configured []interface{}) ([]*ecs.Volume, error) {
 		volumes = append(volumes, l)
 	}
 
-	return volumes, nil
+	return volumes
 }
 
 // Takes JSON in a string. Decodes JSON into


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: unparam linting in expandEcsVolumes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (15.08s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (17.54s)
--- PASS: TestValidateAwsEcsTaskDefinitionContainerDefinitions (0.00s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (18.39s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (18.76s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (18.28s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (18.82s)
--- PASS: TestAccAWSEcsTaskDefinition_withPidMode (21.42s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (21.76s)
--- PASS: TestAccAWSEcsTaskDefinition_basic (22.59s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (23.49s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (24.50s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolume (24.69s)
--- PASS: TestAccAWSEcsTaskDefinition_ProxyConfiguration (26.38s)
--- PASS: TestAccAWSEcsTaskDefinition_inferenceAccelerator (11.23s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (27.13s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (29.47s)
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (33.01s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (34.82s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (35.46s)
--- PASS: TestAccAWSEcsTaskDefinition_withIPCMode (46.63s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (81.39s)
```
