### PR TITLE
resource/elasticsearch_domain: allow empty string for EBS volume type validation

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -141,11 +141,14 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								elasticsearch.VolumeTypeStandard,
-								elasticsearch.VolumeTypeGp2,
-								elasticsearch.VolumeTypeIo1,
-							}, false),
+							ValidateFunc: validation.Any(
+								validation.StringIsEmpty,
+								validation.StringInSlice([]string{
+									elasticsearch.VolumeTypeStandard,
+									elasticsearch.VolumeTypeGp2,
+									elasticsearch.VolumeTypeIo1,
+								}, false),
+							),
 						},
 					},
 				},

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -801,7 +801,7 @@ func TestAccAWSElasticSearchDomain_update_volume_type(t *testing.T) {
 func TestAccAWSElasticSearchDomain_WithVolumeType_Missing(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 	resourceName := "aws_elasticsearch_domain.test"
-	rInt := acctest.RandInt()
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(16, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckIamServiceLinkedRoleEs(t) },
@@ -809,7 +809,7 @@ func TestAccAWSElasticSearchDomain_WithVolumeType_Missing(t *testing.T) {
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccESDomainConfigWithDisabledEBSAndVolumeType(rInt, ""),
+				Config: testAccESDomainConfigWithDisabledEBSAndVolumeType(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "cluster_config.#", "1"),
@@ -824,7 +824,7 @@ func TestAccAWSElasticSearchDomain_WithVolumeType_Missing(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     resourceId,
+				ImportStateId:     rName,
 				ImportStateVerify: true,
 			},
 		},
@@ -1086,10 +1086,10 @@ resource "aws_elasticsearch_domain" "test" {
 `, randInt)
 }
 
-func testAccESDomainConfigWithDisabledEBSAndVolumeType(rInt int, volumeType string) string {
+func testAccESDomainConfigWithDisabledEBSAndVolumeType(rName, volumeType string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = "tf-test-%d"
+  domain_name = "%s"
   elasticsearch_version = "6.0"
   
   cluster_config {
@@ -1103,7 +1103,7 @@ resource "aws_elasticsearch_domain" "test" {
     volume_type = "%s"
   }
 }
-`, rInt, volumeType)
+`, rName, volumeType)
 }
 
 func testAccESDomainConfig_DomainEndpointOptions(randInt int, enforceHttps bool, tlsSecurityPolicy string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13867 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/elasticsearch_domain: allow empty string for EBS volume type validation
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticSearchDomain_duplicate (516.34s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (919.19s)
--- PASS: TestAccAWSElasticSearchDomain_basic (1014.49s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (1015.40s)
--- PASS: TestAccAWSElasticSearchDomain_vpc (1178.69s)
--- PASS: TestAccAWSElasticSearchDomain_tags (1181.80s)
--- PASS: TestAccAWSElasticSearchDomain_v23 (1259.18s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (1290.76s)
--- PASS: TestAccAWSElasticSearchDomain_NodeToNodeEncryption (1489.17s)
--- PASS: TestAccAWSElasticSearchDomain_complex (1544.80s)
--- PASS: TestAccAWSElasticSearchDomain_WithVolumeType_Missing (737.85s)
--- PASS: TestAccAWSElasticSearchDomain_policy (1768.78s)
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (1935.11s)
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (1974.92s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsUpdate (1991.91s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove (2341.19s)
--- PASS: TestAccAWSElasticSearchDomain_RequireHTTPS (2632.20s)
--- PASS: TestAccAWSElasticSearchDomain_update (3211.26s)
--- PASS: TestAccAWSElasticSearchDomain_update_volume_type (2755.73s)
--- PASS: TestAccAWSElasticSearchDomain_withDedicatedMaster (4035.40s)
--- PASS: TestAccAWSElasticSearchDomain_warm (4357.87s)
--- PASS: TestAccAWSElasticSearchDomain_update_version (3728.00s)
--- PASS: TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig (5896.41s)
```
