### PR TITLE
r/aws_apigatewayv2_route: Update route key

### DIFF
--- a/aws/resource_aws_apigatewayv2_route.go
+++ b/aws/resource_aws_apigatewayv2_route.go
@@ -187,6 +187,9 @@ func resourceAwsApiGatewayV2RouteUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChange("request_models") {
 		req.RequestModels = stringMapToPointers(d.Get("request_models").(map[string]interface{}))
 	}
+	if d.HasChange("route_key") {
+		req.RouteKey = aws.String(d.Get("route_key").(string))
+	}
 	if d.HasChange("route_response_selection_expression") {
 		req.RouteResponseSelectionExpression = aws.String(d.Get("route_response_selection_expression").(string))
 	}

--- a/aws/resource_aws_apigatewayv2_route_test.go
+++ b/aws/resource_aws_apigatewayv2_route_test.go
@@ -63,7 +63,7 @@ func TestAccAWSAPIGatewayV2Route_disappears(t *testing.T) {
 				Config: testAccAWSAPIGatewayV2RouteConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2RouteExists(resourceName, &apiId, &v),
-					testAccCheckAWSAPIGatewayV2RouteDisappears(&apiId, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayV2Route(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -148,7 +148,7 @@ func TestAccAWSAPIGatewayV2Route_JwtAuthorization(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "model_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "operation_name", ""),
 					resource.TestCheckResourceAttr(resourceName, "request_models.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "route_key", "$connect"),
+					resource.TestCheckResourceAttr(resourceName, "route_key", "GET /test"),
 					resource.TestCheckResourceAttr(resourceName, "route_response_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "target", ""),
 				),
@@ -170,7 +170,7 @@ func TestAccAWSAPIGatewayV2Route_JwtAuthorization(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "model_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "operation_name", ""),
 					resource.TestCheckResourceAttr(resourceName, "request_models.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "route_key", "$connect"),
+					resource.TestCheckResourceAttr(resourceName, "route_key", "GET /test"),
 					resource.TestCheckResourceAttr(resourceName, "route_response_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "target", ""),
 				),
@@ -322,6 +322,57 @@ func TestAccAWSAPIGatewayV2Route_Target(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayV2Route_UpdateRouteKey(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetRouteOutput
+	resourceName := "aws_apigatewayv2_route.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2RouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2RouteConfig_routeKey(rName, "GET /path"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2RouteExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "api_key_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", apigatewayv2.AuthorizationTypeNone),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "model_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "operation_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "request_models.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "route_key", "GET /path"),
+					resource.TestCheckResourceAttr(resourceName, "route_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "target", ""),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayV2RouteConfig_routeKey(rName, "POST /new/path"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2RouteExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "api_key_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", apigatewayv2.AuthorizationTypeNone),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "model_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "operation_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "request_models.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "route_key", "POST /new/path"),
+					resource.TestCheckResourceAttr(resourceName, "route_response_selection_expression", ""),
+					resource.TestCheckResourceAttr(resourceName, "target", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2RouteImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAPIGatewayV2RouteDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
 
@@ -345,19 +396,6 @@ func testAccCheckAWSAPIGatewayV2RouteDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckAWSAPIGatewayV2RouteDisappears(apiId *string, v *apigatewayv2.GetRouteOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
-
-		_, err := conn.DeleteRoute(&apigatewayv2.DeleteRouteInput{
-			ApiId:   apiId,
-			RouteId: v.RouteId,
-		})
-
-		return err
-	}
 }
 
 func testAccCheckAWSAPIGatewayV2RouteExists(n string, vApiId *string, v *apigatewayv2.GetRouteOutput) resource.TestCheckFunc {
@@ -421,6 +459,15 @@ resource "aws_apigatewayv2_api" "test" {
 `, rName)
 }
 
+func testAccAWSAPIGatewayV2RouteConfig_apiHttp(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+}
+`, rName)
+}
+
 func testAccAWSAPIGatewayV2RouteConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2RouteConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_route" "test" {
@@ -457,7 +504,7 @@ func testAccAWSAPIGatewayV2RouteConfig_jwtAuthorization(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_jwt(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_route" "test" {
   api_id    = "${aws_apigatewayv2_api.test.id}"
-  route_key = "$connect"
+  route_key = "GET /test"
 
   authorization_type = "JWT"
   authorizer_id      = "${aws_apigatewayv2_authorizer.test.id}"
@@ -471,7 +518,7 @@ func testAccAWSAPIGatewayV2RouteConfig_jwtAuthorizationUpdated(rName string) str
 	return testAccAWSAPIGatewayV2AuthorizerConfig_jwt(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_route" "test" {
   api_id    = "${aws_apigatewayv2_api.test.id}"
-  route_key = "$connect"
+  route_key = "GET /test"
 
   authorization_type = "JWT"
   authorizer_id      = "${aws_apigatewayv2_authorizer.test.id}"
@@ -507,6 +554,17 @@ resource "aws_apigatewayv2_route" "test" {
   }
 }
 `)
+}
+
+func testAccAWSAPIGatewayV2RouteConfig_routeKey(rName, routeKey string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2RouteConfig_apiHttp(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_route" "test" {
+  api_id    = "${aws_apigatewayv2_api.test.id}"
+  route_key = %[1]q
+}
+`, routeKey))
 }
 
 // Simple attributes - No authorization, models or targets.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13814.
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/13527.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_route: Update route key
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Route_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Route_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Route_basic
=== PAUSE TestAccAWSAPIGatewayV2Route_basic
=== RUN   TestAccAWSAPIGatewayV2Route_disappears
=== PAUSE TestAccAWSAPIGatewayV2Route_disappears
=== RUN   TestAccAWSAPIGatewayV2Route_Authorizer
=== PAUSE TestAccAWSAPIGatewayV2Route_Authorizer
=== RUN   TestAccAWSAPIGatewayV2Route_JwtAuthorization
=== PAUSE TestAccAWSAPIGatewayV2Route_JwtAuthorization
=== RUN   TestAccAWSAPIGatewayV2Route_Model
=== PAUSE TestAccAWSAPIGatewayV2Route_Model
=== RUN   TestAccAWSAPIGatewayV2Route_SimpleAttributes
=== PAUSE TestAccAWSAPIGatewayV2Route_SimpleAttributes
=== RUN   TestAccAWSAPIGatewayV2Route_Target
=== PAUSE TestAccAWSAPIGatewayV2Route_Target
=== RUN   TestAccAWSAPIGatewayV2Route_UpdateRouteKey
=== PAUSE TestAccAWSAPIGatewayV2Route_UpdateRouteKey
=== CONT  TestAccAWSAPIGatewayV2Route_basic
=== CONT  TestAccAWSAPIGatewayV2Route_SimpleAttributes
=== CONT  TestAccAWSAPIGatewayV2Route_Model
=== CONT  TestAccAWSAPIGatewayV2Route_UpdateRouteKey
=== CONT  TestAccAWSAPIGatewayV2Route_Target
=== CONT  TestAccAWSAPIGatewayV2Route_JwtAuthorization
=== CONT  TestAccAWSAPIGatewayV2Route_Authorizer
=== CONT  TestAccAWSAPIGatewayV2Route_disappears
--- PASS: TestAccAWSAPIGatewayV2Route_disappears (25.28s)
--- PASS: TestAccAWSAPIGatewayV2Route_basic (28.88s)
--- PASS: TestAccAWSAPIGatewayV2Route_Target (31.58s)
--- PASS: TestAccAWSAPIGatewayV2Route_UpdateRouteKey (46.16s)
--- PASS: TestAccAWSAPIGatewayV2Route_SimpleAttributes (61.37s)
--- PASS: TestAccAWSAPIGatewayV2Route_Model (62.11s)
--- PASS: TestAccAWSAPIGatewayV2Route_JwtAuthorization (70.85s)
--- PASS: TestAccAWSAPIGatewayV2Route_Authorizer (79.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	79.902s
```
