### PR TITLE
tech-debt/structure: remove always nil error param from expandNeptuneParameters func

### DIFF
--- a/aws/resource_aws_neptune_cluster_parameter_group.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group.go
@@ -195,10 +195,7 @@ func resourceAwsNeptuneClusterParameterGroupUpdate(d *schema.ResourceData, meta 
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		parameters, err := expandNeptuneParameters(ns.Difference(os).List())
-		if err != nil {
-			return err
-		}
+		parameters := expandNeptuneParameters(ns.Difference(os).List())
 
 		if len(parameters) > 0 {
 			// We can only modify 20 parameters at a time, so walk them until
@@ -217,7 +214,7 @@ func resourceAwsNeptuneClusterParameterGroupUpdate(d *schema.ResourceData, meta 
 				}
 
 				log.Printf("[DEBUG] Modify Neptune Cluster Parameter Group: %s", modifyOpts)
-				_, err = conn.ModifyDBClusterParameterGroup(&modifyOpts)
+				_, err := conn.ModifyDBClusterParameterGroup(&modifyOpts)
 				if err != nil {
 					return fmt.Errorf("Error modifying Neptune Cluster Parameter Group: %s", err)
 				}

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -97,7 +97,7 @@ func resourceAwsNeptuneParameterGroupCreate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error creating Neptune Parameter Group: %s", err)
 	}
 
-	d.SetId(*resp.DBParameterGroup.DBParameterGroupName)
+	d.SetId(aws.StringValue(resp.DBParameterGroup.DBParameterGroupName))
 	d.Set("arn", resp.DBParameterGroup.DBParameterGroupArn)
 	log.Printf("[INFO] Neptune Parameter Group ID: %s", d.Id())
 
@@ -185,17 +185,11 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		toRemove, err := expandNeptuneParameters(os.Difference(ns).List())
-		if err != nil {
-			return err
-		}
+		toRemove := expandNeptuneParameters(os.Difference(ns).List())
 
 		log.Printf("[DEBUG] Parameters to remove: %#v", toRemove)
 
-		toAdd, err := expandNeptuneParameters(ns.Difference(os).List())
-		if err != nil {
-			return err
-		}
+		toAdd := expandNeptuneParameters(ns.Difference(os).List())
 
 		log.Printf("[DEBUG] Parameters to add: %#v", toAdd)
 
@@ -213,7 +207,7 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 
 			log.Printf("[DEBUG] Reset Neptune Parameter Group: %s", resetOpts)
 			err := resource.Retry(30*time.Second, func() *resource.RetryError {
-				_, err = conn.ResetDBParameterGroup(&resetOpts)
+				_, err := conn.ResetDBParameterGroup(&resetOpts)
 				if err != nil {
 					if isAWSErr(err, "InvalidDBParameterGroupState", " has pending changes") {
 						return resource.RetryableError(err)
@@ -243,7 +237,7 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 			}
 
 			log.Printf("[DEBUG] Modify Neptune Parameter Group: %s", modifyOpts)
-			_, err = conn.ModifyDBParameterGroup(&modifyOpts)
+			_, err := conn.ModifyDBParameterGroup(&modifyOpts)
 			if err != nil {
 				return fmt.Errorf("Error modifying Neptune Parameter Group: %s", err)
 			}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -475,7 +475,7 @@ func expandElastiCacheParameters(configured []interface{}) ([]*elasticache.Param
 
 // Takes the result of flatmap.Expand for an array of parameters and
 // returns Parameter API compatible objects
-func expandNeptuneParameters(configured []interface{}) ([]*neptune.Parameter, error) {
+func expandNeptuneParameters(configured []interface{}) []*neptune.Parameter {
 	parameters := make([]*neptune.Parameter, 0, len(configured))
 
 	// Loop over our configured parameters and create
@@ -492,7 +492,7 @@ func expandNeptuneParameters(configured []interface{}) ([]*neptune.Parameter, er
 		parameters = append(parameters, p)
 	}
 
-	return parameters, nil
+	return parameters
 }
 
 // Flattens an access log into something that flatmap.Flatten() can handle


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: remove always nil error param from expandNeptuneParameters func
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSNeptuneParameterGroup_Description (11.10s)
--- PASS: TestAccAWSNeptuneParameterGroup_basic (17.38s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_basic (17.46s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_namePrefix (21.94s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Description (24.34s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Parameter (24.58s)
--- PASS: TestAccAWSNeptuneParameterGroup_Parameter (33.33s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Tags (33.52s)
--- PASS: TestAccAWSNeptuneParameterGroup_Tags (39.02s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_generatedName (39.39s)
```
