### PR TITLE
r/codeartifact_domain - new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -490,6 +490,7 @@ func Provider() *schema.Provider {
 			"aws_codedeploy_deployment_group":                         resourceAwsCodeDeployDeploymentGroup(),
 			"aws_codecommit_repository":                               resourceAwsCodeCommitRepository(),
 			"aws_codecommit_trigger":                                  resourceAwsCodeCommitTrigger(),
+			"aws_codeartifact_domain":                                 resourceAwsCodeArtifactDomain(),
 			"aws_codebuild_project":                                   resourceAwsCodeBuildProject(),
 			"aws_codebuild_report_group":                              resourceAwsCodeBuildReportGroup(),
 			"aws_codebuild_source_credential":                         resourceAwsCodeBuildSourceCredential(),

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -87,7 +87,7 @@ func resourceAwsCodeArtifactDomainRead(d *schema.ResourceData, meta interface{})
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading CodeArtifact Domain (%s): %s", d.Id(), err)
 	}
 
 	d.Set("domain", sm.Domain.Name)
@@ -111,8 +111,12 @@ func resourceAwsCodeArtifactDomainDelete(d *schema.ResourceData, meta interface{
 
 	_, err := conn.DeleteDomain(input)
 
+	if isAWSErr(err, codeartifact.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
+
 	if err != nil {
-		return fmt.Errorf("error deleting CodeArtifact Domain: %s", err)
+		return fmt.Errorf("error deleting CodeArtifact Domain (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -1,0 +1,122 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codeartifact"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAwsCodeArtifactDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCodeArtifactDomainCreate,
+		Read:   resourceAwsCodeArtifactDomainRead,
+		Delete: resourceAwsCodeArtifactDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"encryption_key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"asset_size_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"repository_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsCodeArtifactDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codeartifactconn
+	log.Print("[DEBUG] Creating CodeArtifact Domain")
+
+	params := &codeartifact.CreateDomainInput{
+		Domain:        aws.String(d.Get("domain").(string)),
+		EncryptionKey: aws.String(d.Get("encryption_key").(string)),
+	}
+
+	domain, err := conn.CreateDomain(params)
+	if err != nil {
+		return fmt.Errorf("error creating CodeArtifact Domain: %s", err)
+	}
+
+	d.SetId(aws.StringValue(domain.Domain.Name))
+
+	return resourceAwsCodeArtifactDomainRead(d, meta)
+}
+
+func resourceAwsCodeArtifactDomainRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codeartifactconn
+
+	log.Printf("[DEBUG] Reading CodeArtifact Domain: %s", d.Id())
+
+	sm, err := conn.DescribeDomain(&codeartifact.DescribeDomainInput{
+		Domain: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, codeartifact.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] CodeArtifact Domain %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("domain", sm.Domain.Name)
+	d.Set("arn", sm.Domain.Arn)
+	d.Set("encryption_key", sm.Domain.EncryptionKey)
+	d.Set("owner", sm.Domain.Owner)
+	d.Set("asset_size_bytes", sm.Domain.AssetSizeBytes)
+	d.Set("repository_count", sm.Domain.RepositoryCount)
+
+	if err := d.Set("created_time", sm.Domain.CreatedTime.Format(time.RFC3339)); err != nil {
+		log.Printf("[DEBUG] Error setting created_time: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsCodeArtifactDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codeartifactconn
+	log.Printf("[DEBUG] Deleting CodeArtifact Domain: %s", d.Id())
+
+	input := &codeartifact.DeleteDomainInput{
+		Domain: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteDomain(input)
+
+	if err != nil {
+		return fmt.Errorf("error deleting CodeArtifact Domain: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -30,9 +30,10 @@ func resourceAwsCodeArtifactDomain() *schema.Resource {
 				ForceNew: true,
 			},
 			"encryption_key": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
 			},
 			"owner": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/codeartifact"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceAwsCodeArtifactDomain() *schema.Resource {

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -98,7 +98,7 @@ func resourceAwsCodeArtifactDomainRead(d *schema.ResourceData, meta interface{})
 	d.Set("repository_count", sm.Domain.RepositoryCount)
 
 	if err := d.Set("created_time", sm.Domain.CreatedTime.Format(time.RFC3339)); err != nil {
-		log.Printf("[DEBUG] Error setting created_time: %s", err)
+		return fmt.Errorf("[DEBUG] Error setting created_time: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -96,10 +96,7 @@ func resourceAwsCodeArtifactDomainRead(d *schema.ResourceData, meta interface{})
 	d.Set("owner", sm.Domain.Owner)
 	d.Set("asset_size_bytes", sm.Domain.AssetSizeBytes)
 	d.Set("repository_count", sm.Domain.RepositoryCount)
-
-	if err := d.Set("created_time", sm.Domain.CreatedTime.Format(time.RFC3339)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting created_time: %s", err)
-	}
+	d.Set("created_time", sm.Domain.CreatedTime.Format(time.RFC3339))
 
 	return nil
 }

--- a/aws/resource_aws_codeartifact_domain.go
+++ b/aws/resource_aws_codeartifact_domain.go
@@ -65,7 +65,7 @@ func resourceAwsCodeArtifactDomainCreate(d *schema.ResourceData, meta interface{
 
 	domain, err := conn.CreateDomain(params)
 	if err != nil {
-		return fmt.Errorf("error creating CodeArtifact Domain: %s", err)
+		return fmt.Errorf("error creating CodeArtifact Domain: %w", err)
 	}
 
 	d.SetId(aws.StringValue(domain.Domain.Name))
@@ -87,7 +87,7 @@ func resourceAwsCodeArtifactDomainRead(d *schema.ResourceData, meta interface{})
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading CodeArtifact Domain (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading CodeArtifact Domain (%s): %w", d.Id(), err)
 	}
 
 	d.Set("domain", sm.Domain.Name)
@@ -116,7 +116,7 @@ func resourceAwsCodeArtifactDomainDelete(d *schema.ResourceData, meta interface{
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting CodeArtifact Domain (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting CodeArtifact Domain (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -60,7 +60,7 @@ func testSweepCodeArtifactDomains(region string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing Kinesis Streams: %w", err)
+		return fmt.Errorf("error listing CodeArtifact Domains: %w", err)
 	}
 
 	return sweeperErrs.ErrorOrNil()

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codeartifact"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"testing"
+)
+
+func TestAccAWSCodeArtifactDomain_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codeartifact_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeArtifactDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeArtifactDomainBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactDomainExists(resourceName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "codeartifact", fmt.Sprintf("domain/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "domain", rName),
+					resource.TestCheckResourceAttr(resourceName, "asset_size_bytes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "repository_count", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeArtifactDomain_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codeartifact_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeArtifactDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeArtifactDomainBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeArtifactDomainExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCodeArtifactDomain(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCodeArtifactDomainExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no CodeArtifact domain set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).codeartifactconn
+
+		_, err := conn.DescribeDomain(&codeartifact.DescribeDomainInput{
+			Domain: aws.String(rs.Primary.ID),
+		})
+
+		return err
+	}
+}
+
+func testAccCheckAWSCodeArtifactDomainDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_codeartifact_domain" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).codeartifactconn
+		resp, err := conn.DescribeDomain(&codeartifact.DescribeDomainInput{
+			Domain: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if aws.StringValue(resp.Domain.Name) == rs.Primary.ID {
+				return fmt.Errorf("CodeArtifact Domain %s still exists", rs.Primary.ID)
+			}
+		}
+
+		if isAWSErr(err, codeartifact.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSCodeArtifactDomainBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_codeartifact_domain" "test" {
+  domain         = %[1]q
+  encryption_key = "${aws_kms_key.test.arn}"
+}
+`, rName)
+}

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -28,6 +28,7 @@ func TestAccAWSCodeArtifactDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "asset_size_bytes", "0"),
 					resource.TestCheckResourceAttr(resourceName, "repository_count", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_time"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_key", "aws_kms_key.test", "arn"),
 					testAccCheckResourceAttrAccountID(resourceName, "owner"),
 				),
 			},

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codeartifact"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func init() {
@@ -188,7 +188,7 @@ resource "aws_kms_key" "test" {
 
 resource "aws_codeartifact_domain" "test" {
   domain         = %[1]q
-  encryption_key = "${aws_kms_key.test.arn}"
+  encryption_key = aws_kms_key.test.arn
 }
 `, rName)
 }

--- a/aws/resource_aws_codeartifact_domain_test.go
+++ b/aws/resource_aws_codeartifact_domain_test.go
@@ -182,7 +182,7 @@ func testAccCheckAWSCodeArtifactDomainDestroy(s *terraform.State) error {
 func testAccAWSCodeArtifactDomainBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
   deletion_window_in_days = 7
 }
 

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -38,7 +38,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of Domain.
 * `owner` - The AWS account ID that owns the domain.
 * `repository_count` - The number of repositories in the domain.
-* `created_time` - A timestamp that represents the date and time the domain was created in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8). 
+* `created_time` - A timestamp that represents the date and time the domain was created in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
 * `asset_size_bytes` - The total size of all assets in the domain.
 
 ## Import

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -28,7 +28,7 @@ resource "aws_codeartifact_domain" "example" {
 The following arguments are supported:
 
 * `domain` - (Required) The name of the domain to create. All domain names in an AWS Region that are in the same AWS account must be unique. The domain name is used as the prefix in DNS hostnames. Do not use sensitive information in a domain name because it is publicly discoverable.
-* `encryption_key` - (Required) The encryption key for the domain. This is used to encrypt content stored in a domain. An encryption key can be a key ID, a key Amazon Resource Name (ARN), a key alias, or a key alias ARN.
+* `encryption_key` - (Required) The encryption key for the domain. This is used to encrypt content stored in a domain. The KMS Key Amazon Resource Name (ARN).
 
 ## Attributes Reference
 

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -43,8 +43,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-CodeArtifact Domain can be imported using the CodeArtifact Domain name, e.g.
+CodeArtifact Domain can be imported using the CodeArtifact Domain arn, e.g.
 
 ```
-$ terraform import aws_codeartifact_domain.example example.com
+$ terraform import aws_codeartifact_domain.example arn:aws:codeartifact:us-west-2:012345678912:domain/tf-acc-test-8593714120730241305
 ```

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "CodeArtifact"
+layout: "aws"
+page_title: "AWS: aws_codeartifact_domain"
+description: |-
+  Provides a CodeArtifact Domain resource.
+---
+
+# Resource: aws_codeartifact_domain
+
+Provides a CodeArtifact Domains Resource.
+
+## Example Usage
+
+```hcl
+resource "aws_kms_key" "example" {
+  description = "domain key"
+}
+
+resource "aws_codeartifact_domain" "example" {
+  domain         = "example.com"
+  encryption_key = "${aws_kms_key.example.arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The name of the domain to create. All domain names in an AWS Region that are in the same AWS account must be unique. The domain name is used as the prefix in DNS hostnames. Do not use sensitive information in a domain name because it is publicly discoverable.
+* `encryption_key` - (Required) The encryption key for the domain. This is used to encrypt content stored in a domain. An encryption key can be a key ID, a key Amazon Resource Name (ARN), a key alias, or a key alias ARN.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The Name of Domain.
+* `arn` - The ARN of Domain.
+* `owner` - The AWS account ID that owns the domain.
+* `repository_count` - The number of repositories in the domain.
+* `created_time` - A timestamp that represents the date and time the domain was created.
+* `asset_size_bytes` - The total size of all assets in the domain.
+
+## Import
+
+CodeArtifact Domain can be imported using the CodeArtifact Domain name, e.g.
+
+```
+$ terraform import aws_codeartifact_domain.example example.com
+```

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_codeartifact_domain
 
-Provides a CodeArtifact Domains Resource.
+Provides a CodeArtifact Domain Resource.
 
 ## Example Usage
 
@@ -38,7 +38,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of Domain.
 * `owner` - The AWS account ID that owns the domain.
 * `repository_count` - The number of repositories in the domain.
-* `created_time` - A timestamp that represents the date and time the domain was created.
+* `created_time` - A timestamp that represents the date and time the domain was created in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8). 
 * `asset_size_bytes` - The total size of all assets in the domain.
 
 ## Import

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -18,7 +18,7 @@ resource "aws_kms_key" "example" {
 }
 
 resource "aws_codeartifact_domain" "example" {
-  domain         = "example.com"
+  domain         = "example"
   encryption_key = "${aws_kms_key.example.arn}"
 }
 ```

--- a/website/docs/r/codeartifact_domain.html.markdown
+++ b/website/docs/r/codeartifact_domain.html.markdown
@@ -19,7 +19,7 @@ resource "aws_kms_key" "example" {
 
 resource "aws_codeartifact_domain" "example" {
   domain         = "example"
-  encryption_key = "${aws_kms_key.example.arn}"
+  encryption_key = aws_kms_key.example.arn
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13714

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_codeartifact_domain - new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeArtifactDomain_'
--- PASS: TestAccAWSCodeArtifactDomain_basic (55.00s)
--- PASS: TestAccAWSCodeArtifactDomain_disappears (57.10s)
```
