### PR TITLE
r/aws_appmesh_virtual_node: Disallow empty 'backend' blocks

### DIFF
--- a/aws/resource_aws_appmesh_virtual_node.go
+++ b/aws/resource_aws_appmesh_virtual_node.go
@@ -68,8 +68,7 @@ func resourceAwsAppmeshVirtualNode() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"virtual_service": {
 										Type:     schema.TypeList,
-										Optional: true,
-										MinItems: 0,
+										Required: true,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/website/docs/r/appmesh_virtual_node.html.markdown
+++ b/website/docs/r/appmesh_virtual_node.html.markdown
@@ -187,7 +187,7 @@ The `spec` object supports the following:
 
 The `backend` object supports the following:
 
-* `virtual_service` - (Optional) Specifies a virtual service to use as a backend for a virtual node.
+* `virtual_service` - (Required) Specifies a virtual service to use as a backend for a virtual node.
 
 The `virtual_service` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14040.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_appmesh_virtual_node: The  `virtual_service` attribute in the `backend` configuration block is now required
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAppmesh/VirtualNode/'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAppmesh/VirtualNode/ -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/VirtualNode
=== RUN   TestAccAWSAppmesh/VirtualNode/cloudMapServiceDiscovery
=== RUN   TestAccAWSAppmesh/VirtualNode/listenerHealthChecks
=== RUN   TestAccAWSAppmesh/VirtualNode/logging
=== RUN   TestAccAWSAppmesh/VirtualNode/tags
=== RUN   TestAccAWSAppmesh/VirtualNode/basic
--- PASS: TestAccAWSAppmesh (304.87s)
    --- PASS: TestAccAWSAppmesh/VirtualNode (304.87s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/cloudMapServiceDiscovery (119.19s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/listenerHealthChecks (46.49s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/logging (45.73s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/tags (65.41s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/basic (28.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	304.932s
```
