### PR TITLE
tests/provider: Initial goreleaser configuration and CI workflow

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -247,7 +247,7 @@ jobs:
       - name: goreleaser build
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: build --snapshot
+          args: build -p 1 --snapshot --timeout 1h
 
   tfproviderdocs:
     needs: [terraform_providers_schema]

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -241,13 +241,14 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - name: goreleaser check
+        continue-on-error: true
         uses: goreleaser/goreleaser-action@v2
         with:
           args: check
       - name: goreleaser build
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: build -p 1 --snapshot --timeout 1h
+          args: build --snapshot --timeout 1h
 
   tfproviderdocs:
     needs: [terraform_providers_schema]

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - .github/workflows/terraform_provider.yml
       - .golangci.yml
+      - .goreleaser.yml
       - aws/**
       - awsproviderlint/**
       - docs/index.md
@@ -224,6 +225,29 @@ jobs:
         key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
     - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint
     - run: golangci-lint run ./aws/...
+
+  goreleaser:
+    needs: [go_mod_download]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/cache@v2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      - name: goreleaser check
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: check
+      - name: goreleaser build
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: build --snapshot
 
   tfproviderdocs:
     needs: [terraform_providers_schema]

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ example.tf
 terraform.tfplan
 terraform.tfstate
 bin/
+dist/
 modules-dev/
 /pkg/
 website/.vagrant

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ before:
     - go mod download
 builds:
   - binary: '{{ .ProjectName }}_{{ .Version }}'
+    flags:
+      - -trimpath
     goarch:
       - '386'
       - amd64
@@ -22,7 +24,8 @@ builds:
       - goarch: '386'
         goos: darwin
     ldflags:
-      - -s -w -X github.com/terraform-providers/terraform-provider-aws/aws/version.ProviderVersion={{.Version}}
+      - -s -w -X aws/version.ProviderVersion={{.Version}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
 changelog:
   skip: true
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    format: zip
+before:
+  hooks:
+    - go mod download
+builds:
+  - binary: '{{ .ProjectName }}_{{ .Version }}'
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - '386'
+      - amd64
+      - arm
+      - arm64
+    goos:
+      - darwin
+      - freebsd
+      - linux
+      - windows
+    ignore:
+      - goarch: '386'
+        goos: darwin
+    ldflags:
+      - -s -w -X github.com/terraform-providers/terraform-provider-aws/aws/version.ProviderVersion={{.Version}}
+changelog:
+  skip: true
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+release:
+  disable: true
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,13 +1,13 @@
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - files:
+      - none*
     format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 before:
   hooks:
     - go mod download
 builds:
   - binary: '{{ .ProjectName }}_{{ .Version }}'
-    env:
-      - CGO_ENABLED=0
     goarch:
       - '386'
       - amd64
@@ -28,6 +28,8 @@ changelog:
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+env:
+  - CGO_ENABLED=0
 release:
   disable: true
 signs:

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -82,11 +82,8 @@ Create an issue to cover the update noting down any areas of particular interest
 Ensure that the following steps are tracked within the issue and completed within the resulting pull request.
 
 - Update go version in `go.mod`
-- Verify all formatting, linting, and testing works as expected
-- Verify `gox` builds for all currently supported architectures:
-```
-gox -os='linux darwin windows freebsd openbsd solaris' -arch='386 amd64 arm' -osarch='!darwin/arm !darwin/386' -ldflags '-s -w -X aws/version.ProviderVersion=99.99.99 -X aws/version.ProtocolVersion=4' -output 'results/{{.OS}}_{{.Arch}}/terraform-provider-aws_v99.99.99_x4' .
-```
+- Verify `make test lint` works as expected
+- Verify `goreleaser build --snapshot` succeeds for all currently supported architectures
 - Verify `goenv` support for the new version
 - Update `docs/DEVELOPMENT.md`
 - Update `.github/workflows/*.yml`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8988
Reference: https://www.terraform.io/docs/registry/providers/publishing.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Going forward, the Terraform Provider release process for the Terraform Registry will recommend `goreleaser` for all providers, including the official ones released via a separate process today. Given this decision is now more final, we can begin the process of using this tool for CI. In the future, we can also support nightly builds and later releases via the new GitHub release process. For now though, we leverage it just to verify codebase cross-compilation for all platforms that will be supported after the upcoming 3.0.0 release.

Output from acceptance testing: N/A (CI testing)