### PR TITLE
Fix typo in EFS access point docs

### DIFF
--- a/website/docs/r/efs_access_point.html.markdown
+++ b/website/docs/r/efs_access_point.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 The `posix_user` block supports the following:
 
 * `gid` - (Required) The POSIX group ID used for all file system operations using this access point.
-* `uid` - (Required) he POSIX user ID used for all file system operations using this access point.
+* `uid` - (Required) The POSIX user ID used for all file system operations using this access point.
 * `secondary_gids` - (Optional) Secondary POSIX group IDs used for all file system operations using this access point.
 
 ### Root Directory


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
Fixes a typo in the EFS Access Point docs. Changes `he` to `the`. 