### PR TITLE
r/aws_apigatewayv2_stage: 'data_trace_enabled' and 'logging_level' are only valid for WebSocket APIs

### DIFF
--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"strings"
@@ -9,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/apigatewayv2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
@@ -57,6 +55,10 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"api_protocol_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -97,13 +99,7 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 								apigatewayv2.LoggingLevelInfo,
 								apigatewayv2.LoggingLevelOff,
 							}, false),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// Not set for HTTP APIs.
-								if d.Id() != "" && old == "" && new == apigatewayv2.LoggingLevelOff {
-									return true
-								}
-								return false
-							},
+							DiffSuppressFunc: suppressIfApigatewayv2ProtocolType(apigatewayv2.ProtocolTypeHttp),
 						},
 						"throttling_burst_limit": {
 							Type:     schema.TypeInt,
@@ -164,13 +160,7 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 								apigatewayv2.LoggingLevelInfo,
 								apigatewayv2.LoggingLevelOff,
 							}, false),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// Not set for HTTP APIs.
-								if d.Id() != "" && old == "" && new == apigatewayv2.LoggingLevelOff {
-									return true
-								}
-								return false
-							},
+							DiffSuppressFunc: suppressIfApigatewayv2ProtocolType(apigatewayv2.ProtocolTypeHttp),
 						},
 						"route_key": {
 							Type:     schema.TypeString,
@@ -186,7 +176,6 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 						},
 					},
 				},
-				Set: apiGatewayV2RouteSettingsHash,
 			},
 			"stage_variables": {
 				Type:     schema.TypeMap,
@@ -247,6 +236,7 @@ func resourceAwsApiGatewayV2StageCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	d.SetId(aws.StringValue(resp.StageName))
+	d.Set("api_protocol_type", protocolType)
 
 	return resourceAwsApiGatewayV2StageRead(d, meta)
 }
@@ -303,14 +293,7 @@ func resourceAwsApiGatewayV2StageRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
-	apiOutput, err := conn.GetApi(&apigatewayv2.GetApiInput{
-		ApiId: aws.String(apiId),
-	})
-	if err != nil {
-		return fmt.Errorf("error reading API Gateway v2 API (%s): %s", apiId, err)
-	}
-
-	switch aws.StringValue(apiOutput.ProtocolType) {
+	switch d.Get("api_protocol_type").(string) {
 	case apigatewayv2.ProtocolTypeWebsocket:
 		executionArn := arn.ARN{
 			Partition: meta.(*AWSClient).partition,
@@ -339,19 +322,10 @@ func resourceAwsApiGatewayV2StageUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChanges("access_log_settings", "auto_deploy", "client_certificate_id",
 		"default_route_settings", "deployment_id", "description",
 		"route_settings", "stage_variables") {
-		apiId := d.Get("api_id").(string)
-
-		apiOutput, err := conn.GetApi(&apigatewayv2.GetApiInput{
-			ApiId: aws.String(apiId),
-		})
-		if err != nil {
-			return fmt.Errorf("error reading API Gateway v2 API (%s): %s", apiId, err)
-		}
-
-		protocolType := aws.StringValue(apiOutput.ProtocolType)
+		protocolType := d.Get("api_protocol_type").(string)
 
 		req := &apigatewayv2.UpdateStageInput{
-			ApiId:     aws.String(apiId),
+			ApiId:     aws.String(d.Get("api_id").(string)),
 			StageName: aws.String(d.Id()),
 		}
 		if d.HasChange("access_log_settings") {
@@ -390,7 +364,7 @@ func resourceAwsApiGatewayV2StageUpdate(d *schema.ResourceData, meta interface{}
 		}
 
 		log.Printf("[DEBUG] Updating API Gateway v2 stage: %s", req)
-		_, err = conn.UpdateStage(req)
+		_, err := conn.UpdateStage(req)
 		if err != nil {
 			return fmt.Errorf("error updating API Gateway v2 stage (%s): %s", d.Id(), err)
 		}
@@ -447,8 +421,16 @@ func resourceAwsApiGatewayV2StageImport(d *schema.ResourceData, meta interface{}
 		return nil, fmt.Errorf("API Gateway v2 stage (%s) was created via quick create", stageName)
 	}
 
+	apiOutput, err := conn.GetApi(&apigatewayv2.GetApiInput{
+		ApiId: aws.String(apiId),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error reading API Gateway v2 API (%s): %s", apiId, err)
+	}
+
 	d.SetId(stageName)
 	d.Set("api_id", apiId)
+	d.Set("api_protocol_type", apiOutput.ProtocolType)
 
 	return []*schema.ResourceData{d}, nil
 }
@@ -531,20 +513,20 @@ func expandApiGatewayV2RouteSettings(vSettings *schema.Set, protocolType string)
 
 		mSettings := v.(map[string]interface{})
 
-		if v, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType == apigatewayv2.ProtocolTypeWebsocket {
-			routeSettings.DataTraceEnabled = aws.Bool(v)
+		if vDataTraceEnabled, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType == apigatewayv2.ProtocolTypeWebsocket {
+			routeSettings.DataTraceEnabled = aws.Bool(vDataTraceEnabled)
 		}
-		if v, ok := mSettings["detailed_metrics_enabled"].(bool); ok {
-			routeSettings.DetailedMetricsEnabled = aws.Bool(v)
+		if vDetailedMetricsEnabled, ok := mSettings["detailed_metrics_enabled"].(bool); ok {
+			routeSettings.DetailedMetricsEnabled = aws.Bool(vDetailedMetricsEnabled)
 		}
-		if v, ok := mSettings["logging_level"].(string); ok && v != "" && protocolType == apigatewayv2.ProtocolTypeWebsocket {
-			routeSettings.LoggingLevel = aws.String(v)
+		if vLoggingLevel, ok := mSettings["logging_level"].(string); ok && vLoggingLevel != "" && protocolType == apigatewayv2.ProtocolTypeWebsocket {
+			routeSettings.LoggingLevel = aws.String(vLoggingLevel)
 		}
-		if v, ok := mSettings["throttling_burst_limit"].(int); ok {
-			routeSettings.ThrottlingBurstLimit = aws.Int64(int64(v))
+		if vThrottlingBurstLimit, ok := mSettings["throttling_burst_limit"].(int); ok {
+			routeSettings.ThrottlingBurstLimit = aws.Int64(int64(vThrottlingBurstLimit))
 		}
-		if v, ok := mSettings["throttling_rate_limit"].(float64); ok {
-			routeSettings.ThrottlingRateLimit = aws.Float64(v)
+		if vThrottlingRateLimit, ok := mSettings["throttling_rate_limit"].(float64); ok {
+			routeSettings.ThrottlingRateLimit = aws.Float64(vThrottlingRateLimit)
 		}
 
 		settings[mSettings["route_key"].(string)] = routeSettings
@@ -553,7 +535,7 @@ func expandApiGatewayV2RouteSettings(vSettings *schema.Set, protocolType string)
 	return settings
 }
 
-func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSettings) *schema.Set {
+func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSettings) []interface{} {
 	vSettings := []interface{}{}
 
 	for k, routeSetting := range settings {
@@ -567,32 +549,13 @@ func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSet
 		})
 	}
 
-	return schema.NewSet(apiGatewayV2RouteSettingsHash, vSettings)
+	return vSettings
 }
 
-func apiGatewayV2RouteSettingsHash(vSettings interface{}) int {
-	var buf bytes.Buffer
-
-	mSettings := vSettings.(map[string]interface{})
-
-	if v, ok := mSettings["route_key"].(string); ok {
-		buf.WriteString(fmt.Sprintf("%s-", v))
+// suppressIfApigatewayv2ProtocolType suppresses attribute differences
+// if the API protocol type is the specified value.
+func suppressIfApigatewayv2ProtocolType(t string) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		return d.Get("api_protocol_type").(string) == t
 	}
-	if v, ok := mSettings["data_trace_enabled"].(bool); ok {
-		buf.WriteString(fmt.Sprintf("%t-", v))
-	}
-	if v, ok := mSettings["detailed_metrics_enabled"].(bool); ok {
-		buf.WriteString(fmt.Sprintf("%t-", v))
-	}
-	if v, ok := mSettings["logging_level"].(string); ok {
-		buf.WriteString(fmt.Sprintf("%s-", v))
-	}
-	if v, ok := mSettings["throttling_burst_limit"].(int); ok {
-		buf.WriteString(fmt.Sprintf("%d-", v))
-	}
-	if v, ok := mSettings["throttling_rate_limit"].(float64); ok {
-		buf.WriteString(fmt.Sprintf("%g-", v))
-	}
-
-	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -164,6 +164,13 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 								apigatewayv2.LoggingLevelInfo,
 								apigatewayv2.LoggingLevelOff,
 							}, false),
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// Not set for HTTP APIs.
+								if old == "" && new == apigatewayv2.LoggingLevelOff {
+									return true
+								}
+								return false
+							},
 						},
 						"route_key": {
 							Type:     schema.TypeString,
@@ -194,8 +201,19 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 func resourceAwsApiGatewayV2StageCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigatewayv2conn
 
+	apiId := d.Get("api_id").(string)
+
+	apiOutput, err := conn.GetApi(&apigatewayv2.GetApiInput{
+		ApiId: aws.String(apiId),
+	})
+	if err != nil {
+		return fmt.Errorf("error reading API Gateway v2 API (%s): %s", apiId, err)
+	}
+
+	protocolType := aws.StringValue(apiOutput.ProtocolType)
+
 	req := &apigatewayv2.CreateStageInput{
-		ApiId:      aws.String(d.Get("api_id").(string)),
+		ApiId:      aws.String(apiId),
 		AutoDeploy: aws.Bool(d.Get("auto_deploy").(bool)),
 		StageName:  aws.String(d.Get("name").(string)),
 		Tags:       keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().Apigatewayv2Tags(),
@@ -207,7 +225,7 @@ func resourceAwsApiGatewayV2StageCreate(d *schema.ResourceData, meta interface{}
 		req.ClientCertificateId = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("default_route_settings"); ok {
-		req.DefaultRouteSettings = expandApiGatewayV2DefaultRouteSettings(v.([]interface{}))
+		req.DefaultRouteSettings = expandApiGatewayV2DefaultRouteSettings(v.([]interface{}), protocolType)
 	}
 	if v, ok := d.GetOk("deployment_id"); ok {
 		req.DeploymentId = aws.String(v.(string))
@@ -216,7 +234,7 @@ func resourceAwsApiGatewayV2StageCreate(d *schema.ResourceData, meta interface{}
 		req.Description = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("route_settings"); ok {
-		req.RouteSettings = expandApiGatewayV2RouteSettings(v.(*schema.Set))
+		req.RouteSettings = expandApiGatewayV2RouteSettings(v.(*schema.Set), protocolType)
 	}
 	if v, ok := d.GetOk("stage_variables"); ok {
 		req.StageVariables = stringMapToPointers(v.(map[string]interface{}))
@@ -321,8 +339,19 @@ func resourceAwsApiGatewayV2StageUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChanges("access_log_settings", "auto_deploy", "client_certificate_id",
 		"default_route_settings", "deployment_id", "description",
 		"route_settings", "stage_variables") {
+		apiId := d.Get("api_id").(string)
+
+		apiOutput, err := conn.GetApi(&apigatewayv2.GetApiInput{
+			ApiId: aws.String(apiId),
+		})
+		if err != nil {
+			return fmt.Errorf("error reading API Gateway v2 API (%s): %s", apiId, err)
+		}
+
+		protocolType := aws.StringValue(apiOutput.ProtocolType)
+
 		req := &apigatewayv2.UpdateStageInput{
-			ApiId:     aws.String(d.Get("api_id").(string)),
+			ApiId:     aws.String(apiId),
 			StageName: aws.String(d.Id()),
 		}
 		if d.HasChange("access_log_settings") {
@@ -335,7 +364,7 @@ func resourceAwsApiGatewayV2StageUpdate(d *schema.ResourceData, meta interface{}
 			req.ClientCertificateId = aws.String(d.Get("client_certificate_id").(string))
 		}
 		if d.HasChange("default_route_settings") {
-			req.DefaultRouteSettings = expandApiGatewayV2DefaultRouteSettings(d.Get("default_route_settings").([]interface{}))
+			req.DefaultRouteSettings = expandApiGatewayV2DefaultRouteSettings(d.Get("default_route_settings").([]interface{}), protocolType)
 		}
 		if d.HasChange("deployment_id") {
 			req.DeploymentId = aws.String(d.Get("deployment_id").(string))
@@ -344,7 +373,7 @@ func resourceAwsApiGatewayV2StageUpdate(d *schema.ResourceData, meta interface{}
 			req.Description = aws.String(d.Get("description").(string))
 		}
 		if d.HasChange("route_settings") {
-			req.RouteSettings = expandApiGatewayV2RouteSettings(d.Get("route_settings").(*schema.Set))
+			req.RouteSettings = expandApiGatewayV2RouteSettings(d.Get("route_settings").(*schema.Set), protocolType)
 		}
 		if d.HasChange("stage_variables") {
 			o, n := d.GetChange("stage_variables")
@@ -361,7 +390,7 @@ func resourceAwsApiGatewayV2StageUpdate(d *schema.ResourceData, meta interface{}
 		}
 
 		log.Printf("[DEBUG] Updating API Gateway v2 stage: %s", req)
-		_, err := conn.UpdateStage(req)
+		_, err = conn.UpdateStage(req)
 		if err != nil {
 			return fmt.Errorf("error updating API Gateway v2 stage (%s): %s", d.Id(), err)
 		}
@@ -453,7 +482,7 @@ func flattenApiGatewayV2AccessLogSettings(settings *apigatewayv2.AccessLogSettin
 	}}
 }
 
-func expandApiGatewayV2DefaultRouteSettings(vSettings []interface{}) *apigatewayv2.RouteSettings {
+func expandApiGatewayV2DefaultRouteSettings(vSettings []interface{}, protocolType string) *apigatewayv2.RouteSettings {
 	routeSettings := &apigatewayv2.RouteSettings{}
 
 	if len(vSettings) == 0 || vSettings[0] == nil {
@@ -461,13 +490,13 @@ func expandApiGatewayV2DefaultRouteSettings(vSettings []interface{}) *apigateway
 	}
 	mSettings := vSettings[0].(map[string]interface{})
 
-	if vDataTraceEnabled, ok := mSettings["data_trace_enabled"].(bool); ok {
+	if vDataTraceEnabled, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType == apigatewayv2.ProtocolTypeWebsocket {
 		routeSettings.DataTraceEnabled = aws.Bool(vDataTraceEnabled)
 	}
 	if vDetailedMetricsEnabled, ok := mSettings["detailed_metrics_enabled"].(bool); ok {
 		routeSettings.DetailedMetricsEnabled = aws.Bool(vDetailedMetricsEnabled)
 	}
-	if vLoggingLevel, ok := mSettings["logging_level"].(string); ok && vLoggingLevel != "" {
+	if vLoggingLevel, ok := mSettings["logging_level"].(string); ok && vLoggingLevel != "" && protocolType == apigatewayv2.ProtocolTypeWebsocket {
 		routeSettings.LoggingLevel = aws.String(vLoggingLevel)
 	}
 	if vThrottlingBurstLimit, ok := mSettings["throttling_burst_limit"].(int); ok {
@@ -494,7 +523,7 @@ func flattenApiGatewayV2DefaultRouteSettings(routeSettings *apigatewayv2.RouteSe
 	}}
 }
 
-func expandApiGatewayV2RouteSettings(vSettings *schema.Set) map[string]*apigatewayv2.RouteSettings {
+func expandApiGatewayV2RouteSettings(vSettings *schema.Set, protocolType string) map[string]*apigatewayv2.RouteSettings {
 	settings := map[string]*apigatewayv2.RouteSettings{}
 
 	for _, v := range vSettings.List() {
@@ -502,13 +531,13 @@ func expandApiGatewayV2RouteSettings(vSettings *schema.Set) map[string]*apigatew
 
 		mSettings := v.(map[string]interface{})
 
-		if v, ok := mSettings["data_trace_enabled"].(bool); ok {
+		if v, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType == apigatewayv2.ProtocolTypeWebsocket {
 			routeSettings.DataTraceEnabled = aws.Bool(v)
 		}
 		if v, ok := mSettings["detailed_metrics_enabled"].(bool); ok {
 			routeSettings.DetailedMetricsEnabled = aws.Bool(v)
 		}
-		if v, ok := mSettings["logging_level"].(string); ok {
+		if v, ok := mSettings["logging_level"].(string); ok && v != "" && protocolType == apigatewayv2.ProtocolTypeWebsocket {
 			routeSettings.LoggingLevel = aws.String(v)
 		}
 		if v, ok := mSettings["throttling_burst_limit"].(int); ok {

--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -81,9 +81,10 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"data_trace_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
+							Type:             schema.TypeBool,
+							Optional:         true,
+							Default:          false,
+							DiffSuppressFunc: suppressIfApigatewayv2ProtocolType(apigatewayv2.ProtocolTypeHttp),
 						},
 						"detailed_metrics_enabled": {
 							Type:     schema.TypeBool,
@@ -142,9 +143,10 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"data_trace_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
+							Type:             schema.TypeBool,
+							Optional:         true,
+							Default:          false,
+							DiffSuppressFunc: suppressIfApigatewayv2ProtocolType(apigatewayv2.ProtocolTypeHttp),
 						},
 						"detailed_metrics_enabled": {
 							Type:     schema.TypeBool,
@@ -245,6 +247,8 @@ func resourceAwsApiGatewayV2StageRead(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).apigatewayv2conn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
+	protocolType := d.Get("api_protocol_type").(string)
+
 	apiId := d.Get("api_id").(string)
 	resp, err := conn.GetStage(&apigatewayv2.GetStageInput{
 		ApiId:     aws.String(apiId),
@@ -281,7 +285,7 @@ func resourceAwsApiGatewayV2StageRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("deployment_id", resp.DeploymentId)
 	d.Set("description", resp.Description)
 	d.Set("name", stageName)
-	err = d.Set("route_settings", flattenApiGatewayV2RouteSettings(resp.RouteSettings))
+	err = d.Set("route_settings", flattenApiGatewayV2RouteSettings(resp.RouteSettings, protocolType))
 	if err != nil {
 		return fmt.Errorf("error setting route_settings: %s", err)
 	}
@@ -293,7 +297,7 @@ func resourceAwsApiGatewayV2StageRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 
-	switch d.Get("api_protocol_type").(string) {
+	switch protocolType {
 	case apigatewayv2.ProtocolTypeWebsocket:
 		executionArn := arn.ARN{
 			Partition: meta.(*AWSClient).partition,
@@ -472,13 +476,13 @@ func expandApiGatewayV2DefaultRouteSettings(vSettings []interface{}, protocolTyp
 	}
 	mSettings := vSettings[0].(map[string]interface{})
 
-	if vDataTraceEnabled, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType == apigatewayv2.ProtocolTypeWebsocket {
+	if vDataTraceEnabled, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType != apigatewayv2.ProtocolTypeHttp {
 		routeSettings.DataTraceEnabled = aws.Bool(vDataTraceEnabled)
 	}
 	if vDetailedMetricsEnabled, ok := mSettings["detailed_metrics_enabled"].(bool); ok {
 		routeSettings.DetailedMetricsEnabled = aws.Bool(vDetailedMetricsEnabled)
 	}
-	if vLoggingLevel, ok := mSettings["logging_level"].(string); ok && vLoggingLevel != "" && protocolType == apigatewayv2.ProtocolTypeWebsocket {
+	if vLoggingLevel, ok := mSettings["logging_level"].(string); ok && vLoggingLevel != "" && protocolType != apigatewayv2.ProtocolTypeHttp {
 		routeSettings.LoggingLevel = aws.String(vLoggingLevel)
 	}
 	if vThrottlingBurstLimit, ok := mSettings["throttling_burst_limit"].(int); ok {
@@ -513,13 +517,15 @@ func expandApiGatewayV2RouteSettings(vSettings *schema.Set, protocolType string)
 
 		mSettings := v.(map[string]interface{})
 
-		if vDataTraceEnabled, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType == apigatewayv2.ProtocolTypeWebsocket {
+		routeKey := mSettings["route_key"].(string)
+
+		if vDataTraceEnabled, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType != apigatewayv2.ProtocolTypeHttp {
 			routeSettings.DataTraceEnabled = aws.Bool(vDataTraceEnabled)
 		}
 		if vDetailedMetricsEnabled, ok := mSettings["detailed_metrics_enabled"].(bool); ok {
 			routeSettings.DetailedMetricsEnabled = aws.Bool(vDetailedMetricsEnabled)
 		}
-		if vLoggingLevel, ok := mSettings["logging_level"].(string); ok && vLoggingLevel != "" && protocolType == apigatewayv2.ProtocolTypeWebsocket {
+		if vLoggingLevel, ok := mSettings["logging_level"].(string); ok && vLoggingLevel != "" && protocolType != apigatewayv2.ProtocolTypeHttp {
 			routeSettings.LoggingLevel = aws.String(vLoggingLevel)
 		}
 		if vThrottlingBurstLimit, ok := mSettings["throttling_burst_limit"].(int); ok {
@@ -529,20 +535,28 @@ func expandApiGatewayV2RouteSettings(vSettings *schema.Set, protocolType string)
 			routeSettings.ThrottlingRateLimit = aws.Float64(vThrottlingRateLimit)
 		}
 
-		settings[mSettings["route_key"].(string)] = routeSettings
+		settings[routeKey] = routeSettings
 	}
 
 	return settings
 }
 
-func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSettings) []interface{} {
+func flattenApiGatewayV2RouteSettings(settings map[string]*apigatewayv2.RouteSettings, protocolType string) []interface{} {
 	vSettings := []interface{}{}
 
 	for k, routeSetting := range settings {
+		// Schema defaults.
+		dataTraceEnabled := false
+		loggingLevel := apigatewayv2.LoggingLevelOff
+		if protocolType != apigatewayv2.ProtocolTypeHttp {
+			dataTraceEnabled = aws.BoolValue(routeSetting.DataTraceEnabled)
+			loggingLevel = aws.StringValue(routeSetting.LoggingLevel)
+		}
+
 		vSettings = append(vSettings, map[string]interface{}{
-			"data_trace_enabled":       aws.BoolValue(routeSetting.DataTraceEnabled),
+			"data_trace_enabled":       dataTraceEnabled,
 			"detailed_metrics_enabled": aws.BoolValue(routeSetting.DetailedMetricsEnabled),
-			"logging_level":            aws.StringValue(routeSetting.LoggingLevel),
+			"logging_level":            loggingLevel,
 			"route_key":                k,
 			"throttling_burst_limit":   int(aws.Int64Value(routeSetting.ThrottlingBurstLimit)),
 			"throttling_rate_limit":    aws.Float64Value(routeSetting.ThrottlingRateLimit),

--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -91,19 +91,12 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 						"logging_level": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  apigatewayv2.LoggingLevelOff,
+							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								apigatewayv2.LoggingLevelError,
 								apigatewayv2.LoggingLevelInfo,
 								apigatewayv2.LoggingLevelOff,
 							}, false),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// Not set for HTTP APIs.
-								if d.Id() != "" && old == "" && new == apigatewayv2.LoggingLevelOff {
-									return true
-								}
-								return false
-							},
 						},
 						"throttling_burst_limit": {
 							Type:     schema.TypeInt,
@@ -158,19 +151,12 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 						"logging_level": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  apigatewayv2.LoggingLevelOff,
+							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								apigatewayv2.LoggingLevelError,
 								apigatewayv2.LoggingLevelInfo,
 								apigatewayv2.LoggingLevelOff,
 							}, false),
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								// Not set for HTTP APIs.
-								if d.Id() != "" && old == "" && new == apigatewayv2.LoggingLevelOff {
-									return true
-								}
-								return false
-							},
 						},
 						"route_key": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -99,7 +99,7 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 							}, false),
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								// Not set for HTTP APIs.
-								if old == "" && new == apigatewayv2.LoggingLevelOff {
+								if d.Id() != "" && old == "" && new == apigatewayv2.LoggingLevelOff {
 									return true
 								}
 								return false
@@ -166,7 +166,7 @@ func resourceAwsApiGatewayV2Stage() *schema.Resource {
 							}, false),
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								// Not set for HTTP APIs.
-								if old == "" && new == apigatewayv2.LoggingLevelOff {
+								if d.Id() != "" && old == "" && new == apigatewayv2.LoggingLevelOff {
 									return true
 								}
 								return false

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -349,6 +349,30 @@ func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsWebSocketUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", "INFO"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "1111"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "9999"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(fmt.Sprintf(".+/%s", rName))),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("wss://.+\\.execute-api\\.%s.amazonaws\\.com/%s", testAccGetRegion(), rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccAWSAPIGatewayV2StageImportStateIdFunc(resourceName),
 				ImportState:       true,
@@ -404,6 +428,30 @@ func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "2222"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "8888"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "execution_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", testAccGetRegion(), rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsHttpUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "1111"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "9999"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "execution_arn", ""),
@@ -546,6 +594,54 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAWSAPIGatewayV2StageConfig_routeSettingsWebSocketUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(fmt.Sprintf(".+/%s", rName))),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("wss://.+\\.execute-api\\.%s.amazonaws\\.com/%s", testAccGetRegion(), rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "3"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
+						"data_trace_enabled":       "false",
+						"detailed_metrics_enabled": "false",
+						"logging_level":            "OFF",
+						"route_key":                "$default",
+						"throttling_burst_limit":   "1111",
+						"throttling_rate_limit":    "9999",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
+						"data_trace_enabled":       "false",
+						"detailed_metrics_enabled": "false",
+						"logging_level":            "INFO",
+						"route_key":                "$connect",
+						"throttling_burst_limit":   "0",
+						"throttling_rate_limit":    "0",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
+						"data_trace_enabled":       "false",
+						"detailed_metrics_enabled": "false",
+						"logging_level":            "OFF",
+						"route_key":                "$disconnect",
+						"throttling_burst_limit":   "0",
+						"throttling_rate_limit":    "0",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccAWSAPIGatewayV2StageImportStateIdFunc(resourceName),
 				ImportState:       true,
@@ -617,6 +713,38 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp(t *testing.T) {
 						"route_key":                "$default",
 						"throttling_burst_limit":   "2222",
 						"throttling_rate_limit":    "8888",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2StageConfig_routeSettingsHttpUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "execution_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", testAccGetRegion(), rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
+						"data_trace_enabled":       "false",
+						"detailed_metrics_enabled": "false",
+						"logging_level":            "OFF",
+						"route_key":                "$default",
+						"throttling_burst_limit":   "1111",
+						"throttling_rate_limit":    "9999",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -1011,7 +1139,9 @@ resource "aws_apigatewayv2_stage" "test" {
 }
 
 func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsWebSocket(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName),
+		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
   name   = %[1]q
@@ -1024,7 +1154,26 @@ resource "aws_apigatewayv2_stage" "test" {
     throttling_rate_limit    = 8888
   }
 }
-`, rName)
+`, rName))
+}
+
+func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsWebSocketUpdated(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id = "${aws_apigatewayv2_api.test.id}"
+  name   = %[1]q
+
+  default_route_settings {
+    data_trace_enabled       = false
+    detailed_metrics_enabled = true
+    logging_level            = "INFO"
+    throttling_burst_limit   = 1111
+    throttling_rate_limit    = 9999
+  }
+}
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsHttp(rName string) string {
@@ -1044,6 +1193,22 @@ resource "aws_apigatewayv2_stage" "test" {
 `, rName))
 }
 
+func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsHttpUpdated(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2StageConfig_apiHttp(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id = "${aws_apigatewayv2_api.test.id}"
+  name   = %[1]q
+
+  default_route_settings {
+    throttling_burst_limit = 1111
+    throttling_rate_limit  = 9999
+  }
+}
+`, rName))
+}
+
 func testAccAWSAPIGatewayV2StageConfig_deployment(rName string) string {
 	return testAccAWSAPIGatewayV2DeploymentConfig_basic(rName, rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
@@ -1056,7 +1221,9 @@ resource "aws_apigatewayv2_stage" "test" {
 }
 
 func testAccAWSAPIGatewayV2StageConfig_routeSettingsWebSocket(rName string) string {
-	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName),
+		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
   name   = %[1]q
@@ -1075,7 +1242,35 @@ resource "aws_apigatewayv2_stage" "test" {
     throttling_rate_limit    = 8888
   }
 }
-`, rName)
+`, rName))
+}
+
+func testAccAWSAPIGatewayV2StageConfig_routeSettingsWebSocketUpdated(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id = "${aws_apigatewayv2_api.test.id}"
+  name   = %[1]q
+
+  route_settings {
+    route_key = "$default"
+
+    throttling_burst_limit = 1111
+    throttling_rate_limit  = 9999
+  }
+
+  route_settings {
+    route_key = "$connect"
+
+    logging_level = "INFO"
+  }
+
+  route_settings {
+    route_key = "$disconnect"
+  }
+}
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2StageConfig_routeSettingsHttp(rName string) string {
@@ -1087,11 +1282,29 @@ resource "aws_apigatewayv2_stage" "test" {
   name   = %[1]q
 
   route_settings {
-	route_key = "$default"
+    route_key = "$default"
 
     detailed_metrics_enabled = true
     throttling_burst_limit   = 2222
     throttling_rate_limit    = 8888
+  }
+}
+`, rName))
+}
+
+func testAccAWSAPIGatewayV2StageConfig_routeSettingsHttpUpdated(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2StageConfig_apiHttp(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id = "${aws_apigatewayv2_api.test.id}"
+  name   = %[1]q
+
+  route_settings {
+    route_key = "$default"
+
+    throttling_burst_limit = 1111
+    throttling_rate_limit  = 9999
   }
 }
 `, rName))

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -164,7 +164,7 @@ func TestAccAWSAPIGatewayV2Stage_disappears(t *testing.T) {
 				Config: testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
-					testAccCheckAWSAPIGatewayV2StageDisappears(&apiId, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayV2Stage(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -313,7 +313,7 @@ func TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription(t *testing.T)
 	})
 }
 
-func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings(t *testing.T) {
+func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket(t *testing.T) {
 	var apiId string
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
@@ -325,7 +325,7 @@ func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayV2StageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayV2StageConfig_defaultRouteSettings(rName),
+				Config: testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
@@ -365,6 +365,72 @@ func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetStageOutput
+	resourceName := "aws_apigatewayv2_stage.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2StageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "2222"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "8888"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "execution_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", testAccGetRegion(), rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2StageImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAPIGatewayV2StageConfig_basicHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
@@ -425,7 +491,7 @@ func TestAccAWSAPIGatewayV2Stage_Deployment(t *testing.T) {
 	})
 }
 
-func TestAccAWSAPIGatewayV2Stage_RouteSettings(t *testing.T) {
+func TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket(t *testing.T) {
 	var apiId string
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
@@ -437,7 +503,7 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettings(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayV2StageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayV2StageConfig_routeSettings(rName),
+				Config: testAccAWSAPIGatewayV2StageConfig_routeSettingsWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
@@ -459,7 +525,6 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettings(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
 						"data_trace_enabled":       "false",
 						"detailed_metrics_enabled": "false",
-						"logging_level":            "OFF",
 						"route_key":                "$default",
 						"throttling_burst_limit":   "0",
 						"throttling_rate_limit":    "0",
@@ -493,6 +558,79 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetStageOutput
+	resourceName := "aws_apigatewayv2_stage.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2StageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2StageConfig_routeSettingsHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "execution_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", testAccGetRegion(), rName))),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "route_settings.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
+						"data_trace_enabled":       "false",
+						"detailed_metrics_enabled": "true",
+						"route_key":                "$default",
+						"throttling_burst_limit":   "2222",
+						"throttling_rate_limit":    "8888",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "stage_variables.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2StageImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAPIGatewayV2StageConfig_basicHttp(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", ""),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
@@ -666,19 +804,6 @@ func testAccCheckAWSAPIGatewayV2StageDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckAWSAPIGatewayV2StageDisappears(apiId *string, v *apigatewayv2.GetStageOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
-
-		_, err := conn.DeleteStage(&apigatewayv2.DeleteStageInput{
-			ApiId:     apiId,
-			StageName: v.StageName,
-		})
-
-		return err
-	}
 }
 
 func testAccCheckAWSAPIGatewayV2StageExists(n string, vApiId *string, v *apigatewayv2.GetStageOutput) resource.TestCheckFunc {
@@ -877,7 +1002,7 @@ resource "aws_apigatewayv2_stage" "test" {
 `, rName)
 }
 
-func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettings(rName string) string {
+func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsWebSocket(rName string) string {
 	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
@@ -894,6 +1019,23 @@ resource "aws_apigatewayv2_stage" "test" {
 `, rName)
 }
 
+func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsHttp(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2StageConfig_apiHttp(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id = "${aws_apigatewayv2_api.test.id}"
+  name   = %[1]q
+
+  default_route_settings {
+    detailed_metrics_enabled = true
+    throttling_burst_limit   = 2222
+    throttling_rate_limit    = 8888
+  }
+}
+`, rName))
+}
+
 func testAccAWSAPIGatewayV2StageConfig_deployment(rName string) string {
 	return testAccAWSAPIGatewayV2DeploymentConfig_basic(rName, rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
@@ -905,7 +1047,7 @@ resource "aws_apigatewayv2_stage" "test" {
 `, rName)
 }
 
-func testAccAWSAPIGatewayV2StageConfig_routeSettings(rName string) string {
+func testAccAWSAPIGatewayV2StageConfig_routeSettingsWebSocket(rName string) string {
 	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
   api_id = "${aws_apigatewayv2_api.test.id}"
@@ -926,6 +1068,25 @@ resource "aws_apigatewayv2_stage" "test" {
   }
 }
 `, rName)
+}
+
+func testAccAWSAPIGatewayV2StageConfig_routeSettingsHttp(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2StageConfig_apiHttp(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_stage" "test" {
+  api_id = "${aws_apigatewayv2_api.test.id}"
+  name   = %[1]q
+
+  route_settings {
+	route_key = "$default"
+
+    detailed_metrics_enabled = true
+    throttling_burst_limit   = 2222
+    throttling_rate_limit    = 8888
+  }
+}
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2StageConfig_stageVariables(rName string) string {

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -573,10 +573,6 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
 						"data_trace_enabled":       "false",
 						"detailed_metrics_enabled": "false",
-<<<<<<< HEAD
-=======
-						"logging_level":            "OFF",
->>>>>>> r/aws_apigatewayv2_stage: No need for diff-suppression for new resources.
 						"route_key":                "$default",
 						"throttling_burst_limit":   "0",
 						"throttling_rate_limit":    "0",
@@ -706,10 +702,6 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
 						"data_trace_enabled":       "false",
 						"detailed_metrics_enabled": "true",
-<<<<<<< HEAD
-=======
-						"logging_level":            "OFF",
->>>>>>> r/aws_apigatewayv2_stage: No need for diff-suppression for new resources.
 						"route_key":                "$default",
 						"throttling_burst_limit":   "2222",
 						"throttling_rate_limit":    "8888",

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -388,7 +388,7 @@ func TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.data_trace_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.detailed_metrics_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.logging_level", "INFO"), // No drift detection if not configured
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_burst_limit", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_route_settings.0.throttling_rate_limit", "0"),
 					resource.TestCheckResourceAttr(resourceName, "deployment_id", ""),
@@ -612,7 +612,6 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
 						"data_trace_enabled":       "false",
 						"detailed_metrics_enabled": "false",
-						"logging_level":            "OFF",
 						"route_key":                "$default",
 						"throttling_burst_limit":   "1111",
 						"throttling_rate_limit":    "9999",
@@ -628,7 +627,6 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
 						"data_trace_enabled":       "false",
 						"detailed_metrics_enabled": "false",
-						"logging_level":            "OFF",
 						"route_key":                "$disconnect",
 						"throttling_burst_limit":   "0",
 						"throttling_rate_limit":    "0",
@@ -733,7 +731,6 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
 						"data_trace_enabled":       "false",
 						"detailed_metrics_enabled": "false",
-						"logging_level":            "OFF",
 						"route_key":                "$default",
 						"throttling_burst_limit":   "1111",
 						"throttling_rate_limit":    "9999",

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -30,6 +30,7 @@ func TestAccAWSAPIGatewayV2Stage_basicWebSocket(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "api_protocol_type", "WEBSOCKET"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
 					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
@@ -75,6 +76,7 @@ func TestAccAWSAPIGatewayV2Stage_basicHttp(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "api_protocol_type", "HTTP"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
 					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -30,7 +30,6 @@ func TestAccAWSAPIGatewayV2Stage_basicWebSocket(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "api_protocol_type", "WEBSOCKET"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
 					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),
@@ -76,7 +75,6 @@ func TestAccAWSAPIGatewayV2Stage_basicHttp(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2StageExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "access_log_settings.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "api_protocol_type", "HTTP"),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(fmt.Sprintf("/apis/.+/stages/%s", rName))),
 					resource.TestCheckResourceAttr(resourceName, "auto_deploy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "client_certificate_id", ""),

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -525,6 +525,10 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
 						"data_trace_enabled":       "false",
 						"detailed_metrics_enabled": "false",
+<<<<<<< HEAD
+=======
+						"logging_level":            "OFF",
+>>>>>>> r/aws_apigatewayv2_stage: No need for diff-suppression for new resources.
 						"route_key":                "$default",
 						"throttling_burst_limit":   "0",
 						"throttling_rate_limit":    "0",
@@ -606,6 +610,10 @@ func TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "route_settings.*", map[string]string{
 						"data_trace_enabled":       "false",
 						"detailed_metrics_enabled": "true",
+<<<<<<< HEAD
+=======
+						"logging_level":            "OFF",
+>>>>>>> r/aws_apigatewayv2_stage: No need for diff-suppression for new resources.
 						"route_key":                "$default",
 						"throttling_burst_limit":   "2222",
 						"throttling_rate_limit":    "8888",

--- a/website/docs/r/apigatewayv2_stage.html.markdown
+++ b/website/docs/r/apigatewayv2_stage.html.markdown
@@ -51,7 +51,7 @@ The `default_route_settings` object supports the following:
 Defaults to `false`. Supported only for WebSocket APIs.
 * `detailed_metrics_enabled` - (Optional) Whether detailed metrics are enabled for the default route. Defaults to `false`.
 * `logging_level` - (Optional) The logging level for the default route. Affects the log entries pushed to Amazon CloudWatch Logs.
-Valid values: `ERROR`, `INFO`, `OFF`. Defaults to `OFF`. Supported only for WebSocket APIs.
+Valid values: `ERROR`, `INFO`, `OFF`. Defaults to `OFF`. Supported only for WebSocket APIs. Terraform will only perform drift detection of its value when present in a configuration.
 * `throttling_burst_limit` - (Optional) The throttling burst limit for the default route.
 * `throttling_rate_limit` - (Optional) The throttling rate limit for the default route.
 
@@ -62,7 +62,7 @@ The `route_settings` object supports the following:
 Defaults to `false`. Supported only for WebSocket APIs.
 * `detailed_metrics_enabled` - (Optional) Whether detailed metrics are enabled for the route. Defaults to `false`.
 * `logging_level` - (Optional) The logging level for the route. Affects the log entries pushed to Amazon CloudWatch Logs.
-Valid values: `ERROR`, `INFO`, `OFF`. Defaults to `OFF`. Supported only for WebSocket APIs.
+Valid values: `ERROR`, `INFO`, `OFF`. Defaults to `OFF`. Supported only for WebSocket APIs. Terraform will only perform drift detection of its value when present in a configuration.
 * `throttling_burst_limit` - (Optional) The throttling burst limit for the route.
 * `throttling_rate_limit` - (Optional) The throttling rate limit for the route.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13801.
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/13527.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_stage: Correctly handle `default_route_setting` and `route_setting` `data_trace_enabled` and `logging_level` for HTTP APIs. `logging_level` is now `Computed`, meaning Terraform will only perform drift detection of its value when present in a configuration.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Stage_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Stage_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Stage_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== PAUSE TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== RUN   TestAccAWSAPIGatewayV2Stage_disappears
=== PAUSE TestAccAWSAPIGatewayV2Stage_disappears
=== RUN   TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== PAUSE TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== RUN   TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== PAUSE TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== RUN   TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket
=== RUN   TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_Deployment
=== PAUSE TestAccAWSAPIGatewayV2Stage_Deployment
=== RUN   TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket
=== RUN   TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp
=== PAUSE TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp
=== RUN   TestAccAWSAPIGatewayV2Stage_StageVariables
=== PAUSE TestAccAWSAPIGatewayV2Stage_StageVariables
=== RUN   TestAccAWSAPIGatewayV2Stage_Tags
=== PAUSE TestAccAWSAPIGatewayV2Stage_Tags
=== CONT  TestAccAWSAPIGatewayV2Stage_basicWebSocket
=== CONT  TestAccAWSAPIGatewayV2Stage_Tags
=== CONT  TestAccAWSAPIGatewayV2Stage_StageVariables
=== CONT  TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp
=== CONT  TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket
=== CONT  TestAccAWSAPIGatewayV2Stage_Deployment
=== CONT  TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp
=== CONT  TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket
=== CONT  TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription
=== CONT  TestAccAWSAPIGatewayV2Stage_AccessLogSettings
=== CONT  TestAccAWSAPIGatewayV2Stage_disappears
=== CONT  TestAccAWSAPIGatewayV2Stage_defaultHttpStage
=== CONT  TestAccAWSAPIGatewayV2Stage_basicHttp
--- PASS: TestAccAWSAPIGatewayV2Stage_disappears (27.88s)
--- PASS: TestAccAWSAPIGatewayV2Stage_basicWebSocket (32.97s)
--- PASS: TestAccAWSAPIGatewayV2Stage_defaultHttpStage (33.62s)
--- PASS: TestAccAWSAPIGatewayV2Stage_basicHttp (33.94s)
--- PASS: TestAccAWSAPIGatewayV2Stage_RouteSettingsWebSocket (51.24s)
--- PASS: TestAccAWSAPIGatewayV2Stage_RouteSettingsHttp (51.90s)
--- PASS: TestAccAWSAPIGatewayV2Stage_StageVariables (52.18s)
--- PASS: TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsWebSocket (52.24s)
--- PASS: TestAccAWSAPIGatewayV2Stage_Tags (52.35s)
--- PASS: TestAccAWSAPIGatewayV2Stage_DefaultRouteSettingsHttp (52.43s)
--- PASS: TestAccAWSAPIGatewayV2Stage_Deployment (63.90s)
--- PASS: TestAccAWSAPIGatewayV2Stage_AccessLogSettings (73.62s)
--- PASS: TestAccAWSAPIGatewayV2Stage_ClientCertificateIdAndDescription (108.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	108.789s
```
