### PR TITLE
data-source/efs_filesystem: return error if 0 results found

### DIFF
--- a/aws/data_source_aws_efs_file_system_test.go
+++ b/aws/data_source_aws_efs_file_system_test.go
@@ -67,6 +67,20 @@ func TestAccDataSourceAwsEfsFileSystem_name(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsEfsFileSystem_NonExistent(t *testing.T) {
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsEfsFileSystemIDConfig_NonExistent,
+				ExpectError: regexp.MustCompile(`error reading EFS FileSystem`),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsEfsFileSystemCheck(dName, rName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[dName]
@@ -101,11 +115,17 @@ func testAccDataSourceAwsEfsFileSystemCheck(dName, rName string) resource.TestCh
 	}
 }
 
+const testAccDataSourceAwsEfsFileSystemIDConfig_NonExistent = `
+data "aws_efs_file_system" "test" {
+  file_system_id = "fs-nonexistent"
+}
+`
+
 const testAccDataSourceAwsEfsFileSystemNameConfig = `
 resource "aws_efs_file_system" "test" {}
 
 data "aws_efs_file_system" "test" {
-creation_token = "${aws_efs_file_system.test.creation_token}"
+  creation_token = "${aws_efs_file_system.test.creation_token}"
 }
 `
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13410 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/efs_filesystem: return error if 0 results found
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccDataSourceAwsEfsFileSystem_NonExistent (3.84s)
--- PASS: TestAccDataSourceAwsEfsFileSystem_name (29.47s)
--- PASS: TestAccDataSourceAwsEfsFileSystem_id (30.12s)
```
