### PR TITLE
r/aws_customer_gateway: Allow 4-byte ASNs

### DIFF
--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -30,7 +30,7 @@ func resourceAwsCustomerGateway() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(1, 65534),
+				ValidateFunc: validation.IntBetween(0, 4294967295),
 			},
 
 			"ip_address": {

--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -27,10 +27,10 @@ func resourceAwsCustomerGateway() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"bgp_asn": {
-				Type:         schema.TypeInt,
+				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(0, 4294967295),
+				ValidateFunc: validate4ByteAsn,
 			},
 
 			"ip_address": {
@@ -66,7 +66,7 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 
 	ipAddress := d.Get("ip_address").(string)
 	vpnType := d.Get("type").(string)
-	bgpAsn := d.Get("bgp_asn").(int)
+	bgpAsn := d.Get("bgp_asn").(string)
 
 	alreadyExists, err := resourceAwsCustomerGatewayExists(vpnType, ipAddress, bgpAsn, conn)
 	if err != nil {
@@ -74,11 +74,16 @@ func resourceAwsCustomerGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if alreadyExists {
-		return fmt.Errorf("An existing customer gateway for IpAddress: %s, VpnType: %s, BGP ASN: %d has been found", ipAddress, vpnType, bgpAsn)
+		return fmt.Errorf("An existing customer gateway for IpAddress: %s, VpnType: %s, BGP ASN: %s has been found", ipAddress, vpnType, bgpAsn)
+	}
+
+	i64BgpAsn, err := strconv.ParseInt(bgpAsn, 10, 64)
+	if err != nil {
+		return err
 	}
 
 	createOpts := &ec2.CreateCustomerGatewayInput{
-		BgpAsn:   aws.Int64(int64(bgpAsn)),
+		BgpAsn:   aws.Int64(i64BgpAsn),
 		PublicIp: aws.String(ipAddress),
 		Type:     aws.String(vpnType),
 	}
@@ -150,7 +155,7 @@ func customerGatewayRefreshFunc(conn *ec2.EC2, gatewayId string) resource.StateR
 	}
 }
 
-func resourceAwsCustomerGatewayExists(vpnType, ipAddress string, bgpAsn int, conn *ec2.EC2) (bool, error) {
+func resourceAwsCustomerGatewayExists(vpnType, ipAddress, bgpAsn string, conn *ec2.EC2) (bool, error) {
 	ipAddressFilter := &ec2.Filter{
 		Name:   aws.String("ip-address"),
 		Values: []*string{aws.String(ipAddress)},
@@ -161,10 +166,9 @@ func resourceAwsCustomerGatewayExists(vpnType, ipAddress string, bgpAsn int, con
 		Values: []*string{aws.String(vpnType)},
 	}
 
-	bgp := strconv.Itoa(bgpAsn)
 	bgpAsnFilter := &ec2.Filter{
 		Name:   aws.String("bgp-asn"),
-		Values: []*string{aws.String(bgp)},
+		Values: []*string{aws.String(bgpAsn)},
 	}
 
 	resp, err := conn.DescribeCustomerGateways(&ec2.DescribeCustomerGatewaysInput{
@@ -215,20 +219,12 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	customerGateway := resp.CustomerGateways[0]
+	d.Set("bgp_asn", customerGateway.BgpAsn)
 	d.Set("ip_address", customerGateway.IpAddress)
 	d.Set("type", customerGateway.Type)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(customerGateway.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
-	}
-
-	if aws.StringValue(customerGateway.BgpAsn) != "" {
-		val, err := strconv.ParseInt(aws.StringValue(customerGateway.BgpAsn), 0, 0)
-		if err != nil {
-			return fmt.Errorf("error parsing bgp_asn: %s", err)
-		}
-
-		d.Set("bgp_asn", int(val))
 	}
 
 	arn := arn.ARN{

--- a/aws/resource_aws_customer_gateway_test.go
+++ b/aws/resource_aws_customer_gateway_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -27,6 +28,7 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway(resourceName, &gateway),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`customer-gateway/cgw-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn", strconv.Itoa(rBgpAsn)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -134,6 +136,35 @@ func TestAccAWSCustomerGateway_disappears(t *testing.T) {
 					testAccCheckResourceDisappears(testAccProvider, resourceAwsCustomerGateway(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCustomerGateway_4ByteAsn(t *testing.T) {
+	var gateway ec2.CustomerGateway
+	rBgpAsn := strconv.FormatInt(int64(randIntRange(64512, 65534))*10000, 10)
+	resourceName := "aws_customer_gateway.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckCustomerGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomerGatewayConfig4ByteAsn(rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomerGateway(resourceName, &gateway),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`customer-gateway/cgw-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn", rBgpAsn),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -274,6 +305,16 @@ func testAccCustomerGatewayConfigForceReplace(rBgpAsn int) string {
 resource "aws_customer_gateway" "test" {
   bgp_asn    = %d
   ip_address = "172.10.10.1"
+  type       = "ipsec.1"
+}
+`, rBgpAsn)
+}
+
+func testAccCustomerGatewayConfig4ByteAsn(rBgpAsn string) string {
+	return fmt.Sprintf(`
+resource "aws_customer_gateway" "test" {
+  bgp_asn    = %[1]q
+  ip_address = "172.0.0.1"
   type       = "ipsec.1"
 }
 `, rBgpAsn)

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2126,6 +2126,21 @@ func validateAmazonSideAsn(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
+func validate4ByteAsn(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	asn, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q (%q) must be a 64-bit integer", k, v))
+		return
+	}
+
+	if asn < 0 || asn > 4294967295 {
+		errors = append(errors, fmt.Errorf("%q (%q) must be in the range 0 to 4294967295", k, v))
+	}
+	return
+}
+
 func validateIotThingTypeName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`[a-zA-Z0-9:_-]+`).MatchString(value) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2727,6 +2727,37 @@ func TestValidateAmazonSideAsn(t *testing.T) {
 	}
 }
 
+func TestValidate4ByteAsn(t *testing.T) {
+	validAsns := []string{
+		"0",
+		"1",
+		"65534",
+		"65535",
+		"4294967294",
+		"4294967295",
+	}
+	for _, v := range validAsns {
+		_, errors := validate4ByteAsn(v, "bgp_asn")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid ASN: %q", v, errors)
+		}
+	}
+
+	invalidAsns := []string{
+		"-1",
+		"ABCDEFG",
+		"",
+		"4294967296",
+		"9999999999",
+	}
+	for _, v := range invalidAsns {
+		_, errors := validate4ByteAsn(v, "bgp_asn")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid ASN", v)
+		}
+	}
+}
+
 func TestValidateLaunchTemplateName(t *testing.T) {
 	validNames := []string{
 		"fooBAR123",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14027.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_customer_gateway: Support 4-byte ASN values for `bgp_asn` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCustomerGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSCustomerGateway_basic -timeout 120m
=== RUN   TestAccAWSCustomerGateway_basic
=== PAUSE TestAccAWSCustomerGateway_basic
=== CONT  TestAccAWSCustomerGateway_basic
--- PASS: TestAccAWSCustomerGateway_basic (62.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	62.588s
```
