### PR TITLE
r/ses_receipt_filter - add arn attribute + validations for all arguments + docs

### DIFF
--- a/aws/resource_aws_ses_receipt_filter_test.go
+++ b/aws/resource_aws_ses_receipt_filter_test.go
@@ -24,6 +24,7 @@ func TestAccAWSSESReceiptFilter_basic(t *testing.T) {
 				Config: testAccAWSSESReceiptFilterConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESReceiptFilterExists(resourceName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ses", fmt.Sprintf("receipt-filter/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "cidr", "10.10.10.10"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy", "Block"),
@@ -33,6 +34,27 @@ func TestAccAWSSESReceiptFilter_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSESReceiptFilter_disappears(t *testing.T) {
+	resourceName := "aws_ses_receipt_filter.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSESReceiptFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSESReceiptFilterConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESReceiptFilterExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSesReceiptFilter(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -281,6 +281,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   - [`aws_ses_domain_identity` resource](/docs/providers/aws/r/ses_domain_identity.html)
   - [`aws_ses_domain_identity_verification` resource](/docs/providers/aws/r/ses_domain_identity_verification.html)
   - [`aws_ses_email_identity` resource](/docs/providers/aws/r/ses_email_identity.html)
+  - [`aws_ses_receipt_filter` resource](/docs/providers/aws/r/ses_receipt_filter.html)  
   - [`aws_ssm_document` data source](/docs/providers/aws/d/ssm_document.html)
   - [`aws_ssm_document` resource](/docs/providers/aws/r/ssm_document.html)
   - [`aws_ssm_parameter` data source](/docs/providers/aws/d/ssm_parameter.html)

--- a/website/docs/r/ses_receipt_filter.html.markdown
+++ b/website/docs/r/ses_receipt_filter.html.markdown
@@ -27,3 +27,18 @@ The following arguments are supported:
 * `name` - (Required) The name of the filter
 * `cidr` - (Required) The IP address or address range to filter, in CIDR notation
 * `policy` - (Required) Block or Allow
+
+## Attributes Reference
+
+In addition to the arguments, which are exported, the following attributes are exported:
+
+* `id` - The SES receipt filter name.
+* `arn` - The SES receipt filter ARN.
+
+## Import
+
+SES Receipt Filter can be imported using their `name`, e.g.
+
+```
+$ terraform import aws_ses_receipt_filter.test some-filter
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624, #13527

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ses_receipt_filter - add arn attribute
resource_aws_ses_receipt_filter - add plan time validations to `name`, `cidr`, and `policy`
resource_aws_ses_receipt_filter - add missing doc for import and attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSESReceiptFilter_'
--- PASS: TestAccAWSSESReceiptFilter_basic (46.59s)
--- PASS: TestAccAWSSESReceiptFilter_disappears (30.71s)
```
