### PR TITLE
resource/aws_cognito_user_pool_client: Mark client secret as sensitive

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -30,8 +30,9 @@ func resourceAwsCognitoUserPoolClient() *schema.Resource {
 			},
 
 			"client_secret": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"generate_secret": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cognito_user_pool_client: Mark `client_secret` as sensitive
```

Prevent the sensitive `client_secret` attribute being leaked in logs.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPoolClient'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCognitoUserPoolClient -timeout 120m
=== RUN   TestAccAWSCognitoUserPoolClient_basic
=== PAUSE TestAccAWSCognitoUserPoolClient_basic
=== RUN   TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== PAUSE TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
=== RUN   TestAccAWSCognitoUserPoolClient_Name
=== PAUSE TestAccAWSCognitoUserPoolClient_Name
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
=== PAUSE TestAccAWSCognitoUserPoolClient_allFields
=== RUN   TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== PAUSE TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== RUN   TestAccAWSCognitoUserPoolClient_analyticsConfig
=== PAUSE TestAccAWSCognitoUserPoolClient_analyticsConfig
=== RUN   TestAccAWSCognitoUserPoolClient_disappears
=== PAUSE TestAccAWSCognitoUserPoolClient_disappears
=== CONT  TestAccAWSCognitoUserPoolClient_basic
=== CONT  TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
=== CONT  TestAccAWSCognitoUserPoolClient_disappears
=== CONT  TestAccAWSCognitoUserPoolClient_analyticsConfig
=== CONT  TestAccAWSCognitoUserPoolClient_Name
=== CONT  TestAccAWSCognitoUserPoolClient_allFields
=== CONT  TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (19.21s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (22.39s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (22.45s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (35.62s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (36.20s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (36.39s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfig (59.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.304s
```
