### PR TITLE
resource/aws_db_instance: Prevent schema version 1 upgrade panic on missing state

### DIFF
--- a/aws/resource_aws_db_instance_migrate.go
+++ b/aws/resource_aws_db_instance_migrate.go
@@ -378,6 +378,11 @@ func resourceAwsDbInstanceResourceV0() *schema.Resource {
 }
 
 func resourceAwsDbInstanceStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		return nil, nil
+	}
+
 	rawState["delete_automated_backups"] = true
+
 	return rawState, nil
 }

--- a/aws/resource_aws_db_instance_migrate_test.go
+++ b/aws/resource_aws_db_instance_migrate_test.go
@@ -5,40 +5,54 @@ import (
 	"testing"
 )
 
-func testResourceAwsDbInstanceStateDataV0() map[string]interface{} {
-	return map[string]interface{}{
-		"allocated_storage": 10,
-		"engine":            "mariadb",
-		"identifier":        "my-test-instance",
-		"instance_class":    "db.t2.micro",
-		"password":          "avoid-plaintext-passwords",
-		"username":          "tfacctest",
-		"tags":              map[string]interface{}{"key1": "value1"},
-	}
-}
-
-func testResourceAwsDbInstanceStateDataV1() map[string]interface{} {
-	v0 := testResourceAwsDbInstanceStateDataV0()
-	return map[string]interface{}{
-		"allocated_storage":        v0["allocated_storage"],
-		"delete_automated_backups": true,
-		"engine":                   v0["engine"],
-		"identifier":               v0["identifier"],
-		"instance_class":           v0["instance_class"],
-		"password":                 v0["password"],
-		"username":                 v0["username"],
-		"tags":                     v0["tags"],
-	}
-}
-
 func TestResourceAwsDbInstanceStateUpgradeV0(t *testing.T) {
-	expected := testResourceAwsDbInstanceStateDataV1()
-	actual, err := resourceAwsDbInstanceStateUpgradeV0(testResourceAwsDbInstanceStateDataV0(), nil)
-	if err != nil {
-		t.Fatalf("error migrating state: %s", err)
+	testCases := []struct {
+		Description   string
+		InputState    map[string]interface{}
+		ExpectedState map[string]interface{}
+	}{
+		{
+			Description:   "missing state",
+			InputState:    nil,
+			ExpectedState: nil,
+		},
+		{
+			Description: "adds delete_automated_backups",
+			InputState: map[string]interface{}{
+				"allocated_storage": 10,
+				"engine":            "mariadb",
+				"identifier":        "my-test-instance",
+				"instance_class":    "db.t2.micro",
+				"password":          "avoid-plaintext-passwords",
+				"username":          "tfacctest",
+				"tags":              map[string]interface{}{"key1": "value1"},
+			},
+			ExpectedState: map[string]interface{}{
+				"allocated_storage":        10,
+				"delete_automated_backups": true,
+				"engine":                   "mariadb",
+				"identifier":               "my-test-instance",
+				"instance_class":           "db.t2.micro",
+				"password":                 "avoid-plaintext-passwords",
+				"username":                 "tfacctest",
+				"tags":                     map[string]interface{}{"key1": "value1"},
+			},
+		},
 	}
 
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.Description, func(t *testing.T) {
+			got, err := resourceAwsDbInstanceStateUpgradeV0(testCase.InputState, nil)
+
+			if err != nil {
+				t.Fatalf("error migrating state: %s", err)
+			}
+
+			if !reflect.DeepEqual(testCase.ExpectedState, got) {
+				t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", testCase.ExpectedState, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12771

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_instance: Prevent schema version 1 upgrade panic on missing state
```

It is not entirely clear how the state is empty in certain scenarios, however we can at least pass it through rather than panicking.

Previously:

```
--- FAIL: TestResourceAwsDbInstanceStateUpgradeV0 (0.00s)
    --- FAIL: TestResourceAwsDbInstanceStateUpgradeV0/missing_state (0.00s)
panic: assignment to entry in nil map [recovered]
  panic: assignment to entry in nil map

goroutine 1457 [running]:
testing.tRunner.func1.1(0x6577da0, 0x7d89790)
  /usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc0012f07e0)
  /usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:943 +0x3f9
panic(0x6577da0, 0x7d89790)
  /usr/local/Cellar/go/1.14.3/libexec/src/runtime/panic.go:969 +0x166
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsDbInstanceStateUpgradeV0(...)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_db_instance_migrate.go:381
github.com/terraform-providers/terraform-provider-aws/aws.TestResourceAwsDbInstanceStateUpgradeV0.func1(0xc0012f07e0)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_db_instance_migrate_test.go:47 +0x65
```

Output from acceptance testing: N/A (covered via unit testing)
