### PR TITLE
Typo in tag error for resourceAwsSsmParameterRead

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -150,7 +150,7 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	tags, err := keyvaluetags.SsmListTags(ssmconn, name, ssm.ResourceTypeForTaggingParameter)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for SSM Maintenance Window (%s): %s", name, err)
+		return fmt.Errorf("error listing tags for SSM Parameter (%s): %s", name, err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMParameter*' -R
                                                                                                                            
==> Checking that code complies with gofmt requirements...                                                                                                                                    
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSSMParameter* -timeout 120m                                                                                                    
=== RUN   TestAccAWSSSMParameter_basic                                                                                                                                                        
=== PAUSE TestAccAWSSSMParameter_basic                                                                                                                                                        
=== RUN   TestAccAWSSSMParameter_Tier
=== PAUSE TestAccAWSSSMParameter_Tier
=== RUN   TestAccAWSSSMParameter_disappears
=== PAUSE TestAccAWSSSMParameter_disappears
=== RUN   TestAccAWSSSMParameter_overwrite
=== PAUSE TestAccAWSSSMParameter_overwrite
=== RUN   TestAccAWSSSMParameter_tags
=== PAUSE TestAccAWSSSMParameter_tags
=== RUN   TestAccAWSSSMParameter_updateType
=== PAUSE TestAccAWSSSMParameter_updateType
=== RUN   TestAccAWSSSMParameter_updateDescription
=== PAUSE TestAccAWSSSMParameter_updateDescription
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
=== PAUSE TestAccAWSSSMParameter_changeNameForcesNew
=== RUN   TestAccAWSSSMParameter_fullPath
=== PAUSE TestAccAWSSSMParameter_fullPath
=== RUN   TestAccAWSSSMParameter_secure
=== PAUSE TestAccAWSSSMParameter_secure
=== RUN   TestAccAWSSSMParameter_secure_with_key
=== PAUSE TestAccAWSSSMParameter_secure_with_key
=== RUN   TestAccAWSSSMParameter_secure_keyUpdate
=== PAUSE TestAccAWSSSMParameter_secure_keyUpdate
=== CONT  TestAccAWSSSMParameter_basic
=== CONT  TestAccAWSSSMParameter_fullPath
=== CONT  TestAccAWSSSMParameter_secure_keyUpdate
=== CONT  TestAccAWSSSMParameter_tags
=== CONT  TestAccAWSSSMParameter_Tier
=== CONT  TestAccAWSSSMParameter_secure_with_key
=== CONT  TestAccAWSSSMParameter_secure
=== CONT  TestAccAWSSSMParameter_updateDescription
=== CONT  TestAccAWSSSMParameter_disappears
=== CONT  TestAccAWSSSMParameter_changeNameForcesNew
=== CONT  TestAccAWSSSMParameter_overwrite
=== CONT  TestAccAWSSSMParameter_updateType
--- PASS: TestAccAWSSSMParameter_disappears (45.36s)
--- PASS: TestAccAWSSSMParameter_basic (67.94s) 
--- PASS: TestAccAWSSSMParameter_secure (67.97s)
--- PASS: TestAccAWSSSMParameter_fullPath (68.00s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (96.02s)
--- PASS: TestAccAWSSSMParameter_updateType (111.08s)
--- PASS: TestAccAWSSSMParameter_updateDescription (111.38s)
--- PASS: TestAccAWSSSMParameter_overwrite (112.57s)
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (113.55s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (140.01s)
--- PASS: TestAccAWSSSMParameter_Tier (159.45s) 
--- PASS: TestAccAWSSSMParameter_tags (160.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       160.797s
...
```
Bumped into a misleading/incorrect error message - just a typo/copypasta fix