### PR TITLE
r/aws_apigatewayv2_integration: Add 'request_parameters' attribute

### DIFF
--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -37,6 +37,7 @@ func TestAccAWSAPIGatewayV2Integration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "integration_uri", ""),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
@@ -101,6 +102,8 @@ func TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "integration_uri", "http://www.example.com"),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.stage", "'value1'"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.application/json", ""),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", "$request.body.name"),
@@ -122,6 +125,9 @@ func TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "integration_uri", "http://www.example.org"),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", "WHEN_NO_TEMPLATES"),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.header.x-userid", "'value2'"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.path.op", "'value3'"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.application/json", "#set($number=42)"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.application/xml", "#set($percent=$number/100)"),
@@ -166,6 +172,7 @@ func TestAccAWSAPIGatewayV2Integration_Lambda(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "integration_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "29000"),
@@ -208,6 +215,7 @@ func TestAccAWSAPIGatewayV2Integration_VpcLink(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "integration_uri", "http://www.example.net"),
 					resource.TestCheckResourceAttr(resourceName, "passthrough_behavior", "NEVER"),
 					resource.TestCheckResourceAttr(resourceName, "payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "request_templates.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "template_selection_expression", ""),
 					resource.TestCheckResourceAttr(resourceName, "timeout_milliseconds", "12345"),
@@ -335,6 +343,10 @@ resource "aws_apigatewayv2_integration" "test" {
   template_selection_expression = "$request.body.name"
   timeout_milliseconds          = 28999
 
+  request_parameters = {
+    "integration.request.querystring.stage" = "'value1'"
+  }
+
   request_templates = {
     "application/json" = ""
   }
@@ -356,6 +368,11 @@ resource "aws_apigatewayv2_integration" "test" {
   passthrough_behavior          = "WHEN_NO_TEMPLATES"
   template_selection_expression = "$request.body.id"
   timeout_milliseconds          = 51
+
+  request_parameters = {
+	"integration.request.header.x-userid" = "'value2'"
+	"integration.request.path.op"         = "'value3'"
+  }
 
   request_templates = {
     "application/json" = "#set($number=42)"

--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -64,6 +64,8 @@ For an `HTTP` integration, specify a fully-qualified URL. For an HTTP API privat
 * `passthrough_behavior` - (Optional) The pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the `request_templates` attribute.
 Valid values: `WHEN_NO_MATCH`, `WHEN_NO_TEMPLATES`, `NEVER`. Default is `WHEN_NO_MATCH`. Supported only for WebSocket APIs.
 * `payload_format_version` - (Optional) The [format of the payload](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) sent to an integration. Valid values: `1.0`, `2.0`. Default is `1.0`.
+* `request_parameters` - (Optional) A key-value map specifying request parameters that are passed from the method request to the backend.
+Supported only for WebSocket APIs.
 * `request_templates` - (Optional) A map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. Supported only for WebSocket APIs.
 * `template_selection_expression` - (Optional) The [template selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-template-selection-expressions) for the integration.
 * `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds or 29 seconds.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14046.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_integration: Add `request_parameters` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Integration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Integration_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Integration_basic
=== PAUSE TestAccAWSAPIGatewayV2Integration_basic
=== RUN   TestAccAWSAPIGatewayV2Integration_disappears
=== PAUSE TestAccAWSAPIGatewayV2Integration_disappears
=== RUN   TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_Lambda
=== PAUSE TestAccAWSAPIGatewayV2Integration_Lambda
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLink
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLink
=== CONT  TestAccAWSAPIGatewayV2Integration_basic
=== CONT  TestAccAWSAPIGatewayV2Integration_Lambda
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLink
=== CONT  TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_disappears
--- PASS: TestAccAWSAPIGatewayV2Integration_disappears (24.62s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basic (28.21s)
--- PASS: TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp (44.85s)
--- PASS: TestAccAWSAPIGatewayV2Integration_Lambda (60.92s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLink (751.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	751.801s
```
