### PR TITLE
feature(sagemaker notebook): Add support for DefaultCodeRepository

### DIFF
--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -85,6 +85,12 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 				}, false),
 			},
 
+			"default_code_repository": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -104,6 +110,10 @@ func resourceAwsSagemakerNotebookInstanceCreate(d *schema.ResourceData, meta int
 
 	if v, ok := d.GetOk("direct_internet_access"); ok {
 		createOpts.DirectInternetAccess = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("default_code_repository"); ok {
+		createOpts.DefaultCodeRepository = aws.String(v.(string))
 	}
 
 	if s, ok := d.GetOk("subnet_id"); ok {
@@ -197,6 +207,10 @@ func resourceAwsSagemakerNotebookInstanceRead(d *schema.ResourceData, meta inter
 
 	if err := d.Set("direct_internet_access", notebookInstance.DirectInternetAccess); err != nil {
 		return fmt.Errorf("error setting direct_internet_access for sagemaker notebook instance (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("default_code_repository", notebookInstance.DefaultCodeRepository); err != nil {
+		return fmt.Errorf("error setting default_code_repository for sagemaker notebook instance (%s): %s", d.Id(), err)
 	}
 
 	tags, err := keyvaluetags.SagemakerListTags(conn, aws.StringValue(notebookInstance.NotebookInstanceArn))

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -368,6 +368,42 @@ func testAccCheckAWSSagemakerNotebookDirectInternetAccess(notebook *sagemaker.De
 	}
 }
 
+func TestAccAWSSagemakerNotebookInstance_default_code_repository(t *testing.T) {
+	var notebook sagemaker.DescribeNotebookInstanceOutput
+	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
+	var resourceName = "aws_sagemaker_notebook_instance.foo"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerNotebookInstanceConfigDefaultCodeRepository(notebookName, "https://github.com/terraform-providers/terraform-provider-aws.git"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerNotebookDefaultCodeRepository(&notebook, "https://github.com/terraform-providers/terraform-provider-aws.git"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSagemakerNotebookDefaultCodeRepository(notebook *sagemaker.DescribeNotebookInstanceOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		defaultCodeRepository := notebook.DefaultCodeRepository
+		if *defaultCodeRepository != expected {
+			return fmt.Errorf("default_code_repository setting is incorrect: %s", *notebook.DefaultCodeRepository)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckAWSSagemakerNotebookInstanceTags(notebook *sagemaker.DescribeNotebookInstanceOutput, key string, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
@@ -592,4 +628,54 @@ resource "aws_subnet" "sagemaker" {
   }
 }
 `, notebookName, directInternetAccess)
+}
+
+func testAccAWSSagemakerNotebookInstanceConfigDefaultCodeRepository(notebookName string, defaultCodeRepository string) string {
+	return fmt.Sprintf(`
+resource "aws_sagemaker_notebook_instance" "foo" {
+	name = %[1]q
+	role_arn = aws_iam_role.foo.arn
+	instance_type = "ml.t2.medium"
+	security_groups = [aws_security_group.test.id]
+	subnet_id = aws_subnet.sagemaker.id
+	default_code_repository = %[2]q
+}
+
+resource "aws_iam_role" "foo" {
+	name = %[1]q
+	path = "/"
+	assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "aws_iam_policy_document" "assume_role" {
+	statement {
+		actions = [ "sts:AssumeRole" ]
+		principals {
+			type = "Service"
+			identifiers = [ "sagemaker.amazonaws.com" ]
+		}
+	}
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-sagemaker-notebook-instance-default-code-repository"
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_subnet" "sagemaker" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.0.0/24"
+
+  tags = {
+    Name = "tf-acc-test-sagemaker-notebook-instance-default-code-repository"
+  }
+}
+`, notebookName, defaultCodeRepository)
 }

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -38,6 +38,7 @@ The following arguments are supported:
 * `kms_key_id` - (Optional) The AWS Key Management Service (AWS KMS) key that Amazon SageMaker uses to encrypt the model artifacts at rest using Amazon S3 server-side encryption.
 * `lifecycle_config_name` - (Optional) The name of a lifecycle configuration to associate with the notebook instance.
 * `direct_internet_access` - (Optional) Set to `Disabled` to disable internet access to notebook. Requires `security_groups` and `subnet_id` to be set. Supported values: `Enabled` (Default) or `Disabled`. If set to `Disabled`, the notebook instance will be able to access resources only in your VPC, and will not be able to connect to Amazon SageMaker training and endpoint services unless your configure a NAT Gateway in your VPC.
+* `default_code_repository` - (Optional) The Git repository associated with the notebook instance as its default code repository
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #8959

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add default_code_repository option to Sagemaker Notebook Instance resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance_default_code_repository'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSSagemakerNotebookInstance_default_code_repository -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSagemakerNotebookInstance_default_code_repository
=== PAUSE TestAccAWSSagemakerNotebookInstance_default_code_repository
=== CONT  TestAccAWSSagemakerNotebookInstance_default_code_repository
--- PASS: TestAccAWSSagemakerNotebookInstance_default_code_repository (404.79s)
```
