### PR TITLE
resource/spot_fleet_request: remove unused error param

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -765,7 +765,7 @@ func buildAwsSpotFleetLaunchSpecifications(
 	return specs, nil
 }
 
-func buildLaunchTemplateConfigs(d *schema.ResourceData) ([]*ec2.LaunchTemplateConfig, error) {
+func buildLaunchTemplateConfigs(d *schema.ResourceData) []*ec2.LaunchTemplateConfig {
 	launchTemplateConfigs := d.Get("launch_template_config").(*schema.Set)
 	configs := make([]*ec2.LaunchTemplateConfig, 0)
 
@@ -839,7 +839,7 @@ func buildLaunchTemplateConfigs(d *schema.ResourceData) ([]*ec2.LaunchTemplateCo
 		configs = append(configs, ltc)
 	}
 
-	return configs, nil
+	return configs
 }
 
 func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{}) error {
@@ -870,10 +870,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if launchTemplateConfigsOk {
-		launchTemplates, err := buildLaunchTemplateConfigs(d)
-		if err != nil {
-			return err
-		}
+		launchTemplates:= buildLaunchTemplateConfigs(d)
 		spotFleetConfig.LaunchTemplateConfigs = launchTemplates
 	}
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -870,7 +870,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if launchTemplateConfigsOk {
-		launchTemplates:= buildLaunchTemplateConfigs(d)
+		launchTemplates := buildLaunchTemplateConfigs(d)
 		spotFleetConfig.LaunchTemplateConfigs = launchTemplates
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt/spot_fleet_request: remove unused error param
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (265.08s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (266.74s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (268.56s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (268.66s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (290.27s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (292.29s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (295.30s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (297.29s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (299.09s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (330.90s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (336.41s)
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (337.40s)
--- SKIP: TestAccAWSSpotFleetRequest_WithInstanceStoreAmi (0.00s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (62.02s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (405.84s)
--- PASS: TestAccAWSSpotFleetRequest_basic (409.00s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (182.01s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (475.18s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (181.81s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (547.45s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (251.68s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (266.40s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (322.62s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (617.01s)
--- PASS: TestAccAWSSpotFleetRequest_disappears (293.32s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (310.07s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (423.36s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (905.38s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (281.15s)
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (519.59s)
--- PASS: TestAccAWSSpotFleetRequest_tags (284.98s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (364.54s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (273.04s)
```