### PR TITLE
Add documentation for aws_db_snapshot timeouts

### DIFF
--- a/website/docs/r/db_snapshot.html.markdown
+++ b/website/docs/r/db_snapshot.html.markdown
@@ -62,6 +62,12 @@ In addition to all arguments above, the following attributes are exported:
 * `storage_type` - Specifies the storage type associated with DB snapshot.
 * `vpc_id` - Specifies the storage type associated with DB snapshot.
 
+## Timeouts
+
+`aws_db_snapshot` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `read` - (Default `20 minutes`)  Length of time to wait for the snapshot to become available
+
 ## Import
 
 `aws_db_snapshot` can be imported by using the snapshot identifier, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Summary

There is a configurable timeout for the `aws_db_snapshot` resource, but it wasn't documented.

This threw me because I kept hitting the default limit of 20 minutes, and had to dig into the code to realise that there was a configurable timeout[1].

[1] https://github.com/terraform-providers/terraform-provider-aws/blob/27f00164f7ee6b1a19b68a716d2cbd3a8c7aaee6/aws/resource_aws_db_snapshot.go#L25-L27
