### PR TITLE
tech-debt/structure: remove always nil error param from expandParameters func

### DIFF
--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -139,7 +139,7 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if len(describeResp.DBParameterGroups) != 1 ||
-		*describeResp.DBParameterGroups[0].DBParameterGroupName != d.Id() {
+		aws.StringValue(describeResp.DBParameterGroups[0].DBParameterGroupName) != d.Id() {
 		return fmt.Errorf("Unable to find Parameter Group: %#v", describeResp.DBParameterGroups)
 	}
 
@@ -189,15 +189,12 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 		// _and_ the "system"/"engine-default" Source parameters _that appear in the
 		// config_ in the state, or the user gets a perpetual diff. See
 		// terraform-providers/terraform-provider-aws#593 for more context and details.
-		confParams, err := expandParameters(configParams.List())
-		if err != nil {
-			return err
-		}
+		confParams := expandParameters(configParams.List())
 		for _, param := range parameters {
 			if param.Source == nil || param.ParameterName == nil {
 				continue
 			}
-			if *param.Source == "user" {
+			if aws.StringValue(param.Source) == "user" {
 				userParams = append(userParams, param)
 				continue
 			}
@@ -206,13 +203,13 @@ func resourceAwsDbParameterGroupRead(d *schema.ResourceData, meta interface{}) e
 				if cp.ParameterName == nil {
 					continue
 				}
-				if *cp.ParameterName == *param.ParameterName {
+				if aws.StringValue(cp.ParameterName) == aws.StringValue(param.ParameterName) {
 					userParams = append(userParams, param)
 					break
 				}
 			}
 			if !paramFound {
-				log.Printf("[DEBUG] Not persisting %s to state, as its source is %q and it isn't in the config", *param.ParameterName, *param.Source)
+				log.Printf("[DEBUG] Not persisting %s to state, as its source is %q and it isn't in the config", aws.StringValue(param.ParameterName), aws.StringValue(param.Source))
 			}
 		}
 	}
@@ -254,10 +251,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 		ns := n.(*schema.Set)
 
 		// Expand the "parameter" set to aws-sdk-go compat []rds.Parameter
-		parameters, err := expandParameters(ns.Difference(os).List())
-		if err != nil {
-			return err
-		}
+		parameters := expandParameters(ns.Difference(os).List())
 
 		if len(parameters) > 0 {
 			// We can only modify 20 parameters at a time, so walk them until
@@ -276,7 +270,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 				}
 
 				log.Printf("[DEBUG] Modify DB Parameter Group: %s", modifyOpts)
-				_, err = rdsconn.ModifyDBParameterGroup(&modifyOpts)
+				_, err := rdsconn.ModifyDBParameterGroup(&modifyOpts)
 				if err != nil {
 					return fmt.Errorf("Error modifying DB Parameter Group: %s", err)
 				}
@@ -284,10 +278,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 		// Reset parameters that have been removed
-		resetParameters, err := expandParameters(os.Difference(ns).List())
-		if err != nil {
-			return err
-		}
+		resetParameters := expandParameters(os.Difference(ns).List())
 		if len(resetParameters) > 0 {
 			maxParams := 20
 			for resetParameters != nil {
@@ -306,7 +297,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 				}
 
 				log.Printf("[DEBUG] Reset DB Parameter Group: %s", resetOpts)
-				_, err = rdsconn.ResetDBParameterGroup(&resetOpts)
+				_, err := rdsconn.ResetDBParameterGroup(&resetOpts)
 				if err != nil {
 					return fmt.Errorf("Error resetting DB Parameter Group: %s", err)
 				}

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -141,7 +141,7 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 	}
 
 	if len(describeResp.DBClusterParameterGroups) != 1 ||
-		*describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName != d.Id() {
+		aws.StringValue(describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName) != d.Id() {
 		return fmt.Errorf("Unable to find Cluster Parameter Group: %#v", describeResp.DBClusterParameterGroups)
 	}
 
@@ -196,11 +196,7 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 		ns := n.(*schema.Set)
 
 		// Expand the "parameter" set to aws-sdk-go compat []rds.Parameter
-		parameters, err := expandParameters(ns.Difference(os).List())
-		if err != nil {
-			return err
-		}
-
+		parameters := expandParameters(ns.Difference(os).List())
 		if len(parameters) > 0 {
 			// We can only modify 20 parameters at a time, so walk them until
 			// we've got them all.
@@ -218,7 +214,7 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 				}
 
 				log.Printf("[DEBUG] Modify DB Cluster Parameter Group: %s", modifyOpts)
-				_, err = rdsconn.ModifyDBClusterParameterGroup(&modifyOpts)
+				_, err := rdsconn.ModifyDBClusterParameterGroup(&modifyOpts)
 				if err != nil {
 					return fmt.Errorf("error modifying DB Cluster Parameter Group: %s", err)
 				}
@@ -226,10 +222,7 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 		}
 
 		// Reset parameters that have been removed
-		parameters, err = expandParameters(os.Difference(ns).List())
-		if err != nil {
-			return err
-		}
+		parameters = expandParameters(os.Difference(ns).List())
 		if len(parameters) > 0 {
 			for parameters != nil {
 				parameterGroupName := d.Get("name").(string)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -321,7 +321,7 @@ func expandIPPerms(
 
 // Takes the result of flatmap.Expand for an array of parameters and
 // returns Parameter API compatible objects
-func expandParameters(configured []interface{}) ([]*rds.Parameter, error) {
+func expandParameters(configured []interface{}) []*rds.Parameter {
 	var parameters []*rds.Parameter
 
 	// Loop over our configured parameters and create
@@ -342,7 +342,7 @@ func expandParameters(configured []interface{}) ([]*rds.Parameter, error) {
 		parameters = append(parameters, p)
 	}
 
-	return parameters, nil
+	return parameters
 }
 
 func expandRedshiftParameters(configured []interface{}) ([]*redshift.Parameter, error) {

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -566,10 +566,7 @@ func TestExpandParameters(t *testing.T) {
 			"apply_method": "immediate",
 		},
 	}
-	parameters, err := expandParameters(expanded)
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
+	parameters := expandParameters(expanded)
 
 	expected := &rds.Parameter{
 		ParameterName:  aws.String("character_set_client"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: remove always nil error param from expandParameters func
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestExpandIPPerms_nonVPC (0.00s)
--- PASS: TestExpandIPPerms_NegOneProtocol (0.00s)
--- PASS: TestExpandListeners_invalid (0.00s)
--- PASS: TestDiffStringMaps (0.00s)
--- PASS: TestFlattenHealthCheck (0.00s)
--- PASS: TestExpandIPPerms (0.00s)
--- PASS: TestExpandListeners (0.00s)
--- PASS: TestExpandStringListEmptyItems (0.00s)
--- PASS: TestExpandStringList (0.00s)
--- PASS: TestFlattenOrganizationsOrganizationalUnits (0.00s)
--- PASS: TestExpandParameters (0.00s)
--- PASS: TestExpandStepAdjustments (0.00s)
--- PASS: TestExpandElasticacheParameters (0.00s)
--- PASS: TestExpandRedshiftParameters (0.00s)
--- PASS: TestFlattenParameters (0.00s)
--- PASS: TestFlattenRedshiftParameters (0.00s)
--- PASS: TestFlattenElasticacheParameters (0.00s)
--- PASS: TestExpandInstanceString (0.00s)
--- PASS: TestFlattenNetworkInterfacesPrivateIPAddresses (0.00s)
--- PASS: TestFlattenGroupIdentifiers (0.00s)
--- PASS: TestExpandPrivateIPAddresses (0.00s)
--- PASS: TestFlattenAttachmentWhenNoInstanceId (0.00s)
--- PASS: TestFlattenResourceRecords (0.00s)
    --- PASS: TestFlattenResourceRecords/TXT (0.00s)
    --- PASS: TestFlattenResourceRecords/SPF (0.00s)
    --- PASS: TestFlattenResourceRecords/CNAME (0.00s)
    --- PASS: TestFlattenResourceRecords/MX (0.00s)
--- PASS: TestFlattenStepAdjustments (0.00s)
--- PASS: TestFlattenAttachment (0.00s)
--- PASS: TestFlattenSecurityGroups (0.00s)
--- PASS: TestFlattenKinesisShardLevelMetrics (0.00s)
--- PASS: TestFlattenAsgEnabledMetrics (0.00s)
--- PASS: TestFlattenApiGatewayThrottleSettings (0.00s)
--- PASS: TestExpandPolicyAttributes (0.00s)
--- PASS: TestCheckYamlString (0.00s)
--- PASS: TestFlattenPolicyAttributes (0.00s)
--- PASS: TestExpandPolicyAttributes_invalid (0.00s)
--- PASS: TestCognitoUserPoolSchemaAttributeMatchesStandardAttribute (0.00s)
--- PASS: TestNormalizeCloudFormationTemplate (0.00s)
--- PASS: TestExpandPolicyAttributes_empty (0.00s)
--- PASS: TestCanonicalXML (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_modified (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_flaw (0.00s)
    --- PASS: TestCanonicalXML/A_note (0.00s)
--- PASS: TestExpandRdsClusterScalingConfiguration_serverless (0.00s)
--- PASS: TestExpandRdsClusterScalingConfiguration_basic (0.00s)
--- PASS: TestAccAWSDBParameterGroup_Disappears (12.79s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (17.29s)
--- PASS: TestAccAWSDBParameterGroup_Only (25.24s)
--- PASS: TestAccAWSDBParameterGroup_generatedName (25.38s)
--- PASS: TestAccAWSDBParameterGroup_namePrefix (27.49s)
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (31.31s)
--- PASS: TestAccAWSDBParameterGroup_MatchDefault (34.70s)
--- PASS: TestAccAWSDBClusterParameterGroup_only (35.97s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (36.27s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (37.54s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (39.91s)
--- PASS: TestAccAWSDBParameterGroup_withApplyMethod (53.62s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (55.11s)
--- PASS: TestAccAWSDBParameterGroup_basic (56.18s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (73.21s)
--- PASS: TestAccAWSDBParameterGroup_limit (74.90s)
```
