### PR TITLE
resource/autoscaling_group: reintroduce changes made in #9478

### DIFF
--- a/aws/resource_aws_autoscaling_attachment_test.go
+++ b/aws/resource_aws_autoscaling_attachment_test.go
@@ -250,6 +250,10 @@ resource "aws_autoscaling_group" "asg" {
     value               = "terraform-asg-lg-assoc-test"
     propagate_at_launch = true
   }
+
+  lifecycle {
+    ignore_changes = [load_balancers, target_group_arns]
+  }
 }
 
 resource "aws_launch_configuration" "as_conf" {
@@ -312,6 +316,10 @@ resource "aws_autoscaling_group" "asg" {
     key                 = "Name"
     value               = "terraform-asg-lg-assoc-test"
     propagate_at_launch = true
+  }
+
+  lifecycle {
+    ignore_changes = [load_balancers, target_group_arns]
   }
 }
 `, rInt, rInt)

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -262,12 +262,9 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 				Optional: true,
 			},
 
-			// DEPRECATED: Computed: true should be removed in a major version release
-			// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9513
 			"load_balancers": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -337,12 +334,9 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 				Default:  false,
 			},
 
-			// DEPRECATED: Computed: true should be removed in a major version release
-			// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/9513
 			"target_group_arns": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -461,6 +461,7 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 
 func TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup(t *testing.T) {
 	var group autoscaling.Group
+	resourceName := "aws_autoscaling_group.bar"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -470,13 +471,13 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup(t *testing.T) {
 			{
 				Config: testAccAWSAutoScalingGroupConfigWithLoadBalancer,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
-					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "load_balancers.#", "1"),
-					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "target_group_arns.#", "0"),
+					testAccCheckAWSAutoScalingGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "load_balancers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target_group_arns.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_autoscaling_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -492,14 +493,13 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup(t *testing.T) {
 			{
 				Config: testAccAWSAutoScalingGroupConfigWithTargetGroup,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
-					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "target_group_arns.#", "1"),
-					// DEPRECATED: This value will be 0 when Computed: true is removed
-					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "load_balancers.#", "1"),
+					testAccCheckAWSAutoScalingGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "target_group_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancers.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_autoscaling_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -515,14 +515,13 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup(t *testing.T) {
 			{
 				Config: testAccAWSAutoScalingGroupConfigWithLoadBalancer,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
-					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "load_balancers.#", "1"),
-					// DEPRECATED: This value will be 0 when Computed: true is removed
-					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "target_group_arns.#", "1"),
+					testAccCheckAWSAutoScalingGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "load_balancers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target_group_arns.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "aws_autoscaling_group.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -195,7 +195,6 @@ resource "aws_autoscaling_attachment" "example" {
 
 resource "aws_autoscaling_group" "example"{
   # ... other configuration ...
-  load_balancers = [aws_elb.example.id]  
 }
 ```
 
@@ -209,7 +208,6 @@ resource "aws_autoscaling_attachment" "example" {
 
 resource "aws_autoscaling_group" "example"{
   # ... other configuration ...
-  load_balancers = [aws_elb.example.id]
 
   lifecycle {
     ignore_changes = [load_balancers, target_group_arns]

--- a/website/docs/r/autoscaling_attachment.html.markdown
+++ b/website/docs/r/autoscaling_attachment.html.markdown
@@ -41,7 +41,6 @@ resource "aws_autoscaling_attachment" "asg_attachment_bar" {
 ```hcl
 resource "aws_autoscaling_group" "asg" {
   # ... other configuration ...
-  load_balancers = [aws_elb.test.id]
 
   lifecycle {
     ignore_changes = [load_balancers, target_group_arns]

--- a/website/docs/r/autoscaling_attachment.html.markdown
+++ b/website/docs/r/autoscaling_attachment.html.markdown
@@ -12,26 +12,45 @@ Provides an AutoScaling Attachment resource.
 
 ~> **NOTE on AutoScaling Groups and ASG Attachments:** Terraform currently provides
 both a standalone ASG Attachment resource (describing an ASG attached to
-an ELB), and an [AutoScaling Group resource](autoscaling_group.html) with
-`load_balancers` defined in-line. At this time you cannot use an ASG with in-line
-load balancers in conjunction with an ASG Attachment resource. Doing so will cause a
-conflict and will overwrite attachments.
+an ELB or ALB), and an [AutoScaling Group resource](autoscaling_group.html) with
+`load_balancers` and `target_group_arns` defined in-line. At this time you can use an ASG with in-line
+`load balancers` or `target_group_arns` in conjunction with an ASG Attachment resource, however, to prevent
+unintended resource updates, the `aws_autoscaling_group` resource must be configured 
+to ignore changes to the `load_balancers` and `target_group_arns` arguments within a [`lifecycle` configuration block](/docs/configuration/resources.html#lifecycle-lifecycle-customizations).
 
 ## Example Usage
 
 ```hcl
 # Create a new load balancer attachment
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
-  autoscaling_group_name = "${aws_autoscaling_group.asg.id}"
-  elb                    = "${aws_elb.bar.id}"
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  elb                    = aws_elb.bar.id
 }
 ```
 
 ```hcl
 # Create a new ALB Target Group attachment
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
-  autoscaling_group_name = "${aws_autoscaling_group.asg.id}"
-  alb_target_group_arn   = "${aws_alb_target_group.test.arn}"
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  alb_target_group_arn   = aws_alb_target_group.test.arn
+}
+```
+
+## With An AutoScaling Group Resource
+
+```hcl
+resource "aws_autoscaling_group" "asg" {
+  # ... other configuration ...
+  load_balancers = [aws_elb.test.id]
+
+  lifecycle {
+    ignore_changes = [load_balancers, target_group_arns]
+  }
+}
+
+resource "aws_autoscaling_attachment" "asg_attachment_bar" {
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  elb                    = aws_elb.test.id
 }
 ```
 

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -304,10 +304,6 @@ In addition to all arguments above, the following attributes are exported:
 * `desired_capacity` -The number of Amazon EC2 instances that should be running in the group.
 * `launch_configuration` - The launch configuration of the autoscale group
 * `vpc_zone_identifier` (Optional) - The VPC zone identifier
-* `load_balancers` (Optional) The load balancer names associated with the
-   autoscaling group.
-* `target_group_arns` (Optional) list of Target Group ARNs that apply to this
-AutoScaling Group
 
 ~> **NOTE:** When using `ELB` as the `health_check_type`, `health_check_grace_period` is required.
 


### PR DESCRIPTION
…from exported attributes list

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3265
Reference #9478

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/autoscaling_group: reintroduce changes made in #9478; enable drift detection for target_group_arns and load_balancers
```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (389.35s)

--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (44.38s)
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (51.23s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (72.06s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (78.50s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (85.45s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (91.89s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (97.87s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (109.13s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (42.31s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (44.36s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (66.41s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity (44.55s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (163.88s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (45.58s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (181.92s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (53.01s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (151.65s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (203.54s)
--- PASS: TestAccAWSAutoScalingGroup_tags (204.92s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (109.52s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (44.78s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (81.30s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (41.66s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (72.72s)
--- PASS: TestAccAWSAutoScalingGroup_launchTempPartitionNum (46.69s)
--- PASS: TestAccAWSAutoScalingGroup_basic (259.97s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (262.49s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (265.15s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (135.15s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (295.39s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (259.13s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (320.66s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (135.33s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (377.59s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (401.63s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (673.21s)
```
```
--- PASS: TestAccAWSAutoscalingAttachment_elb (112.57s)
--- PASS: TestAccAWSAutoscalingAttachment_albTargetGroup (139.62s)
```