### PR TITLE
Remove "it's" contraction due to format error in website

### DIFF
--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -141,7 +141,7 @@ resource "aws_cognito_user_pool" "example" {
     developer_only_attribute = false
     mutable                  = true  // false for "sub"
     required                 = false // true for "sub"
-    string_attribute_constraints {   // if it's a string
+    string_attribute_constraints {   // if it is a string
       min_length = 0                 // 10 for "birthdate"
       max_length = 2048              // 10 for "birthdate"
     }


### PR DESCRIPTION
Hey there,

Here we just remove a simple contraction that caused a format error in the UI, as it is shown below:

<img width="876" alt="Screen Shot 2020-06-30 at 08 47 39" src="https://user-images.githubusercontent.com/21130697/86123753-67667600-bab0-11ea-825e-b2bf9dd7db55.png">


Instead of "it's", it has been switched to "it is"

### Community Note

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
cognito_user_pool: Remove "it's" contraction in docs due to website ui format error
```

Output from acceptance testing:

```
N/A
```
