### PR TITLE
New Data Sources: aws_outposts_outpost_instance_type(s)

### DIFF
--- a/aws/data_source_aws_outposts_outpost_instance_type.go
+++ b/aws/data_source_aws_outposts_outpost_instance_type.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/outposts"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsOutpostsOutpostInstanceType() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOutpostsOutpostInstanceTypeRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+			"instance_type": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"preferred_instance_types"},
+			},
+			"preferred_instance_types": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ConflictsWith: []string{"instance_type"},
+				Elem:          &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsOutpostsOutpostInstanceTypeRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).outpostsconn
+
+	input := &outposts.GetOutpostInstanceTypesInput{
+		OutpostId: aws.String(d.Get("arn").(string)), // Accepts both ARN and ID; prefer ARN which is more common
+	}
+
+	var outpostID string
+	var foundInstanceTypes []string
+
+	for {
+		output, err := conn.GetOutpostInstanceTypes(input)
+
+		if err != nil {
+			return fmt.Errorf("error getting Outpost Instance Types: %w", err)
+		}
+
+		if output == nil {
+			break
+		}
+
+		outpostID = aws.StringValue(output.OutpostId)
+
+		for _, outputInstanceType := range output.InstanceTypes {
+			foundInstanceTypes = append(foundInstanceTypes, aws.StringValue(outputInstanceType.InstanceType))
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	if len(foundInstanceTypes) == 0 {
+		return fmt.Errorf("no Outpost Instance Types found matching criteria; try different search")
+	}
+
+	var resultInstanceType string
+
+	// Check requested instance type
+	if v, ok := d.GetOk("instance_type"); ok {
+		for _, foundInstanceType := range foundInstanceTypes {
+			if foundInstanceType == v.(string) {
+				resultInstanceType = v.(string)
+				break
+			}
+		}
+	}
+
+	// Search preferred instance types in their given order and set result
+	// instance type for first match found
+	if l := d.Get("preferred_instance_types").([]interface{}); len(l) > 0 {
+		for _, elem := range l {
+			preferredInstanceType, ok := elem.(string)
+
+			if !ok {
+				continue
+			}
+
+			for _, foundInstanceType := range foundInstanceTypes {
+				if foundInstanceType == preferredInstanceType {
+					resultInstanceType = preferredInstanceType
+					break
+				}
+			}
+
+			if resultInstanceType != "" {
+				break
+			}
+		}
+	}
+
+	if resultInstanceType == "" && len(foundInstanceTypes) > 1 {
+		return fmt.Errorf("multiple Outpost Instance Types found matching criteria; try different search")
+	}
+
+	if resultInstanceType == "" && len(foundInstanceTypes) == 1 {
+		resultInstanceType = foundInstanceTypes[0]
+	}
+
+	if resultInstanceType == "" {
+		return fmt.Errorf("no Outpost Instance Types found matching criteria; try different search")
+	}
+
+	d.Set("instance_type", resultInstanceType)
+
+	d.SetId(outpostID)
+
+	return nil
+}

--- a/aws/data_source_aws_outposts_outpost_instance_type_test.go
+++ b/aws/data_source_aws_outposts_outpost_instance_type_test.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSOutpostsOutpostInstanceTypeDataSource_InstanceType(t *testing.T) {
+	dataSourceName := "data.aws_outposts_outpost_instance_type.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSOutpostsOutpostInstanceTypeDataSourceConfigInstanceType(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "instance_type", regexp.MustCompile(`^.+$`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSOutpostsOutpostInstanceTypeDataSource_PreferredInstanceTypes(t *testing.T) {
+	dataSourceName := "data.aws_outposts_outpost_instance_type.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSOutpostsOutpostInstanceTypeDataSourceConfigPreferredInstanceTypes(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "instance_type", regexp.MustCompile(`^.+$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSOutpostsOutpostInstanceTypeDataSourceConfigInstanceType() string {
+	return fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost_instance_types" "test" {
+  arn = tolist(data.aws_outposts_outposts.test.arns)[0]
+}
+
+data "aws_outposts_outpost_instance_type" "test" {
+  arn           = tolist(data.aws_outposts_outposts.test.arns)[0]
+  instance_type = tolist(data.aws_outposts_outpost_instance_types.test.instance_types)[0]
+}
+`)
+}
+
+func testAccAWSOutpostsOutpostInstanceTypeDataSourceConfigPreferredInstanceTypes() string {
+	return fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost_instance_types" "test" {
+  arn = tolist(data.aws_outposts_outposts.test.arns)[0]
+}
+
+data "aws_outposts_outpost_instance_type" "test" {
+  arn                      = tolist(data.aws_outposts_outposts.test.arns)[0]
+  preferred_instance_types = data.aws_outposts_outpost_instance_types.test.instance_types
+}
+`)
+}

--- a/aws/data_source_aws_outposts_outpost_instance_types.go
+++ b/aws/data_source_aws_outposts_outpost_instance_types.go
@@ -1,0 +1,71 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/outposts"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsOutpostsOutpostInstanceTypes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOutpostsOutpostInstanceTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+			"instance_types": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsOutpostsOutpostInstanceTypesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).outpostsconn
+
+	input := &outposts.GetOutpostInstanceTypesInput{
+		OutpostId: aws.String(d.Get("arn").(string)), // Accepts both ARN and ID; prefer ARN which is more common
+	}
+
+	var outpostID string
+	var instanceTypes []string
+
+	for {
+		output, err := conn.GetOutpostInstanceTypes(input)
+
+		if err != nil {
+			return fmt.Errorf("error getting Outpost Instance Types: %w", err)
+		}
+
+		if output == nil {
+			break
+		}
+
+		outpostID = aws.StringValue(output.OutpostId)
+
+		for _, outputInstanceType := range output.InstanceTypes {
+			instanceTypes = append(instanceTypes, aws.StringValue(outputInstanceType.InstanceType))
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	if err := d.Set("instance_types", instanceTypes); err != nil {
+		return fmt.Errorf("error setting instance_types: %w", err)
+	}
+
+	d.SetId(outpostID)
+
+	return nil
+}

--- a/aws/data_source_aws_outposts_outpost_instance_types_test.go
+++ b/aws/data_source_aws_outposts_outpost_instance_types_test.go
@@ -1,0 +1,52 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAWSOutpostsOutpostInstanceTypesDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_outposts_outpost_instance_types.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSOutpostsOutpostInstanceTypesDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOutpostsOutpostInstanceTypesAttributes(dataSourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckOutpostsOutpostInstanceTypesAttributes(dataSourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", dataSourceName)
+		}
+
+		if v := rs.Primary.Attributes["instance_types.#"]; v == "0" {
+			return fmt.Errorf("expected at least one instance_types result, got none")
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSOutpostsOutpostInstanceTypesDataSourceConfig() string {
+	return fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost_instance_types" "test" {
+  arn = tolist(data.aws_outposts_outposts.test.arns)[0]
+}
+`)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -289,6 +289,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_organizations_organization":                 dataSourceAwsOrganizationsOrganization(),
 			"aws_organizations_organizational_units":         dataSourceAwsOrganizationsOrganizationalUnits(),
 			"aws_outposts_outpost":                           dataSourceAwsOutpostsOutpost(),
+			"aws_outposts_outpost_instance_type":             dataSourceAwsOutpostsOutpostInstanceType(),
+			"aws_outposts_outpost_instance_types":            dataSourceAwsOutpostsOutpostInstanceTypes(),
 			"aws_outposts_outposts":                          dataSourceAwsOutpostsOutposts(),
 			"aws_outposts_site":                              dataSourceAwsOutpostsSite(),
 			"aws_outposts_sites":                             dataSourceAwsOutpostsSites(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2457,6 +2457,12 @@
                                     <a href="/docs/providers/aws/d/outposts_outpost.html">aws_outposts_outpost</a>
                                 </li>
                                 <li>
+                                    <a href="/docs/providers/aws/d/outposts_outpost_instance_type.html">aws_outposts_outpost_instance_type</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/outposts_outpost_instance_types.html">aws_outposts_outpost_instance_types</a>
+                                </li>
+                                <li>
                                     <a href="/docs/providers/aws/d/outposts_outposts.html">aws_outposts_outposts</a>
                                 </li>
                                 <li>

--- a/website/docs/d/outposts_outpost_instance_type.html.markdown
+++ b/website/docs/d/outposts_outpost_instance_type.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Outposts"
+layout: "aws"
+page_title: "AWS: aws_outposts_outpost_instance_type"
+description: |-
+  Information about single Outpost Instance Type.
+---
+
+# Data Source: aws_outposts_outpost_instance_type
+
+Information about single Outpost Instance Type.
+
+## Example Usage
+
+```hcl
+data "aws_outposts_outpost_instance_type" "example" {
+  arn                      = data.aws_outposts_outpost.example.arn
+  preferred_instance_types = ["m5.large", "m5.4xlarge"]
+}
+
+resource "aws_ec2_instance" "example" {
+  # ... other configuration ...
+
+  instance_type = data.aws_outposts_outpost_instance_type.example.instance_type
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `arn` - (Required) Outpost Amazon Resource Name (ARN).
+
+The following arguments are optional:
+
+* `instance_type` - (Optional) Desired instance type. Conflicts with `preferred_instance_types`.
+* `preferred_instance_types` - (Optional) Ordered list of preferred instance types. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned. Conflicts with `instance_type`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Outpost identifier.

--- a/website/docs/d/outposts_outpost_instance_types.html.markdown
+++ b/website/docs/d/outposts_outpost_instance_types.html.markdown
@@ -1,0 +1,31 @@
+---
+subcategory: "Outposts"
+layout: "aws"
+page_title: "AWS: aws_outposts_outpost_instance_types"
+description: |-
+  Information about Outpost Instance Types.
+---
+
+# Data Source: aws_outposts_outpost_instance_types
+
+Information about Outposts Instance Types.
+
+## Example Usage
+
+```hcl
+data "aws_outposts_outpost_instance_types" "example" {
+  arn = data.aws_outposts_outpost.example.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `arn` - (Required) Outpost Amazon Resource Name (ARN).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `instance_types` - Set of instance types.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/13822/files#diff-683cc9195188c9a328fd277aa3f8bc50R3490
Reference: https://www.terraform.io/docs/providers/aws/d/ec2_instance_type_offering.html
Reference: https://www.terraform.io/docs/providers/aws/d/ec2_instance_type_offerings.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Data Source:** `aws_outposts_outpost_instance_type`
* **New Data Source:** `aws_outposts_outpost_instance_types`
```

Outposts can have varying instance types. Provide a lookup mechanism, similar to the `aws_ec2_instance_type_offering` data source.

Output from acceptance testing:

```
--- PASS: TestAccAWSOutpostsOutpostInstanceTypeDataSource_InstanceType (30.44s)
--- PASS: TestAccAWSOutpostsOutpostInstanceTypeDataSource_PreferredInstanceTypes (30.53s)

--- PASS: TestAccAWSOutpostsOutpostInstanceTypesDataSource_basic (25.47s)
```