### PR TITLE
r/aws_vpc_endpoint: Wait for VPC Endpoint connection acceptance

### DIFF
--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -183,14 +183,14 @@ func resourceAwsVpcEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 	vpce := resp.VpcEndpoint
 	d.SetId(aws.StringValue(vpce.VpcEndpointId))
 
-	if _, ok := d.GetOk("auto_accept"); ok && aws.StringValue(vpce.State) == "pendingAcceptance" {
-		if err := vpcEndpointAccept(conn, d.Id(), aws.StringValue(vpce.ServiceName)); err != nil {
+	if v, ok := d.GetOk("auto_accept"); ok && v.(bool) && aws.StringValue(vpce.State) == "pendingAcceptance" {
+		if err := vpcEndpointAccept(conn, d.Id(), aws.StringValue(vpce.ServiceName), d.Timeout(schema.TimeoutCreate)); err != nil {
 			return err
 		}
 	}
 
 	if err := vpcEndpointWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return err
+		return fmt.Errorf("error waiting for VPC Endpoint (%s) to become available: %s", d.Id(), err)
 	}
 
 	return resourceAwsVpcEndpointRead(d, meta)
@@ -301,8 +301,8 @@ func resourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) error 
 func resourceAwsVpcEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if _, ok := d.GetOk("auto_accept"); ok && d.Get("state").(string) == "pendingAcceptance" {
-		if err := vpcEndpointAccept(conn, d.Id(), d.Get("service_name").(string)); err != nil {
+	if d.HasChange("auto_accept") && d.Get("auto_accept").(bool) && d.Get("state").(string) == "pendingAcceptance" {
+		if err := vpcEndpointAccept(conn, d.Id(), d.Get("service_name").(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return err
 		}
 	}
@@ -375,7 +375,7 @@ func resourceAwsVpcEndpointDelete(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func vpcEndpointAccept(conn *ec2.EC2, vpceId, svcName string) error {
+func vpcEndpointAccept(conn *ec2.EC2, vpceId, svcName string, timeout time.Duration) error {
 	describeSvcReq := &ec2.DescribeVpcEndpointServiceConfigurationsInput{}
 	describeSvcReq.Filters = buildEC2AttributeFilterList(
 		map[string]string{
@@ -385,7 +385,7 @@ func vpcEndpointAccept(conn *ec2.EC2, vpceId, svcName string) error {
 
 	describeSvcResp, err := conn.DescribeVpcEndpointServiceConfigurations(describeSvcReq)
 	if err != nil {
-		return fmt.Errorf("Error reading VPC Endpoint Service: %s", err)
+		return fmt.Errorf("error reading VPC Endpoint Service (%s): %s", svcName, err)
 	}
 	if describeSvcResp == nil || len(describeSvcResp.ServiceConfigurations) == 0 {
 		return fmt.Errorf("No matching VPC Endpoint Service found")
@@ -399,7 +399,21 @@ func vpcEndpointAccept(conn *ec2.EC2, vpceId, svcName string) error {
 	log.Printf("[DEBUG] Accepting VPC Endpoint connection: %#v", acceptEpReq)
 	_, err = conn.AcceptVpcEndpointConnections(acceptEpReq)
 	if err != nil {
-		return fmt.Errorf("Error accepting VPC Endpoint connection: %s", err)
+		return fmt.Errorf("error accepting VPC Endpoint (%s) connection: %s", vpceId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"pendingAcceptance"},
+		Target:     []string{"available"},
+		Refresh:    vpcEndpointStateRefresh(conn, vpceId),
+		Timeout:    timeout,
+		Delay:      5 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for VPC Endpoint (%s) to be accepted: %s", vpceId, err)
 	}
 
 	return nil
@@ -448,11 +462,10 @@ func vpcEndpointWaitUntilAvailable(conn *ec2.EC2, vpceId string, timeout time.Du
 		Delay:      5 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
-	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for VPC Endpoint (%s) to become available: %s", vpceId, err)
-	}
 
-	return nil
+	_, err := stateConf.WaitForState()
+
+	return err
 }
 
 func vpcEndpointWaitUntilDeleted(conn *ec2.EC2, vpceId string, timeout time.Duration) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13387.
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/13853.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_vpc_endpoint: Wait for VPC Endpoint connection acceptance
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpcEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSVpcEndpoint_ -timeout 120m
=== RUN   TestAccAWSVpcEndpoint_gatewayBasic
=== PAUSE TestAccAWSVpcEndpoint_gatewayBasic
=== RUN   TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicyAndTags
=== PAUSE TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicyAndTags
=== RUN   TestAccAWSVpcEndpoint_gatewayPolicy
=== PAUSE TestAccAWSVpcEndpoint_gatewayPolicy
=== RUN   TestAccAWSVpcEndpoint_interfaceBasic
=== PAUSE TestAccAWSVpcEndpoint_interfaceBasic
=== RUN   TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
=== PAUSE TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
=== RUN   TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== PAUSE TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== RUN   TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== PAUSE TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== RUN   TestAccAWSVpcEndpoint_removed
=== PAUSE TestAccAWSVpcEndpoint_removed
=== CONT  TestAccAWSVpcEndpoint_gatewayBasic
=== CONT  TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate
--- PASS: TestAccAWSVpcEndpoint_gatewayBasic (52.10s)
=== CONT  TestAccAWSVpcEndpoint_removed
--- PASS: TestAccAWSVpcEndpoint_removed (43.32s)
=== CONT  TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== CONT  TestAccAWSVpcEndpoint_interfaceBasic
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnCreate (323.60s)
--- PASS: TestAccAWSVpcEndpoint_interfaceBasic (146.49s)
=== CONT  TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSServiceAcceptOnUpdate (376.70s)
=== CONT  TestAccAWSVpcEndpoint_gatewayPolicy
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (84.84s)
=== CONT  TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicyAndTags
--- PASS: TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicyAndTags (92.71s)
--- PASS: TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup (401.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	871.680s
```
