### PR TITLE
r/aws_cloudwatch_log_stream: Support resource import

### DIFF
--- a/aws/resource_aws_cloudwatch_log_stream.go
+++ b/aws/resource_aws_cloudwatch_log_stream.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -17,6 +18,9 @@ func resourceAwsCloudWatchLogStream() *schema.Resource {
 		Create: resourceAwsCloudWatchLogStreamCreate,
 		Read:   resourceAwsCloudWatchLogStreamRead,
 		Delete: resourceAwsCloudWatchLogStreamDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsCloudWatchLogStreamImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
@@ -115,6 +119,21 @@ func resourceAwsCloudWatchLogStreamDelete(d *schema.ResourceData, meta interface
 	}
 
 	return nil
+}
+
+func resourceAwsCloudWatchLogStreamImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), ":")
+	if len(parts) != 2 {
+		return []*schema.ResourceData{}, fmt.Errorf("Wrong format of resource: %s. Please follow 'log-group-name:log-stream-name'", d.Id())
+	}
+
+	logGroupName := parts[0]
+	logStreamName := parts[1]
+
+	d.SetId(logStreamName)
+	d.Set("log_group_name", logGroupName)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func lookupCloudWatchLogStream(conn *cloudwatchlogs.CloudWatchLogs,

--- a/aws/resource_aws_cloudwatch_log_stream_test.go
+++ b/aws/resource_aws_cloudwatch_log_stream_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -13,7 +12,8 @@ import (
 
 func TestAccAWSCloudWatchLogStream_basic(t *testing.T) {
 	var ls cloudwatchlogs.LogStream
-	rName := acctest.RandString(15)
+	resourceName := "aws_cloudwatch_log_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,8 +23,14 @@ func TestAccAWSCloudWatchLogStream_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogStreamConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogStreamExists("aws_cloudwatch_log_stream.foobar", &ls),
+					testAccCheckCloudWatchLogStreamExists(resourceName, &ls),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSCloudWatchLogStreamImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -32,7 +38,8 @@ func TestAccAWSCloudWatchLogStream_basic(t *testing.T) {
 
 func TestAccAWSCloudWatchLogStream_disappears(t *testing.T) {
 	var ls cloudwatchlogs.LogStream
-	rName := acctest.RandString(15)
+	resourceName := "aws_cloudwatch_log_stream.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -42,8 +49,8 @@ func TestAccAWSCloudWatchLogStream_disappears(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogStreamConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogStreamExists("aws_cloudwatch_log_stream.foobar", &ls),
-					testAccCheckCloudWatchLogStreamDisappears(&ls, rName),
+					testAccCheckCloudWatchLogStreamExists(resourceName, &ls),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchLogStream(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -51,22 +58,12 @@ func TestAccAWSCloudWatchLogStream_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckCloudWatchLogStreamDisappears(ls *cloudwatchlogs.LogStream, lgn string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
-		opts := &cloudwatchlogs.DeleteLogStreamInput{
-			LogGroupName:  aws.String(lgn),
-			LogStreamName: ls.LogStreamName,
-		}
-		_, err := conn.DeleteLogStream(opts)
-		return err
-	}
-}
-
 func TestAccAWSCloudWatchLogStream_disappears_LogGroup(t *testing.T) {
 	var ls cloudwatchlogs.LogStream
 	var lg cloudwatchlogs.LogGroup
-	rName := acctest.RandString(15)
+	resourceName := "aws_cloudwatch_log_stream.test"
+	logGroupResourceName := "aws_cloudwatch_log_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -76,9 +73,9 @@ func TestAccAWSCloudWatchLogStream_disappears_LogGroup(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchLogStreamConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchLogStreamExists("aws_cloudwatch_log_stream.foobar", &ls),
-					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
-					testAccCheckCloudWatchLogGroupDisappears(&lg),
+					testAccCheckCloudWatchLogStreamExists(resourceName, &ls),
+					testAccCheckCloudWatchLogGroupExists(logGroupResourceName, &lg),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchLogGroup(), logGroupResourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -132,6 +129,17 @@ func testAccCheckAWSCloudWatchLogStreamDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccAWSCloudWatchLogStreamImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not Found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s:%s", rs.Primary.Attributes["log_group_name"], rs.Primary.ID), nil
+	}
+}
+
 func TestValidateCloudWatchLogStreamName(t *testing.T) {
 	validNames := []string{
 		"test-log-stream",
@@ -161,13 +169,13 @@ func TestValidateCloudWatchLogStreamName(t *testing.T) {
 
 func testAccAWSCloudWatchLogStreamConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_cloudwatch_log_group" "foobar" {
-  name = "%s"
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
 }
 
-resource "aws_cloudwatch_log_stream" "foobar" {
-  name           = "%s"
-  log_group_name = "${aws_cloudwatch_log_group.foobar.id}"
+resource "aws_cloudwatch_log_stream" "test" {
+  name           = %[1]q
+  log_group_name = "${aws_cloudwatch_log_group.test.id}"
 }
-`, rName, rName)
+`, rName)
 }

--- a/website/docs/r/cloudwatch_log_stream.html.markdown
+++ b/website/docs/r/cloudwatch_log_stream.html.markdown
@@ -35,3 +35,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) specifying the log stream.
+
+## Import
+
+Cloudwatch Log Stream can be imported using the stream's `log_group_name` and `name`, e.g.
+
+```
+$ terraform import aws_cloudwatch_log_stream.foo Yada:SampleLogStream1234
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13683.
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/13527.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cloudwatch_log_stream: Support resource import
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCloudWatchLogStream_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchLogStream_ -timeout 120m
=== RUN   TestAccAWSCloudWatchLogStream_basic
=== PAUSE TestAccAWSCloudWatchLogStream_basic
=== RUN   TestAccAWSCloudWatchLogStream_disappears
=== PAUSE TestAccAWSCloudWatchLogStream_disappears
=== RUN   TestAccAWSCloudWatchLogStream_disappears_LogGroup
=== PAUSE TestAccAWSCloudWatchLogStream_disappears_LogGroup
=== CONT  TestAccAWSCloudWatchLogStream_basic
=== CONT  TestAccAWSCloudWatchLogStream_disappears_LogGroup
=== CONT  TestAccAWSCloudWatchLogStream_disappears
--- PASS: TestAccAWSCloudWatchLogStream_disappears_LogGroup (20.11s)
--- PASS: TestAccAWSCloudWatchLogStream_disappears (23.34s)
--- PASS: TestAccAWSCloudWatchLogStream_basic (26.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.600s
```
