### PR TITLE
r/ebs_snapshot - add import support

### DIFF
--- a/aws/resource_aws_ebs_snapshot.go
+++ b/aws/resource_aws_ebs_snapshot.go
@@ -19,6 +19,9 @@ func resourceAwsEbsSnapshot() *schema.Resource {
 		Read:   resourceAwsEbsSnapshotRead,
 		Update: resourceAwsEbsSnapshotUpdate,
 		Delete: resourceAwsEbsSnapshotDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -122,7 +125,7 @@ func resourceAwsEbsSnapshotRead(d *schema.ResourceData, meta interface{}) error 
 	res, err := conn.DescribeSnapshots(req)
 	if err != nil {
 		if isAWSErr(err, "InvalidSnapshot.NotFound", "") {
-			log.Printf("[WARN] Snapshot %q Not found - removing from state", d.Id())
+			log.Printf("[WARN] EBS Snapshot %q Not found - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
@@ -130,7 +133,7 @@ func resourceAwsEbsSnapshotRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if len(res.Snapshots) == 0 {
-		log.Printf("[WARN] Snapshot %q Not found - removing from state", d.Id())
+		log.Printf("[WARN] EBS Snapshot %q Not found - removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/aws/resource_aws_ebs_snapshot_test.go
+++ b/aws/resource_aws_ebs_snapshot_test.go
@@ -28,7 +28,13 @@ func TestAccAWSEBSSnapshot_basic(t *testing.T) {
 					testAccCheckSnapshotExists(resourceName, &v),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`snapshot/snap-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -51,6 +57,11 @@ func TestAccAWSEBSSnapshot_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAwsEbsSnapshotConfigBasicTags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -90,6 +101,11 @@ func TestAccAWSEBSSnapshot_withDescription(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -111,6 +127,11 @@ func TestAccAWSEBSSnapshot_withKms(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "kms_key_id",
 						regexp.MustCompile(`^arn:aws:kms:[a-z]{2}-[a-z]+-\d{1}:[0-9]{12}:key/[a-z0-9-]{36}$`)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -194,14 +215,21 @@ func testAccCheckAWSEbsSnapshotDestroy(s *terraform.State) error {
 
 func testAccAwsEbsSnapshotConfigBasic(rName string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${data.aws_region.current.name}a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 
   tags = {
-    Name = "%s"
+    Name = %[1]q
   }
 }
 
@@ -218,10 +246,17 @@ resource "aws_ebs_snapshot" "test" {
 
 func testAccAwsEbsSnapshotConfigBasicTags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${data.aws_region.current.name}a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 }
 
@@ -243,10 +278,17 @@ resource "aws_ebs_snapshot" "test" {
 
 func testAccAwsEbsSnapshotConfigBasicTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${data.aws_region.current.name}a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 }
 
@@ -269,53 +311,59 @@ resource "aws_ebs_snapshot" "test" {
 
 func testAccAwsEbsSnapshotConfigWithDescription(rName string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 resource "aws_ebs_volume" "description_test" {
-  availability_zone = "${data.aws_region.current.name}a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 }
 
 resource "aws_ebs_snapshot" "test" {
   volume_id   = "${aws_ebs_volume.description_test.id}"
-  description = "%s"
+  description = %[1]q
 }
 `, rName)
 }
 
 func testAccAwsEbsSnapshotConfigWithKms(rName string) string {
 	return fmt.Sprintf(`
-variable "name" {
-  default = "%s"
-}
+data "aws_availability_zones" "available" {
+  state = "available"
 
-data "aws_region" "current" {}
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 
   tags = {
-    Name = "${var.name}"
+    Name = %[1]q
   }
 }
 
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${data.aws_region.current.name}a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
   encrypted         = true
   kms_key_id        = "${aws_kms_key.test.arn}"
 
   tags = {
-    Name = "${var.name}"
+    Name = %[1]q
   }
 }
 
 resource "aws_ebs_snapshot" "test" {
   volume_id = "${aws_ebs_volume.test.id}"
-
-  tags = {
-    Name = "${var.name}"
-  }
 }
 `, rName)
 }

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -60,3 +60,11 @@ In addition to all arguments above, the following attributes are exported:
 * `kms_key_id` - The ARN for the KMS encryption key.
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot.
 * `tags` - A map of tags for the snapshot.
+
+## Import
+
+EBS Snapshot can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_ebs_snapshot.id snap-049df61146c4d7901
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ebs_snapshot: add import support
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEBSSnapshot_'
--- PASS: TestAccAWSEBSSnapshot_basic (76.29s)
--- PASS: TestAccAWSEBSSnapshot_tags (122.35s)
--- PASS: TestAccAWSEBSSnapshot_withDescription (59.37s)
--- PASS: TestAccAWSEBSSnapshot_withKms (99.61s)
--- PASS: TestAccAWSEBSSnapshot_disappears (61.28s)
```
