### PR TITLE
tech-debt/structure: remove always nil error param from expandElastiCacheParameters func

### DIFF
--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -194,25 +194,25 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 					paramsToModify = append(paramsToModify[:i], paramsToModify[i+1:]...)
 
 					// If we are only trying to remove reserved-memory and not perform
-					// an update to reserved-memory or reserved-memory-percentage, we
+					// an update to reserved-memory or reserved-memory-percent, we
 					// can attempt to workaround the API issue by switching it to
-					// reserved-memory-percentage first then reset that temporary parameter.
+					// reserved-memory-percent first then reset that temporary parameter.
 
-					tryReservedMemoryPercentageWorkaround := true
+					tryReservedMemoryPercentWorkaround := true
 
 					allConfiguredParameters := expandElastiCacheParameters(d.Get("parameter").(*schema.Set).List())
 					for _, configuredParameter := range allConfiguredParameters {
-						if aws.StringValue(configuredParameter.ParameterName) == "reserved-memory" || aws.StringValue(configuredParameter.ParameterName) == "reserved-memory-percentage" {
-							tryReservedMemoryPercentageWorkaround = false
+						if aws.StringValue(configuredParameter.ParameterName) == "reserved-memory" || aws.StringValue(configuredParameter.ParameterName) == "reserved-memory-percent" {
+							tryReservedMemoryPercentWorkaround = false
 							break
 						}
 					}
 
-					if !tryReservedMemoryPercentageWorkaround {
+					if !tryReservedMemoryPercentWorkaround {
 						break
 					}
 
-					// The reserved-memory-percentage parameter does not exist in redis2.6 and redis2.8
+					// The reserved-memory-percent parameter does not exist in redis2.6 and redis2.8
 					family := d.Get("family").(string)
 					if family == "redis2.6" || family == "redis2.8" {
 						log.Printf("[WARN] Cannot reset Elasticache Parameter Group (%s) reserved-memory parameter with %s family", d.Id(), family)
@@ -223,7 +223,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 						CacheParameterGroupName: aws.String(d.Get("name").(string)),
 						ParameterNameValues: []*elasticache.ParameterNameValue{
 							{
-								ParameterName:  aws.String("reserved-memory-percentage"),
+								ParameterName:  aws.String("reserved-memory-percent"),
 								ParameterValue: aws.String("0"),
 							},
 						},
@@ -231,7 +231,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 					_, err = conn.ModifyCacheParameterGroup(modifyInput)
 
 					if err != nil {
-						log.Printf("[WARN] Error attempting reserved-memory workaround to switch to reserved-memory-percentage: %s", err)
+						log.Printf("[WARN] Error attempting reserved-memory workaround to switch to reserved-memory-percent: %s", err)
 						break
 					}
 
@@ -239,7 +239,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 						CacheParameterGroupName: aws.String(d.Get("name").(string)),
 						ParameterNameValues: []*elasticache.ParameterNameValue{
 							{
-								ParameterName:  aws.String("reserved-memory-percentage"),
+								ParameterName:  aws.String("reserved-memory-percent"),
 								ParameterValue: aws.String("0"),
 							},
 						},
@@ -248,7 +248,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 					_, err = conn.ResetCacheParameterGroup(resetInput)
 
 					if err != nil {
-						log.Printf("[WARN] Error attempting reserved-memory workaround to reset reserved-memory-percentage: %s", err)
+						log.Printf("[WARN] Error attempting reserved-memory workaround to reset reserved-memory-percent: %s", err)
 					}
 
 					break

--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -100,7 +100,7 @@ func resourceAwsElasticacheParameterGroupRead(d *schema.ResourceData, meta inter
 	}
 
 	if len(describeResp.CacheParameterGroups) != 1 ||
-		*describeResp.CacheParameterGroups[0].CacheParameterGroupName != d.Id() {
+		aws.StringValue(describeResp.CacheParameterGroups[0].CacheParameterGroupName) != d.Id() {
 		return fmt.Errorf("Unable to find Parameter Group: %#v", describeResp.CacheParameterGroups)
 	}
 
@@ -139,17 +139,11 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		toRemove, err := expandElastiCacheParameters(os.Difference(ns).List())
-		if err != nil {
-			return err
-		}
+		toRemove := expandElastiCacheParameters(os.Difference(ns).List())
 
 		log.Printf("[DEBUG] Parameters to remove: %#v", toRemove)
 
-		toAdd, err := expandElastiCacheParameters(ns.Difference(os).List())
-		if err != nil {
-			return err
-		}
+		toAdd := expandElastiCacheParameters(ns.Difference(os).List())
 
 		log.Printf("[DEBUG] Parameters to add: %#v", toAdd)
 
@@ -171,7 +165,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 
 			log.Printf("[DEBUG] Reset Cache Parameter Group: %s", resetOpts)
 			err := resource.Retry(30*time.Second, func() *resource.RetryError {
-				_, err = conn.ResetCacheParameterGroup(&resetOpts)
+				_, err := conn.ResetCacheParameterGroup(&resetOpts)
 				if err != nil {
 					if isAWSErr(err, "InvalidCacheParameterGroupState", " has pending changes") {
 						return resource.RetryableError(err)
@@ -206,11 +200,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 
 					tryReservedMemoryPercentageWorkaround := true
 
-					allConfiguredParameters, err := expandElastiCacheParameters(d.Get("parameter").(*schema.Set).List())
-					if err != nil {
-						return fmt.Errorf("error expanding parameter configuration: %s", err)
-					}
-
+					allConfiguredParameters := expandElastiCacheParameters(d.Get("parameter").(*schema.Set).List())
 					for _, configuredParameter := range allConfiguredParameters {
 						if aws.StringValue(configuredParameter.ParameterName) == "reserved-memory" || aws.StringValue(configuredParameter.ParameterName) == "reserved-memory-percentage" {
 							tryReservedMemoryPercentageWorkaround = false
@@ -293,7 +283,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 			}
 
 			log.Printf("[DEBUG] Modify Cache Parameter Group: %s", modifyOpts)
-			_, err = conn.ModifyCacheParameterGroup(&modifyOpts)
+			_, err := conn.ModifyCacheParameterGroup(&modifyOpts)
 			if err != nil {
 				return fmt.Errorf("Error modifying Cache Parameter Group: %s", err)
 			}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -454,7 +454,7 @@ func expandOptionSetting(list []interface{}) []*rds.OptionSetting {
 
 // Takes the result of flatmap.Expand for an array of parameters and
 // returns Parameter API compatible objects
-func expandElastiCacheParameters(configured []interface{}) ([]*elasticache.ParameterNameValue, error) {
+func expandElastiCacheParameters(configured []interface{}) []*elasticache.ParameterNameValue {
 	parameters := make([]*elasticache.ParameterNameValue, 0, len(configured))
 
 	// Loop over our configured parameters and create
@@ -470,7 +470,7 @@ func expandElastiCacheParameters(configured []interface{}) ([]*elasticache.Param
 		parameters = append(parameters, p)
 	}
 
-	return parameters, nil
+	return parameters
 }
 
 // Takes the result of flatmap.Expand for an array of parameters and

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -618,10 +618,7 @@ func TestExpandElasticacheParameters(t *testing.T) {
 			"apply_method": "immediate",
 		},
 	}
-	parameters, err := expandElastiCacheParameters(expanded)
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
+	parameters := expandElastiCacheParameters(expanded)
 
 	expected := &elasticache.ParameterNameValue{
 		ParameterName:  aws.String("activerehashing"),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: remove always nil error param from expandElastiCacheParameters func
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestExpandRedshiftParameters (0.00s)
--- PASS: TestExpandIPPerms_NegOneProtocol (0.00s)
--- PASS: TestFlattenOrganizationsOrganizationalUnits (0.00s)
--- PASS: TestExpandListeners (0.00s)
--- PASS: TestFlattenHealthCheck (0.00s)
--- PASS: TestExpandIPPerms_nonVPC (0.00s)
--- PASS: TestExpandListeners_invalid (0.00s)
--- PASS: TestDiffStringMaps (0.00s)
--- PASS: TestExpandStepAdjustments (0.00s)
--- PASS: TestExpandStringList (0.00s)
--- PASS: TestFlattenElasticacheParameters (0.00s)
--- PASS: TestExpandInstanceString (0.00s)
--- PASS: TestExpandIPPerms (0.00s)
--- PASS: TestExpandElasticacheParameters (0.00s)
--- PASS: TestFlattenParameters (0.00s)
--- PASS: TestFlattenNetworkInterfacesPrivateIPAddresses (0.00s)
--- PASS: TestFlattenGroupIdentifiers (0.00s)
--- PASS: TestExpandStringListEmptyItems (0.00s)
--- PASS: TestExpandParameters (0.00s)
--- PASS: TestFlattenRedshiftParameters (0.00s)
--- PASS: TestExpandPrivateIPAddresses (0.00s)
--- PASS: TestFlattenStepAdjustments (0.00s)
--- PASS: TestFlattenResourceRecords (0.00s)
    --- PASS: TestFlattenResourceRecords/TXT (0.00s)
    --- PASS: TestFlattenResourceRecords/SPF (0.00s)
    --- PASS: TestFlattenResourceRecords/CNAME (0.00s)
    --- PASS: TestFlattenResourceRecords/MX (0.00s)
--- PASS: TestFlattenSecurityGroups (0.00s)
--- PASS: TestFlattenAttachmentWhenNoInstanceId (0.00s)
--- PASS: TestFlattenAttachment (0.00s)
--- PASS: TestFlattenAsgEnabledMetrics (0.00s)
--- PASS: TestFlattenApiGatewayThrottleSettings (0.00s)
--- PASS: TestExpandPolicyAttributes (0.00s)
--- PASS: TestFlattenKinesisShardLevelMetrics (0.00s)
--- PASS: TestExpandPolicyAttributes_empty (0.00s)
--- PASS: TestFlattenPolicyAttributes (0.00s)
--- PASS: TestExpandPolicyAttributes_invalid (0.00s)
--- PASS: TestCheckYamlString (0.00s)
--- PASS: TestNormalizeCloudFormationTemplate (0.00s)
--- PASS: TestCanonicalXML (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_modified (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_flaw (0.00s)
    --- PASS: TestCanonicalXML/A_note (0.00s)
--- PASS: TestCognitoUserPoolSchemaAttributeMatchesStandardAttribute (0.00s)
--- PASS: TestExpandRdsClusterScalingConfiguration_serverless (0.00s)
--- PASS: TestExpandRdsClusterScalingConfiguration_basic (0.00s)
--- PASS: TestAccAWSElasticacheParameterGroup_basic (21.70s)
--- PASS: TestAccAWSElasticacheParameterGroup_Description (21.79s)
--- PASS: TestAccAWSElasticacheParameterGroup_UppercaseName (22.68s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeAllParameters (32.92s)
--- PASS: TestAccAWSElasticacheParameterGroup_addParameter (35.16s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter (35.85s)
--- PASS: TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter (95.50s)

--- FAIL: TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter (84.50s)
```
