### PR TITLE
resource/route53: remove unused error return param

### DIFF
--- a/aws/resource_aws_route53_record_migrate.go
+++ b/aws/resource_aws_route53_record_migrate.go
@@ -13,10 +13,7 @@ func resourceAwsRoute53RecordMigrateState(
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS Route53 Record State v0; migrating to v1 then v2")
-		v1InstanceState, err := migrateRoute53RecordStateV0toV1(is)
-		if err != nil {
-			return v1InstanceState, err
-		}
+		v1InstanceState := migrateRoute53RecordStateV0toV1(is)
 		return migrateRoute53RecordStateV1toV2(v1InstanceState)
 	case 1:
 		log.Println("[INFO] Found AWS Route53 Record State v1; migrating to v2")
@@ -26,17 +23,17 @@ func resourceAwsRoute53RecordMigrateState(
 	}
 }
 
-func migrateRoute53RecordStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+func migrateRoute53RecordStateV0toV1(is *terraform.InstanceState) *terraform.InstanceState {
 	if is.Empty() {
 		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
-		return is, nil
+		return is
 	}
 
 	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
 	newName := strings.TrimSuffix(is.Attributes["name"], ".")
 	is.Attributes["name"] = newName
 	log.Printf("[DEBUG] Attributes after migration: %#v, new name: %s", is.Attributes, newName)
-	return is, nil
+	return is
 }
 
 func migrateRoute53RecordStateV1toV2(is *terraform.InstanceState) (*terraform.InstanceState, error) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/route_53: remove unused error return param
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAWSRoute53RecordMigrateState (0.00s)
--- PASS: TestAWSRoute53RecordMigrateStateV1toV2 (0.00s)
```
