### PR TITLE
Make ES Domain delete timeout configurable

### DIFF
--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -1048,6 +1048,10 @@ resource "aws_elasticsearch_domain" "test" {
     ebs_enabled = true
     volume_size = 10
   }
+
+  timeouts {
+    delete = "180m"
+  }
 }
 `, randInt)
 }

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -318,6 +318,7 @@ In addition to all arguments above, the following attributes are exported:
 `aws_elasticsearch_domain` provides the following [Timeouts](/docs/configuration/resources.html#operation-timeouts) configuration options:
 
 * `update` - (Optional, Default: `60m`) How long to wait for updates.
+* `delete` - (Optional, Default: `90m`) How long to wait for deleting.
 
 ## Import
 


### PR DESCRIPTION
It is common that deleting ES domains will take more than
90 minutes (which is default for now) if the comains has a bunch of data.

`update` has been already made configurable at:
https://github.com/terraform-providers/terraform-provider-aws/pull/12916

NOTE: This feature was introduced at #6243

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
