### PR TITLE
r/ec2_traffic_mirror_session - add arn attribute

### DIFF
--- a/aws/resource_aws_ec2_traffic_mirror_session_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_session_test.go
@@ -182,17 +182,6 @@ func testAccCheckAWSEc2TrafficMirrorSessionExists(name string, session *ec2.Traf
 	}
 }
 
-func testAccCheckAWSEc2TrafficMirrorSessionDisappears(session *ec2.TrafficMirrorSession) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		_, err := conn.DeleteTrafficMirrorSession(&ec2.DeleteTrafficMirrorSessionInput{
-			TrafficMirrorSessionId: session.TrafficMirrorSessionId,
-		})
-
-		return err
-	}
-}
-
 func testAccTrafficMirrorSessionConfigBase(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "azs" {

--- a/aws/resource_aws_ec2_traffic_mirror_session_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_session_test.go
@@ -42,6 +42,7 @@ func TestAccAWSEc2TrafficMirrorSession_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "session_number", strconv.Itoa(session)),
 					resource.TestMatchResourceAttr(resourceName, "virtual_network_id", regexp.MustCompile(`\d+`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`traffic-mirror-session/tms-.+`)),
 				),
 			},
 			// update of description, packet length and VNI
@@ -142,7 +143,7 @@ func TestAccAWSEc2TrafficMirrorSession_disappears(t *testing.T) {
 				Config: testAccTrafficMirrorSessionConfig(rName, session),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEc2TrafficMirrorSessionExists(resourceName, &v),
-					testAccCheckAWSEc2TrafficMirrorSessionDisappears(&v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEc2TrafficMirrorSession(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -249,6 +249,7 @@ for more information about connecting to alternate AWS endpoints or AWS compatib
   - [`aws_ebs_volume` data source](/docs/providers/aws/d/ebs_volume.html)
   - [`aws_ec2_capacity_reservation` resource](/docs/providers/aws/r/ec2_capacity_reservation.html)
   - [`aws_ec2_client_vpn_endpoint` resource](/docs/providers/aws/r/ec2_client_vpn_endpoint.html)
+  - [`aws_ec2_traffic_mirror_session` resource](/docs/providers/aws/r/ec2_traffic_mirror_session.html)  
   - [`aws_ec2_traffic_mirror_target` resource](/docs/providers/aws/r/ec2_traffic_mirror_target.html)
   - [`aws_ecs_capacity_provider` resource (import)](/docs/providers/aws/r/ecs_capacity_provider.html)
   - [`aws_ecs_cluster` resource (import)](/docs/providers/aws/r/ecs_cluster.html)

--- a/website/docs/r/ec2_traffic_mirror_session.html.markdown
+++ b/website/docs/r/ec2_traffic_mirror_session.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The ARN of the traffic mirror session.
 * `id` - The name of the session.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13624, #13527

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ec2_traffic_mirror_session - add arn attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2TrafficMirrorSession_'
--- PASS: TestAccAWSEc2TrafficMirrorSession_basic (441.27s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_tags (457.70s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_disappears (315.75s)
```
