### PR TITLE
resource/aws_db_instance_role_association: Prevent immediate read after creation panic

### DIFF
--- a/aws/resource_aws_db_instance_role_association.go
+++ b/aws/resource_aws_db_instance_role_association.go
@@ -207,6 +207,10 @@ func waitForRdsDbInstanceRoleAssociation(conn *rds.RDS, dbInstanceIdentifier, ro
 				return nil, "", err
 			}
 
+			if dbInstanceRole == nil {
+				return nil, rdsDbInstanceRoleStatusPending, nil
+			}
+
 			return dbInstanceRole, aws.StringValue(dbInstanceRole.Status), nil
 		},
 		Timeout: 5 * time.Minute,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11745

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_instance_role_association: Prevent immediate read after creation panic
```

Likely due to some slight eventual consistency in the RDS APIs.

Output from acceptance testing:

```
--- PASS: TestAccAWSDbInstanceRoleAssociation_disappears (583.61s)
--- PASS: TestAccAWSDbInstanceRoleAssociation_basic (693.95s)
```
