### PR TITLE
additional typeset re-writes

### DIFF
--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -82,7 +82,9 @@ func TestAccAWSAutoscalingPolicy_basic(t *testing.T) {
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_step", &policy),
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_step", "policy_type", "StepScaling"),
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_step", "estimated_instance_warmup", "20"),
-					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_step", "step_adjustment.997979330.scaling_adjustment", "10"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_autoscaling_policy.foobar_step", "step_adjustment.*", map[string]string{
+						"scaling_adjustment": "10",
+					}),
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_target_tracking", &policy),
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_target_tracking", "policy_type", "TargetTrackingScaling"),
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_target_tracking", "target_tracking_configuration.#", "1"),

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func init() {
@@ -361,15 +362,17 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "is_ipv6_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "logging_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_header.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.http_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.https_port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.origin_keepalive_timeout", "5"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.origin_protocol_policy", "http-only"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.origin_read_timeout", "30"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.origin_ssl_protocols.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.domain_name", "www.example.com"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "origin.*", map[string]string{
+						"custom_header.#":                                 "0",
+						"custom_origin_config.#":                          "1",
+						"custom_origin_config.0.http_port":                "80",
+						"custom_origin_config.0.https_port":               "443",
+						"custom_origin_config.0.origin_keepalive_timeout": "5",
+						"custom_origin_config.0.origin_protocol_policy":   "http-only",
+						"custom_origin_config.0.origin_read_timeout":      "30",
+						"custom_origin_config.0.origin_ssl_protocols.#":   "2",
+						"domain_name": "www.example.com",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "price_class", "PriceClass_All"),
 					resource.TestCheckResourceAttr(resourceName, "restrictions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "restrictions.0.geo_restriction.#", "1"),
@@ -1088,16 +1091,18 @@ func TestAccAWSCloudFrontDistribution_OriginGroups(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
 					resource.TestCheckResourceAttr(resourceName, "origin_group.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.origin_id", "groupS3"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.failover_criteria.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.failover_criteria.0.status_codes.#", "4"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.failover_criteria.0.status_codes.1057413486", "403"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.failover_criteria.0.status_codes.1883721641", "404"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.failover_criteria.0.status_codes.2661388106", "502"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.failover_criteria.0.status_codes.2895637960", "500"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.member.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.member.0.origin_id", "primaryS3"),
-					resource.TestCheckResourceAttr(resourceName, "origin_group.1789175660.member.1.origin_id", "failoverS3"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "origin_group.*", map[string]string{
+						"origin_id":                                   "groupS3",
+						"failover_criteria.#":                         "1",
+						"failover_criteria.0.status_codes.#":          "4",
+						"failover_criteria.0.status_codes.1057413486": "403",
+						"failover_criteria.0.status_codes.1883721641": "404",
+						"failover_criteria.0.status_codes.2661388106": "502",
+						"failover_criteria.0.status_codes.2895637960": "500",
+						"member.#":           "2",
+						"member.0.origin_id": "primaryS3",
+						"member.1.origin_id": "failoverS3",
+					}),
 				),
 			},
 		},

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -211,7 +211,7 @@ func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "callback_urls.*", "https://www.example.com/redirect"),
 					resource.TestCheckResourceAttr(resourceName, "default_redirect_uri", "https://www.example.com/redirect"),
 					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "logout_urls.2102268273", "https://www.example.com/login"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "logout_urls.*", "https://www.example.com/login"),
 					resource.TestCheckResourceAttr(resourceName, "prevent_user_existence_errors", "LEGACY"),
 				),
 			},

--- a/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAwsDxHostedPublicVirtualInterface_basic(t *testing.T) {
@@ -55,8 +56,8 @@ func TestAccAwsDxHostedPublicVirtualInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "customer_address", customerAddress),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.1752038751", "210.52.109.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.4290081960", "175.45.176.0/22"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "210.52.109.0/24"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "175.45.176.0/22"),
 					resource.TestCheckResourceAttr(resourceName, "vlan", strconv.Itoa(vlan)),
 					// Accepter's attributes:
 					resource.TestCheckResourceAttrSet(accepterResourceName, "arn"),
@@ -115,8 +116,8 @@ func TestAccAwsDxHostedPublicVirtualInterface_AccepterTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "customer_address", customerAddress),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.1752038751", "210.52.109.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.4290081960", "175.45.176.0/22"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "210.52.109.0/24"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "175.45.176.0/22"),
 					resource.TestCheckResourceAttr(resourceName, "vlan", strconv.Itoa(vlan)),
 					// Accepter's attributes:
 					resource.TestCheckResourceAttrSet(accepterResourceName, "arn"),
@@ -142,8 +143,8 @@ func TestAccAwsDxHostedPublicVirtualInterface_AccepterTags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "customer_address", customerAddress),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.1752038751", "210.52.109.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.4290081960", "175.45.176.0/22"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "210.52.109.0/24"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "175.45.176.0/22"),
 					resource.TestCheckResourceAttr(resourceName, "vlan", strconv.Itoa(vlan)),
 					// Accepter's attributes:
 					resource.TestCheckResourceAttrSet(accepterResourceName, "arn"),

--- a/aws/resource_aws_dx_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_public_virtual_interface_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAwsDxPublicVirtualInterface_basic(t *testing.T) {
@@ -53,8 +54,8 @@ func TestAccAwsDxPublicVirtualInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "customer_address", customerAddress),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.1752038751", "210.52.109.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.4290081960", "175.45.176.0/22"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "210.52.109.0/24"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "175.45.176.0/22"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "vlan", strconv.Itoa(vlan)),
 				),
@@ -104,8 +105,8 @@ func TestAccAwsDxPublicVirtualInterface_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "customer_address", customerAddress),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.1752038751", "210.52.109.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.4290081960", "175.45.176.0/22"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "210.52.109.0/24"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "175.45.176.0/22"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
@@ -128,8 +129,8 @@ func TestAccAwsDxPublicVirtualInterface_Tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "customer_address", customerAddress),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.1752038751", "210.52.109.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "route_filter_prefixes.4290081960", "175.45.176.0/22"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "210.52.109.0/24"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "route_filter_prefixes.*", "175.45.176.0/22"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2b"),

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -336,7 +336,6 @@ func TestAccAWSInstance_EbsBlockDevice_KmsKeyArn(t *testing.T) {
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
 						"encrypted": "true",
 					}),
-					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.2634515331.encrypted", "true"),
 					// TODO: TypeSet check implement attr pair helper
 					resource.TestCheckResourceAttrPair(resourceName, "ebs_block_device.2634515331.kms_key_id", kmsKeyResourceName, "arn"),
 				),

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
@@ -65,7 +66,7 @@ func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.553690328", "config.amazonaws.com"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "config.amazonaws.com"),
 				),
 			},
 			{
@@ -78,8 +79,8 @@ func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.553690328", "config.amazonaws.com"),
-					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.3567899500", "ds.amazonaws.com"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "config.amazonaws.com"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "ds.amazonaws.com"),
 				),
 			},
 			{
@@ -87,7 +88,7 @@ func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.4066123156", "fms.amazonaws.com"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "aws_service_access_principals.*", "fms.amazonaws.com"),
 				),
 			},
 		},

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -2856,21 +2856,15 @@ func testAccCheckAWSS3BucketReplicationRules(n string, providerF func() *schema.
 
 func testAccCheckAWSS3BucketUpdateGrantSingle(resourceName string) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
-		id := s.RootModule().Resources["data.aws_canonical_user_id.current"].Primary.ID
-		gh := fmt.Sprintf("grant.%v", grantHash(map[string]interface{}{
-			"id":   id,
-			"type": "CanonicalUser",
-			"uri":  "",
-			"permissions": schema.NewSet(
-				schema.HashString,
-				[]interface{}{"FULL_CONTROL", "WRITE"},
-			),
-		}))
 		for _, t := range []resource.TestCheckFunc{
-			resource.TestCheckResourceAttr(resourceName, gh+".permissions.#", "2"),
-			resource.TestCheckResourceAttr(resourceName, gh+".permissions.3535167073", "FULL_CONTROL"),
-			resource.TestCheckResourceAttr(resourceName, gh+".permissions.2319431919", "WRITE"),
-			resource.TestCheckResourceAttr(resourceName, gh+".type", "CanonicalUser"),
+			tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "grant.*", map[string]string{
+				"permissions.#": "2",
+			}),
+			tfawsresource.TestCheckTypeSetElemAttr(resourceName, "grant.*.permissions.*", "FULL_CONTROL"),
+			tfawsresource.TestCheckTypeSetElemAttr(resourceName, "grant.*.permissions.*", "WRITE"),
+			tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "grant.*", map[string]string{
+				"type": "CanonicalUser",
+			}),
 		} {
 			if err := t(s); err != nil {
 				return err
@@ -2902,13 +2896,19 @@ func testAccCheckAWSS3BucketUpdateGrantMulti(resourceName string) func(s *terraf
 			),
 		}))
 		for _, t := range []resource.TestCheckFunc{
+			// TODO TypeSet Check to differentiate between sets
 			resource.TestCheckResourceAttr(resourceName, gh1+".permissions.#", "1"),
-			resource.TestCheckResourceAttr(resourceName, gh1+".permissions.2931993811", "READ"),
-			resource.TestCheckResourceAttr(resourceName, gh1+".type", "CanonicalUser"),
+			tfawsresource.TestCheckTypeSetElemAttr(resourceName, "grant.*.permissions.*", "READ"),
+			tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "grant.*", map[string]string{
+				"type": "CanonicalUser",
+			}),
+			// TODO TypeSet Check to differentiate between sets
 			resource.TestCheckResourceAttr(resourceName, gh2+".permissions.#", "1"),
-			resource.TestCheckResourceAttr(resourceName, gh2+".permissions.1600971645", "READ_ACP"),
-			resource.TestCheckResourceAttr(resourceName, gh2+".type", "Group"),
-			resource.TestCheckResourceAttr(resourceName, gh2+".uri", "http://acs.amazonaws.com/groups/s3/LogDelivery"),
+			tfawsresource.TestCheckTypeSetElemAttr(resourceName, "grant.*.permissions.*", "READ_ACP"),
+			tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "grant.*", map[string]string{
+				"type": "Group",
+				"uri":  "http://acs.amazonaws.com/groups/s3/LogDelivery",
+			}),
 		} {
 			if err := t(s); err != nil {
 				return err


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: additional acctest typeset re-writes 
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (65.29s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (67.21s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (69.49s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (79.22s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (85.50s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (90.70s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (93.32s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (93.95s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (97.78s)
--- PASS: TestAccAWSInstanceDataSource_VPC (100.41s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (117.32s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (118.19s)
--- PASS: TestAccAWSAutoscalingPolicy_disappears (43.81s)
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (44.80s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Custom (42.15s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (137.99s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.31s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (140.16s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.34s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Predefined (49.00s)
--- PASS: TestAccAWSAutoscalingPolicy_zerovalue (46.17s)
--- PASS: TestAccAWSAutoscalingPolicy_basic (70.93s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (176.15s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (183.23s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (197.14s)
--- PASS: TestAccAWSInstanceDataSource_basic (247.13s)
--- PASS: TestAccAWSInstancesDataSource_basic (192.27s)
--- PASS: TestAccAWSInstancesDataSource_tags (192.04s)
--- PASS: TestAccAWSInstancesDataSource_instance_state_names (192.07s)
--- PASS: TestAccAWSInstanceDataSource_tags (268.09s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (187.96s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (312.59s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (9.02s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (23.98s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (14.74s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (8.64s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (221.83s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (14.00s)
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (7.38s)
--- SKIP: TestAccAwsDxHostedPublicVirtualInterface_basic (0.00s)
--- SKIP: TestAccAwsDxHostedPublicVirtualInterface_AccepterTags (0.00s)
--- SKIP: TestAccAwsDxPublicVirtualInterface_basic (0.00s)
--- SKIP: TestAccAwsDxPublicVirtualInterface_Tags (0.00s)
--- PASS: TestFetchRootDevice (0.00s)
    --- PASS: TestFetchRootDevice/device_name_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/device_name_not_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/no_images (0.00s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfig (27.60s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (231.39s)
--- SKIP: TestAccAWSInstance_inEc2Classic (1.12s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (201.08s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (211.11s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (205.42s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (218.93s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (386.78s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (382.68s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (383.07s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (382.44s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (382.50s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (399.20s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (392.66s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (429.04s)
--- PASS: TestAccAWSInstance_basic (138.36s)
--- SKIP: TestAccAWSInstance_outpost (1.58s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (79.25s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (10.25s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (183.79s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (184.10s)
--- PASS: TestAccAWSInstance_vpc (85.52s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (94.23s)
--- PASS: TestAccAWSInstance_userDataBase64 (151.34s)
--- PASS: TestAccAWSInstance_disableApiTermination (106.83s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (66.01s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (180.26s)
--- PASS: TestAccAWSInstance_sourceDestCheck (124.69s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (80.01s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (362.48s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (423.05s)
--- PASS: TestAccAWSInstance_rootInstanceStore (170.58s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (83.40s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (175.22s)
--- PASS: TestAccAWSInstance_blockDevices (180.77s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (87.52s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (428.54s)
--- PASS: TestAccAWSInstance_volumeTags (92.16s)
--- PASS: TestAccAWSInstance_placementGroup (180.33s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (93.73s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (65.17s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (187.47s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (625.00s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (75.37s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (299.13s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (64.01s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (125.20s)
--- PASS: TestAccAWSInstance_tags (167.51s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (600.04s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (128.33s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (67.62s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (68.75s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS (113.22s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (119.91s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (133.07s)
--- PASS: TestAccAWSInstance_privateIP (186.50s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (125.58s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (65.31s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (75.86s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (103.82s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (175.32s)
--- PASS: TestAccAWSInstance_keyPairCheck (185.44s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (65.64s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (124.93s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (80.97s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (83.96s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (80.88s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (78.37s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (183.50s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (89.03s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (80.40s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (90.11s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (101.73s)
--- PASS: TestInstanceHostIDSchema (0.00s)
--- PASS: TestInstanceCpuCoreCountSchema (0.00s)
--- PASS: TestInstanceCpuThreadsPerCoreSchema (0.00s)
--- PASS: TestFlattenOrganizationsRoots (0.00s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_basic (11.55s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (124.87s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (106.37s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty (1.02s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (87.08s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_removed (19.00s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (116.20s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (88.11s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_updateBasic (32.46s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag (17.68s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty (1.14s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix (18.88s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags (20.65s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (160.06s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove (18.81s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default (12.57s)
--- PASS: TestAccAWSS3BucketInventory_basic (13.91s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (11.98s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (11.39s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags (29.53s)
--- PASS: TestAccAWSS3BucketMetric_basic (12.07s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full (21.65s)
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (11.14s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (95.75s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (17.21s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (93.14s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (17.58s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (18.02s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (17.66s)
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (1.33s)
--- PASS: TestAccAWSS3BucketNotification_Queue (12.50s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (179.13s)
--- PASS: TestAccAWSS3BucketNotification_Topic (14.09s)
--- PASS: TestAccAWSS3BucketNotification_Topic_Multiple (13.44s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (130.28s)
--- PASS: TestAccAWSS3BucketObject_empty (11.08s)
--- PASS: TestAccAWSS3BucketObject_content (11.28s)
--- PASS: TestAccAWSS3BucketObject_source (12.08s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (30.54s)
--- PASS: TestAccAWSS3BucketObject_etagEncryption (12.82s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction (33.47s)
--- PASS: TestAccAWSS3BucketNotification_update (22.04s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias (33.77s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (11.75s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (11.59s)
--- PASS: TestAccAWSInstance_changeInstanceType (356.15s)
--- PASS: TestAccAWSS3BucketObject_NonVersioned (12.52s)
--- PASS: TestAccAWSS3BucketObject_sse (11.59s)
--- PASS: TestAccAWSS3BucketObject_kms (12.11s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (21.08s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (20.64s)
--- PASS: TestAccAWSS3BucketObject_updates (23.53s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (21.33s)
--- PASS: TestAccAWSS3BucketObject_acl (30.12s)
--- PASS: TestAccAWSS3BucketObject_metadata (29.79s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_basic (15.36s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (22.45s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears (15.57s)
--- PASS: TestAccAWSS3BucketPolicy_basic (21.36s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (32.78s)
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (25.67s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_bucketDisappears (11.22s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (30.05s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (37.01s)
--- PASS: TestAccAWSS3BucketObject_tags (41.77s)
--- PASS: TestAccAWSS3BucketObject_storageClass (45.82s)
--- PASS: TestAccAWSS3Bucket_basic (14.10s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (40.13s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (15.45s)
--- PASS: TestAccAWSS3Bucket_namePrefix (14.88s)
--- PASS: TestAccAWSS3Bucket_generatedName (13.79s)
--- PASS: TestAccAWSS3MultiBucket_withTags (17.38s)
--- PASS: TestAccAWSS3Bucket_region (13.96s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls (32.31s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets (31.18s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy (32.64s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls (32.03s)
--- PASS: TestAccAWSInstance_disappears (202.24s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (21.16s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (14.67s)
--- PASS: TestAccAWSS3Bucket_acceleration (29.99s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (39.84s)
--- PASS: TestAccAWSS3Bucket_AclToGrant (23.10s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (32.33s)
--- PASS: TestAccAWSS3Bucket_GrantToAcl (22.23s)
--- PASS: TestAccAWSS3Bucket_Policy (31.05s)
--- PASS: TestAccAWSInstance_hibernation (192.98s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (25.68s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (11.14s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (17.15s)
--- PASS: TestAccAWSS3Bucket_UpdateGrant (35.21s)
--- PASS: TestAccAWSInstance_multipleRegions (575.56s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (31.49s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (14.00s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (33.13s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (19.93s)
--- PASS: TestAccAWSS3Bucket_Logging (20.18s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (27.89s)
--- PASS: TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock (16.13s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (26.13s)
--- PASS: TestAWSS3BucketName (0.00s)
--- PASS: TestBucketRegionalDomainName (0.00s)
--- PASS: TestWebsiteEndpoint (0.00s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (284.94s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (318.99s)
--- PASS: TestAccAWSS3Bucket_Versioning (34.62s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (11.99s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (12.15s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (12.31s)
--- PASS: TestAccAWSS3Bucket_objectLock (20.70s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (29.61s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (90.63s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (44.47s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (44.54s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation (64.62s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (66.55s)
--- PASS: TestAccAWSS3Bucket_Replication (108.98s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (113.86s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (377.05s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (410.49s)
```
