### PR TITLE
Add ARN for AWS Foundational Security Best Practices

### DIFF
--- a/website/docs/r/securityhub_standards_subscription.markdown
+++ b/website/docs/r/securityhub_standards_subscription.markdown
@@ -34,10 +34,11 @@ The following arguments are supported:
 
 Currently available standards:
 
-| Name                | ARN                                                                   |
-|---------------------|-----------------------------------------------------------------------|
-| CIS AWS Foundations | `arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0` |
-| PCI DSS             | `arn:aws:securityhub:us-east-1::standards/pci-dss/v/3.2.1`            |
+| Name                                     | ARN                                                                                         |
+|------------------------------------------|---------------------------------------------------------------------------------------------|
+| AWS Foundational Security Best Practices | `arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0` |
+| CIS AWS Foundations                      | `arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0`                       |
+| PCI DSS                                  | `arn:aws:securityhub:us-east-1::standards/pci-dss/v/3.2.1`                                  |
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Community Note

This already works by adding the `arn`, but it's not documented.

https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```