### PR TITLE
AWS Cloud Map resource tagging

### DIFF
--- a/aws/resource_aws_service_discovery_http_namespace.go
+++ b/aws/resource_aws_service_discovery_http_namespace.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter"
 )
 
@@ -14,6 +15,7 @@ func resourceAwsServiceDiscoveryHttpNamespace() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsServiceDiscoveryHttpNamespaceCreate,
 		Read:   resourceAwsServiceDiscoveryHttpNamespaceRead,
+		Update: resourceAwsServiceDiscoveryHttpNamespaceUpdate,
 		Delete: resourceAwsServiceDiscoveryHttpNamespaceDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -32,6 +34,7 @@ func resourceAwsServiceDiscoveryHttpNamespace() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -47,6 +50,7 @@ func resourceAwsServiceDiscoveryHttpNamespaceCreate(d *schema.ResourceData, meta
 
 	input := &servicediscovery.CreateHttpNamespaceInput{
 		Name:             aws.String(name),
+		Tags:             keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().ServicediscoveryTags(),
 		CreatorRequestId: aws.String(resource.UniqueId()),
 	}
 
@@ -87,6 +91,7 @@ func resourceAwsServiceDiscoveryHttpNamespaceCreate(d *schema.ResourceData, meta
 
 func resourceAwsServiceDiscoveryHttpNamespaceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sdconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	input := &servicediscovery.GetNamespaceInput{
 		Id: aws.String(d.Id()),
@@ -101,11 +106,35 @@ func resourceAwsServiceDiscoveryHttpNamespaceRead(d *schema.ResourceData, meta i
 		return fmt.Errorf("error reading Service Discovery HTTP Namespace (%s): %s", d.Id(), err)
 	}
 
+	arn := aws.StringValue(resp.Namespace.Arn)
 	d.Set("name", resp.Namespace.Name)
 	d.Set("description", resp.Namespace.Description)
-	d.Set("arn", resp.Namespace.Arn)
+	d.Set("arn", arn)
+
+	tags, err := keyvaluetags.ServicediscoveryListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for resource (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
+}
+
+func resourceAwsServiceDiscoveryHttpNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.ServicediscoveryUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Service Discovery HTTP Namespace (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsServiceDiscoveryHttpNamespaceRead(d, meta)
 }
 
 func resourceAwsServiceDiscoveryHttpNamespaceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_service_discovery_http_namespace_test.go
+++ b/aws/resource_aws_service_discovery_http_namespace_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -105,6 +106,7 @@ func TestAccAWSServiceDiscoveryHttpNamespace_basic(t *testing.T) {
 				Config: testAccServiceDiscoveryHttpNamespaceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceDiscoveryHttpNamespaceExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`namespace/.+`)),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),

--- a/aws/resource_aws_service_discovery_http_namespace_test.go
+++ b/aws/resource_aws_service_discovery_http_namespace_test.go
@@ -108,12 +108,34 @@ func TestAccAWSServiceDiscoveryHttpNamespace_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryHttpNamespace_disappears(t *testing.T) {
+	resourceName := "aws_service_discovery_http_namespace.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryHttpNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryHttpNamespaceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryHttpNamespaceExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceDiscoveryHttpNamespace(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -139,6 +161,49 @@ func TestAccAWSServiceDiscoveryHttpNamespace_Description(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryHttpNamespace_Tags(t *testing.T) {
+	resourceName := "aws_service_discovery_http_namespace.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryHttpNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryHttpNamespaceConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryHttpNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDiscoveryHttpNamespaceConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryHttpNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccServiceDiscoveryHttpNamespaceConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryHttpNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -188,7 +253,7 @@ func testAccCheckAwsServiceDiscoveryHttpNamespaceExists(name string) resource.Te
 func testAccServiceDiscoveryHttpNamespaceConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_service_discovery_http_namespace" "test" {
-  name = %q
+  name = %[1]q
 }
 `, rName)
 }
@@ -196,8 +261,33 @@ resource "aws_service_discovery_http_namespace" "test" {
 func testAccServiceDiscoveryHttpNamespaceConfigDescription(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_service_discovery_http_namespace" "test" {
-  description = %q
-  name        = %q
+  description = %[1]q
+  name        = %[2]q
 }
 `, description, rName)
+}
+
+func testAccServiceDiscoveryHttpNamespaceConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_http_namespace" "test" {
+  name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccServiceDiscoveryHttpNamespaceConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_http_namespace" "test" {
+  name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_service_discovery_private_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter"
 )
 
@@ -15,6 +16,7 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespace() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsServiceDiscoveryPrivateDnsNamespaceCreate,
 		Read:   resourceAwsServiceDiscoveryPrivateDnsNamespaceRead,
+		Update: resourceAwsServiceDiscoveryPrivateDnsNamespaceUpdate,
 		Delete: resourceAwsServiceDiscoveryPrivateDnsNamespaceDelete,
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
@@ -44,6 +46,7 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespace() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -70,6 +73,7 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespaceCreate(d *schema.ResourceData
 
 	input := &servicediscovery.CreatePrivateDnsNamespaceInput{
 		Name:             aws.String(name),
+		Tags:             keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().ServicediscoveryTags(),
 		Vpc:              aws.String(d.Get("vpc").(string)),
 		CreatorRequestId: aws.String(requestId),
 	}
@@ -111,6 +115,7 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespaceCreate(d *schema.ResourceData
 
 func resourceAwsServiceDiscoveryPrivateDnsNamespaceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sdconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	input := &servicediscovery.GetNamespaceInput{
 		Id: aws.String(d.Id()),
@@ -125,13 +130,38 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespaceRead(d *schema.ResourceData, 
 		return err
 	}
 
+	arn := aws.StringValue(resp.Namespace.Arn)
 	d.Set("description", resp.Namespace.Description)
-	d.Set("arn", resp.Namespace.Arn)
+	d.Set("arn", arn)
 	d.Set("name", resp.Namespace.Name)
 	if resp.Namespace.Properties != nil {
 		d.Set("hosted_zone", resp.Namespace.Properties.DnsProperties.HostedZoneId)
 	}
+
+	tags, err := keyvaluetags.ServicediscoveryListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for resource (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
+}
+
+func resourceAwsServiceDiscoveryPrivateDnsNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.ServicediscoveryUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Service Discovery Private DNS Namespace (%s) tags: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsServiceDiscoveryHttpNamespaceRead(d, meta)
 }
 
 func resourceAwsServiceDiscoveryPrivateDnsNamespaceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -94,7 +94,8 @@ func testSweepServiceDiscoveryPrivateDnsNamespaces(region string) error {
 }
 
 func TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic(t *testing.T) {
-	rName := acctest.RandString(5) + ".example.com"
+	resourceName := "aws_service_discovery_private_dns_namespace.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -104,23 +105,26 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic(t *testing.T) {
 			{
 				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists("aws_service_discovery_private_dns_namespace.test"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "hosted_zone"),
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`namespace/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_service_discovery_private_dns_namespace.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc("aws_service_discovery_private_dns_namespace.test"),
+				ImportStateIdFunc: testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
-	rName := acctest.RandString(64-len("example.com")) + ".example.com"
+func TestAccAWSServiceDiscoveryPrivateDnsNamespace_disappears(t *testing.T) {
+	resourceName := "aws_service_discovery_private_dns_namespace.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -130,16 +134,30 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
 			{
 				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists("aws_service_discovery_private_dns_namespace.test"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "hosted_zone"),
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceDiscoveryPrivateDnsNamespace(), resourceName),
 				),
+				ExpectNonEmptyPlan: true,
 			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryPrivateDnsNamespace_Description(t *testing.T) {
+	resourceName := "aws_service_discovery_private_dns_namespace.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
+		Steps: []resource.TestStep{
 			{
-				ResourceName:      "aws_service_discovery_private_dns_namespace.test",
-				ImportState:       true,
-				ImportStateIdFunc: testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc("aws_service_discovery_private_dns_namespace.test"),
-				ImportStateVerify: true,
+				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfigDescription(rName, "test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+				),
 			},
 		},
 	})
@@ -149,7 +167,7 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
 //  * https://github.com/terraform-providers/terraform-provider-aws/issues/2830
 //  * https://github.com/terraform-providers/terraform-provider-aws/issues/5532
 func TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap(t *testing.T) {
-	rName := acctest.RandString(5) + ".example.com"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -159,6 +177,50 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap(t *testing.T) {
 			{
 				Config:      testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(rName),
 				ExpectError: regexp.MustCompile(`ConflictingDomainExists`),
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryPrivateDnsNamespace_Tags(t *testing.T) {
+	resourceName := "aws_service_discovery_private_dns_namespace.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccServiceDiscoveryPrivateDnsNamespaceConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -220,30 +282,47 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-service-discovery-private-dns-ns"
+    Name = %[1]q
   }
 }
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
-  name        = "%s"
-  description = "test"
-  vpc         = "${aws_vpc.test.id}"
+  name = "%[1]s.tf"
+  vpc  = "${aws_vpc.test.id}"
 }
 `, rName)
 }
 
-func testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(topDomain string) string {
+func testAccServiceDiscoveryPrivateDnsNamespaceConfigDescription(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-service-discovery-private-dns-ns"
+    Name = %[2]q
+  }
+}
+
+resource "aws_service_discovery_private_dns_namespace" "test" {
+  description = %[1]q
+  name        = "%[2]s.tf"
+  vpc         = "${aws_vpc.test.id}"
+}
+`, description, rName)
+}
+
+func testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
   }
 }
 
 resource "aws_service_discovery_private_dns_namespace" "top" {
-  name = %q
+  name = "%[1]s.tf"
   vpc  = "${aws_vpc.test.id}"
 }
 
@@ -252,7 +331,50 @@ resource "aws_service_discovery_private_dns_namespace" "subdomain" {
   name = "${aws_service_discovery_private_dns_namespace.top.name}"
   vpc  = "${aws_service_discovery_private_dns_namespace.top.vpc}"
 }
-`, topDomain)
+`, rName)
+}
+
+func testAccServiceDiscoveryPrivateDnsNamespaceConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_service_discovery_private_dns_namespace" "test" {
+  name = "%[1]s.tf"
+  vpc  = "${aws_vpc.test.id}"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccServiceDiscoveryPrivateDnsNamespaceConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_service_discovery_private_dns_namespace" "test" {
+  name = "%[1]s.tf"
+  vpc  = "${aws_vpc.test.id}"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
 func testAccServiceDiscoveryPrivateDnsNamespaceImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {

--- a/aws/resource_aws_service_discovery_public_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -94,7 +95,7 @@ func testSweepServiceDiscoveryPublicDnsNamespaces(region string) error {
 
 func TestAccAWSServiceDiscoveryPublicDnsNamespace_basic(t *testing.T) {
 	resourceName := "aws_service_discovery_public_dns_namespace.test"
-	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha) + ".terraformtesting.com"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -104,9 +105,11 @@ func TestAccAWSServiceDiscoveryPublicDnsNamespace_basic(t *testing.T) {
 			{
 				Config: testAccServiceDiscoveryPublicDnsNamespaceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists("aws_service_discovery_public_dns_namespace.test"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_public_dns_namespace.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_public_dns_namespace.test", "hosted_zone"),
+					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`namespace/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -118,9 +121,9 @@ func TestAccAWSServiceDiscoveryPublicDnsNamespace_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSServiceDiscoveryPublicDnsNamespace_longname(t *testing.T) {
+func TestAccAWSServiceDiscoveryPublicDnsNamespace_disappears(t *testing.T) {
 	resourceName := "aws_service_discovery_public_dns_namespace.test"
-	rName := acctest.RandStringFromCharSet(64-len("terraformtesting.com"), acctest.CharSetAlpha) + ".terraformtesting.com"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -130,15 +133,73 @@ func TestAccAWSServiceDiscoveryPublicDnsNamespace_longname(t *testing.T) {
 			{
 				Config: testAccServiceDiscoveryPublicDnsNamespaceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists("aws_service_discovery_public_dns_namespace.test"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_public_dns_namespace.test", "arn"),
-					resource.TestCheckResourceAttrSet("aws_service_discovery_public_dns_namespace.test", "hosted_zone"),
+					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceDiscoveryPublicDnsNamespace(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryPublicDnsNamespace_Description(t *testing.T) {
+	resourceName := "aws_service_discovery_public_dns_namespace.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryPublicDnsNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryPublicDnsNamespaceConfigDescription(rName, "test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryPublicDnsNamespace_Tags(t *testing.T) {
+	resourceName := "aws_service_discovery_public_dns_namespace.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryPublicDnsNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryPublicDnsNamespaceConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDiscoveryPublicDnsNamespaceConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccServiceDiscoveryPublicDnsNamespaceConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -188,8 +249,41 @@ func testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(name string) resour
 func testAccServiceDiscoveryPublicDnsNamespaceConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_service_discovery_public_dns_namespace" "test" {
-  name        = %q
-  description = "test"
+  name = "%[1]s.tf"
 }
 `, rName)
+}
+
+func testAccServiceDiscoveryPublicDnsNamespaceConfigDescription(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_public_dns_namespace" "test" {
+  description = %[1]q
+  name        = "%[2]s.tf"
+}
+`, description, rName)
+}
+
+func testAccServiceDiscoveryPublicDnsNamespaceConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_public_dns_namespace" "test" {
+  name = "%[1]s.tf"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccServiceDiscoveryPublicDnsNamespaceConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_public_dns_namespace" "test" {
+  name = "%[1]s.tf"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_service_discovery_service.go
+++ b/aws/resource_aws_service_discovery_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter"
 )
 
@@ -127,6 +128,7 @@ func resourceAwsServiceDiscoveryService() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -140,6 +142,7 @@ func resourceAwsServiceDiscoveryServiceCreate(d *schema.ResourceData, meta inter
 
 	input := &servicediscovery.CreateServiceInput{
 		Name: aws.String(d.Get("name").(string)),
+		Tags: keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().ServicediscoveryTags(),
 	}
 
 	dnsConfig := d.Get("dns_config").([]interface{})
@@ -170,13 +173,14 @@ func resourceAwsServiceDiscoveryServiceCreate(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	d.SetId(*resp.Service.Id)
-	d.Set("arn", resp.Service.Arn)
-	return nil
+	d.SetId(aws.StringValue(resp.Service.Id))
+
+	return resourceAwsServiceDiscoveryServiceRead(d, meta)
 }
 
 func resourceAwsServiceDiscoveryServiceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sdconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	input := &servicediscovery.GetServiceInput{
 		Id: aws.String(d.Id()),
@@ -193,47 +197,62 @@ func resourceAwsServiceDiscoveryServiceRead(d *schema.ResourceData, meta interfa
 	}
 
 	service := resp.Service
-	d.Set("arn", service.Arn)
+	arn := aws.StringValue(service.Arn)
+	d.Set("arn", arn)
 	d.Set("name", service.Name)
 	d.Set("description", service.Description)
 	d.Set("namespace_id", service.NamespaceId)
 	d.Set("dns_config", flattenServiceDiscoveryDnsConfig(service.DnsConfig))
 	d.Set("health_check_config", flattenServiceDiscoveryHealthCheckConfig(service.HealthCheckConfig))
 	d.Set("health_check_custom_config", flattenServiceDiscoveryHealthCheckCustomConfig(service.HealthCheckCustomConfig))
+
+	tags, err := keyvaluetags.ServicediscoveryListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for resource (%s): %s", arn, err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 
 func resourceAwsServiceDiscoveryServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sdconn
 
-	input := &servicediscovery.UpdateServiceInput{
-		Id: aws.String(d.Id()),
-	}
+	if d.HasChanges("description", "dns_config", "health_check_config") {
+		input := &servicediscovery.UpdateServiceInput{
+			Id: aws.String(d.Id()),
+			Service: &servicediscovery.ServiceChange{
+				Description: aws.String(d.Get("description").(string)),
+				DnsConfig:   expandServiceDiscoveryDnsConfigChange(d.Get("dns_config").([]interface{})[0].(map[string]interface{})),
+			},
+		}
 
-	sc := &servicediscovery.ServiceChange{
-		DnsConfig: expandServiceDiscoveryDnsConfigChange(d.Get("dns_config").([]interface{})[0].(map[string]interface{})),
-	}
-
-	if d.HasChange("description") {
-		sc.Description = aws.String(d.Get("description").(string))
-	}
-
-	if d.HasChange("health_check_config") {
 		hcconfig := d.Get("health_check_config").([]interface{})
-		sc.HealthCheckConfig = expandServiceDiscoveryHealthCheckConfig(hcconfig[0].(map[string]interface{}))
+		if len(hcconfig) > 0 {
+			input.Service.HealthCheckConfig = expandServiceDiscoveryHealthCheckConfig(hcconfig[0].(map[string]interface{}))
+		}
+
+		output, err := conn.UpdateService(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating Service Discovery Service (%s): %w", d.Id(), err)
+		}
+
+		if output != nil && output.OperationId != nil {
+			if _, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId)); err != nil {
+				return fmt.Errorf("error waiting for Service Discovery Service (%s) update: %w", d.Id(), err)
+			}
+		}
 	}
 
-	input.Service = sc
-
-	output, err := conn.UpdateService(input)
-
-	if err != nil {
-		return fmt.Errorf("error updating Service Discovery Service (%s): %w", d.Id(), err)
-	}
-
-	if output != nil && output.OperationId != nil {
-		if _, err := waiter.OperationSuccess(conn, aws.StringValue(output.OperationId)); err != nil {
-			return fmt.Errorf("error waiting for Service Discovery Service (%s) update: %w", d.Id(), err)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.ServicediscoveryUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating Service Discovery Private DNS Namespace (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -114,7 +115,7 @@ func testSweepServiceDiscoveryServices(region string) error {
 
 func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 	resourceName := "aws_service_discovery_service.test"
-	rName := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
@@ -130,7 +131,9 @@ func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.0.type", "A"),
 					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.0.ttl", "5"),
 					resource.TestCheckResourceAttr(resourceName, "dns_config.0.routing_policy", "MULTIVALUE"),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`service/.+`)),
 				),
 			},
 			{
@@ -147,7 +150,9 @@ func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.0.ttl", "10"),
 					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.1.type", "AAAA"),
 					resource.TestCheckResourceAttr(resourceName, "dns_config.0.dns_records.1.ttl", "5"),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`service/.+`)),
 				),
 			},
 		},
@@ -155,7 +160,7 @@ func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 }
 
 func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -171,7 +176,9 @@ func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.failure_threshold", "5"),
 					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.resource_path", "/path"),
 					resource.TestCheckResourceAttr(resourceName, "dns_config.0.routing_policy", "WEIGHTED"),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`service/.+`)),
 				),
 			},
 			{
@@ -186,7 +193,19 @@ func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.type", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.failure_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check_config.0.resource_path", "/updated-path"),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`service/.+`)),
+				),
+			},
+			{
+				Config: testAccServiceDiscoveryServiceConfig_public_update_noHealthCheckConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "health_check_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`service/.+`)),
 				),
 			},
 		},
@@ -194,7 +213,7 @@ func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
 }
 
 func TestAccAWSServiceDiscoveryService_http(t *testing.T) {
-	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -207,13 +226,78 @@ func TestAccAWSServiceDiscoveryService_http(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "namespace_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`service/.+`)),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryService_disappears(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	resourceName := "aws_service_discovery_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryServiceConfig_http(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsServiceDiscoveryService(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSServiceDiscoveryService_Tags(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	resourceName := "aws_service_discovery_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryServiceConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDiscoveryServiceConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccServiceDiscoveryServiceConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -266,18 +350,17 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-service-discovery-service-private"
+    Name = %[1]q
   }
 }
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
-  name        = "tf-sd-%s.terraform.local"
-  description = "test"
-  vpc         = "${aws_vpc.test.id}"
+  name = "%[1]s.tf"
+  vpc  = "${aws_vpc.test.id}"
 }
 
 resource "aws_service_discovery_service" "test" {
-  name = "tf-sd-%s"
+  name = %[1]q
 
   dns_config {
     namespace_id = "${aws_service_discovery_private_dns_namespace.test.id}"
@@ -289,10 +372,10 @@ resource "aws_service_discovery_service" "test" {
   }
 
   health_check_custom_config {
-    failure_threshold = %d
+    failure_threshold = %[2]d
   }
 }
-`, rName, rName, th)
+`, rName, th)
 }
 
 func testAccServiceDiscoveryServiceConfig_private_update(rName string, th int) string {
@@ -301,18 +384,19 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-service-discovery-service-private"
+    Name = %[1]q
   }
 }
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
-  name        = "tf-sd-%s.terraform.local"
-  description = "test"
+  name        = "%[1]s.tf"
   vpc         = "${aws_vpc.test.id}"
 }
 
 resource "aws_service_discovery_service" "test" {
-  name = "tf-sd-%s"
+  name = %[1]q
+
+  description = "test"
 
   dns_config {
     namespace_id = "${aws_service_discovery_private_dns_namespace.test.id}"
@@ -331,21 +415,22 @@ resource "aws_service_discovery_service" "test" {
   }
 
   health_check_custom_config {
-    failure_threshold = %d
+    failure_threshold = %[2]d
   }
 }
-`, rName, rName, th)
+`, rName, th)
 }
 
 func testAccServiceDiscoveryServiceConfig_public(rName string, th int, path string) string {
 	return fmt.Sprintf(`
 resource "aws_service_discovery_public_dns_namespace" "test" {
-  name        = "tf-sd-%s.terraform.com"
-  description = "test"
+  name = "%[1]s.tf"
 }
 
 resource "aws_service_discovery_service" "test" {
-  name = "tf-sd-%s"
+  name = %[1]q
+
+  description = "test"
 
   dns_config {
     namespace_id = "${aws_service_discovery_public_dns_namespace.test.id}"
@@ -359,24 +444,81 @@ resource "aws_service_discovery_service" "test" {
   }
 
   health_check_config {
-    failure_threshold = %d
-    resource_path     = "%s"
+    failure_threshold = %[2]d
+    resource_path     = %[3]q
     type              = "HTTP"
   }
 }
-`, rName, rName, th, path)
+`, rName, th, path)
+}
+
+func testAccServiceDiscoveryServiceConfig_public_update_noHealthCheckConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_public_dns_namespace" "test" {
+  name = "%[1]s.tf"
+}
+
+resource "aws_service_discovery_service" "test" {
+  name = %[1]q
+
+  dns_config {
+    namespace_id = "${aws_service_discovery_public_dns_namespace.test.id}"
+
+    dns_records {
+      ttl  = 5
+      type = "A"
+    }
+
+    routing_policy = "WEIGHTED"
+  }
+}
+`, rName)
 }
 
 func testAccServiceDiscoveryServiceConfig_http(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_service_discovery_http_namespace" "test" {
-  name = "tf-sd-ns-%s"
-  description = "test"
+  name = %[1]q
 }
 
 resource "aws_service_discovery_service" "test" {
-  name = "tf-sd-%s"
+  name         = %[1]q
   namespace_id = "${aws_service_discovery_http_namespace.test.id}"
 }
-`, rName, rName)
+`, rName)
+}
+
+func testAccServiceDiscoveryServiceConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_http_namespace" "test" {
+  name = %[1]q
+}
+
+resource "aws_service_discovery_service" "test" {
+  name         = %[1]q
+  namespace_id = "${aws_service_discovery_http_namespace.test.id}"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccServiceDiscoveryServiceConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_http_namespace" "test" {
+  name = %[1]q
+}
+
+resource "aws_service_discovery_service" "test" {
+  name         = %[1]q
+  namespace_id = "${aws_service_discovery_http_namespace.test.id}"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/r/service_discovery_http_namespace.html.markdown
+++ b/website/docs/r/service_discovery_http_namespace.html.markdown
@@ -24,6 +24,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the http namespace.
 * `description` - (Optional) The description that you specify for the namespace when you create it.
+* `tags` - (Optional) A map of tags to assign to the namespace.
 
 ## Attributes Reference
 

--- a/website/docs/r/service_discovery_private_dns_namespace.html.markdown
+++ b/website/docs/r/service_discovery_private_dns_namespace.html.markdown
@@ -31,6 +31,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the namespace.
 * `vpc` - (Required) The ID of VPC that you want to associate the namespace with.
 * `description` - (Optional) The description that you specify for the namespace when you create it.
+* `tags` - (Optional) A map of tags to assign to the namespace.
 
 ## Attributes Reference
 

--- a/website/docs/r/service_discovery_public_dns_namespace.html.markdown
+++ b/website/docs/r/service_discovery_public_dns_namespace.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the namespace.
 * `description` - (Optional) The description that you specify for the namespace when you create it.
+* `tags` - (Optional) A map of tags to assign to the namespace.
 
 ## Attributes Reference
 

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -81,6 +81,7 @@ The following arguments are supported:
 * `health_check_config` - (Optional) A complex type that contains settings for an optional health check. Only for Public DNS namespaces.
 * `health_check_custom_config` - (Optional, ForceNew) A complex type that contains settings for ECS managed health checks.
 * `namespace_id` - (Optional) The ID of the namespace that you want to use to create the service.
+* `tags` - (Optional) A map of tags to assign to the service.
 
 ### dns_config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13696.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
release/aws_service_discovery_http_namespace: Add `tags` argument
release/aws_service_discovery_private_dns_namespace: Add `tags` argument
release/aws_service_discovery_public_dns_namespace: Add `tags` argument
release/aws_service_discovery_service: Add `tags` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSServiceDiscoveryHttpNamespace_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSServiceDiscoveryHttpNamespace_ -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryHttpNamespace_basic
=== PAUSE TestAccAWSServiceDiscoveryHttpNamespace_basic
=== RUN   TestAccAWSServiceDiscoveryHttpNamespace_disappears
=== PAUSE TestAccAWSServiceDiscoveryHttpNamespace_disappears
=== RUN   TestAccAWSServiceDiscoveryHttpNamespace_Description
=== PAUSE TestAccAWSServiceDiscoveryHttpNamespace_Description
=== RUN   TestAccAWSServiceDiscoveryHttpNamespace_Tags
=== PAUSE TestAccAWSServiceDiscoveryHttpNamespace_Tags
=== CONT  TestAccAWSServiceDiscoveryHttpNamespace_basic
=== CONT  TestAccAWSServiceDiscoveryHttpNamespace_Tags
=== CONT  TestAccAWSServiceDiscoveryHttpNamespace_Description
=== CONT  TestAccAWSServiceDiscoveryHttpNamespace_disappears
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_disappears (91.23s)
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_Description (97.32s)
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_basic (97.73s)
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_Tags (129.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	129.305s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSServiceDiscoveryPrivateDnsNamespace_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSServiceDiscoveryPrivateDnsNamespace_ -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
=== PAUSE TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_disappears
=== PAUSE TestAccAWSServiceDiscoveryPrivateDnsNamespace_disappears
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_Description
=== PAUSE TestAccAWSServiceDiscoveryPrivateDnsNamespace_Description
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap
=== PAUSE TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_Tags
=== PAUSE TestAccAWSServiceDiscoveryPrivateDnsNamespace_Tags
=== CONT  TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
=== CONT  TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (130.39s)
=== CONT  TestAccAWSServiceDiscoveryPrivateDnsNamespace_Description
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap (194.52s)
=== CONT  TestAccAWSServiceDiscoveryPrivateDnsNamespace_disappears
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_Description (127.27s)
=== CONT  TestAccAWSServiceDiscoveryPrivateDnsNamespace_Tags
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_disappears (125.96s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_Tags (175.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	433.239s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSServiceDiscoveryPublicDnsNamespace_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSServiceDiscoveryPublicDnsNamespace_ -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryPublicDnsNamespace_basic
=== PAUSE TestAccAWSServiceDiscoveryPublicDnsNamespace_basic
=== RUN   TestAccAWSServiceDiscoveryPublicDnsNamespace_disappears
=== PAUSE TestAccAWSServiceDiscoveryPublicDnsNamespace_disappears
=== RUN   TestAccAWSServiceDiscoveryPublicDnsNamespace_Description
=== PAUSE TestAccAWSServiceDiscoveryPublicDnsNamespace_Description
=== RUN   TestAccAWSServiceDiscoveryPublicDnsNamespace_Tags
=== PAUSE TestAccAWSServiceDiscoveryPublicDnsNamespace_Tags
=== CONT  TestAccAWSServiceDiscoveryPublicDnsNamespace_Tags
=== CONT  TestAccAWSServiceDiscoveryPublicDnsNamespace_Description
--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_Description (114.29s)
=== CONT  TestAccAWSServiceDiscoveryPublicDnsNamespace_disappears
--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_Tags (148.95s)
=== CONT  TestAccAWSServiceDiscoveryPublicDnsNamespace_basic
--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_disappears (110.72s)
--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_basic (117.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	266.793s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSServiceDiscoveryService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSServiceDiscoveryService_ -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryService_private
=== PAUSE TestAccAWSServiceDiscoveryService_private
=== RUN   TestAccAWSServiceDiscoveryService_public
=== PAUSE TestAccAWSServiceDiscoveryService_public
=== RUN   TestAccAWSServiceDiscoveryService_http
=== PAUSE TestAccAWSServiceDiscoveryService_http
=== RUN   TestAccAWSServiceDiscoveryService_disappears
=== PAUSE TestAccAWSServiceDiscoveryService_disappears
=== RUN   TestAccAWSServiceDiscoveryService_Tags
=== PAUSE TestAccAWSServiceDiscoveryService_Tags
=== CONT  TestAccAWSServiceDiscoveryService_private
=== CONT  TestAccAWSServiceDiscoveryService_disappears
=== CONT  TestAccAWSServiceDiscoveryService_Tags
=== CONT  TestAccAWSServiceDiscoveryService_http
=== CONT  TestAccAWSServiceDiscoveryService_public
--- PASS: TestAccAWSServiceDiscoveryService_disappears (95.59s)
--- PASS: TestAccAWSServiceDiscoveryService_http (100.01s)
--- PASS: TestAccAWSServiceDiscoveryService_Tags (135.01s)
--- PASS: TestAccAWSServiceDiscoveryService_public (156.15s)
--- PASS: TestAccAWSServiceDiscoveryService_private (158.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	158.683s
```
