### PR TITLE
Fixed a typo in the lifecycle_hook "import" example

### DIFF
--- a/website/docs/r/autoscaling_lifecycle_hook.html.markdown
+++ b/website/docs/r/autoscaling_lifecycle_hook.html.markdown
@@ -74,5 +74,5 @@ The following arguments are supported:
 AutoScaling Lifecycle Hooks can be imported using the role autoscaling_group_name and name separated by `/`.
 
 ```
-$ terraform import aws_aws_autoscaling_lifecycle_hook.test-lifecycle-hook asg-name/lifecycle-hook-name
+$ terraform import aws_autoscaling_lifecycle_hook.test-lifecycle-hook asg-name/lifecycle-hook-name
 ```


### PR DESCRIPTION
Hello, this is a trivial typo fix in the [documentation](https://www.terraform.io/docs/providers/aws/r/autoscaling_lifecycle_hook.html#import) about importing existing autoscaling lifecycle hooks :)

The current example is using a wrong resource name (double **aws_aws**), which creates some confusion for lazy copy-paste monkeys like me:
```
$ terraform import aws_aws_autoscaling_lifecycle_hook.test-lifecycle-hook asg-name/lifecycle-hook-name
```

And I changed it simply to:

```
$ terraform import aws_autoscaling_lifecycle_hook.test-lifecycle-hook asg-name/lifecycle-hook-name
```

Thank you.

Terraform is awesome  :heart: 