### PR TITLE
resource/network_acl_rule: remove unused test method param

### DIFF
--- a/aws/resource_aws_network_acl_rule_test.go
+++ b/aws/resource_aws_network_acl_rule_test.go
@@ -175,7 +175,6 @@ func TestAccAWSNetworkAclRule_ipv6ICMP(t *testing.T) {
 
 // Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/6710
 func TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate(t *testing.T) {
-	var networkAcl ec2.NetworkAcl
 	var vpc ec2.Vpc
 	vpcResourceName := "aws_vpc.test"
 	resourceName := "aws_network_acl_rule.test"

--- a/aws/resource_aws_network_acl_rule_test.go
+++ b/aws/resource_aws_network_acl_rule_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestAccAWSNetworkAclRule_basic(t *testing.T) {
-	var networkAcl ec2.NetworkAcl
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,9 +24,9 @@ func TestAccAWSNetworkAclRule_basic(t *testing.T) {
 			{
 				Config: testAccAWSNetworkAclRuleBasicConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
-					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.qux", &networkAcl),
-					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.wibble", &networkAcl),
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz"),
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.qux"),
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.wibble"),
 				),
 			},
 			{
@@ -53,7 +52,6 @@ func TestAccAWSNetworkAclRule_basic(t *testing.T) {
 }
 
 func TestAccAWSNetworkAclRule_disappears(t *testing.T) {
-	var networkAcl ec2.NetworkAcl
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,7 +61,7 @@ func TestAccAWSNetworkAclRule_disappears(t *testing.T) {
 			{
 				Config: testAccAWSNetworkAclRuleBasicConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz"),
 					testAccCheckAWSNetworkAclRuleDelete("aws_network_acl_rule.baz"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -73,7 +71,6 @@ func TestAccAWSNetworkAclRule_disappears(t *testing.T) {
 }
 
 func TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears(t *testing.T) {
-	var networkAcl ec2.NetworkAcl
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -83,7 +80,7 @@ func TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears(t *testing.T) {
 			{
 				Config: testAccAWSNetworkAclRuleIngressEgressSameNumberMissing,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz"),
 					testAccCheckAWSNetworkAclRuleDelete("aws_network_acl_rule.baz"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -129,7 +126,6 @@ func TestAccAWSNetworkAclRule_missingParam(t *testing.T) {
 }
 
 func TestAccAWSNetworkAclRule_ipv6(t *testing.T) {
-	var networkAcl ec2.NetworkAcl
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -139,7 +135,7 @@ func TestAccAWSNetworkAclRule_ipv6(t *testing.T) {
 			{
 				Config: testAccAWSNetworkAclRuleIpv6Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz"),
 				),
 			},
 			{
@@ -153,7 +149,6 @@ func TestAccAWSNetworkAclRule_ipv6(t *testing.T) {
 }
 
 func TestAccAWSNetworkAclRule_ipv6ICMP(t *testing.T) {
-	var networkAcl ec2.NetworkAcl
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_network_acl_rule.test"
 
@@ -165,7 +160,7 @@ func TestAccAWSNetworkAclRule_ipv6ICMP(t *testing.T) {
 			{
 				Config: testAccAWSNetworkAclRuleConfigIpv6ICMP(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSNetworkAclRuleExists(resourceName, &networkAcl),
+					testAccCheckAWSNetworkAclRuleExists(resourceName),
 				),
 			},
 			{
@@ -204,7 +199,7 @@ func TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate(t *testi
 					testAccCheckVpcExists(vpcResourceName, &vpc),
 					resource.TestCheckResourceAttr(vpcResourceName, "assign_generated_ipv6_cidr_block", "true"),
 					resource.TestMatchResourceAttr(vpcResourceName, "ipv6_cidr_block", regexp.MustCompile(`/56$`)),
-					testAccCheckAWSNetworkAclRuleExists(resourceName, &networkAcl),
+					testAccCheckAWSNetworkAclRuleExists(resourceName),
 				),
 			},
 			{
@@ -340,7 +335,7 @@ func testAccCheckAWSNetworkAclRuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSNetworkAclRuleExists(n string, networkAcl *ec2.NetworkAcl) resource.TestCheckFunc {
+func testAccCheckAWSNetworkAclRuleExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/network_acl_rule: remove unused test method param
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestResourceAWSNetworkAclRule_validateICMPArgumentValue (0.00s)
--- PASS: TestAccAWSNetworkAclRule_missingParam (13.57s)
--- PASS: TestAccAWSNetworkAclRule_ipv6 (15.45s)
--- PASS: TestAccAWSNetworkAclRule_disappears (15.76s)
--- PASS: TestAccAWSNetworkAclRule_disappears_NetworkAcl (15.99s)
--- PASS: TestAccAWSNetworkAclRule_ingressEgressSameNumberDisappears (16.11s)
--- PASS: TestAccAWSNetworkAclRule_ipv6ICMP (16.05s)
--- PASS: TestAccAWSNetworkAclRule_basic (19.43s)
--- PASS: TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate (22.65s)
--- PASS: TestAccAWSNetworkAclRule_tcpProtocol (23.90s)
--- PASS: TestAccAWSNetworkAclRule_allProtocol (24.71s)
```
