### PR TITLE
tech-debt/structure: remove always nil error param from expandDocDBParameters func

### DIFF
--- a/aws/resource_aws_docdb_cluster_parameter_group.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group.go
@@ -143,7 +143,7 @@ func resourceAwsDocDBClusterParameterGroupRead(d *schema.ResourceData, meta inte
 	}
 
 	if len(describeResp.DBClusterParameterGroups) != 1 ||
-		*describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName != d.Id() {
+		aws.StringValue(describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName) != d.Id() {
 		return fmt.Errorf("Unable to find Cluster Parameter Group: %#v", describeResp.DBClusterParameterGroups)
 	}
 
@@ -195,10 +195,7 @@ func resourceAwsDocDBClusterParameterGroupUpdate(d *schema.ResourceData, meta in
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		parameters, err := expandDocDBParameters(ns.Difference(os).List())
-		if err != nil {
-			return err
-		}
+		parameters := expandDocDBParameters(ns.Difference(os).List())
 		if len(parameters) > 0 {
 			// We can only modify 20 parameters at a time, so walk them until
 			// we've got them all.

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -370,7 +370,7 @@ func expandRedshiftParameters(configured []interface{}) ([]*redshift.Parameter, 
 
 // Takes the result of flatmap.Expand for an array of parameters and
 // returns Parameter API compatible objects
-func expandDocDBParameters(configured []interface{}) ([]*docdb.Parameter, error) {
+func expandDocDBParameters(configured []interface{}) []*docdb.Parameter {
 	parameters := make([]*docdb.Parameter, 0, len(configured))
 
 	// Loop over our configured parameters and create
@@ -387,7 +387,7 @@ func expandDocDBParameters(configured []interface{}) ([]*docdb.Parameter, error)
 		parameters = append(parameters, p)
 	}
 
-	return parameters, nil
+	return parameters
 }
 
 func expandOptionConfiguration(configured []interface{}) []*rds.OptionConfiguration {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: remove always nil error param from expandDocDBParameters func
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (7.99s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (9.58s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (10.13s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (10.31s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (10.40s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (14.80s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (20.31s)
```
