### PR TITLE
tech-debt/structure: remove always nil error param from expandRedshiftParameters func

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -345,7 +345,7 @@ func expandParameters(configured []interface{}) ([]*rds.Parameter, error) {
 	return parameters, nil
 }
 
-func expandRedshiftParameters(configured []interface{}) ([]*redshift.Parameter, error) {
+func expandRedshiftParameters(configured []interface{}) []*redshift.Parameter {
 	var parameters []*redshift.Parameter
 
 	// Loop over our configured parameters and create
@@ -365,7 +365,7 @@ func expandRedshiftParameters(configured []interface{}) ([]*redshift.Parameter, 
 		parameters = append(parameters, p)
 	}
 
-	return parameters, nil
+	return parameters
 }
 
 // Takes the result of flatmap.Expand for an array of parameters and

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -592,10 +592,7 @@ func TestExpandRedshiftParameters(t *testing.T) {
 			"value": "utf8",
 		},
 	}
-	parameters, err := expandRedshiftParameters(expanded)
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
+	parameters := expandRedshiftParameters(expanded)
 
 	expected := &redshift.Parameter{
 		ParameterName:  aws.String("character_set_client"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: remove always nil error param from expandRedshiftParameters func
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestExpandStepAdjustments (0.00s)
--- PASS: TestExpandElasticacheParameters (0.00s)
--- PASS: TestFlattenRedshiftParameters (0.00s)
--- PASS: TestFlattenParameters (0.00s)
--- PASS: TestExpandParameters (0.00s)
--- PASS: TestExpandRedshiftParameters (0.00s)
--- PASS: TestExpandStringList (0.00s)
--- PASS: TestDiffStringMaps (0.00s)
--- PASS: TestFlattenHealthCheck (0.00s)
--- PASS: TestFlattenOrganizationsOrganizationalUnits (0.00s)
--- PASS: TestExpandListeners (0.00s)
--- PASS: TestExpandIPPerms_nonVPC (0.00s)
--- PASS: TestExpandIPPerms_NegOneProtocol (0.00s)
--- PASS: TestExpandStringListEmptyItems (0.00s)
--- PASS: TestExpandIPPerms (0.00s)
--- PASS: TestExpandListeners_invalid (0.00s)
--- PASS: TestFlattenElasticacheParameters (0.00s)
--- PASS: TestFlattenNetworkInterfacesPrivateIPAddresses (0.00s)
--- PASS: TestFlattenGroupIdentifiers (0.00s)
--- PASS: TestExpandInstanceString (0.00s)
--- PASS: TestFlattenAttachment (0.00s)
--- PASS: TestExpandPrivateIPAddresses (0.00s)
--- PASS: TestFlattenAttachmentWhenNoInstanceId (0.00s)
--- PASS: TestFlattenResourceRecords (0.00s)
    --- PASS: TestFlattenResourceRecords/TXT (0.00s)
    --- PASS: TestFlattenResourceRecords/SPF (0.00s)
    --- PASS: TestFlattenResourceRecords/CNAME (0.00s)
    --- PASS: TestFlattenResourceRecords/MX (0.00s)
--- PASS: TestFlattenStepAdjustments (0.00s)
--- PASS: TestFlattenAsgEnabledMetrics (0.00s)
--- PASS: TestExpandPolicyAttributes (0.00s)
--- PASS: TestFlattenKinesisShardLevelMetrics (0.00s)
--- PASS: TestFlattenSecurityGroups (0.00s)
--- PASS: TestCanonicalXML (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_modified (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_flaw (0.00s)
    --- PASS: TestCanonicalXML/A_note (0.00s)
--- PASS: TestExpandPolicyAttributes_invalid (0.00s)
--- PASS: TestFlattenApiGatewayThrottleSettings (0.00s)
--- PASS: TestExpandPolicyAttributes_empty (0.00s)
--- PASS: TestFlattenPolicyAttributes (0.00s)
--- PASS: TestCognitoUserPoolSchemaAttributeMatchesStandardAttribute (0.00s)
--- PASS: TestExpandRdsClusterScalingConfiguration_serverless (0.00s)
--- PASS: TestNormalizeCloudFormationTemplate (0.00s)
--- PASS: TestCheckYamlString (0.00s)
--- PASS: TestExpandRdsClusterScalingConfiguration_basic (0.00s)
--- PASS: TestAccAWSRedshiftParameterGroup_basic (9.11s)
--- PASS: TestAccAWSRedshiftParameterGroup_withParameters (9.70s)
--- PASS: TestAccAWSRedshiftParameterGroup_withoutParameters (9.44s)
--- PASS: TestAccAWSRedshiftParameterGroup_withTags (20.46s)
```