### PR TITLE
resource/redshift: remove unused error return param

### DIFF
--- a/aws/resource_aws_redshift_security_group.go
+++ b/aws/resource_aws_redshift_security_group.go
@@ -174,10 +174,7 @@ func resourceAwsRedshiftSecurityGroupUpdate(d *schema.ResourceData, meta interfa
 		os := o.(*schema.Set)
 		ns := n.(*schema.Set)
 
-		removeIngressRules, err := expandRedshiftSGRevokeIngress(os.Difference(ns).List())
-		if err != nil {
-			return err
-		}
+		removeIngressRules := expandRedshiftSGRevokeIngress(os.Difference(ns).List())
 		if len(removeIngressRules) > 0 {
 			for _, r := range removeIngressRules {
 				r.ClusterSecurityGroupName = aws.String(d.Id())
@@ -189,10 +186,7 @@ func resourceAwsRedshiftSecurityGroupUpdate(d *schema.ResourceData, meta interfa
 			}
 		}
 
-		addIngressRules, err := expandRedshiftSGAuthorizeIngress(ns.Difference(os).List())
-		if err != nil {
-			return err
-		}
+		addIngressRules := expandRedshiftSGAuthorizeIngress(ns.Difference(os).List())
 		if len(addIngressRules) > 0 {
 			for _, r := range addIngressRules {
 				r.ClusterSecurityGroupName = aws.String(d.Id())
@@ -330,7 +324,7 @@ func resourceAwsRedshiftSecurityGroupStateRefreshFunc(
 	}
 }
 
-func expandRedshiftSGAuthorizeIngress(configured []interface{}) ([]redshift.AuthorizeClusterSecurityGroupIngressInput, error) {
+func expandRedshiftSGAuthorizeIngress(configured []interface{}) []redshift.AuthorizeClusterSecurityGroupIngressInput {
 	var ingress []redshift.AuthorizeClusterSecurityGroupIngressInput
 
 	// Loop over our configured parameters and create
@@ -355,10 +349,10 @@ func expandRedshiftSGAuthorizeIngress(configured []interface{}) ([]redshift.Auth
 		ingress = append(ingress, i)
 	}
 
-	return ingress, nil
+	return ingress
 }
 
-func expandRedshiftSGRevokeIngress(configured []interface{}) ([]redshift.RevokeClusterSecurityGroupIngressInput, error) {
+func expandRedshiftSGRevokeIngress(configured []interface{}) []redshift.RevokeClusterSecurityGroupIngressInput {
 	var ingress []redshift.RevokeClusterSecurityGroupIngressInput
 
 	// Loop over our configured parameters and create
@@ -383,5 +377,5 @@ func expandRedshiftSGRevokeIngress(configured []interface{}) ([]redshift.RevokeC
 		ingress = append(ingress, i)
 	}
 
-	return ingress, nil
+	return ingress
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates  #13278 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/redshift: remove unused error return param
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSRedshiftSecurityGroup_basic (12.98s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressCidr (13.13s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup (15.49s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup (34.98s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressCidr (30.53s)
```
