### PR TITLE
Add slack integration for maintainer team to post daily open PR count for team members

### DIFF
--- a/.github/workflows/team_slack_bot.yml
+++ b/.github/workflows/team_slack_bot.yml
@@ -1,0 +1,20 @@
+name: team-slack-bot
+
+on:
+  schedule:
+    - cron:  '0 15 * * 1-5'
+
+jobs:
+  open-pr-stats:
+    runs-on: ubuntu-latest
+    name: open-pr-stats
+    steps:
+    - name: open-pr-stats
+      uses: breathingdust/github-team-slackbot@v13
+      with:
+        github_token: ${{ secrets.GITHUB_ACTIONS_TOKEN}}
+        org: terraform-providers
+        team_slug: aws-provider
+        slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+        slack_channel: ${{ secrets.SLACK_CHANNEL }}
+        


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Adds a simple slack integration to post daily Open PR counts for team members in an organization.
