### PR TITLE
docs/provider: Use 0.12 interpolation syntax

### DIFF
--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -40,17 +40,11 @@ resource "aws_route53_zone" "dev" {
 }
 
 resource "aws_route53_record" "dev-ns" {
-  zone_id = "${aws_route53_zone.main.zone_id}"
+  zone_id = aws_route53_zone.main.zone_id
   name    = "dev.example.com"
   type    = "NS"
   ttl     = "30"
-
-  records = [
-    "${aws_route53_zone.dev.name_servers.0}",
-    "${aws_route53_zone.dev.name_servers.1}",
-    "${aws_route53_zone.dev.name_servers.2}",
-    "${aws_route53_zone.dev.name_servers.3}",
-  ]
+  records = aws_route53_zone.dev.name_servers
 }
 ```
 
@@ -65,7 +59,7 @@ resource "aws_route53_zone" "private" {
   name = "example.com"
 
   vpc {
-    vpc_id = "${aws_vpc.example.id}"
+    vpc_id = aws_vpc.example.id
   }
 }
 ```


### PR DESCRIPTION
The examples used <0.12 interpolation syntax which made them more verbose than necessary.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #8950

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update Route53 documentation for 0.12
```
