### PR TITLE
tech-debt/structure: remove always nil error param from expandPolicyAttributes func

### DIFF
--- a/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -80,12 +80,8 @@ func resourceAwsLBSSLNegotiationPolicyCreate(d *schema.ResourceData, meta interf
 
 	// Check for Policy Attributes
 	if v, ok := d.GetOk("attribute"); ok {
-		var err error
 		// Expand the "attribute" set to aws-sdk-go compat []*elb.PolicyAttribute
-		lbspOpts.PolicyAttributes, err = expandPolicyAttributes(v.(*schema.Set).List())
-		if err != nil {
-			return err
-		}
+		lbspOpts.PolicyAttributes = expandPolicyAttributes(v.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] Load Balancer Policy opts: %#v", lbspOpts)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2123,7 +2123,7 @@ func flattenApiGatewayThrottleSettings(settings *apigateway.ThrottleSettings) []
 
 // Takes the result of flatmap.Expand for an array of policy attributes and
 // returns ELB API compatible objects
-func expandPolicyAttributes(configured []interface{}) ([]*elb.PolicyAttribute, error) {
+func expandPolicyAttributes(configured []interface{}) []*elb.PolicyAttribute {
 	attributes := make([]*elb.PolicyAttribute, 0, len(configured))
 
 	// Loop over our configured attributes and create
@@ -2140,7 +2140,7 @@ func expandPolicyAttributes(configured []interface{}) ([]*elb.PolicyAttribute, e
 
 	}
 
-	return attributes, nil
+	return attributes
 }
 
 // Flattens an array of PolicyAttributes into a []interface{}

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -172,49 +172,49 @@ func TestExpandIPPerms(t *testing.T) {
 	exp := expected[0]
 	perm := perms[0]
 
-	if *exp.FromPort != *perm.FromPort {
+	if aws.Int64Value(exp.FromPort) != aws.Int64Value(perm.FromPort) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.FromPort,
-			*exp.FromPort)
+			aws.Int64Value(perm.FromPort),
+			aws.Int64Value(exp.FromPort))
 	}
 
-	if *exp.IpRanges[0].CidrIp != *perm.IpRanges[0].CidrIp {
+	if aws.StringValue(exp.IpRanges[0].CidrIp) != aws.StringValue(perm.IpRanges[0].CidrIp) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.IpRanges[0].CidrIp,
-			*exp.IpRanges[0].CidrIp)
+			aws.StringValue(perm.IpRanges[0].CidrIp),
+			aws.StringValue(exp.IpRanges[0].CidrIp))
 	}
 
-	if *exp.UserIdGroupPairs[0].UserId != *perm.UserIdGroupPairs[0].UserId {
+	if aws.StringValue(exp.UserIdGroupPairs[0].UserId) != aws.StringValue(perm.UserIdGroupPairs[0].UserId) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIdGroupPairs[0].UserId,
-			*exp.UserIdGroupPairs[0].UserId)
+			aws.StringValue(perm.UserIdGroupPairs[0].UserId),
+			aws.StringValue(exp.UserIdGroupPairs[0].UserId))
 	}
 
-	if *exp.UserIdGroupPairs[0].GroupId != *perm.UserIdGroupPairs[0].GroupId {
+	if aws.StringValue(exp.UserIdGroupPairs[0].GroupId) != aws.StringValue(perm.UserIdGroupPairs[0].GroupId) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIdGroupPairs[0].GroupId,
-			*exp.UserIdGroupPairs[0].GroupId)
+			aws.StringValue(perm.UserIdGroupPairs[0].GroupId),
+			aws.StringValue(exp.UserIdGroupPairs[0].GroupId))
 	}
 
-	if *exp.UserIdGroupPairs[1].GroupId != *perm.UserIdGroupPairs[1].GroupId {
+	if aws.StringValue(exp.UserIdGroupPairs[1].GroupId) != aws.StringValue(perm.UserIdGroupPairs[1].GroupId) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIdGroupPairs[1].GroupId,
-			*exp.UserIdGroupPairs[1].GroupId)
+			aws.StringValue(perm.UserIdGroupPairs[1].GroupId),
+			aws.StringValue(exp.UserIdGroupPairs[1].GroupId))
 	}
 
 	exp = expected[1]
 	perm = perms[1]
 
-	if *exp.UserIdGroupPairs[0].GroupId != *perm.UserIdGroupPairs[0].GroupId {
+	if aws.StringValue(exp.UserIdGroupPairs[0].GroupId) != aws.StringValue(perm.UserIdGroupPairs[0].GroupId) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIdGroupPairs[0].GroupId,
-			*exp.UserIdGroupPairs[0].GroupId)
+			aws.StringValue(perm.UserIdGroupPairs[0].GroupId),
+			aws.StringValue(exp.UserIdGroupPairs[0].GroupId))
 	}
 }
 
@@ -264,25 +264,25 @@ func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
 	exp := expected[0]
 	perm := perms[0]
 
-	if *exp.FromPort != *perm.FromPort {
+	if aws.Int64Value(exp.FromPort) != aws.Int64Value(perm.FromPort) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.FromPort,
-			*exp.FromPort)
+			aws.Int64Value(perm.FromPort),
+			aws.Int64Value(exp.FromPort))
 	}
 
-	if *exp.IpRanges[0].CidrIp != *perm.IpRanges[0].CidrIp {
+	if aws.StringValue(exp.IpRanges[0].CidrIp) != aws.StringValue(perm.IpRanges[0].CidrIp) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.IpRanges[0].CidrIp,
-			*exp.IpRanges[0].CidrIp)
+			aws.StringValue(perm.IpRanges[0].CidrIp),
+			aws.StringValue(exp.IpRanges[0].CidrIp))
 	}
 
-	if *exp.UserIdGroupPairs[0].UserId != *perm.UserIdGroupPairs[0].UserId {
+	if aws.StringValue(exp.UserIdGroupPairs[0].UserId) != aws.StringValue(perm.UserIdGroupPairs[0].UserId) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIdGroupPairs[0].UserId,
-			*exp.UserIdGroupPairs[0].UserId)
+			aws.StringValue(perm.UserIdGroupPairs[0].UserId),
+			aws.StringValue(exp.UserIdGroupPairs[0].UserId))
 	}
 
 	// Now test the error case. This *should* error when either from_port
@@ -369,42 +369,42 @@ func TestExpandIPPerms_nonVPC(t *testing.T) {
 	exp := expected[0]
 	perm := perms[0]
 
-	if *exp.FromPort != *perm.FromPort {
+	if aws.Int64Value(exp.FromPort) != aws.Int64Value(perm.FromPort) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.FromPort,
-			*exp.FromPort)
+			aws.Int64Value(perm.FromPort),
+			aws.Int64Value(exp.FromPort))
 	}
 
-	if *exp.IpRanges[0].CidrIp != *perm.IpRanges[0].CidrIp {
+	if aws.StringValue(exp.IpRanges[0].CidrIp) != aws.StringValue(perm.IpRanges[0].CidrIp) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.IpRanges[0].CidrIp,
-			*exp.IpRanges[0].CidrIp)
+			aws.StringValue(perm.IpRanges[0].CidrIp),
+			aws.StringValue(exp.IpRanges[0].CidrIp))
 	}
 
-	if *exp.UserIdGroupPairs[0].GroupName != *perm.UserIdGroupPairs[0].GroupName {
+	if aws.StringValue(exp.UserIdGroupPairs[0].GroupName) != aws.StringValue(perm.UserIdGroupPairs[0].GroupName) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIdGroupPairs[0].GroupName,
-			*exp.UserIdGroupPairs[0].GroupName)
+			aws.StringValue(perm.UserIdGroupPairs[0].GroupName),
+			aws.StringValue(exp.UserIdGroupPairs[0].GroupName))
 	}
 
-	if *exp.UserIdGroupPairs[1].GroupName != *perm.UserIdGroupPairs[1].GroupName {
+	if aws.StringValue(exp.UserIdGroupPairs[1].GroupName) != aws.StringValue(perm.UserIdGroupPairs[1].GroupName) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIdGroupPairs[1].GroupName,
-			*exp.UserIdGroupPairs[1].GroupName)
+			aws.StringValue(perm.UserIdGroupPairs[1].GroupName),
+			aws.StringValue(exp.UserIdGroupPairs[1].GroupName))
 	}
 
 	exp = expected[1]
 	perm = perms[1]
 
-	if *exp.UserIdGroupPairs[0].GroupName != *perm.UserIdGroupPairs[0].GroupName {
+	if aws.StringValue(exp.UserIdGroupPairs[0].GroupName) != aws.StringValue(perm.UserIdGroupPairs[0].GroupName) {
 		t.Fatalf(
 			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			*perm.UserIdGroupPairs[0].GroupName,
-			*exp.UserIdGroupPairs[0].GroupName)
+			aws.StringValue(perm.UserIdGroupPairs[0].GroupName),
+			aws.StringValue(exp.UserIdGroupPairs[0].GroupName))
 	}
 }
 
@@ -830,12 +830,12 @@ func TestExpandPrivateIPAddresses(t *testing.T) {
 		t.Fatalf("expected result had %d elements, but got %d", 2, len(result))
 	}
 
-	if *result[0].PrivateIpAddress != "192.168.0.1" || !*result[0].Primary {
-		t.Fatalf("expected ip to be 192.168.0.1 and Primary, but got %v, %t", *result[0].PrivateIpAddress, *result[0].Primary)
+	if aws.StringValue(result[0].PrivateIpAddress) != "192.168.0.1" || !aws.BoolValue(result[0].Primary) {
+		t.Fatalf("expected ip to be 192.168.0.1 and Primary, but got %v, %t", aws.StringValue(result[0].PrivateIpAddress), aws.BoolValue(result[0].Primary))
 	}
 
-	if *result[1].PrivateIpAddress != "192.168.0.2" || *result[1].Primary {
-		t.Fatalf("expected ip to be 192.168.0.2 and not Primary, but got %v, %t", *result[1].PrivateIpAddress, *result[1].Primary)
+	if aws.StringValue(result[1].PrivateIpAddress) != "192.168.0.2" || aws.BoolValue(result[1].Primary) {
+		t.Fatalf("expected ip to be 192.168.0.2 and not Primary, but got %v, %t", aws.StringValue(result[1].PrivateIpAddress), aws.BoolValue(result[1].Primary))
 	}
 }
 
@@ -1159,10 +1159,7 @@ func TestExpandPolicyAttributes(t *testing.T) {
 			"value": "true",
 		},
 	}
-	attributes, err := expandPolicyAttributes(expanded)
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
+	attributes := expandPolicyAttributes(expanded)
 
 	if len(attributes) != 3 {
 		t.Fatalf("expected number of attributes to be 3, but got %d", len(attributes))
@@ -1188,10 +1185,7 @@ func TestExpandPolicyAttributes_invalid(t *testing.T) {
 			"value": "true",
 		},
 	}
-	attributes, err := expandPolicyAttributes(expanded)
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
+	attributes := expandPolicyAttributes(expanded)
 
 	expected := &elb.PolicyAttribute{
 		AttributeName:  aws.String("Protocol-TLSv1.2"),
@@ -1209,10 +1203,7 @@ func TestExpandPolicyAttributes_invalid(t *testing.T) {
 func TestExpandPolicyAttributes_empty(t *testing.T) {
 	var expanded []interface{}
 
-	attributes, err := expandPolicyAttributes(expanded)
-	if err != nil {
-		t.Fatalf("bad: %#v", err)
-	}
+	attributes := expandPolicyAttributes(expanded)
 
 	if len(attributes) != 0 {
 		t.Fatalf("expected number of attributes to be 0, but got %d", len(attributes))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: remove always nil error param from expandPolicyAttributes func
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestFlattenRedshiftParameters (0.00s)
--- PASS: TestExpandIPPerms_nonVPC (0.00s)
--- PASS: TestExpandIPPerms_NegOneProtocol (0.00s)
--- PASS: TestExpandIPPerms (0.00s)
--- PASS: TestExpandInstanceString (0.00s)
--- PASS: TestDiffStringMaps (0.00s)
--- PASS: TestFlattenHealthCheck (0.00s)
--- PASS: TestExpandListeners (0.00s)
--- PASS: TestFlattenParameters (0.00s)
--- PASS: TestExpandListeners_invalid (0.00s)
--- PASS: TestFlattenElasticacheParameters (0.00s)
--- PASS: TestExpandStepAdjustments (0.00s)
--- PASS: TestExpandRedshiftParameters (0.00s)
--- PASS: TestFlattenOrganizationsOrganizationalUnits (0.00s)
--- PASS: TestExpandParameters (0.00s)
--- PASS: TestFlattenAttachment (0.00s)
--- PASS: TestFlattenAsgEnabledMetrics (0.00s)
--- PASS: TestFlattenResourceRecords (0.00s)
    --- PASS: TestFlattenResourceRecords/TXT (0.00s)
    --- PASS: TestFlattenResourceRecords/SPF (0.00s)
    --- PASS: TestFlattenResourceRecords/CNAME (0.00s)
    --- PASS: TestFlattenResourceRecords/MX (0.00s)
--- PASS: TestFlattenNetworkInterfacesPrivateIPAddresses (0.00s)
--- PASS: TestExpandStringListEmptyItems (0.00s)
--- PASS: TestExpandElasticacheParameters (0.00s)
--- PASS: TestFlattenAttachmentWhenNoInstanceId (0.00s)
--- PASS: TestFlattenStepAdjustments (0.00s)
--- PASS: TestExpandPolicyAttributes_empty (0.00s)
--- PASS: TestExpandPolicyAttributes_invalid (0.00s)
--- PASS: TestExpandPrivateIPAddresses (0.00s)
--- PASS: TestExpandStringList (0.00s)
--- PASS: TestNormalizeCloudFormationTemplate (0.00s)
--- PASS: TestCanonicalXML (0.01s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_modified (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_flaw (0.00s)
    --- PASS: TestCanonicalXML/A_note (0.00s)
--- PASS: TestCognitoUserPoolSchemaAttributeMatchesStandardAttribute (0.00s)
--- PASS: TestFlattenPolicyAttributes (0.00s)
--- PASS: TestFlattenApiGatewayThrottleSettings (0.00s)
--- PASS: TestExpandPolicyAttributes (0.00s)
--- PASS: TestFlattenGroupIdentifiers (0.00s)
--- PASS: TestFlattenKinesisShardLevelMetrics (0.00s)
--- PASS: TestCheckYamlString (0.00s)
--- PASS: TestFlattenSecurityGroups (0.00s)
--- PASS: TestExpandRdsClusterScalingConfiguration_serverless (0.00s)
--- PASS: TestExpandRdsClusterScalingConfiguration_basic (0.00s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_disappears (70.31s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_basic (47.73s)
```
