### PR TITLE
data-source/elasticache_replication_group: adjust error formatting and handling

### DIFF
--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -49,7 +49,6 @@ func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 			"node_type": {
 				Type:     schema.TypeString,
@@ -69,31 +68,32 @@ func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
 
 func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).elasticacheconn
+
+	groupID := d.Get("replication_group_id").(string)
 	input := &elasticache.DescribeReplicationGroupsInput{
-		ReplicationGroupId: aws.String(d.Get("replication_group_id").(string)),
+		ReplicationGroupId: aws.String(groupID),
 	}
 
 	log.Printf("[DEBUG] Reading ElastiCache Replication Group: %s", input)
 	resp, err := conn.DescribeReplicationGroups(input)
 	if err != nil {
-		return err
-	}
-
-	var rg *elasticache.ReplicationGroup
-	for _, r := range resp.ReplicationGroups {
-		if *r.ReplicationGroupId == d.Get("replication_group_id").(string) {
-			rg = r
+		if isAWSErr(err, elasticache.ErrCodeReplicationGroupNotFoundFault, "") {
+			return fmt.Errorf("ElastiCache Replication Group (%s) not found", groupID)
 		}
-	}
-	if rg == nil {
-		return fmt.Errorf("Elasticache Replication Group (%s) not found", d.Get("replication_group_id").(string))
+		return fmt.Errorf("error reading replication group (%s): %w", groupID, err)
 	}
 
-	d.SetId(*rg.ReplicationGroupId)
+	if resp == nil || len(resp.ReplicationGroups) == 0 {
+		return fmt.Errorf("error reading replication group (%s): empty output", groupID)
+	}
+
+	rg := resp.ReplicationGroups[0]
+
+	d.SetId(aws.StringValue(rg.ReplicationGroupId))
 	d.Set("replication_group_description", rg.Description)
 	d.Set("auth_token_enabled", rg.AuthTokenEnabled)
 	if rg.AutomaticFailover != nil {
-		switch *rg.AutomaticFailover {
+		switch aws.StringValue(rg.AutomaticFailover) {
 		case elasticache.AutomaticFailoverStatusDisabled, elasticache.AutomaticFailoverStatusDisabling:
 			d.Set("automatic_failover_enabled", false)
 		case elasticache.AutomaticFailoverStatusEnabled, elasticache.AutomaticFailoverStatusEnabling:
@@ -106,14 +106,14 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 	} else {
 		if rg.NodeGroups == nil {
 			d.SetId("")
-			return fmt.Errorf("Elasticache Replication Group (%s) doesn't have node groups.", d.Get("replication_group_id").(string))
+			return fmt.Errorf("Elasticache Replication Group (%s) doesn't have node groups.", aws.StringValue(rg.ReplicationGroupId))
 		}
 		d.Set("port", rg.NodeGroups[0].PrimaryEndpoint.Port)
 		d.Set("primary_endpoint_address", rg.NodeGroups[0].PrimaryEndpoint.Address)
 	}
 	d.Set("number_cache_clusters", len(rg.MemberClusters))
 	if err := d.Set("member_clusters", flattenStringList(rg.MemberClusters)); err != nil {
-		return fmt.Errorf("error setting member_clusters: %s", err)
+		return fmt.Errorf("error setting member_clusters: %w", err)
 	}
 	d.Set("node_type", rg.CacheNodeType)
 	d.Set("snapshot_window", rg.SnapshotWindow)

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -61,6 +62,20 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent(t *testing.T) {
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsElasticacheReplicationGroupConfig_NonExistent,
+				ExpectError: regexp.MustCompile(`not found`),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsElasticacheReplicationGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
@@ -109,3 +124,9 @@ data "aws_elasticache_replication_group" "test" {
 }
 `, rName)
 }
+
+const testAccDataSourceAwsElasticacheReplicationGroupConfig_NonExistent = `
+data "aws_elasticache_replication_group" "test" {
+  replication_group_id = "tf-acc-test-nonexistent"
+}
+`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13410 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/elasticaceh_replication_group: adjust error formatting and handling
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_NonExistent (5.18s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_basic (769.50s)
--- PASS: TestAccDataSourceAwsElasticacheReplicationGroup_ClusterMode (881.37s)
```
