### PR TITLE
data/aws_ebs_volumes: Add data source

### DIFF
--- a/aws/data_source_aws_ebs_volumes.go
+++ b/aws/data_source_aws_ebs_volumes.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func dataSourceAwsEbsVolumes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEbsVolumesRead,
+		Schema: map[string]*schema.Schema{
+			"filter": ec2CustomFiltersSchema(),
+
+			"tags": tagsSchema(),
+
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceAwsEbsVolumesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeVolumesInput{}
+
+	if tags, tagsOk := d.GetOk("tags"); tagsOk {
+		req.Filters = append(req.Filters, buildEC2TagFilterList(
+			keyvaluetags.New(tags.(map[string]interface{})).Ec2Tags(),
+		)...)
+	}
+
+	if filters, filtersOk := d.GetOk("filter"); filtersOk {
+		req.Filters = append(req.Filters, buildEC2CustomFilterList(
+			filters.(*schema.Set),
+		)...)
+	}
+
+	if len(req.Filters) == 0 {
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] DescribeVolumes %s\n", req)
+	resp, err := conn.DescribeVolumes(req)
+	if err != nil {
+		return fmt.Errorf("error describing EC2 Volumes: %w", err)
+	}
+
+	if resp == nil || len(resp.Volumes) == 0 {
+		return errors.New("no matching volumes found")
+	}
+
+	volumes := make([]string, 0)
+
+	for _, volume := range resp.Volumes {
+		volumes = append(volumes, *volume.VolumeId)
+	}
+
+	d.SetId(resource.UniqueId())
+	if err := d.Set("ids", volumes); err != nil {
+		return fmt.Errorf("error setting ids: %w", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_ebs_volumes_test.go
+++ b/aws/data_source_aws_ebs_volumes_test.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAwsEbsVolumes(t *testing.T) {
+	rInt := acctest.RandIntRange(0, 256)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsEbsVolumeIDsConfig(rInt),
+			},
+			{
+				Config: testAccDataSourceAwsEbsVolumeIDsConfigWithDataSource(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_ebs_volumes.subject_under_test", "ids.#", "2"),
+				),
+			},
+			{
+				// Force the destroy to not refresh the data source (leading to an error)
+				Config: testAccDataSourceAwsEbsVolumeIDsConfig(rInt),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsEbsVolumeIDsConfigWithDataSource(rInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_ebs_volumes" "subject_under_test" {
+  tags = {
+    TestIdentifierSet = "testAccDataSourceAwsEbsVolumes-%d"
+  }
+}
+`, testAccDataSourceAwsEbsVolumeIDsConfig(rInt), rInt)
+}
+
+func testAccDataSourceAwsEbsVolumeIDsConfig(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "azs" {
+  state = "available"
+}
+
+resource "aws_ebs_volume" "volume" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.azs.names[0]
+  size = 1
+
+  tags = {
+    TestIdentifierSet = "testAccDataSourceAwsEbsVolumes-%d"
+  }
+}
+`, rInt)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	homedir "github.com/mitchellh/go-homedir"
+
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -209,6 +210,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ebs_snapshot":                              dataSourceAwsEbsSnapshot(),
 			"aws_ebs_snapshot_ids":                          dataSourceAwsEbsSnapshotIds(),
 			"aws_ebs_volume":                                dataSourceAwsEbsVolume(),
+			"aws_ebs_volumes":                               dataSourceAwsEbsVolumes(),
 			"aws_ec2_coip_pool":                             dataSourceAwsEc2CoipPool(),
 			"aws_ec2_coip_pools":                            dataSourceAwsEc2CoipPools(),
 			"aws_ec2_instance_type_offering":                dataSourceAwsEc2InstanceTypeOffering(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1110,6 +1110,9 @@
                                     <a href="/docs/providers/aws/d/ebs_volume.html">aws_ebs_volume</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/d/ebs_volumes.html">aws_ebs_volumes</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/d/ec2_coip_pool.html">aws_ec2_coip_pool</a>
                                 </li>
                                 <li>

--- a/website/docs/d/ebs_volumes.html.markdown
+++ b/website/docs/d/ebs_volumes.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "VPC"
+layout: "aws"
+page_title: "AWS: aws_ebs_volumes"
+description: |-
+    Provides identifying information for EBS volumes matching given criteria
+---
+
+# Data Source: aws_ebs_volumes
+
+`aws_ebs_volumes` provides identifying information for EBS volumes matching given criteria.
+
+This data source can be useful for getting a list of volume IDs with (for example) matching tags.
+
+## Example Usage
+
+The following demonstrates obtaining a map of availability zone to EBS volume ID for volumes with a given tag value.
+
+```hcl
+data "aws_ebs_volumes" "example" {
+  tags = {
+    VolumeSet = "TestVolumeSet"
+  }
+}
+
+data "aws_ebs_volume" "example" {
+  for_each = data.aws_ebs_volumes.example.ids
+  filter {
+    name = "volume-id"
+    values = [each.value]
+  }
+}
+
+output "availability_zone_to_volume_id" {
+  value = {for s in data.aws_ebs_volume.example : s.id => s.availability_zone}
+}
+```
+
+## Argument Reference
+
+* `filter` - (Optional) Custom filter block as described below.
+
+* `tags` - (Optional) A map of tags, each pair of which must exactly match
+  a pair on the desired volumes.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html).
+  For example, if matching against the `size` filter, use:
+
+```hcl
+data "aws_ebs_volumes" "ten_or_twenty_gb_volumes" {
+  filter {
+    name   = "size"
+    values = ["10", "20"]
+  }
+}
+```
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  EBS Volume IDs will be selected if any one of the given values match.
+
+## Attributes Reference
+
+* `ids` - A set of all the EBS Volume IDs found. This data source will fail if
+  no volumes match the provided criteria.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
*New Data Source:* `aws_ebs_volumes` 
```

## Description

This commit adds a new data source named `aws_ebs_volume_ids`, following the pattern established by `aws_subnet_ids`.

This allows querying a list of volume IDs given a set of filters or tags, which can then be used as inputs to a counted instance of `aws_ebs_volume`.

## Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEbsVolumeIDs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsEbsVolumeIDs -timeout 120m
=== RUN   TestAccDataSourceAwsEbsVolumeIDs
=== PAUSE TestAccDataSourceAwsEbsVolumeIDs
=== CONT  TestAccDataSourceAwsEbsVolumeIDs
--- PASS: TestAccDataSourceAwsEbsVolumeIDs (63.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	64.715s
...
```
