### PR TITLE
tech-debt/import_security_group: no longer return default nil in error param

### DIFF
--- a/aws/import_aws_security_group.go
+++ b/aws/import_aws_security_group.go
@@ -44,10 +44,7 @@ func resourceAwsSecurityGroupImportState(
 	}
 	for ruleType, perms := range permMap {
 		for _, perm := range perms {
-			ds, err := resourceAwsSecurityGroupImportStatePerm(sg, ruleType, perm)
-			if err != nil {
-				return nil, err
-			}
+			ds := resourceAwsSecurityGroupImportStatePerm(sg, ruleType, perm)
 			results = append(results, ds...)
 		}
 	}
@@ -55,7 +52,7 @@ func resourceAwsSecurityGroupImportState(
 	return results, nil
 }
 
-func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType string, perm *ec2.IpPermission) ([]*schema.ResourceData, error) {
+func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType string, perm *ec2.IpPermission) []*schema.ResourceData {
 	/*
 	   Create a separate Security Group Rule for:
 	   * The collection of IpRanges (cidr_blocks)
@@ -128,7 +125,7 @@ func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType str
 		result = append(result, r)
 	}
 
-	return result, nil
+	return result
 }
 
 func resourceAwsSecurityGroupImportStatePermPair(sg *ec2.SecurityGroup, ruleType string, perm *ec2.IpPermission) *schema.ResourceData {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13278

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
import_security_group: remove error return param in resourceAwsSecurityGroupImportStatePerm func
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (4.46s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (5.38s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (19.12s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (20.81s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (25.34s)
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (29.90s)
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (30.42s)
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (30.42s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (31.98s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (32.22s)
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (32.32s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (37.75s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id (39.25s)
--- PASS: TestAccAWSSecurityGroupRule_Egress (40.46s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts (39.68s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts (40.68s)
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (48.12s)
--- PASS: TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash (30.11s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (54.00s)
--- PASS: TestAccAWSSecurityGroup_allowAll (38.67s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (68.03s)
--- PASS: TestAccAWSSecurityGroup_IPRangeAndSecurityGroupWithSameRules (44.68s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (75.41s)
--- PASS: TestAccAWSSecurityGroup_basic (44.33s)
--- PASS: TestAccAWSSecurityGroup_sourceSecurityGroup (48.39s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (79.89s)
--- PASS: TestAccAWSSecurityGroup_vpc (30.99s)
--- SKIP: TestAccAWSSecurityGroup_defaultEgressClassic (1.13s)
--- PASS: TestAccAWSSecurityGroup_IPRangesWithSameRules (53.42s)
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (1.96s)
--- PASS: TestAccAWSSecurityGroup_ipv6 (46.32s)
--- PASS: TestAccAWSSecurityGroup_drift (14.42s)
--- PASS: TestAccAWSSecurityGroup_ingressConfigMode (70.81s)
--- SKIP: TestAccAWSSecurityGroup_ingressWithCidrAndSGsClassic (1.06s)
--- PASS: TestAccAWSSecurityGroup_self (56.49s)
--- PASS: TestAccAWSSecurityGroup_egressConfigMode (72.76s)
--- PASS: TestAccAWSSecurityGroup_vpcProtoNumIngress (44.92s)
--- PASS: TestAccAWSSecurityGroup_generatedName (35.20s)
--- PASS: TestAccAWSSecurityGroup_vpcNegOneIngress (61.32s)
--- PASS: TestAccAWSSecurityGroup_namePrefix (69.80s)
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (99.62s)
--- PASS: TestAccAWSSecurityGroup_driftComplex (53.11s)
--- PASS: TestAccAWSSecurityGroup_change (60.91s)
--- PASS: TestAccAWSSecurityGroup_ingressWithCidrAndSGsVPC (42.17s)
--- PASS: TestAccAWSSecurityGroup_ruleGathering (100.42s)
--- PASS: TestAccAWSSecurityGroup_failWithDiffMismatch (37.31s)
--- PASS: TestAccAWSSecurityGroup_egressWithPrefixList (49.29s)
--- PASS: TestAccAWSSecurityGroup_CIDRandGroups (67.47s)
--- PASS: TestAccAWSSecurityGroup_tags (85.02s)
--- PASS: TestAccAWSSecurityGroup_defaultEgressVPC (93.18s)
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (68.12s)
--- PASS: TestAccAWSSecurityGroup_ruleDescription (98.69s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAppend (64.23s)
--- PASS: TestAccAWSSecurityGroup_rulesDropOnError (46.50s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitCidrBlockExceededAppend (68.28s)
--- PASS: TestAccAWSSecurityGroup_ingressWithPrefixList (79.14s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededPrepend (70.01s)
--- PASS: TestAccAWSSecurityGroup_multiIngress (119.19s)
--- PASS: TestAccAWSSecurityGroup_ruleLimitExceededAllNew (70.40s)
--- PASS: TestAccAWSSecurityGroupRule_Race (203.34s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesTrue (674.93s)
--- PASS: TestAccAWSSecurityGroup_forceRevokeRulesFalse (676.89s)
```
