### PR TITLE
r/aws_backup_selection: Correctly handle disappearing Backup Plan

### DIFF
--- a/aws/resource_aws_backup_selection.go
+++ b/aws/resource_aws_backup_selection.go
@@ -145,7 +145,8 @@ func resourceAwsBackupSelectionRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	resp, err := conn.GetBackupSelection(input)
-	if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") {
+	if isAWSErr(err, backup.ErrCodeResourceNotFoundException, "") ||
+		isAWSErr(err, backup.ErrCodeInvalidParameterValueException, "Cannot find Backup plan") {
 		log.Printf("[WARN] Backup Selection (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -14,14 +14,15 @@ import (
 func TestAccAwsBackupSelection_basic(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
 	resourceName := "aws_backup_selection.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupSelectionConfigBasic(rInt),
+				Config: testAccBackupSelectionConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
 				),
@@ -38,8 +39,8 @@ func TestAccAwsBackupSelection_basic(t *testing.T) {
 
 func TestAccAwsBackupSelection_disappears(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
-	rInt := acctest.RandInt()
 	resourceName := "aws_backup_selection.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
@@ -47,7 +48,7 @@ func TestAccAwsBackupSelection_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupSelectionConfigBasic(rInt),
+				Config: testAccBackupSelectionConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupSelection(), resourceName),
@@ -58,17 +59,42 @@ func TestAccAwsBackupSelection_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsBackupSelection_withTags(t *testing.T) {
+func TestAccAwsBackupSelection_backupPlanDisappears(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
 	resourceName := "aws_backup_selection.test"
-	rInt := acctest.RandInt()
+	backupPlanResourceName := "aws_backup_plan.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupSelectionConfigWithTags(rInt),
+				Config: testAccBackupSelectionConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupSelection(), resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsBackupPlan(), backupPlanResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsBackupSelection_withTags(t *testing.T) {
+	var selection1 backup.GetBackupSelectionOutput
+	resourceName := "aws_backup_selection.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupSelectionConfigWithTags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
 					resource.TestCheckResourceAttr(resourceName, "selection_tag.#", "2"),
@@ -87,14 +113,15 @@ func TestAccAwsBackupSelection_withTags(t *testing.T) {
 func TestAccAwsBackupSelection_withResources(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
 	resourceName := "aws_backup_selection.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupSelectionConfigWithResources(rInt),
+				Config: testAccBackupSelectionConfigWithResources(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
 					resource.TestCheckResourceAttr(resourceName, "resources.#", "2"),
@@ -113,20 +140,21 @@ func TestAccAwsBackupSelection_withResources(t *testing.T) {
 func TestAccAwsBackupSelection_updateTag(t *testing.T) {
 	var selection1, selection2 backup.GetBackupSelectionOutput
 	resourceName := "aws_backup_selection.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBackupSelectionConfigBasic(rInt),
+				Config: testAccBackupSelectionConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
 				),
 			},
 			{
-				Config: testAccBackupSelectionConfigUpdateTag(rInt),
+				Config: testAccBackupSelectionConfigUpdateTag(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupSelectionExists(resourceName, &selection2),
 					testAccCheckAwsBackupSelectionRecreated(t, &selection1, &selection2),
@@ -217,7 +245,7 @@ func testAccAWSBackupSelectionImportStateIDFunc(resourceName string) resource.Im
 	}
 }
 
-func testAccBackupSelectionConfigBase(rInt int) string {
+func testAccBackupSelectionConfigBase(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -226,27 +254,29 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_backup_vault" "test" {
-  name = "tf_acc_test_backup_vault_%d"
+  name = %[1]q
 }
 
 resource "aws_backup_plan" "test" {
-  name = "tf_acc_test_backup_plan_%d"
+  name = %[1]q
 
   rule {
-    rule_name         = "tf_acc_test_backup_rule_%d"
+    rule_name         = %[1]q
     target_vault_name = "${aws_backup_vault.test.name}"
     schedule          = "cron(0 12 * * ? *)"
   }
 }
-`, rInt, rInt, rInt)
+`, rName)
 }
 
-func testAccBackupSelectionConfigBasic(rInt int) string {
-	return testAccBackupSelectionConfigBase(rInt) + fmt.Sprintf(`
+func testAccBackupSelectionConfigBasic(rName string) string {
+	return composeConfig(
+		testAccBackupSelectionConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_backup_selection" "test" {
   plan_id      = "${aws_backup_plan.test.id}"
 
-  name         = "tf_acc_test_backup_selection_%d"
+  name         = %[1]q
   iam_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/service-role/AWSBackupDefaultServiceRole"
 
   selection_tag {
@@ -259,15 +289,17 @@ resource "aws_backup_selection" "test" {
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/"
   ]
 }
-`, rInt)
+`, rName))
 }
 
-func testAccBackupSelectionConfigWithTags(rInt int) string {
-	return testAccBackupSelectionConfigBase(rInt) + fmt.Sprintf(`
+func testAccBackupSelectionConfigWithTags(rName string) string {
+	return composeConfig(
+		testAccBackupSelectionConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_backup_selection" "test" {
   plan_id      = "${aws_backup_plan.test.id}"
 
-  name         = "tf_acc_test_backup_selection_%d"
+  name         = %[1]q
   iam_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/service-role/AWSBackupDefaultServiceRole"
 
   selection_tag {
@@ -286,11 +318,13 @@ resource "aws_backup_selection" "test" {
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/"
   ]
 }
-`, rInt)
+`, rName))
 }
 
-func testAccBackupSelectionConfigWithResources(rInt int) string {
-	return testAccBackupSelectionConfigBase(rInt) + fmt.Sprintf(`
+func testAccBackupSelectionConfigWithResources(rName string) string {
+	return composeConfig(
+		testAccBackupSelectionConfigBase(rName),
+		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -305,12 +339,16 @@ resource "aws_ebs_volume" "test" {
 
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_backup_selection" "test" {
   plan_id      = "${aws_backup_plan.test.id}"
 
-  name         = "tf_acc_test_backup_selection_%d"
+  name         = %[1]q
   iam_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/service-role/AWSBackupDefaultServiceRole"
 
   selection_tag {
@@ -324,15 +362,17 @@ resource "aws_backup_selection" "test" {
     "${aws_ebs_volume.test.1.arn}",
   ]
 }
-`, rInt)
+`, rName))
 }
 
-func testAccBackupSelectionConfigUpdateTag(rInt int) string {
-	return testAccBackupSelectionConfigBase(rInt) + fmt.Sprintf(`
+func testAccBackupSelectionConfigUpdateTag(rName string) string {
+	return composeConfig(
+		testAccBackupSelectionConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_backup_selection" "test" {
   plan_id      = "${aws_backup_plan.test.id}"
 
-  name         = "tf_acc_test_backup_selection_%d"
+  name         = %[1]q
   iam_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/service-role/AWSBackupDefaultServiceRole"
 
   selection_tag {
@@ -345,5 +385,5 @@ resource "aws_backup_selection" "test" {
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/"
   ]
 }
-`, rInt)
+`, rName))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13903.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_backup_selection: Correctly handle the associated backup plan being deleted outside Terraform
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsBackupSelection_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAwsBackupSelection_ -timeout 120m
=== RUN   TestAccAwsBackupSelection_basic
=== PAUSE TestAccAwsBackupSelection_basic
=== RUN   TestAccAwsBackupSelection_disappears
=== PAUSE TestAccAwsBackupSelection_disappears
=== RUN   TestAccAwsBackupSelection_backupPlanDisappears
=== PAUSE TestAccAwsBackupSelection_backupPlanDisappears
=== RUN   TestAccAwsBackupSelection_withTags
=== PAUSE TestAccAwsBackupSelection_withTags
=== RUN   TestAccAwsBackupSelection_withResources
=== PAUSE TestAccAwsBackupSelection_withResources
=== RUN   TestAccAwsBackupSelection_updateTag
=== PAUSE TestAccAwsBackupSelection_updateTag
=== CONT  TestAccAwsBackupSelection_basic
=== CONT  TestAccAwsBackupSelection_withTags
=== CONT  TestAccAwsBackupSelection_updateTag
=== CONT  TestAccAwsBackupSelection_withResources
=== CONT  TestAccAwsBackupSelection_backupPlanDisappears
=== CONT  TestAccAwsBackupSelection_disappears
--- PASS: TestAccAwsBackupSelection_backupPlanDisappears (31.56s)
--- PASS: TestAccAwsBackupSelection_disappears (33.11s)
--- PASS: TestAccAwsBackupSelection_withTags (34.34s)
--- PASS: TestAccAwsBackupSelection_basic (34.89s)
--- PASS: TestAccAwsBackupSelection_withResources (43.95s)
--- PASS: TestAccAwsBackupSelection_updateTag (52.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	52.641s
```

Without the fix the new acceptance test fails:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsBackupSelection_backupPlanDisappears'
\==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAwsBackupSelection_backupPlanDisappears -timeout 120m
=== RUN   TestAccAwsBackupSelection_backupPlanDisappears
=== PAUSE TestAccAwsBackupSelection_backupPlanDisappears
=== CONT  TestAccAwsBackupSelection_backupPlanDisappears
--- FAIL: TestAccAwsBackupSelection_backupPlanDisappears (24.20s)
    testing.go:684: Step 0 error: errors during follow-up refresh:
        
        Error: error reading Backup Selection: InvalidParameterValueException: Cannot find Backup plan with ID 2f1d3251-ced9-4348-9ac0-c218a63426d0
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "ff437f9f-db4b-4a4b-8696-3c58459879df"
          },
          Code_: "ERROR_2304",
          Context: "2f1d3251-ced9-4348-9ac0-c218a63426d0",
          Message_: "Cannot find Backup plan with ID 2f1d3251-ced9-4348-9ac0-c218a63426d0"
        }
        
        
    testing.go:745: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: error reading Backup Selection: InvalidParameterValueException: Cannot find Backup plan with ID 2f1d3251-ced9-4348-9ac0-c218a63426d0
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "71e64601-3bac-49b7-90f9-de5436402fac"
          },
          Code_: "ERROR_2304",
          Context: "2f1d3251-ced9-4348-9ac0-c218a63426d0",
          Message_: "Cannot find Backup plan with ID 2f1d3251-ced9-4348-9ac0-c218a63426d0"
        }
        
        State: <nil>
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	24.254s
FAIL
GNUmakefile:26: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```