### PR TITLE
tests/provider: Update testacc target to error when provided example test pattern

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,17 @@ test: fmtcheck
 	go test $(TEST) $(TESTARGS) -timeout=120s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m
+	@if [ "$(TESTARGS)" = "-run=TestAccXXX" ]; then \
+		echo ""; \
+		echo "Error: Skipping example acceptance testing pattern. Update TESTARGS to match the test naming in the relevant *_test.go file."; \
+		echo ""; \
+		echo "For example if updating aws/resource_aws_acm_certificate.go, use the test names in aws/resource_aws_acm_certificate_test.go starting with TestAcc and up to the underscore:"; \
+		echo "make testacc TESTARGS='-run=TestAccAWSAcmCertificate_'"; \
+		echo ""; \
+		echo "See the contributing guide for more information: https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/contributing/running-and-writing-acceptance-tests.md"; \
+		exit 1; \
+	fi
+	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/docs/contributing/running-and-writing-acceptance-tests.md
+++ b/docs/contributing/running-and-writing-acceptance-tests.md
@@ -68,11 +68,10 @@ is especially important for testing AWS GovCloud (US), which requires:
 export AWS_DEFAULT_REGION=us-gov-west-1
 ```
 
-Tests can then be run by specifying the target provider and a regular
-expression defining the tests to run:
+Tests can then be run by specifying a regular expression defining the tests to run:
 
 ```sh
-$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchDashboard_update'
+$ make testacc TESTARGS='-run=TestAccAWSCloudWatchDashboard_update'
 ==> Checking that code complies with gofmt requirements...
 TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchDashboard_update -timeout 120m
 === RUN   TestAccAWSCloudWatchDashboard_update
@@ -87,7 +86,7 @@ write the regular expression. For example, to run all tests of the
 testing like this:
 
 ```sh
-$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchDashboard'
+$ make testacc TESTARGS='-run=TestAccAWSCloudWatchDashboard'
 ==> Checking that code complies with gofmt requirements...
 TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchDashboard -timeout 120m
 === RUN   TestAccAWSCloudWatchDashboard_importBasic


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The pull request template suggests an example of how to run acceptance testing, but uses a placeholder example since its not feasible to reliably determine this automatically via git, etc. Also given that we have begun adding many more Go packages beyond just the top level provider one, the output can look potentially valid when it really is not meaningful:

```console
$ $ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccXXX -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.594s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap	0.409s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags	0.792s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/naming	1.619s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/apigatewayv2/waiter	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency	0.373s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ecs/waiter	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token	0.343s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/guardduty/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kinesisanalytics/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kms/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/neptune/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/rds/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/secretsmanager/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/servicediscovery/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sfn/waiter	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/aws/internal/service/workspaces/waiter	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource	1.022s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint	[no test files]
?   	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/helper/awsprovidertype/keyvaluetags	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes	2.115s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT001	2.212s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSAT002	0.326s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR001	0.412s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/AWSR002	2.086s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/awsproviderlint/passes/fmtsprintfcallexpr	0.248s [no tests to run]
```

This now focuses the acceptance testing on the top level package to remove the extraneous package output and returns an error when attempting to use the example verbatim:

```console
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...

Error: Skipping example acceptance testing pattern. Update TESTARGS to match the test naming in the relevant *_test.go file.

For example if updating aws/resource_aws_acm_certificate.go, use the test names in aws/resource_aws_acm_certificate_test.go starting with TestAcc and up to the underscore:
make testacc TESTARGS='-run=TestAccAWSAcmCertificate_'

See the contributing guide for more information: https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/contributing/running-and-writing-acceptance-tests.md
make: *** [testacc] Error 1

$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAvailabilityZones_ -timeout 120m
=== RUN   TestAccAWSAvailabilityZones_basic
...
```
