### PR TITLE
TypeSetCheck: Treat unset values as matched

### DIFF
--- a/aws/internal/tfawsresource/testing.go
+++ b/aws/internal/tfawsresource/testing.go
@@ -17,6 +17,14 @@ const (
 // into a TypeSet. The function verifies that an element matches the whole value
 // map.
 //
+// You may check for unset keys, however this will also match keys set to empty
+// string. Please provide a map with at least 1 non-empty value.
+//
+//   map[string]string{
+//	     "key1": "value",
+//       "key2": "",
+//   }
+//
 // Use this function over SDK provided TestCheckFunctions when validating a
 // TypeSet where its elements are a nested object with their own attrs/values.
 //

--- a/aws/internal/tfawsresource/testing_test.go
+++ b/aws/internal/tfawsresource/testing_test.go
@@ -521,6 +521,41 @@ func TestTestCheckTypeSetElemNestedAttrs(t *testing.T) {
 			},
 		},
 		{
+			Description:       "value map has no non-empty values",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values:            map[string]string{"key": ""},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "has no non-empty values")
+			},
+		},
+		{
 			Description:       "attribute path does not end with sentinel value",
 			ResourceAddress:   "example_thing.test",
 			ResourceAttribute: "test",
@@ -559,7 +594,7 @@ func TestTestCheckTypeSetElemNestedAttrs(t *testing.T) {
 			Description:       "attribute not found",
 			ResourceAddress:   "example_thing.test",
 			ResourceAttribute: "test.*",
-			Values:            map[string]string{},
+			Values:            map[string]string{"key": "value"},
 			TerraformState: &terraform.State{
 				Version: 3,
 				Modules: []*terraform.ModuleState{
@@ -769,6 +804,46 @@ func TestTestCheckTypeSetElemNestedAttrs(t *testing.T) {
 										"test.%":          "1",
 										"test.12345.key1": "value1",
 										"test.12345.key2": "value2",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute unset/empty value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]string{
+				"key1": "value1",
+				"key2": "",
+				"key3": "",
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":               "4",
+										"id":              "11111",
+										"test.%":          "1",
+										"test.12345.key1": "value1",
+										"test.12345.key2": "",
+										// key3 is unset
 									},
 								},
 							},


### PR DESCRIPTION
This allows matching Set elements where a key was deliberately unset (therefore not present in state). You must however, provide a value map with at least 1 non-empty value.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13556 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
/usr/local/bin/go test -timeout 30s github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource -run ^(TestTestCheckTypeSetElemAttr|TestTestCheckTypeSetElemNestedAttrs)$

ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource
```
