### PR TITLE
resource/aws_efs_mount_target: Continue allowing empty string in ip_address validation

### DIFF
--- a/aws/resource_aws_efs_mount_target.go
+++ b/aws/resource_aws_efs_mount_target.go
@@ -37,11 +37,14 @@ func resourceAwsEfsMountTarget() *schema.Resource {
 			},
 
 			"ip_address": {
-				Type:         schema.TypeString,
-				Computed:     true,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsIPv4Address,
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.Any(
+					validation.IsIPv4Address,
+					validation.StringIsEmpty,
+				),
 			},
 
 			"security_groups": {

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -102,11 +102,12 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 				Config: testAccAWSEFSMountTargetConfig(ct),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsMountTarget(resourceName, &mount),
-					testAccMatchResourceAttrRegionalHostname(resourceName, "dns_name", "efs", regexp.MustCompile(`fs-[^.]+`)),
-					testAccMatchResourceAttrRegionalARN(resourceName, "file_system_arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
-					resource.TestCheckResourceAttrSet(resourceName, "mount_target_dns_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone_name"),
+					testAccMatchResourceAttrRegionalHostname(resourceName, "dns_name", "efs", regexp.MustCompile(`fs-[^.]+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "file_system_arn", "elasticfilesystem", regexp.MustCompile(`file-system/fs-.+`)),
+					resource.TestMatchResourceAttr(resourceName, "ip_address", regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "mount_target_dns_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
@@ -146,6 +147,57 @@ func TestAccAWSEFSMountTarget_disappears(t *testing.T) {
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsEfsMountTarget(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEFSMountTarget_IpAddress(t *testing.T) {
+	var mount efs.MountTargetDescription
+	resourceName := "aws_efs_mount_target.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsMountTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSMountTargetConfigIpAddress("10.0.0.100"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsMountTarget(resourceName, &mount),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", "10.0.0.100"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13845
+func TestAccAWSEFSMountTarget_IpAddress_EmptyString(t *testing.T) {
+	var mount efs.MountTargetDescription
+	resourceName := "aws_efs_mount_target.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsMountTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSMountTargetConfigIpAddress(""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEfsMountTarget(resourceName, &mount),
+					resource.TestMatchResourceAttr(resourceName, "ip_address", regexp.MustCompile(`\d+\.\d+\.\d+\.\d+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -332,4 +384,47 @@ resource "aws_subnet" "test2" {
   }
 }
 `, ct)
+}
+
+func testAccAWSEFSMountTargetConfigIpAddress(ipAddress string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-efs-mount-target-test"
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "10.0.0.0/24"
+
+  tags = {
+    Name = "tf-acc-efs-mount-target-test"
+  }
+}
+
+resource "aws_efs_file_system" "test" {
+  tags = {
+    Name = "tf-acc-efs-mount-target-test"
+  }
+}
+
+resource "aws_efs_mount_target" "test" {
+  file_system_id = aws_efs_file_system.test.id
+  ip_address     = %[1]q
+  subnet_id      = aws_subnet.test.id
+}
+`, ipAddress)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13845 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_efs_mount_target: Continue allowing empty string (`""`) in `ip_address` argument validation
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEFSMountTarget_disappears (148.46s)
--- PASS: TestAccAWSEFSMountTarget_IpAddress_EmptyString (149.17s)
--- PASS: TestAccAWSEFSMountTarget_IpAddress (149.93s)
--- PASS: TestAccAWSEFSMountTarget_basic (262.20s)
```
