### PR TITLE
aws_ec2_client_vpn_endpoint: add federated auth

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -71,7 +71,14 @@ func resourceAwsEc2ClientVpnEndpoint() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								ec2.ClientVpnAuthenticationTypeCertificateAuthentication,
 								ec2.ClientVpnAuthenticationTypeDirectoryServiceAuthentication,
+								ec2.ClientVpnAuthenticationTypeFederatedAuthentication,
 							}, false),
+						},
+						"saml_provider_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validateArn,
 						},
 						"active_directory_id": {
 							Type:     schema.TypeString,
@@ -366,6 +373,9 @@ func flattenAuthOptsConfig(aopts []*ec2.ClientVpnAuthentication) []map[string]in
 		if aopt.MutualAuthentication != nil {
 			r["root_certificate_chain_arn"] = aws.StringValue(aopt.MutualAuthentication.ClientRootCertificateChain)
 		}
+		if aopt.FederatedAuthentication != nil {
+			r["saml_provider_arn"] = aws.StringValue(aopt.FederatedAuthentication.SamlProviderArn)
+		}
 		if aopt.ActiveDirectory != nil {
 			r["active_directory_id"] = aws.StringValue(aopt.ActiveDirectory.DirectoryId)
 		}
@@ -388,6 +398,12 @@ func expandEc2ClientVpnAuthenticationRequest(data map[string]interface{}) *ec2.C
 	if data["type"].(string) == ec2.ClientVpnAuthenticationTypeDirectoryServiceAuthentication {
 		req.ActiveDirectory = &ec2.DirectoryServiceAuthenticationRequest{
 			DirectoryId: aws.String(data["active_directory_id"].(string)),
+		}
+	}
+
+	if data["type"].(string) == ec2.ClientVpnAuthenticationTypeFederatedAuthentication {
+		req.FederatedAuthentication = &ec2.FederatedAuthenticationRequest{
+			SAMLProviderArn: aws.String(data["saml_provider_arn"].(string)),
 		}
 	}
 


### PR DESCRIPTION
While AWS *can* act as an SSO IdP, I don't think there's a public API for
enabling it. Automated testing might be troublesome.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13401

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_ec2_client_vpn_endpoint: add SAML SSO IdP federated authentication support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsEc2ClientVpnEndpoint'

...
```
