### PR TITLE
tech-debt/structure: remove always nil param from expandApiGatewayMethodParametersOperations func

### DIFF
--- a/aws/resource_aws_api_gateway_method.go
+++ b/aws/resource_aws_api_gateway_method.go
@@ -234,10 +234,7 @@ func resourceAwsApiGatewayMethodUpdate(d *schema.ResourceData, meta interface{})
 				parameters[k] = value
 			}
 		}
-		ops, err := expandApiGatewayMethodParametersOperations(d, "request_parameters", "requestParameters")
-		if err != nil {
-			return err
-		}
+		ops := expandApiGatewayMethodParametersOperations(d, "request_parameters", "requestParameters")
 		operations = append(operations, ops...)
 	}
 

--- a/aws/resource_aws_api_gateway_method_response.go
+++ b/aws/resource_aws_api_gateway_method_response.go
@@ -172,10 +172,7 @@ func resourceAwsApiGatewayMethodResponseUpdate(d *schema.ResourceData, meta inte
 	}
 
 	if d.HasChange("response_parameters") {
-		ops, err := expandApiGatewayMethodParametersOperations(d, "response_parameters", "responseParameters")
-		if err != nil {
-			return err
-		}
+		ops := expandApiGatewayMethodParametersOperations(d, "response_parameters", "responseParameters")
 		operations = append(operations, ops...)
 	}
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1916,7 +1916,7 @@ func deprecatedExpandApiGatewayMethodParametersJSONOperations(d *schema.Resource
 	return operations, nil
 }
 
-func expandApiGatewayMethodParametersOperations(d *schema.ResourceData, key string, prefix string) ([]*apigateway.PatchOperation, error) {
+func expandApiGatewayMethodParametersOperations(d *schema.ResourceData, key string, prefix string) []*apigateway.PatchOperation {
 	operations := make([]*apigateway.PatchOperation, 0)
 
 	oldParameters, newParameters := d.GetChange(key)
@@ -1966,7 +1966,7 @@ func expandApiGatewayMethodParametersOperations(d *schema.ResourceData, key stri
 		}
 	}
 
-	return operations, nil
+	return operations
 }
 
 func expandCloudWatchLogMetricTransformations(m map[string]interface{}) []*cloudwatchlogs.MetricTransformation {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: remove always nil param from expandApiGatewayMethodParametersOperations func
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAPIGatewayMethodResponse_basic (20.69s)
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (52.58s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy (88.08s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted (117.68s)
--- PASS: TestAccAWSAPIGatewayMethod_basic (142.18s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl (177.44s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_Multiple (212.14s)
--- PASS: TestAccAWSAPIGatewayMethod_cognitoauthorizer (214.76s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit (219.30s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds (252.91s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_basic (286.53s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit (379.32s)
--- PASS: TestAccAWSAPIGatewayMethod_customrequestvalidator (431.27s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel (455.70s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled (467.37s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled (570.65s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled (648.60s)
```
