### PR TITLE
Change aws_vpc option instance_tenancy to default (saving users $48/day)

### DIFF
--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -25,7 +25,7 @@ Basic usage with tags:
 ```hcl
 resource "aws_vpc" "main" {
   cidr_block       = "10.0.0.0/16"
-  instance_tenancy = "dedicated"
+  instance_tenancy = "default"
 
   tags = {
     Name = "main"
@@ -38,7 +38,8 @@ resource "aws_vpc" "main" {
 The following arguments are supported:
 
 * `cidr_block` - (Required) The CIDR block for the VPC.
-* `instance_tenancy` - (Optional) A tenancy option for instances launched into the VPC
+* `instance_tenancy` - (Optional) A tenancy option for instances launched into the VPC. Default is `default`, which
+  makes your instances shared on the host. Using either of the other options (`dedicated` or `host`) costs at least $2/hr.
 * `enable_dns_support` - (Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true.
 * `enable_dns_hostnames` - (Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false.
 * `enable_classiclink` - (Optional) A boolean flag to enable/disable ClassicLink


### PR DESCRIPTION
Copy-and-pasting this code will cause users to create VPCs that essentially cost $48 per day. So, I changed the "instance_tenancy" setting to "default" (it was "dedicated".) "default" is the normal mode of operation at AWS (shared instances.)

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
