### PR TITLE
reverse the order the parameter diff

### DIFF
--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -261,14 +261,14 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 				} else {
 					paramsToReset, resetParameters = resetParameters[:maxParams], resetParameters[maxParams:]
 				}
-		
+
 				parameterGroupName := d.Get("name").(string)
 				resetOpts := rds.ResetDBParameterGroupInput{
 					DBParameterGroupName: aws.String(parameterGroupName),
 					Parameters:           paramsToReset,
 					ResetAllParameters:   aws.Bool(false),
 				}
-		
+
 				log.Printf("[DEBUG] Reset DB Parameter Group: %s", resetOpts)
 				_, err := rdsconn.ResetDBParameterGroup(&resetOpts)
 				if err != nil {
@@ -303,7 +303,6 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 				}
 			}
 		}
-
 
 	}
 


### PR DESCRIPTION
do the compare with aws and current  first to remove deleted params
then compare with current and aws to modify  params

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to https://github.com/terraform-providers/terraform-provider-aws/pull/5728

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Reversed the order of the diffs for how db parameters are updated.  The current order leaves a state where if parameters are updated and deleted in the same apply, updated params get the current aws value as opposed to the modified value.  This persists in state and the only fix is to delete the parameter group.  Changing the order of the sequence fixes this bug.

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
