### PR TITLE
Ensure nil is not passed to RetryError helpers

### DIFF
--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -78,7 +78,10 @@ func resourceAwsAcmCertificateValidationCreate(d *schema.ResourceData, meta inte
 		}
 
 		log.Printf("[INFO] ACM Certificate validation for %s done, certificate was issued", certificate_arn)
-		return resource.NonRetryableError(resourceAwsAcmCertificateValidationRead(d, meta))
+		if err := resourceAwsAcmCertificateValidationRead(d, meta); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		resp, err = acmconn.DescribeCertificate(params)

--- a/aws/resource_aws_cloudwatch_event_permission.go
+++ b/aws/resource_aws_cloudwatch_event_permission.go
@@ -111,7 +111,10 @@ func resourceAwsCloudWatchEventPermissionRead(d *schema.ResourceData, meta inter
 		}
 
 		policyStatement, err = getPolicyStatement(output, d.Id())
-		return resource.RetryableError(err)
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
 	})
 
 	if isResourceTimeoutError(err) {

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -198,8 +198,7 @@ func resourceAwsCodePipelineCreate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return resource.RetryableError(err)
 		}
-
-		return resource.NonRetryableError(err)
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		resp, err = conn.CreatePipeline(params)

--- a/aws/resource_aws_codestarnotifications_notification_rule.go
+++ b/aws/resource_aws_codestarnotifications_notification_rule.go
@@ -221,7 +221,10 @@ func cleanupCodeStarNotificationsNotificationRuleTargets(conn *codestarnotificat
 		}
 		targets = targets[:i]
 
-		return resource.RetryableError(reterr)
+		if reterr != nil {
+			return resource.RetryableError(reterr)
+		}
+		return nil
 	})
 
 	if isAWSErr(err, codestarnotifications.ErrCodeValidationException, awsCodeStartNotificationsNotificationRuleErrorSubscribed) {

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -722,8 +722,10 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 			log.Printf("[DEBUG] Received %s, retrying CreateUserPool", err)
 			return resource.RetryableError(err)
 		}
-
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		resp, err = conn.CreateUserPool(params)
@@ -1145,8 +1147,10 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 				params.AdminCreateUserConfig.UnusedAccountValidityDays = nil
 				return resource.RetryableError(err)
 			}
-
-			return resource.NonRetryableError(err)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			return nil
 		})
 		if isResourceTimeoutError(err) {
 			_, err = conn.UpdateUserPool(params)

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -59,9 +59,11 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 
 		if isAWSErr(err, "InvalidParameterException", "Invalid repository policy provided") {
 			return resource.RetryableError(err)
-
 		}
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		out, err = conn.SetRepositoryPolicy(&input)
@@ -135,9 +137,11 @@ func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface
 
 		if isAWSErr(err, "InvalidParameterException", "Invalid repository policy provided") {
 			return resource.RetryableError(err)
-
 		}
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		out, err = conn.SetRepositoryPolicy(&input)

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -158,7 +158,10 @@ func resourceAwsIamRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		if isAWSErr(err, "MalformedPolicyDocument", "Invalid principal in policy") {
 			return resource.RetryableError(err)
 		}
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		createResp, err = iamconn.CreateRole(request)

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -660,7 +660,10 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 			log.Print("[DEBUG] IAM Instance Profile appears to have no IAM roles, retrying...")
 			return resource.RetryableError(err)
 		}
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		runResp, err = conn.RunInstances(runOpts)

--- a/aws/resource_aws_internet_gateway.go
+++ b/aws/resource_aws_internet_gateway.go
@@ -64,7 +64,7 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 		if err == nil {
-			return resource.RetryableError(err)
+			return resource.RetryableError(&resource.NotFoundError{})
 		} else {
 			return resource.NonRetryableError(err)
 		}

--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -356,7 +356,10 @@ func waitForKmsGrantToBeRevoked(conn *kms.KMS, keyId string, grantId string) err
 				fmt.Errorf("Grant still exists while expected to be revoked, retyring revocation check: %s", *grant.GrantId))
 		}
 
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		grant, err = findKmsGrantById(conn, keyId, grantId, nil)

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -124,7 +124,10 @@ func resourceAwsKmsKeyCreate(d *schema.ResourceData, meta interface{}) error {
 		if isAWSErr(err, kms.ErrCodeMalformedPolicyDocumentException, "") {
 			return resource.RetryableError(err)
 		}
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		resp, err = conn.CreateKey(req)

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -931,7 +931,10 @@ func deleteAwsRedshiftCluster(opts *redshift.DeleteClusterInput, conn *redshift.
 			return resource.RetryableError(err)
 		}
 
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if isResourceTimeoutError(err) {
 		_, err = conn.DeleteCluster(opts)

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -191,7 +191,10 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 			log.Printf("[DEBUG] IAM Instance Profile appears to have no IAM roles, retrying...")
 			return resource.RetryableError(err)
 		}
-		return resource.NonRetryableError(err)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 
 	if isResourceTimeoutError(err) {

--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -111,7 +111,7 @@ func resourceAwsSsmActivationCreate(d *schema.ResourceData, meta interface{}) er
 			return resource.RetryableError(err)
 		}
 
-		return resource.NonRetryableError(err)
+		return nil
 	})
 
 	if isResourceTimeoutError(err) {


### PR DESCRIPTION
V2 of the SDK now errors if `nil` is passed to either of the `RetryError` helpers, this is to avoid subtle logical bugs. Certain patterns which naively return `resource.NonRetryableError(err)` when `err == nil` as a convenience to bubbling up nil should be avoided in favor of explicit error checking. It's possible this PR fixes some bugs in the wild 🤷‍♂️, main goal is to remove noise from V2 SDK acceptance tests.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
