### PR TITLE
resource/aws_batch_compute_environment: Remove resource from Terraform state when not found instead of returning error

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -332,13 +332,17 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 	log.Printf("[DEBUG] Read compute environment %s.\n", input)
 
 	result, err := conn.DescribeComputeEnvironments(input)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading Batch Compute Environment (%s): %w", d.Id(), err)
 	}
 
 	if len(result.ComputeEnvironments) == 0 {
-		return fmt.Errorf("One compute environment is expected, but AWS return no compute environment")
+		log.Printf("[WARN] Batch Compute Environment (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
+
 	computeEnvironment := result.ComputeEnvironments[0]
 
 	d.Set("service_role", computeEnvironment.ServiceRole)

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -63,6 +63,27 @@ func testSweepBatchComputeEnvironments(region string) error {
 	return nil
 }
 
+func TestAccAWSBatchComputeEnvironment_disappears(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "aws_batch_compute_environment.ec2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSBatchComputeEnvironmentConfigEC2(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBatchComputeEnvironmentExists(),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBatchComputeEnvironment(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSBatchComputeEnvironment_createEc2(t *testing.T) {
 	rInt := acctest.RandInt()
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/contributing/running-and-writing-acceptance-tests.md#disappears-acceptance-tests
Closes #12337
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_batch_compute_environment: Remove resource from Terraform state when not found instead of returning error
```

Previously:

```
=== CONT  TestAccAWSBatchComputeEnvironment_disappears
    TestAccAWSBatchComputeEnvironment_disappears: testing.go:684: Step 0 error: errors during follow-up refresh:

        Error: One compute environment is expected, but AWS return no compute environment

    TestAccAWSBatchComputeEnvironment_disappears: testing.go:745: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: One compute environment is expected, but AWS return no compute environment

        State: <nil>
--- FAIL: TestAccAWSBatchComputeEnvironment_disappears (59.70s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (35.53s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (35.72s)
--- PASS: TestAccAWSBatchComputeEnvironment_createWithNamePrefix (64.40s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (67.27s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (67.28s)
--- PASS: TestAccAWSBatchComputeEnvironment_disappears (71.92s)
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (72.52s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (72.67s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy (74.33s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (80.45s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (81.01s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (93.78s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (105.25s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (114.21s)
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate (114.41s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus (135.46s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_DesiredVcpus_Computed (171.29s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus (216.35s)
```

