### PR TITLE
Remove hardcoded AMIs in spot instance request tests

### DIFF
--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -516,8 +516,10 @@ func testAccAWSSpotInstanceRequestConfig(rInt int) string {
 		public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 	}
 
+	%v
+
 	resource "aws_spot_instance_request" "foo" {
-		ami = "ami-4fccb37f"
+		ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 		instance_type = "m1.small"
 		key_name = "${aws_key_pair.debugging.key_name}"
 
@@ -533,7 +535,7 @@ func testAccAWSSpotInstanceRequestConfig(rInt int) string {
 			Name = "terraform-test"
 		}
 	}
-`, rInt)
+`, rInt, testAccLatestAmazonLinuxHvmEbsAmiConfig())
 }
 
 func testAccAWSSpotInstanceRequestConfigValidUntil(rInt int, validUntil string) string {
@@ -543,8 +545,10 @@ func testAccAWSSpotInstanceRequestConfigValidUntil(rInt int, validUntil string) 
 		public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 	}
 
+	%v
+
 	resource "aws_spot_instance_request" "foo" {
-		ami = "ami-4fccb37f"
+		ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 		instance_type = "m1.small"
 		key_name = "${aws_key_pair.debugging.key_name}"
 
@@ -564,7 +568,7 @@ func testAccAWSSpotInstanceRequestConfigValidUntil(rInt int, validUntil string) 
 			Name = "terraform-test"
 		}
 	}
-`, rInt, validUntil)
+`, rInt, testAccLatestAmazonLinuxHvmEbsAmiConfig(), validUntil)
 }
 
 func testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rInt int) string {
@@ -574,8 +578,10 @@ func testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rInt int) string {
 		public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 	}
 
+	%v
+
 	resource "aws_spot_instance_request" "foo" {
-		ami = "ami-4fccb37f"
+		ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 		instance_type = "m1.small"
 		key_name = "${aws_key_pair.debugging.key_name}"
 
@@ -589,7 +595,7 @@ func testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rInt int) string {
 			Name = "terraform-test"
 		}
 	}
-`, rInt)
+`, rInt, testAccLatestAmazonLinuxHvmEbsAmiConfig())
 }
 
 func testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rInt int) string {
@@ -599,8 +605,10 @@ func testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rInt int) string {
 		public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 	}
 
+	%v
+
 	resource "aws_spot_instance_request" "foo" {
-		ami = "ami-4fccb37f"
+		ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 		instance_type = "m1.small"
 		key_name = "${aws_key_pair.debugging.key_name}"
 
@@ -618,7 +626,7 @@ func testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rInt int) string {
 			Name = "terraform-test"
 		}
 	}
-`, rInt)
+`, rInt, testAccLatestAmazonLinuxHvmEbsAmiConfig())
 }
 
 func testAccAWSSpotInstanceRequestConfig_withBlockDuration(rInt int) string {
@@ -628,8 +636,10 @@ func testAccAWSSpotInstanceRequestConfig_withBlockDuration(rInt int) string {
 		public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 	}
 
+	%v
+
 	resource "aws_spot_instance_request" "foo" {
-		ami = "ami-4fccb37f"
+		ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 		instance_type = "m1.small"
 		key_name = "${aws_key_pair.debugging.key_name}"
 
@@ -647,7 +657,7 @@ func testAccAWSSpotInstanceRequestConfig_withBlockDuration(rInt int) string {
 			Name = "terraform-test"
 		}
 	}
-`, rInt)
+`, rInt, testAccLatestAmazonLinuxHvmEbsAmiConfig())
 }
 
 func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
@@ -683,8 +693,10 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+%v
+
 resource "aws_spot_instance_request" "foo_VPC" {
-	ami = "ami-4fccb37f"
+	ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 	instance_type = "m1.small"
 	key_name = "${aws_key_pair.debugging.key_name}"
 
@@ -703,7 +715,7 @@ tags = {
 		Name = "terraform-test-VPC"
 	}
 }
-`, rInt)
+`, rInt, testAccLatestAmazonLinuxHvmEbsAmiConfig())
 }
 
 func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int) string {
@@ -718,14 +730,16 @@ data "aws_availability_zones" "available" {
   }
 }
 
+%v
+
 resource "aws_spot_instance_request" "foo" {
-	ami                         = "ami-4fccb37f"
+	ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 	instance_type               = "m1.small"
 	spot_price                  = "0.05"
 	wait_for_fulfillment        = true
 	subnet_id                   = "${aws_subnet.tf_test_subnet.id}"
 	vpc_security_group_ids      = ["${aws_security_group.tf_test_sg_ssh.id}"]
-  associate_public_ip_address = true
+	associate_public_ip_address = true
 }
 
 resource "aws_vpc" "default" {
@@ -757,7 +771,7 @@ tags = {
 		Name = "tf_test_sg_ssh-%d"
 	}
 }
-`, rInt, rInt)
+`, testAccLatestAmazonLinuxHvmEbsAmiConfig(), rInt, rInt)
 }
 
 func testAccAWSSpotInstanceRequestConfig_getPasswordData(rInt int) string {
@@ -791,8 +805,10 @@ func testAccAWSSpotInstanceRequestConfig_getPasswordData(rInt int) string {
 
 func testAccAWSSpotInstanceRequestInterruptConfig(interruption_behavior string) string {
 	return fmt.Sprintf(`
+	%v
+
 	resource "aws_spot_instance_request" "foo" {
-		ami = "ami-19e92861"
+		ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 		instance_type = "c5.large"
 
 		// base price is $0.067 hourly, so bidding above that should theoretically
@@ -804,5 +820,5 @@ func testAccAWSSpotInstanceRequestInterruptConfig(interruption_behavior string) 
 		wait_for_fulfillment = true
 
 		instance_interruption_behaviour = "%s"
-	}`, interruption_behavior)
+	}`, testAccLatestAmazonLinuxHvmEbsAmiConfig(), interruption_behavior)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Central management issue: #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

See [AWSAT002](https://github.com/terraform-providers/terraform-provider-aws/tree/master/awsproviderlint/passes/AWSAT002)

### Current stats of acceptance tests for this PR:

| Partition | Passing | Failing | Test |
| ---------|-------:|------:|:-----:|
| us-gov | 5 | 6* | With-PR |
| us-gov | 0 | 11 | Pre-PR |
| standard | 11 | 0 | With-PR |
| standard | 11 | 0 | Pre-PR |

* All the current failures are the same. I think we'll need to handle them in a separate PR (not sure of the cause):

```
Error: Error while waiting for spot request ({
          ...
          State: "open",
          Status: {
            Code: "pending-evaluation",
            Message: "Your Spot request has been submitted for review, and is pending evaluation.",
            UpdateTime: 2020-07-07 23:40:40 +0000 UTC
          },
          Type: "persistent"
        }) to resolve: unexpected state 'bad-parameters', wanted target 'fulfilled'. last error: %!s(<nil>)
```