### PR TITLE
AWS Workspaces fix for issue 13558

### DIFF
--- a/aws/resource_aws_workspaces_workspace.go
+++ b/aws/resource_aws_workspaces_workspace.go
@@ -248,7 +248,7 @@ func resourceAwsWorkspacesWorkspaceUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	if d.HasChange("workspace_properties.0.running_mode_auto_stop_timeout_in_minutes") || (d.Get("workspace_properties.0.running_mode") != workspaces.RunningModeAlwaysOn) {
+	if d.HasChange("workspace_properties.0.running_mode_auto_stop_timeout_in_minutes") {
 		if err := workspacePropertyUpdate("running_mode_auto_stop_timeout_in_minutes", conn, d); err != nil {
 			return err
 		}
@@ -366,22 +366,18 @@ func expandWorkspaceProperties(properties []interface{}) *workspaces.WorkspacePr
 
 	p := properties[0].(map[string]interface{})
 
-	if p["running_mode"] == workspaces.RunningModeAlwaysOn {
-		return &workspaces.WorkspaceProperties{
-			ComputeTypeName:   aws.String(p["compute_type_name"].(string)),
-			RootVolumeSizeGib: aws.Int64(int64(p["root_volume_size_gib"].(int))),
-			RunningMode:       aws.String(p["running_mode"].(string)),
-			UserVolumeSizeGib: aws.Int64(int64(p["user_volume_size_gib"].(int))),
-		}
-	} else {
-		return &workspaces.WorkspaceProperties{
-			ComputeTypeName:                     aws.String(p["compute_type_name"].(string)),
-			RootVolumeSizeGib:                   aws.Int64(int64(p["root_volume_size_gib"].(int))),
-			RunningMode:                         aws.String(p["running_mode"].(string)),
-			RunningModeAutoStopTimeoutInMinutes: aws.Int64(int64(p["running_mode_auto_stop_timeout_in_minutes"].(int))),
-			UserVolumeSizeGib:                   aws.Int64(int64(p["user_volume_size_gib"].(int))),
-		}
+	workspaceProperties := &workspaces.WorkspaceProperties{
+		ComputeTypeName:   aws.String(p["compute_type_name"].(string)),
+		RootVolumeSizeGib: aws.Int64(int64(p["root_volume_size_gib"].(int))),
+		RunningMode:       aws.String(p["running_mode"].(string)),
+		UserVolumeSizeGib: aws.Int64(int64(p["user_volume_size_gib"].(int))),
 	}
+
+	if p["running_mode"] == workspaces.RunningModeAutoStop {
+		workspaceProperties.RunningModeAutoStopTimeoutInMinutes = aws.Int64(int64(p["running_mode_auto_stop_timeout_in_minutes"].(int)))
+	}
+
+	return workspaceProperties
 }
 
 func flattenWorkspaceProperties(properties *workspaces.WorkspaceProperties) []map[string]interface{} {

--- a/aws/resource_aws_workspaces_workspace.go
+++ b/aws/resource_aws_workspaces_workspace.go
@@ -248,7 +248,7 @@ func resourceAwsWorkspacesWorkspaceUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	if d.HasChange("workspace_properties.0.running_mode_auto_stop_timeout_in_minutes") || (d.Get("workspace_properties.0.running_mode") != "ALWAYS_ON") {
+	if d.HasChange("workspace_properties.0.running_mode_auto_stop_timeout_in_minutes") || (d.Get("workspace_properties.0.running_mode") != workspaces.RunningModeAlwaysOn) {
 		if err := workspacePropertyUpdate("running_mode_auto_stop_timeout_in_minutes", conn, d); err != nil {
 			return err
 		}
@@ -366,7 +366,7 @@ func expandWorkspaceProperties(properties []interface{}) *workspaces.WorkspacePr
 
 	p := properties[0].(map[string]interface{})
 
-	if p["running_mode"] == "ALWAYS_ON" {
+	if p["running_mode"] == workspaces.RunningModeAlwaysOn {
 		return &workspaces.WorkspaceProperties{
 			ComputeTypeName:   aws.String(p["compute_type_name"].(string)),
 			RootVolumeSizeGib: aws.Int64(int64(p["root_volume_size_gib"].(int))),

--- a/aws/resource_aws_workspaces_workspace.go
+++ b/aws/resource_aws_workspaces_workspace.go
@@ -248,7 +248,7 @@ func resourceAwsWorkspacesWorkspaceUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	if d.HasChange("workspace_properties.0.running_mode_auto_stop_timeout_in_minutes") {
+	if d.HasChange("workspace_properties.0.running_mode_auto_stop_timeout_in_minutes") || (d.Get("workspace_properties.0.running_mode") != "ALWAYS_ON") {
 		if err := workspacePropertyUpdate("running_mode_auto_stop_timeout_in_minutes", conn, d); err != nil {
 			return err
 		}
@@ -366,12 +366,21 @@ func expandWorkspaceProperties(properties []interface{}) *workspaces.WorkspacePr
 
 	p := properties[0].(map[string]interface{})
 
-	return &workspaces.WorkspaceProperties{
-		ComputeTypeName:                     aws.String(p["compute_type_name"].(string)),
-		RootVolumeSizeGib:                   aws.Int64(int64(p["root_volume_size_gib"].(int))),
-		RunningMode:                         aws.String(p["running_mode"].(string)),
-		RunningModeAutoStopTimeoutInMinutes: aws.Int64(int64(p["running_mode_auto_stop_timeout_in_minutes"].(int))),
-		UserVolumeSizeGib:                   aws.Int64(int64(p["user_volume_size_gib"].(int))),
+	if p["running_mode"] == "ALWAYS_ON" {
+		return &workspaces.WorkspaceProperties{
+			ComputeTypeName:   aws.String(p["compute_type_name"].(string)),
+			RootVolumeSizeGib: aws.Int64(int64(p["root_volume_size_gib"].(int))),
+			RunningMode:       aws.String(p["running_mode"].(string)),
+			UserVolumeSizeGib: aws.Int64(int64(p["user_volume_size_gib"].(int))),
+		}
+	} else {
+		return &workspaces.WorkspaceProperties{
+			ComputeTypeName:                     aws.String(p["compute_type_name"].(string)),
+			RootVolumeSizeGib:                   aws.Int64(int64(p["root_volume_size_gib"].(int))),
+			RunningMode:                         aws.String(p["running_mode"].(string)),
+			RunningModeAutoStopTimeoutInMinutes: aws.Int64(int64(p["running_mode_auto_stop_timeout_in_minutes"].(int))),
+			UserVolumeSizeGib:                   aws.Int64(int64(p["user_volume_size_gib"].(int))),
+		}
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #13558

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
This is my first submission to any project, ever. Please forgive sloppiness. I appreciate any feedback. I just made some small changes to the existing document to allow workspaces with the ALWAYS_ON to be created and updated. These changes include skipping updating the running_mode_auto_stop_timeout_in_minutes property if the running_mode is set to ALWAYS_ON and removing running_mode_auto_stop_timeout_in_minutes from the extended properties used in creation if the running_mode is set to ALWAYS_ON.

```


Test results:

ian@UbuntuNUC:~/development/terraform-providers/terraform-provider-aws$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsWorkspacesWorkspace*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWorkspacesWorkspace* -timeout 120m
=== RUN   TestAccAwsWorkspacesWorkspace_basic
=== PAUSE TestAccAwsWorkspacesWorkspace_basic
=== RUN   TestAccAwsWorkspacesWorkspace_tags
=== PAUSE TestAccAwsWorkspacesWorkspace_tags
=== RUN   TestAccAwsWorkspacesWorkspace_workspaceProperties
=== PAUSE TestAccAwsWorkspacesWorkspace_workspaceProperties
=== RUN   TestAccAwsWorkspacesWorkspace_validateRootVolumeSize
=== PAUSE TestAccAwsWorkspacesWorkspace_validateRootVolumeSize
=== RUN   TestAccAwsWorkspacesWorkspace_validateUserVolumeSize
=== PAUSE TestAccAwsWorkspacesWorkspace_validateUserVolumeSize
=== CONT  TestAccAwsWorkspacesWorkspace_basic
=== CONT  TestAccAwsWorkspacesWorkspace_validateRootVolumeSize
=== CONT  TestAccAwsWorkspacesWorkspace_workspaceProperties
=== CONT  TestAccAwsWorkspacesWorkspace_validateUserVolumeSize
=== CONT  TestAccAwsWorkspacesWorkspace_tags
--- PASS: TestAccAwsWorkspacesWorkspace_validateRootVolumeSize (2.83s)
--- PASS: TestAccAwsWorkspacesWorkspace_validateUserVolumeSize (2.84s)
--- PASS: TestAccAwsWorkspacesWorkspace_tags (1820.33s)
--- PASS: TestAccAwsWorkspacesWorkspace_basic (1833.78s)
--- PASS: TestAccAwsWorkspacesWorkspace_workspaceProperties (1928.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1928.844s
