### PR TITLE
resource/wafv2_regex_pattern_set: rewrite typeset checks

### DIFF
--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 	"regexp"
 	"testing"
 
@@ -31,8 +32,12 @@ func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", rName),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "regular_expression.1641128102.regex_string", "one"),
-					resource.TestCheckResourceAttr(resourceName, "regular_expression.265355341.regex_string", "two"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+						"regex_string": "one",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+						"regex_string": "two",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -45,9 +50,15 @@ func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "Updated"),
 					resource.TestCheckResourceAttr(resourceName, "scope", wafv2.ScopeRegional),
 					resource.TestCheckResourceAttr(resourceName, "regular_expression.#", "3"),
-					resource.TestCheckResourceAttr(resourceName, "regular_expression.1641128102.regex_string", "one"),
-					resource.TestCheckResourceAttr(resourceName, "regular_expression.265355341.regex_string", "two"),
-					resource.TestCheckResourceAttr(resourceName, "regular_expression.2339296779.regex_string", "three"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+						"regex_string": "one",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+						"regex_string": "two",
+					}),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "regular_expression.*", map[string]string{
+						"regex_string": "three",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},

--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 	"regexp"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/wafv2_regex_pattern_set: rewrite typeset checks
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAwsWafv2RegexPatternSet_Minimal (17.84s)
--- PASS: TestAccAwsWafv2RegexPatternSet_Disappears (20.98s)
--- PASS: TestAccAwsWafv2RegexPatternSet_ChangeNameForceNew (29.78s)
--- PASS: TestAccAwsWafv2RegexPatternSet_Basic (31.54s)
--- PASS: TestAccAwsWafv2RegexPatternSet_Tags (43.59s)
```
