### PR TITLE
resource/aws_elastictranscoder_preset: Prevent empty configuration block panics

### DIFF
--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -361,7 +361,7 @@ func expandETThumbnails(d *schema.ResourceData) *elastictranscoder.Thumbnails {
 	}
 
 	l := list.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	t := l[0].(map[string]interface{})
@@ -410,7 +410,7 @@ func expandETAudioParams(d *schema.ResourceData) *elastictranscoder.AudioParamet
 	}
 
 	l := list.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	audio := l[0].(map[string]interface{})
@@ -427,7 +427,7 @@ func expandETAudioParams(d *schema.ResourceData) *elastictranscoder.AudioParamet
 
 func expandETAudioCodecOptions(d *schema.ResourceData) *elastictranscoder.AudioCodecOptions {
 	l := d.Get("audio_codec_options").([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
@@ -456,7 +456,7 @@ func expandETAudioCodecOptions(d *schema.ResourceData) *elastictranscoder.AudioC
 
 func expandETVideoParams(d *schema.ResourceData) *elastictranscoder.VideoParameters {
 	l := d.Get("video").([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	p := l[0].(map[string]interface{})
@@ -541,6 +541,10 @@ func expandETVideoWatermarks(d *schema.ResourceData) []*elastictranscoder.Preset
 	var watermarks []*elastictranscoder.PresetWatermark
 
 	for _, w := range s.List() {
+		if w == nil {
+			continue
+		}
+
 		p := w.(map[string]interface{})
 		watermark := &elastictranscoder.PresetWatermark{
 			HorizontalAlign:  aws.String(p["horizontal_align"].(string)),

--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -58,6 +58,33 @@ func TestAccAWSElasticTranscoderPreset_disappears(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14087
+func TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty(t *testing.T) {
+	var preset elastictranscoder.Preset
+	resourceName := "aws_elastictranscoder_preset.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckElasticTranscoderPresetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsElasticTranscoderPresetConfigAudioCodecOptionsEmpty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckElasticTranscoderPresetExists(resourceName, &preset),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"audio_codec_options.#"}, // Due to incorrect schema (should be nested under audio)
+			},
+		},
+	})
+}
+
 func TestAccAWSElasticTranscoderPreset_Description(t *testing.T) {
 	var preset elastictranscoder.Preset
 	resourceName := "aws_elastictranscoder_preset.test"
@@ -209,6 +236,25 @@ resource "aws_elastictranscoder_preset" "test" {
     codec              = "mp3"
     sample_rate        = 44100
   }
+}
+`, rName)
+}
+
+func testAccAwsElasticTranscoderPresetConfigAudioCodecOptionsEmpty(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elastictranscoder_preset" "test" {
+  container = "mp4"
+  name      = %[1]q
+
+  audio {
+    audio_packing_mode = "SingleTrack"
+    bit_rate           = 320
+    channels           = 2
+    codec              = "mp3"
+    sample_rate        = 44100
+  }
+
+  audio_codec_options {}
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_elastictranscoder_preset: Prevent empty configuration block panics
```

Previously:

```
=== CONT  TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 378 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandETAudioCodecOptions(0xc000fb9880, 0xc0028af590)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_elastic_transcoder_preset.go:434 +0x458
github.com/terraform-providers/terraform-provider-aws/aws.expandETAudioParams(0xc000fb9880, 0xc0027d5708)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_elastic_transcoder_preset.go:423 +0x2a0
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsElasticTranscoderPresetCreate(0xc000fb9880, 0x66543e0, 0xc002660000, 0x2, 0xbbdb620)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_elastic_transcoder_preset.go:326 +0x6c
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticTranscoderPreset_disappears (13.09s)
--- PASS: TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty (18.51s)
--- PASS: TestAccAWSElasticTranscoderPreset_Description (18.51s)
--- PASS: TestAccAWSElasticTranscoderPreset_basic (18.98s)
--- PASS: TestAccAWSElasticTranscoderPreset_Full (34.69s)
```
