### PR TITLE
resource/aws_spot_fleet_request: Increase default delete timeout to 15 minutes

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -31,7 +31,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 
 		SchemaVersion: 1,

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -39,7 +39,7 @@ func testSweepSpotFleetRequests(region string) error {
 			id := aws.StringValue(config.SpotFleetRequestId)
 
 			log.Printf("[INFO] Deleting Spot Fleet Request: %s", id)
-			err := deleteSpotFleetRequest(id, true, 5*time.Minute, conn)
+			err := deleteSpotFleetRequest(id, true, 15*time.Minute, conn)
 			if err != nil {
 				log.Printf("[ERROR] Failed to delete Spot Fleet Request (%s): %s", id, err)
 			}
@@ -261,7 +261,7 @@ func TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec(t *testing.T) {
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
@@ -302,7 +302,7 @@ func TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate(t *testing.T) {
 	validUntil := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
 	resourceName := "aws_spot_fleet_request.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
@@ -1146,7 +1146,7 @@ func TestAccAWSSpotFleetRequest_disappears(t *testing.T) {
 				Config: testAccAWSSpotFleetRequestConfig(rName, rInt, validUntil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSSpotFleetRequestExists(resourceName, &sfr),
-					testAccCheckAWSSpotFleetRequestDisappears(&sfr),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSpotFleetRequest(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -1194,16 +1194,6 @@ func testAccCheckAWSSpotFleetRequestExists(
 		*sfr = *resp.SpotFleetRequestConfigs[0]
 
 		return nil
-	}
-}
-
-func testAccCheckAWSSpotFleetRequestDisappears(sfr *ec2.SpotFleetRequestConfig) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		sfrId := aws.StringValue(sfr.SpotFleetRequestId)
-		err := deleteSpotFleetRequest(sfrId, true, 5*time.Minute, conn)
-
-		return err
 	}
 }
 

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -235,7 +235,7 @@ The `launch_template_config` block supports the following:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 10 mins) Used when requesting the spot instance (only valid if `wait_for_fulfillment = true`)
-* `delete` - (Defaults to 5 mins) Used when destroying the spot instance
+* `delete` - (Defaults to 15 mins) Used when destroying the spot instance
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13065
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13527

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_spot_fleet_request: Increase default delete timeout to 15 minutes
```

The EC2 documentation does not provide too much guidance on how long EC2 Instance termination should take ("a few minutes"), however in practice we have seen many errors at 5 minutes on instances with no actual workload. While watching the request logs and viewing the EC2 console, it appears there may also be eventual consistency between instance termination and when the `DescribeSpotFleetInstances` API response has active instances removed.

This changeset also provides minor testing improvements such as using `resource.ParallelTest()` for tests missing it and switching the disappears testing to use the shared `testAccCheckResourceDisappears()` function.

Output from acceptance testing:

```
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (319.23s)
--- PASS: TestAccAWSSpotFleetRequest_basic (298.32s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (649.15s)
--- PASS: TestAccAWSSpotFleetRequest_disappears (454.76s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (354.21s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (298.39s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (434.74s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (474.48s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (161.36s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (168.88s)
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (500.29s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (236.95s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (241.01s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (536.94s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (235.98s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (248.40s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (301.21s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (250.00s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (343.81s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (311.80s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (288.35s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (319.60s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (72.49s)
--- PASS: TestAccAWSSpotFleetRequest_tags (340.04s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (643.56s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (929.39s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (329.00s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (266.68s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (287.66s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (299.45s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (483.65s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (347.27s)
```
