### PR TITLE
r/aws_iot_policy: Support resource import & ForceNew on name

### DIFF
--- a/aws/resource_aws_iot_policy.go
+++ b/aws/resource_aws_iot_policy.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,14 +15,19 @@ func resourceAwsIotPolicy() *schema.Resource {
 		Read:   resourceAwsIotPolicyRead,
 		Update: resourceAwsIotPolicyUpdate,
 		Delete: resourceAwsIotPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 			"policy": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -45,11 +51,10 @@ func resourceAwsIotPolicyCreate(d *schema.ResourceData, meta interface{}) error 
 	})
 
 	if err != nil {
-		log.Printf("[ERROR] %s", err)
-		return err
+		return fmt.Errorf("error creating IoT Policy: %s", err)
 	}
 
-	d.SetId(*out.PolicyName)
+	d.SetId(aws.StringValue(out.PolicyName))
 
 	return resourceAwsIotPolicyRead(d, meta)
 }
@@ -61,13 +66,20 @@ func resourceAwsIotPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		PolicyName: aws.String(d.Id()),
 	})
 
+	if isAWSErr(err, iot.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] IoT Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		log.Printf("[ERROR] %s", err)
-		return err
+		return fmt.Errorf("error reading IoT Policy (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", out.PolicyArn)
 	d.Set("default_version_id", out.DefaultVersionId)
+	d.Set("name", out.PolicyName)
+	d.Set("policy", out.PolicyDocument)
 
 	return nil
 }
@@ -83,8 +95,7 @@ func resourceAwsIotPolicyUpdate(d *schema.ResourceData, meta interface{}) error 
 		})
 
 		if err != nil {
-			log.Printf("[ERROR] %s", err)
-			return err
+			return fmt.Errorf("error updating IoT Policy (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -100,19 +111,23 @@ func resourceAwsIotPolicyDelete(d *schema.ResourceData, meta interface{}) error 
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error listing IoT Policy (%s) versions: %s", d.Id(), err)
 	}
 
 	// Delete all non-default versions of the policy
 	for _, ver := range out.PolicyVersions {
-		if !*ver.IsDefaultVersion {
+		if !aws.BoolValue(ver.IsDefaultVersion) {
 			_, err = conn.DeletePolicyVersion(&iot.DeletePolicyVersionInput{
 				PolicyName:      aws.String(d.Id()),
 				PolicyVersionId: ver.VersionId,
 			})
+
+			if isAWSErr(err, iot.ErrCodeResourceNotFoundException, "") {
+				continue
+			}
+
 			if err != nil {
-				log.Printf("[ERROR] %s", err)
-				return err
+				return fmt.Errorf("error deleting IoT Policy (%s) version (%s): %s", d.Id(), aws.StringValue(ver.VersionId), err)
 			}
 		}
 	}
@@ -122,9 +137,12 @@ func resourceAwsIotPolicyDelete(d *schema.ResourceData, meta interface{}) error 
 		PolicyName: aws.String(d.Id()),
 	})
 
+	if isAWSErr(err, iot.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+
 	if err != nil {
-		log.Printf("[ERROR] %s", err)
-		return err
+		return fmt.Errorf("error deleting IoT Policy (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_iot_policy.go
+++ b/aws/resource_aws_iot_policy.go
@@ -23,6 +23,7 @@ func resourceAwsIotPolicy() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"policy": {
 				Type:             schema.TypeString,

--- a/aws/resource_aws_iot_policy_test.go
+++ b/aws/resource_aws_iot_policy_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestAccAWSIoTPolicy_basic(t *testing.T) {
-	rName := acctest.RandomWithPrefix("PubSubToAnyTopic-")
+	var v iot.GetPolicyOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_iot_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,18 +26,46 @@ func TestAccAWSIoTPolicy_basic(t *testing.T) {
 			{
 				Config: testAccAWSIoTPolicyConfigInitialState(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_iot_policy.pubsub", "name", rName),
-					resource.TestCheckResourceAttrSet("aws_iot_policy.pubsub", "arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_policy.pubsub", "default_version_id"),
-					resource.TestCheckResourceAttrSet("aws_iot_policy.pubsub", "policy"),
+					testAccCheckAWSIoTPolicyExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "iot", fmt.Sprintf("policy/%s", rName)),
+					resource.TestCheckResourceAttrSet(resourceName, "default_version_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSIoTPolicy_disappears(t *testing.T) {
+	var v iot.GetPolicyOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_iot_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTPolicyDestroy_basic,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTPolicyConfigInitialState(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTPolicyExists(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsIotPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSIoTPolicy_invalidJson(t *testing.T) {
-	rName := acctest.RandomWithPrefix("PubSubToAnyTopic-")
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -83,9 +113,35 @@ func testAccCheckAWSIoTPolicyDestroy_basic(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckAWSIoTPolicyExists(n string, v *iot.GetPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No IoT Policy ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+
+		resp, err := conn.GetPolicy(&iot.GetPolicyInput{
+			PolicyName: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		*v = *resp
+
+		return nil
+	}
+}
+
 func testAccAWSIoTPolicyConfigInitialState(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iot_policy" "pubsub" {
+resource "aws_iot_policy" "test" {
   name = "%s"
 
   policy = <<EOF
@@ -104,7 +160,7 @@ EOF
 
 func testAccAWSIoTPolicyInvalidJsonConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_iot_policy" "pubsub" {
+resource "aws_iot_policy" "test" {
   name = "%s"
 
   policy = <<EOF

--- a/website/docs/r/iot_policy.html.markdown
+++ b/website/docs/r/iot_policy.html.markdown
@@ -51,7 +51,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-IoT policis can be imported using the `name`, e.g.
+IoT policies can be imported using the `name`, e.g.
 
 ```
 $ terraform import aws_iot_policy.pubsub PubSubToAnyTopic

--- a/website/docs/r/iot_policy.html.markdown
+++ b/website/docs/r/iot_policy.html.markdown
@@ -48,3 +48,11 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - The name of this policy.
 * `default_version_id` - The default version of this policy.
 * `policy` - The policy document.
+
+## Import
+
+IoT policis can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_iot_policy.pubsub PubSubToAnyTopic
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13703.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11684.
Relates #13527.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_iot_policy: Support resource import
resource/aws_iot_policy: ForceNew on name changes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSIoTPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSIoTPolicy_ -timeout 120m
=== RUN   TestAccAWSIoTPolicy_basic
=== PAUSE TestAccAWSIoTPolicy_basic
=== RUN   TestAccAWSIoTPolicy_disappears
=== PAUSE TestAccAWSIoTPolicy_disappears
=== RUN   TestAccAWSIoTPolicy_invalidJson
=== PAUSE TestAccAWSIoTPolicy_invalidJson
=== CONT  TestAccAWSIoTPolicy_basic
=== CONT  TestAccAWSIoTPolicy_invalidJson
=== CONT  TestAccAWSIoTPolicy_disappears
--- PASS: TestAccAWSIoTPolicy_invalidJson (9.76s)
--- PASS: TestAccAWSIoTPolicy_disappears (17.98s)
--- PASS: TestAccAWSIoTPolicy_basic (23.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	23.993s
```
