### PR TITLE
resource/aws_launch_template: Skip extra API call during update and parallelize new tests

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -814,18 +814,7 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	dltv, err := conn.DescribeLaunchTemplateVersions(&ec2.DescribeLaunchTemplateVersionsInput{
-		LaunchTemplateId: aws.String(d.Id()),
-		Versions:         aws.StringSlice([]string{"$Latest"}),
-	})
-	if err != nil {
-		return fmt.Errorf("Error describing $Latest Launch Template Version for Launch Template (%s): %w", d.Id(), err)
-	}
-	if dltv == nil || len(dltv.LaunchTemplateVersions) == 0 {
-		return fmt.Errorf("Error describing $Latest Launch Template Version for Launch Template (%s): empty output", d.Id())
-	}
-
-	latestVersion := aws.Int64Value(dltv.LaunchTemplateVersions[0].VersionNumber)
+	latestVersion := int64(d.Get("latest_version").(int))
 	defaultVersion := d.Get("default_version").(int)
 
 	if d.HasChanges(updateKeys...) {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -946,7 +946,7 @@ func TestAccAWSLaunchTemplate_defaultVersion(t *testing.T) {
 	description := "Test Description 1"
 	descriptionNew := "Test Description 2"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
@@ -991,7 +991,7 @@ func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
 	description := "Test Description 1"
 	descriptionNew := "Test Description 2"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLaunchTemplate_associatePublicIPAddress (83.66s)
--- PASS: TestAccAWSLaunchTemplate_basic (18.66s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (44.60s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (80.12s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (19.63s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (24.41s)
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (17.45s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (19.60s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (19.71s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (19.74s)
--- PASS: TestAccAWSLaunchTemplate_data (19.40s)
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (42.00s)
--- PASS: TestAccAWSLaunchTemplate_description (31.44s)
--- PASS: TestAccAWSLaunchTemplate_disappears (12.33s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (70.24s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (31.01s)
--- PASS: TestAccAWSLaunchTemplate_hibernation (42.71s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (17.43s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (81.64s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (19.95s)
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (17.98s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (39.09s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (17.84s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (19.19s)
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceAddresses (37.13s)
--- PASS: TestAccAWSLaunchTemplate_placement_partitionNum (34.66s)
--- PASS: TestAccAWSLaunchTemplate_tags (31.81s)
--- PASS: TestAccAWSLaunchTemplate_update (88.86s)
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (53.21s)
```
