### PR TITLE
resource/security_group: remove unused error return param

### DIFF
--- a/aws/import_aws_security_group.go
+++ b/aws/import_aws_security_group.go
@@ -184,9 +184,7 @@ func resourceAwsSecurityGroupImportStatePermPair(sg *ec2.SecurityGroup, ruleType
 		}
 	}
 
-	if err := setFromIPPerm(d, sg, perm); err != nil {
-		return nil, fmt.Errorf("Error importing AWS Security Group: %s", err)
-	}
+	setFromIPPerm(d, sg, perm)
 
 	return d, nil
 }

--- a/aws/import_aws_security_group.go
+++ b/aws/import_aws_security_group.go
@@ -84,10 +84,7 @@ func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType str
 			IpRanges:      perm.IpRanges,
 		}
 
-		r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
-		if err != nil {
-			return nil, err
-		}
+		r := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
 		result = append(result, r)
 	}
 
@@ -100,10 +97,7 @@ func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType str
 			Ipv6Ranges:    perm.Ipv6Ranges,
 		}
 
-		r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
-		if err != nil {
-			return nil, err
-		}
+		r := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
 		result = append(result, r)
 	}
 
@@ -117,10 +111,7 @@ func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType str
 				UserIdGroupPairs: []*ec2.UserIdGroupPair{pair},
 			}
 
-			r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
-			if err != nil {
-				return nil, err
-			}
+			r := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
 			result = append(result, r)
 		}
 	}
@@ -133,17 +124,14 @@ func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType str
 			ToPort:        perm.ToPort,
 		}
 
-		r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
-		if err != nil {
-			return nil, err
-		}
+		r := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
 		result = append(result, r)
 	}
 
 	return result, nil
 }
 
-func resourceAwsSecurityGroupImportStatePermPair(sg *ec2.SecurityGroup, ruleType string, perm *ec2.IpPermission) (*schema.ResourceData, error) {
+func resourceAwsSecurityGroupImportStatePermPair(sg *ec2.SecurityGroup, ruleType string, perm *ec2.IpPermission) *schema.ResourceData {
 	// Construct the rule. We do this by populating the absolute
 	// minimum necessary for Refresh on the rule to work. This
 	// happens to be a lot of fields since they're almost all needed
@@ -186,5 +174,5 @@ func resourceAwsSecurityGroupImportStatePermPair(sg *ec2.SecurityGroup, ruleType
 
 	setFromIPPerm(d, sg, perm)
 
-	return d, nil
+	return d
 }

--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -30,9 +30,7 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 				if err != nil {
 					return nil, err
 				}
-				if err := populateSecurityGroupRuleFromImport(d, importParts); err != nil {
-					return nil, err
-				}
+				populateSecurityGroupRuleFromImport(d, importParts)
 				return []*schema.ResourceData{d}, nil
 			},
 		},
@@ -326,9 +324,8 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[DEBUG] Found rule for Security Group Rule (%s): %s", d.Id(), rule)
 
 	d.Set("type", ruleType)
-	if err := setFromIPPerm(d, sg, p); err != nil {
-		return fmt.Errorf("Error setting IP Permission for Security Group Rule: %s", err)
-	}
+
+	setFromIPPerm(d, sg, p)
 
 	d.Set("description", descriptionFromIPPerm(d, rule))
 
@@ -731,7 +728,7 @@ func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) (*ec2.IpPermiss
 	return &perm, nil
 }
 
-func setFromIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup, rule *ec2.IpPermission) error {
+func setFromIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup, rule *ec2.IpPermission) {
 	isVPC := sg.VpcId != nil && *sg.VpcId != ""
 
 	d.Set("from_port", rule.FromPort)
@@ -777,8 +774,6 @@ func setFromIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup, rule *ec2.IpPe
 			d.Set("source_security_group_id", s.GroupName)
 		}
 	}
-
-	return nil
 }
 
 func descriptionFromIPPerm(d *schema.ResourceData, rule *ec2.IpPermission) string {
@@ -998,7 +993,7 @@ func validateSecurityGroupRuleImportString(importStr string) ([]string, error) {
 	return importParts, nil
 }
 
-func populateSecurityGroupRuleFromImport(d *schema.ResourceData, importParts []string) error {
+func populateSecurityGroupRuleFromImport(d *schema.ResourceData, importParts []string) {
 	log.Printf("[DEBUG] Populating resource data on import: %v", importParts)
 
 	sgID := importParts[0]
@@ -1040,6 +1035,4 @@ func populateSecurityGroupRuleFromImport(d *schema.ResourceData, importParts []s
 	d.Set("ipv6_cidr_blocks", ipv6cidrs)
 	d.Set("cidr_blocks", cidrs)
 	d.Set("prefix_list_ids", prefixList)
-
-	return nil
 }

--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -329,7 +329,6 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 
 	setFromIPPerm(d, sg, p)
 
-
 	d.Set("description", descriptionFromIPPerm(d, rule))
 
 	if strings.Contains(d.Id(), "_") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/security_group: remove unused error return param
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestIpPermissionIDHash (0.00s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (4.09s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (5.20s)
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (23.52s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (24.29s)
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (24.74s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (28.17s)
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (28.27s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (28.58s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (29.89s)
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (30.05s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (31.29s)
--- PASS: TestAccAWSSecurityGroupRule_Egress (32.69s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (34.02s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (35.42s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (38.09s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts (36.12s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (41.80s)
--- PASS: TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash (18.21s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (45.60s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts (41.95s)
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (49.82s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id (58.79s)
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (45.87s)
--- PASS: TestAccAWSSecurityGroupRule_Race (97.66s)
```
