### PR TITLE
awsproviderlint: Enforce kms_key_id as ARN attribute in AWSAT001 check

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -169,7 +169,8 @@ func TestAccAWSDBInstance_generatedName(t *testing.T) {
 
 func TestAccAWSDBInstance_kmsKey(t *testing.T) {
 	var v rds.DBInstance
-	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+	kmsKeyResourceName := "aws_kms_key.foo"
+	resourceName := "aws_db_instance.bar"
 
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAWSDBInstanceConfigKmsKeyId, ri)
@@ -182,11 +183,22 @@ func TestAccAWSDBInstance_kmsKey(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
+					testAccCheckAWSDBInstanceExists(resourceName, &v),
 					testAccCheckAWSDBInstanceAttributes(&v),
-					resource.TestMatchResourceAttr(
-						"aws_db_instance.bar", "kms_key_id", keyRegex),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"delete_automated_backups",
+					"final_snapshot_identifier",
+					"password",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})

--- a/aws/resource_aws_ebs_snapshot_test.go
+++ b/aws/resource_aws_ebs_snapshot_test.go
@@ -113,6 +113,7 @@ func TestAccAWSEBSSnapshot_withDescription(t *testing.T) {
 func TestAccAWSEBSSnapshot_withKms(t *testing.T) {
 	var v ec2.Snapshot
 	rName := fmt.Sprintf("tf-acc-ebs-snapshot-kms-%s", acctest.RandString(7))
+	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_ebs_snapshot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -124,8 +125,7 @@ func TestAccAWSEBSSnapshot_withKms(t *testing.T) {
 				Config: testAccAwsEbsSnapshotConfigWithKms(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists(resourceName, &v),
-					resource.TestMatchResourceAttr(resourceName, "kms_key_id",
-						regexp.MustCompile(`^arn:aws:kms:[a-z]{2}-[a-z]+-\d{1}:[0-9]{12}:key/[a-z0-9-]{36}$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
 				),
 			},
 			{

--- a/aws/resource_aws_fsx_windows_file_system_test.go
+++ b/aws/resource_aws_fsx_windows_file_system_test.go
@@ -89,7 +89,7 @@ func TestAccAWSFsxWindowsFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "copy_tags_to_backups", "false"),
 					resource.TestMatchResourceAttr(resourceName, "daily_automatic_backup_start_time", regexp.MustCompile(`^\d\d:\d\d$`)),
 					resource.TestMatchResourceAttr(resourceName, "dns_name", regexp.MustCompile(`fs-.+\..+`)),
-					resource.TestMatchResourceAttr(resourceName, "kms_key_id", regexp.MustCompile(`^arn:`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "kms_key_id", "kms", regexp.MustCompile(`key/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_ids.#", "1"),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "0"),

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -192,7 +192,7 @@ func TestAccAWSRDSClusterInstance_generatedName(t *testing.T) {
 
 func TestAccAWSRDSClusterInstance_kmsKey(t *testing.T) {
 	var v rds.DBInstance
-	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+	kmsKeyResourceName := "aws_kms_key.foo"
 	resourceName := "aws_rds_cluster_instance.cluster_instances"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -204,7 +204,7 @@ func TestAccAWSRDSClusterInstance_kmsKey(t *testing.T) {
 				Config: testAccAWSClusterInstanceConfigKmsKey(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &v),
-					resource.TestMatchResourceAttr(resourceName, "kms_key_id", keyRegex),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
 				),
 			},
 			{

--- a/awsproviderlint/passes/AWSAT001/AWSAT001.go
+++ b/awsproviderlint/passes/AWSAT001/AWSAT001.go
@@ -70,16 +70,16 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func AttributeNameAppearsArnRelated(attributeName string) bool {
-	if attributeName == "arn" {
+	if attributeName == "arn" || attributeName == "kms_key_id" {
 		return true
 	}
 
-	if strings.HasSuffix(attributeName, "_arn") {
+	if strings.HasSuffix(attributeName, "_arn") || strings.HasSuffix(attributeName, "_kms_key_id") {
 		return true
 	}
 
 	// Handle flatmap nested attribute
-	if strings.HasSuffix(attributeName, ".arn") {
+	if strings.HasSuffix(attributeName, ".arn") || strings.HasSuffix(attributeName, ".kms_key_id") {
 		return true
 	}
 

--- a/awsproviderlint/passes/AWSAT001/AWSAT001_test.go
+++ b/awsproviderlint/passes/AWSAT001/AWSAT001_test.go
@@ -34,8 +34,18 @@ func TestAttributeNameAppearsArnRelated(t *testing.T) {
 			Expected:      true,
 		},
 		{
+			Name:          "equals kms_key_id",
+			AttributeName: "kms_key_id",
+			Expected:      true,
+		},
+		{
 			Name:          "arn suffix",
 			AttributeName: "some_arn",
+			Expected:      true,
+		},
+		{
+			Name:          "kms_key_id suffix",
+			AttributeName: "some_kms_key_id",
 			Expected:      true,
 		},
 		{
@@ -44,8 +54,18 @@ func TestAttributeNameAppearsArnRelated(t *testing.T) {
 			Expected:      true,
 		},
 		{
+			Name:          "nested attribute equals kms_key_id",
+			AttributeName: "config_block.0.kms_key_id",
+			Expected:      true,
+		},
+		{
 			Name:          "nested attribute arn suffix",
 			AttributeName: "config_block.0.some_arn",
+			Expected:      true,
+		},
+		{
+			Name:          "nested attribute kms_key_id suffix",
+			AttributeName: "config_block.0.some_kms_key_id",
 			Expected:      true,
 		},
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously, test failures could include these outside AWS Commercial:

```
--- FAIL: TestAccAWSEBSSnapshot_withKms (88.99s)
testing.go:684: Step 0 error: Check failed: Check 2/2 error: aws_ebs_snapshot.test: Attribute 'kms_key_id' didn't match "^arn:aws:kms:[a-z]{2}-[a-z]+-\\d{1}:[0-9]{12}:key/[a-z0-9-]{36}$", got "arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/59dff49a-68bc-407d-959c-deb91757d55b"
```

New AWSAT001 check test failures:

```
aws/resource_aws_db_instance_test.go:187:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_ebs_snapshot_test.go:127:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_fsx_windows_file_system_test.go:92:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
aws/resource_aws_rds_cluster_instance_test.go:207:6: AWSAT001: prefer resource.TestCheckResourceAttrPair() or ARN check functions (e.g. testAccMatchResourceAttrRegionalARN)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSEBSSnapshot_withKms (41.72s)
--- PASS: TestAccAWSDBInstance_kmsKey (486.55s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (691.04s)
--- PASS: TestAccAWSFsxWindowsFileSystem_basic (3121.42s)
```

Output from acceptance testing in AWS GovCloud (US) (hardcoded AZ and service availability PreCheck test failures will be separately addressed in the future):

```
--- PASS: TestAccAWSEBSSnapshot_withKms (60.17s)
--- PASS: TestAccAWSDBInstance_kmsKey (479.81s)

--- FAIL: TestAccAWSRDSClusterInstance_kmsKey (17.37s)
    TestAccAWSRDSClusterInstance_kmsKey: testing.go:684: Step 0 error: errors during apply:

        Error: error creating RDS cluster: InvalidVPCNetworkStateFault: Availability zones '[us-west-2a, us-west-2b, us-west-2c]' are unavailable in this region, please choose another zone set.

--- FAIL: TestAccAWSFsxWindowsFileSystem_basic (1743.81s)
    TestAccAWSFsxWindowsFileSystem_basic: testing.go:684: Step 0 error: errors during apply:

        Error: Error creating FSx filesystem: RequestError: send request failed
        caused by: Post "https://fsx.us-gov-west-1.amazonaws.com/": dial tcp: lookup fsx.us-gov-west-1.amazonaws.com: no such host
```
