### PR TITLE
resource/waf: remove unused params in methods

### DIFF
--- a/aws/resource_aws_wafregional_web_acl_association.go
+++ b/aws/resource_aws_wafregional_web_acl_association.go
@@ -78,7 +78,7 @@ func resourceAwsWafRegionalWebAclAssociationCreate(d *schema.ResourceData, meta 
 func resourceAwsWafRegionalWebAclAssociationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafregionalconn
 
-	_, resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(d.Id())
+	resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(d.Id())
 
 	input := &wafregional.GetWebACLForResourceInput{
 		ResourceArn: aws.String(resourceArn),
@@ -111,7 +111,7 @@ func resourceAwsWafRegionalWebAclAssociationRead(d *schema.ResourceData, meta in
 func resourceAwsWafRegionalWebAclAssociationDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafregionalconn
 
-	_, resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(d.Id())
+	resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(d.Id())
 
 	log.Printf("[INFO] Deleting WAF Regional Web ACL association: %s", resourceArn)
 
@@ -124,9 +124,8 @@ func resourceAwsWafRegionalWebAclAssociationDelete(d *schema.ResourceData, meta 
 	return err
 }
 
-func resourceAwsWafRegionalWebAclAssociationParseId(id string) (webAclId, resourceArn string) {
+func resourceAwsWafRegionalWebAclAssociationParseId(id string) (resourceArn string) {
 	parts := strings.SplitN(id, ":", 2)
-	webAclId = parts[0]
 	resourceArn = parts[1]
 	return
 }

--- a/aws/resource_aws_wafregional_web_acl_association_test.go
+++ b/aws/resource_aws_wafregional_web_acl_association_test.go
@@ -109,7 +109,7 @@ func testAccCheckWafRegionalWebAclAssociationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(rs.Primary.ID)
+		resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(rs.Primary.ID)
 
 		input := &wafregional.GetWebACLForResourceInput{
 			ResourceArn: aws.String(resourceArn),
@@ -142,7 +142,7 @@ func testAccCheckWafRegionalWebAclAssociationExists(n string) resource.TestCheck
 			return fmt.Errorf("No WebACL association ID is set")
 		}
 
-		_, resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(rs.Primary.ID)
+		resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(rs.Primary.ID)
 
 		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
 
@@ -169,7 +169,7 @@ func testAccCheckWafRegionalWebAclAssociationDisappears(resourceName string) res
 			return fmt.Errorf("No WebACL association ID is set")
 		}
 
-		_, resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(rs.Primary.ID)
+		resourceArn := resourceAwsWafRegionalWebAclAssociationParseId(rs.Primary.ID)
 
 		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
 

--- a/aws/resource_aws_wafv2_rule_group_test.go
+++ b/aws/resource_aws_wafv2_rule_group_test.go
@@ -518,7 +518,7 @@ func TestAccAwsWafv2RuleGroup_IpSetReferenceStatement(t *testing.T) {
 					computeWafv2IpSetRefStatementIndex(&v, &idx),
 					testCheckResourceAttrWithIndexesAddr(resourceName, "rule.%d.statement.#", &idx, "1"),
 					testCheckResourceAttrWithIndexesAddr(resourceName, "rule.%d.statement.0.ip_set_reference_statement.#", &idx, "1"),
-					testAccMatchResourceAttrArnWithIndexesAddr(resourceName, "rule.%d.statement.0.ip_set_reference_statement.0.arn", &idx,  regexp.MustCompile(`regional/ipset/.+$`)),
+					testAccMatchResourceAttrArnWithIndexesAddr(resourceName, "rule.%d.statement.0.ip_set_reference_statement.0.arn", &idx, regexp.MustCompile(`regional/ipset/.+$`)),
 				),
 			},
 			{

--- a/aws/resource_aws_wafv2_rule_group_test.go
+++ b/aws/resource_aws_wafv2_rule_group_test.go
@@ -518,7 +518,7 @@ func TestAccAwsWafv2RuleGroup_IpSetReferenceStatement(t *testing.T) {
 					computeWafv2IpSetRefStatementIndex(&v, &idx),
 					testCheckResourceAttrWithIndexesAddr(resourceName, "rule.%d.statement.#", &idx, "1"),
 					testCheckResourceAttrWithIndexesAddr(resourceName, "rule.%d.statement.0.ip_set_reference_statement.#", &idx, "1"),
-					testAccMatchResourceAttrArnWithIndexesAddr(resourceName, "rule.%d.statement.0.ip_set_reference_statement.0.arn", &idx, "wafv2", regexp.MustCompile(`regional/ipset/.+$`)),
+					testAccMatchResourceAttrArnWithIndexesAddr(resourceName, "rule.%d.statement.0.ip_set_reference_statement.0.arn", &idx,  regexp.MustCompile(`regional/ipset/.+$`)),
 				),
 			},
 			{
@@ -649,7 +649,7 @@ func TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement(t *testing.T) {
 					testCheckResourceAttrWithIndexesAddr(resourceName, "rule.%d.statement.0.regex_pattern_set_reference_statement.#", &idx, "1"),
 					testCheckResourceAttrWithIndexesAddr(resourceName, "rule.%d.statement.0.regex_pattern_set_reference_statement.0.field_to_match.#", &idx, "1"),
 					testCheckResourceAttrWithIndexesAddr(resourceName, "rule.%d.statement.0.regex_pattern_set_reference_statement.0.text_transformation.#", &idx, "1"),
-					testAccMatchResourceAttrArnWithIndexesAddr(resourceName, "rule.%d.statement.0.regex_pattern_set_reference_statement.0.arn", &idx, "wafv2", regexp.MustCompile(`regional/regexpatternset/.+$`)),
+					testAccMatchResourceAttrArnWithIndexesAddr(resourceName, "rule.%d.statement.0.regex_pattern_set_reference_statement.0.arn", &idx, regexp.MustCompile(`regional/regexpatternset/.+$`)),
 				),
 			},
 			{
@@ -937,7 +937,7 @@ func TestAccAwsWafv2RuleGroup_XssMatchStatement(t *testing.T) {
 	})
 }
 
-func testAccMatchResourceAttrArnWithIndexesAddr(name, format string, idx *int, arnService string, arnResourceRegexp *regexp.Regexp) resource.TestCheckFunc {
+func testAccMatchResourceAttrArnWithIndexesAddr(name, format string, idx *int, arnResourceRegexp *regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return testAccMatchResourceAttrRegionalARN(name, fmt.Sprintf(format, *idx), "wafv2", arnResourceRegexp)(s)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt/waf: remove unused params in methods
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSWafRegionalWebAclAssociation_ResourceArn_ApiGatewayStage (46.50s)
--- PASS: TestAccAwsWafv2RuleGroup_Disappears (144.68s)
--- PASS: TestAccAWSWafRegionalWebAclAssociation_disappears (204.19s)
--- PASS: TestAccAwsWafv2RuleGroup_Minimal (206.91s)
--- PASS: TestAccAWSWafRegionalWebAclAssociation_basic (225.99s)
--- PASS: TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement (230.83s)
--- PASS: TestAccAwsWafv2RuleGroup_IpSetReferenceStatement (233.25s)
--- PASS: TestAccAwsWafv2RuleGroup_ChangeCapacityForceNew (364.14s)
--- PASS: TestAccAwsWafv2RuleGroup_ChangeMetricNameForceNew (365.59s)
--- PASS: TestAccAwsWafv2RuleGroup_ChangeNameForceNew (370.06s)
--- PASS: TestAccAwsWafv2RuleGroup_SizeConstraintStatement (406.66s)
--- PASS: TestAccAwsWafv2RuleGroup_SqliMatchStatement (410.57s)
--- PASS: TestAccAwsWafv2RuleGroup_ByteMatchStatement (410.95s)
--- PASS: TestAccAwsWafv2RuleGroup_Basic (420.37s)
--- PASS: TestAccAwsWafv2RuleGroup_GeoMatchStatement (423.20s)
--- PASS: TestAccAwsWafv2RuleGroup_XssMatchStatement (381.53s)
--- PASS: TestAccAwsWafv2RuleGroup_Tags (443.40s)
--- PASS: TestAccAwsWafv2RuleGroup_LogicalRuleStatements (469.33s)
--- PASS: TestAccAwsWafv2RuleGroup_RuleAction (470.71s)
--- PASS: TestAccAwsWafv2RuleGroup_ByteMatchStatement_FieldToMatch (612.57s)
--- PASS: TestAccAWSWafRegionalWebAclAssociation_multipleAssociations (901.66s)
```
