### PR TITLE
tests/resource/aws_db_snapshot: Ensure sweeper runs after aws_db_instance and skips automated snapshots

### DIFF
--- a/aws/resource_aws_db_snapshot_test.go
+++ b/aws/resource_aws_db_snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,6 +19,9 @@ func init() {
 	resource.AddTestSweepers("aws_db_snapshot", &resource.Sweeper{
 		Name: "aws_db_snapshot",
 		F:    testSweepDbSnapshots,
+		Dependencies: []string{
+			"aws_db_instance",
+		},
 	})
 }
 
@@ -45,6 +49,11 @@ func testSweepDbSnapshots(region string) error {
 			id := aws.StringValue(dbSnapshot.DBSnapshotIdentifier)
 			input := &rds.DeleteDBSnapshotInput{
 				DBSnapshotIdentifier: dbSnapshot.DBSnapshotIdentifier,
+			}
+
+			if strings.HasPrefix(id, "rds:") {
+				log.Printf("[INFO] Skipping RDS Automated DB Snapshot: %s", id)
+				continue
 			}
 
 			log.Printf("[INFO] Deleting RDS DB Snapshot: %s", id)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13800

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Looks like the `aws_db_instance` sweeper separately needs to be updated to handle API deletion protection.

Output from sweeper in AWS Commercial:

```
2020/06/23 09:05:56 [DEBUG] Running Sweepers for region (us-west-2):
2020/06/23 09:05:56 [DEBUG] Running Sweeper (aws_db_instance) in region (us-west-2)
...
2020/06/23 09:05:59 [INFO] Deleting DB instance: tf-acc-test-5943499196810915120
2020/06/23 09:06:00 [ERROR] Failed to delete DB instance tf-acc-test-5943499196810915120: InvalidParameterCombination: Cannot delete protected DB Instance, please disable deletion protection and try again.
	status code: 400, request id: 90caa3c3-9f82-4ad5-ad74-a68238240564
2020/06/23 09:06:00 [DEBUG] Running Sweeper (aws_db_snapshot) in region (us-west-2)
2020/06/23 09:06:00 Sweeper Tests ran successfully:
	- aws_db_instance
	- aws_db_snapshot
2020/06/23 09:06:00 [DEBUG] Running Sweepers for region (us-east-1):
2020/06/23 09:06:00 [DEBUG] Running Sweeper (aws_db_instance) in region (us-east-1)
...
2020/06/23 09:06:02 [DEBUG] Running Sweeper (aws_db_snapshot) in region (us-east-1)
2020/06/23 09:06:02 Sweeper Tests ran successfully:
	- aws_db_instance
	- aws_db_snapshot
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.798s
```

Output from sweeper in AWS GovCloud (US):

```
2020/06/23 09:06:15 [DEBUG] Running Sweepers for region (us-gov-west-1):
2020/06/23 09:06:15 [DEBUG] Running Sweeper (aws_db_instance) in region (us-gov-west-1)
...
2020/06/23 09:06:17 [DEBUG] Running Sweeper (aws_db_snapshot) in region (us-gov-west-1)
2020/06/23 09:06:18 Sweeper Tests ran successfully:
	- aws_db_instance
	- aws_db_snapshot
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.148s
```
