### PR TITLE
New Resource: aws_ec2_local_gateway_route_table_vpc_association

### DIFF
--- a/aws/internal/service/ec2/waiter/status.go
+++ b/aws/internal/service/ec2/waiter/status.go
@@ -1,0 +1,41 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// LocalGatewayRouteTableVpcAssociationState fetches the LocalGatewayRouteTableVpcAssociation and its State
+func LocalGatewayRouteTableVpcAssociationState(conn *ec2.EC2, localGatewayRouteTableVpcAssociationID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput{
+			LocalGatewayRouteTableVpcAssociationIds: aws.StringSlice([]string{localGatewayRouteTableVpcAssociationID}),
+		}
+
+		output, err := conn.DescribeLocalGatewayRouteTableVpcAssociations(input)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		var association *ec2.LocalGatewayRouteTableVpcAssociation
+
+		for _, outputAssociation := range output.LocalGatewayRouteTableVpcAssociations {
+			if outputAssociation == nil {
+				continue
+			}
+
+			if aws.StringValue(outputAssociation.LocalGatewayRouteTableVpcAssociationId) == localGatewayRouteTableVpcAssociationID {
+				association = outputAssociation
+				break
+			}
+		}
+
+		if association == nil {
+			return association, ec2.RouteTableAssociationStateCodeDisassociated, nil
+		}
+
+		return association, aws.StringValue(association.State), nil
+	}
+}

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -1,0 +1,52 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for a LocalGatewayRouteTableVpcAssociation to return Associated
+	LocalGatewayRouteTableVpcAssociationAssociatedTimeout = 5 * time.Minute
+
+	// Maximum amount of time to wait for a LocalGatewayRouteTableVpcAssociation to return Disassociated
+	LocalGatewayRouteTableVpcAssociationDisassociatedTimeout = 5 * time.Minute
+)
+
+// LocalGatewayRouteTableVpcAssociationAssociated waits for a LocalGatewayRouteTableVpcAssociation to return Associated
+func LocalGatewayRouteTableVpcAssociationAssociated(conn *ec2.EC2, localGatewayRouteTableVpcAssociationID string) (*ec2.LocalGatewayRouteTableVpcAssociation, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.RouteTableAssociationStateCodeAssociating},
+		Target:  []string{ec2.RouteTableAssociationStateCodeAssociated},
+		Refresh: LocalGatewayRouteTableVpcAssociationState(conn, localGatewayRouteTableVpcAssociationID),
+		Timeout: LocalGatewayRouteTableVpcAssociationAssociatedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.LocalGatewayRouteTableVpcAssociation); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// LocalGatewayRouteTableVpcAssociationDisassociated waits for a LocalGatewayRouteTableVpcAssociation to return Disassociated
+func LocalGatewayRouteTableVpcAssociationDisassociated(conn *ec2.EC2, localGatewayRouteTableVpcAssociationID string) (*ec2.LocalGatewayRouteTableVpcAssociation, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ec2.RouteTableAssociationStateCodeDisassociating},
+		Target:  []string{ec2.RouteTableAssociationStateCodeDisassociated},
+		Refresh: LocalGatewayRouteTableVpcAssociationState(conn, localGatewayRouteTableVpcAssociationID),
+		Timeout: LocalGatewayRouteTableVpcAssociationAssociatedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.LocalGatewayRouteTableVpcAssociation); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -535,6 +535,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ec2_capacity_reservation":                            resourceAwsEc2CapacityReservation(),
 			"aws_ec2_client_vpn_endpoint":                             resourceAwsEc2ClientVpnEndpoint(),
 			"aws_ec2_client_vpn_network_association":                  resourceAwsEc2ClientVpnNetworkAssociation(),
+			"aws_ec2_local_gateway_route_table_vpc_association":       resourceAwsEc2LocalGatewayRouteTableVpcAssociation(),
 			"aws_ec2_fleet":                                           resourceAwsEc2Fleet(),
 			"aws_ec2_tag":                                             resourceAwsEc2Tag(),
 			"aws_ec2_traffic_mirror_filter":                           resourceAwsEc2TrafficMirrorFilter(),

--- a/aws/resource_aws_ec2_local_gateway_route_table_vpc_association.go
+++ b/aws/resource_aws_ec2_local_gateway_route_table_vpc_association.go
@@ -1,0 +1,174 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter"
+)
+
+const (
+	// Missing constant in AWS Go SDK
+	ec2ResourceTypeLocalGatewayRouteTableVpcAssociation = "local-gateway-route-table-vpc-association"
+)
+
+func resourceAwsEc2LocalGatewayRouteTableVpcAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEc2LocalGatewayRouteTableVpcAssociationCreate,
+		Read:   resourceAwsEc2LocalGatewayRouteTableVpcAssociationRead,
+		Update: resourceAwsEc2LocalGatewayRouteTableVpcAssociationUpdate,
+		Delete: resourceAwsEc2LocalGatewayRouteTableVpcAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"local_gateway_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"local_gateway_route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"tags": tagsSchema(),
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEc2LocalGatewayRouteTableVpcAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.CreateLocalGatewayRouteTableVpcAssociationInput{
+		LocalGatewayRouteTableId: aws.String(d.Get("local_gateway_route_table_id").(string)),
+		TagSpecifications:        ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2ResourceTypeLocalGatewayRouteTableVpcAssociation),
+		VpcId:                    aws.String(d.Get("vpc_id").(string)),
+	}
+
+	output, err := conn.CreateLocalGatewayRouteTableVpcAssociation(req)
+
+	if err != nil {
+		return fmt.Errorf("error creating EC2 Local Gateway Route Table VPC Association: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.LocalGatewayRouteTableVpcAssociation.LocalGatewayRouteTableVpcAssociationId))
+
+	if _, err := waiter.LocalGatewayRouteTableVpcAssociationAssociated(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for EC2 Local Gateway Route Table VPC Association (%s) to associate: %w", d.Id(), err)
+	}
+
+	return resourceAwsEc2LocalGatewayRouteTableVpcAssociationRead(d, meta)
+}
+
+func resourceAwsEc2LocalGatewayRouteTableVpcAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	association, err := getEc2LocalGatewayRouteTableVpcAssociation(conn, d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error reading EC2 Local Gateway Route Table VPC Association (%s): %w", d.Id(), err)
+	}
+
+	if association == nil {
+		log.Printf("[WARN] EC2 Local Gateway Route Table VPC Association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if aws.StringValue(association.State) != ec2.RouteTableAssociationStateCodeAssociated {
+		log.Printf("[WARN] EC2 Local Gateway Route Table VPC Association (%s) status (%s), removing from state", d.Id(), aws.StringValue(association.State))
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("local_gateway_id", association.LocalGatewayId)
+	d.Set("local_gateway_route_table_id", association.LocalGatewayRouteTableId)
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(association.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	d.Set("vpc_id", association.VpcId)
+
+	return nil
+}
+
+func resourceAwsEc2LocalGatewayRouteTableVpcAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Local Gateway Route Table VPC Association (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsEc2LocalGatewayRouteTableVpcAssociationRead(d, meta)
+}
+
+func resourceAwsEc2LocalGatewayRouteTableVpcAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	input := &ec2.DeleteLocalGatewayRouteTableVpcAssociationInput{
+		LocalGatewayRouteTableVpcAssociationId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteLocalGatewayRouteTableVpcAssociation(input)
+
+	if isAWSErr(err, "InvalidLocalGatewayRouteTableVpcAssociationID.NotFound", "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting EC2 Local Gateway Route Table VPC Association (%s): %w", d.Id(), err)
+	}
+
+	if _, err := waiter.LocalGatewayRouteTableVpcAssociationDisassociated(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for EC2 Local Gateway Route Table VPC Association (%s) to disassociate: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func getEc2LocalGatewayRouteTableVpcAssociation(conn *ec2.EC2, localGatewayRouteTableVpcAssociationID string) (*ec2.LocalGatewayRouteTableVpcAssociation, error) {
+	input := &ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput{
+		LocalGatewayRouteTableVpcAssociationIds: aws.StringSlice([]string{localGatewayRouteTableVpcAssociationID}),
+	}
+
+	output, err := conn.DescribeLocalGatewayRouteTableVpcAssociations(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, fmt.Errorf("empty response")
+	}
+
+	var association *ec2.LocalGatewayRouteTableVpcAssociation
+
+	for _, outputAssociation := range output.LocalGatewayRouteTableVpcAssociations {
+		if outputAssociation == nil {
+			continue
+		}
+
+		if aws.StringValue(outputAssociation.LocalGatewayRouteTableVpcAssociationId) == localGatewayRouteTableVpcAssociationID {
+			association = outputAssociation
+			break
+		}
+	}
+
+	return association, nil
+}

--- a/aws/resource_aws_ec2_local_gateway_route_table_vpc_association_test.go
+++ b/aws/resource_aws_ec2_local_gateway_route_table_vpc_association_test.go
@@ -1,0 +1,245 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAwsEc2LocalGatewayRouteTableVpcAssociation_basic(t *testing.T) {
+	// Hide Outposts testing behind consistent environment variable
+	outpostArn := os.Getenv("AWS_OUTPOST_ARN")
+	if outpostArn == "" {
+		t.Skip(
+			"Environment variable AWS_OUTPOST_ARN is not set. " +
+				"This environment variable must be set to the ARN of " +
+				"a deployed Outpost to enable this test.")
+	}
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	localGatewayRouteTableDataSourceName := "data.aws_ec2_local_gateway_route_table.test"
+	resourceName := "aws_ec2_local_gateway_route_table_vpc_association.test"
+	vpcResourceName := "aws_vpc.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfig(rName, outpostArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "local_gateway_id", localGatewayRouteTableDataSourceName, "local_gateway_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "local_gateway_route_table_id", localGatewayRouteTableDataSourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsEc2LocalGatewayRouteTableVpcAssociation_disappears(t *testing.T) {
+	// Hide Outposts testing behind consistent environment variable
+	outpostArn := os.Getenv("AWS_OUTPOST_ARN")
+	if outpostArn == "" {
+		t.Skip(
+			"Environment variable AWS_OUTPOST_ARN is not set. " +
+				"This environment variable must be set to the ARN of " +
+				"a deployed Outpost to enable this test.")
+	}
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ec2_local_gateway_route_table_vpc_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfig(rName, outpostArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEc2LocalGatewayRouteTableVpcAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsEc2LocalGatewayRouteTableVpcAssociation_Tags(t *testing.T) {
+	// Hide Outposts testing behind consistent environment variable
+	outpostArn := os.Getenv("AWS_OUTPOST_ARN")
+	if outpostArn == "" {
+		t.Skip(
+			"Environment variable AWS_OUTPOST_ARN is not set. " +
+				"This environment variable must be set to the ARN of " +
+				"a deployed Outpost to enable this test.")
+	}
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ec2_local_gateway_route_table_vpc_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigTags1(rName, outpostArn, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigTags2(rName, outpostArn, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigTags1(rName, outpostArn, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No EC2 Fleet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		association, err := getEc2LocalGatewayRouteTableVpcAssociation(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if association == nil {
+			return fmt.Errorf("EC2 Local Gateway Route Table VPC Association (%s) not found", rs.Primary.ID)
+		}
+
+		if aws.StringValue(association.State) != ec2.RouteTableAssociationStateCodeAssociated {
+			return fmt.Errorf("EC2 Local Gateway Route Table VPC Association (%s) not in associated state: %s", rs.Primary.ID, aws.StringValue(association.State))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsEc2LocalGatewayRouteTableVpcAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ec2_local_gateway_route_table_vpc_association" {
+			continue
+		}
+
+		association, err := getEc2LocalGatewayRouteTableVpcAssociation(conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if association != nil && aws.StringValue(association.State) != ec2.RouteTableAssociationStateCodeDisassociated {
+			return fmt.Errorf("EC2 Local Gateway Route Table VPC Association (%s) still exists in state: %s", rs.Primary.ID, aws.StringValue(association.State))
+		}
+	}
+
+	return nil
+}
+
+func testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigBase(rName, outpostArn string) string {
+	return fmt.Sprintf(`
+data "aws_ec2_local_gateway_route_table" "test" {
+  outpost_arn = %[2]q
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, outpostArn)
+}
+
+func testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfig(rName, outpostArn string) string {
+	return composeConfig(
+		testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigBase(rName, outpostArn),
+		`
+resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.test.id
+  vpc_id                       = aws_vpc.test.id
+}
+`)
+}
+
+func testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigTags1(rName, outpostArn, tagKey1, tagValue1 string) string {
+	return composeConfig(
+		testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigBase(rName, outpostArn),
+		fmt.Sprintf(`
+resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.test.id
+  vpc_id                       = aws_vpc.test.id
+
+  tags = {
+    %[1]q = %[2]q
+  }
+}
+`, tagKey1, tagValue1))
+}
+
+func testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigTags2(rName, outpostArn, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return composeConfig(
+		testAccAwsEc2LocalGatewayRouteTableVpcAssociationConfigBase(rName, outpostArn),
+		fmt.Sprintf(`
+resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.test.id
+  vpc_id                       = aws_vpc.test.id
+
+  tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2))
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1211,6 +1211,9 @@
                                     <a href="/docs/providers/aws/r/ec2_client_vpn_network_association.html">aws_ec2_client_vpn_network_association</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/r/ec2_local_gateway_route_table_vpc_association.html">aws_ec2_local_gateway_route_table_vpc_association</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/r/ec2_fleet.html">aws_ec2_fleet</a>
                                 </li>
                                 <li>

--- a/website/docs/r/ec2_local_gateway_route_table_vpc_association.html.markdown
+++ b/website/docs/r/ec2_local_gateway_route_table_vpc_association.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "EC2"
+layout: "aws"
+page_title: "AWS: aws_ec2_local_gateway_route_table_vpc_association"
+description: |-
+  Manages an EC2 Local Gateway Route Table VPC Association
+---
+
+# Resource: aws_ec2_local_gateway_route_table_vpc_association
+
+Manages an EC2 Local Gateway Route Table VPC Association. More information can be found in the [Outposts User Guide](https://docs.aws.amazon.com/outposts/latest/userguide/outposts-local-gateways.html#vpc-associations).
+
+## Example Usage
+
+```hcl
+data "aws_ec2_local_gateway_route_table" "example" {
+  outpost_arn = "arn:aws:outposts:us-west-2:123456789012:outpost/op-1234567890abcdef"
+}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_ec2_local_gateway_route_table_vpc_association" "example" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.example.id
+  vpc_id                       = aws_vpc.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `local_gateway_route_table_id` - (Required) Identifier of EC2 Local Gateway Route Table.
+* `vpc_id` - (Required) Identifier of EC2 VPC.
+
+The following arguments are optional:
+
+* `tags` - (Optional) Key-value map of resource tags.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Identifier of EC2 Local Gateway Route Table VPC Association.
+
+## Import
+
+`aws_ec2_local_gateway_route_table_vpc_association` can be imported by using the Local Gateway Route Table VPC Association identifier, e.g.
+
+```
+$ terraform import aws_ec2_local_gateway_route_table_vpc_association.example lgw-vpc-assoc-1234567890abcdef
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13501

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_ec2_local_gateway_route_table_vpc_association`
```

Output from acceptance testing:

```
--- PASS: TestAccAwsEc2LocalGatewayRouteTableVpcAssociation_basic (35.14s)
--- PASS: TestAccAwsEc2LocalGatewayRouteTableVpcAssociation_disappears (37.27s)
--- PASS: TestAccAwsEc2LocalGatewayRouteTableVpcAssociation_Tags (74.40s)
```
