### PR TITLE
docs/rds_cluster_instance: the engine/version should match that of the cluster

### DIFF
--- a/website/docs/r/rds_cluster_endpoint.html.markdown
+++ b/website/docs/r/rds_cluster_endpoint.html.markdown
@@ -30,6 +30,8 @@ resource "aws_rds_cluster_instance" "test1" {
   cluster_identifier = "${aws_rds_cluster.default.id}"
   identifier         = "test1"
   instance_class     = "db.t2.small"
+  engine             = "${aws_rds_cluster.default.engine}"
+  engine_version     = "${aws_rds_cluster.default.engine_version}"
 }
 
 resource "aws_rds_cluster_instance" "test2" {
@@ -37,6 +39,8 @@ resource "aws_rds_cluster_instance" "test2" {
   cluster_identifier = "${aws_rds_cluster.default.id}"
   identifier         = "test2"
   instance_class     = "db.t2.small"
+  engine             = "${aws_rds_cluster.default.engine}"
+  engine_version     = "${aws_rds_cluster.default.engine_version}"
 }
 
 resource "aws_rds_cluster_instance" "test3" {
@@ -44,6 +48,8 @@ resource "aws_rds_cluster_instance" "test3" {
   cluster_identifier = "${aws_rds_cluster.default.id}"
   identifier         = "test3"
   instance_class     = "db.t2.small"
+  engine             = "${aws_rds_cluster.default.engine}"
+  engine_version     = "${aws_rds_cluster.default.engine_version}"
 }
 
 resource "aws_rds_cluster_endpoint" "eligible" {

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -31,6 +31,8 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   identifier         = "aurora-cluster-demo-${count.index}"
   cluster_identifier = "${aws_rds_cluster.default.id}"
   instance_class     = "db.r4.large"
+  engine             = "${aws_rds_cluster.default.engine}"
+  engine_version     = "${aws_rds_cluster.default.engine_version}"
 }
 
 resource "aws_rds_cluster" "default" {


### PR DESCRIPTION
If you try to create an RDS instance with a different engine/version to the cluster, you get an InvalidParameterCombination error from Terraform and no instances.

Changing the behaviour so that instances inherit their config from the cluster is a big change, as discussed in https://github.com/terraform-providers/terraform-provider-aws/issues/10585#issuecomment-558804101.

This patch just tweaks the documented examples, so if people copy/paste the example and change the engine/version of the cluster, it will still work correctly.  It also highlights that the engine/version should match between the instance and the cluster.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #10585

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing: n/a