### PR TITLE
Enable UltraWarm in-place

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -242,7 +242,6 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 						"warm_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							ForceNew: true,
 						},
 						"warm_count": {
 							Type:         schema.TypeInt,

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -190,6 +190,15 @@ func TestAccAWSElasticSearchDomain_warm(t *testing.T) {
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccESDomainConfigWarm(rName, "ultrawarm1.medium.elasticsearch", false, 6),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_count", "6"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_type", "ultrawarm1.medium.elasticsearch"),
+				),
+			},
+			{
 				Config: testAccESDomainConfigWarm(rName, "ultrawarm1.medium.elasticsearch", true, 6),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists(resourceName, &domain),

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -190,7 +190,7 @@ func TestAccAWSElasticSearchDomain_warm(t *testing.T) {
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccESDomainConfigWarmDisabled(rName),
+				Config: testAccESDomainConfigWarm(rName, "ultrawarm1.medium.elasticsearch", false, 6),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_enabled", "false"),
@@ -199,7 +199,7 @@ func TestAccAWSElasticSearchDomain_warm(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccESDomainConfigWarmEnabled(rName, "ultrawarm1.medium.elasticsearch", 6),
+				Config: testAccESDomainConfigWarm(rName, "ultrawarm1.medium.elasticsearch", true, 6),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_enabled", "true"),
@@ -214,7 +214,7 @@ func TestAccAWSElasticSearchDomain_warm(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccESDomainConfigWarmEnabled(rName, "ultrawarm1.medium.elasticsearch", 7),
+				Config: testAccESDomainConfigWarm(rName, "ultrawarm1.medium.elasticsearch", true, 7),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_enabled", "true"),
@@ -223,7 +223,7 @@ func TestAccAWSElasticSearchDomain_warm(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccESDomainConfigWarmEnabled(rName, "ultrawarm1.large.elasticsearch", 7),
+				Config: testAccESDomainConfigWarm(rName, "ultrawarm1.large.elasticsearch", true, 7),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_enabled", "true"),
@@ -1121,8 +1121,9 @@ resource "aws_elasticsearch_domain" "test" {
 `, rName, zoneAwarenessEnabled)
 }
 
-func testAccESDomainConfigWarmEnabled(rName, warmType string, warmCnt int) string {
-	return fmt.Sprintf(`
+func testAccESDomainConfigWarm(rName, warmType string, enabled bool, warmCnt int) string {
+	if enabled {
+		return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
   domain_name           = %[1]q
   elasticsearch_version = "6.8"
@@ -1149,10 +1150,8 @@ resource "aws_elasticsearch_domain" "test" {
   }
 }
 `, rName, warmCnt, warmType)
-}
-
-func testAccESDomainConfigWarmDisabled(rName string) string {
-	return fmt.Sprintf(`
+	} else {
+		return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
   domain_name           = %[1]q
   elasticsearch_version = "6.8"
@@ -1177,6 +1176,7 @@ resource "aws_elasticsearch_domain" "test" {
   }
 }
 `, rName)
+	}
 }
 
 func testAccESDomainConfig_WithDedicatedClusterMaster(randInt int, enabled bool) string {

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -1122,61 +1122,40 @@ resource "aws_elasticsearch_domain" "test" {
 }
 
 func testAccESDomainConfigWarm(rName, warmType string, enabled bool, warmCnt int) string {
+	warmConfig := ""
 	if enabled {
-		return fmt.Sprintf(`
-resource "aws_elasticsearch_domain" "test" {
-  domain_name           = %[1]q
-  elasticsearch_version = "6.8"
-
-  cluster_config {
-    zone_awareness_enabled   = true
-    instance_type            = "c5.large.elasticsearch"
-    instance_count           = "3"
-    dedicated_master_enabled = true
-    dedicated_master_count   = "3"
-    dedicated_master_type    = "c5.large.elasticsearch"
-    warm_enabled             = true
-    warm_count               = %[2]d
-    warm_type                = %[3]q
-
-    zone_awareness_config {
-      availability_zone_count = 3
-    }
-  }
-
-  ebs_options {
-    ebs_enabled = true
-    volume_size = 10
-  }
-}
-`, rName, warmCnt, warmType)
-	} else {
-		return fmt.Sprintf(`
-resource "aws_elasticsearch_domain" "test" {
-  domain_name           = %[1]q
-  elasticsearch_version = "6.8"
-
-  cluster_config {
-    zone_awareness_enabled   = true
-    instance_type            = "c5.large.elasticsearch"
-    instance_count           = "3"
-    dedicated_master_enabled = true
-    dedicated_master_count   = "3"
-    dedicated_master_type    = "c5.large.elasticsearch"
-    warm_enabled             = false
-
-    zone_awareness_config {
-      availability_zone_count = 3
-    }
-  }
-
-  ebs_options {
-    ebs_enabled = true
-    volume_size = 10
-  }
-}
-`, rName)
+		warmConfig = fmt.Sprintf(`
+    warm_count = %[1]d
+    warm_type = %[2]q
+`, warmCnt, warmType)
 	}
+
+	return fmt.Sprintf(`
+resource "aws_elasticsearch_domain" "test" {
+  domain_name           = %[1]q
+  elasticsearch_version = "6.8"
+
+  cluster_config {
+    zone_awareness_enabled   = true
+    instance_type            = "c5.large.elasticsearch"
+    instance_count           = "3"
+    dedicated_master_enabled = true
+    dedicated_master_count   = "3"
+    dedicated_master_type    = "c5.large.elasticsearch"
+    warm_enabled             = %[2]t
+    %[3]s
+
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+}
+`, rName, enabled, warmConfig)
 }
 
 func testAccESDomainConfig_WithDedicatedClusterMaster(randInt int, enabled bool) string {

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -194,8 +194,8 @@ func TestAccAWSElasticSearchDomain_warm(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_count", "6"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_type", "ultrawarm1.medium.elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_config.0.warm_type", ""),
 				),
 			},
 			{


### PR DESCRIPTION
Since GA, you can enable UltraWarm in-place on existing domains: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/ultrawarm.html#ultrawarm-enable. This makes [ForceNew](https://www.terraform.io/docs/extend/schemas/schema-behaviors.html#forcenew) unnecessary. Remove `ForceNew` so it does not destroy and recreate the underlying resource.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
Enable Elasticsearch UltraWarm in-place.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticSearchDomain_warm'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticSearchDomain_warm -timeout 120m
=== RUN   TestAccAWSElasticSearchDomain_warm
=== PAUSE TestAccAWSElasticSearchDomain_warm
=== CONT  TestAccAWSElasticSearchDomain_warm
--- PASS: TestAccAWSElasticSearchDomain_warm (4418.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4420.811s
```
