### PR TITLE
resource/aws_dx_gateway: Remove automatic aws_dx_gateway_association import

### DIFF
--- a/aws/resource_aws_dx_gateway.go
+++ b/aws/resource_aws_dx_gateway.go
@@ -18,7 +18,7 @@ func resourceAwsDxGateway() *schema.Resource {
 		Read:   resourceAwsDxGatewayRead,
 		Delete: resourceAwsDxGatewayDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceAwsDxGatewayImportState,
+			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -123,28 +123,6 @@ func resourceAwsDxGatewayDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	return nil
-}
-
-func resourceAwsDxGatewayImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	conn := meta.(*AWSClient).dxconn
-
-	resp, err := conn.DescribeDirectConnectGatewayAssociations(&directconnect.DescribeDirectConnectGatewayAssociationsInput{
-		DirectConnectGatewayId: aws.String(d.Id()),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error reading Direct Connect gateway association: %s", err)
-	}
-
-	results := []*schema.ResourceData{d}
-	for _, assoc := range resp.DirectConnectGatewayAssociations {
-		d := resourceAwsDxGatewayAssociation().Data(nil)
-		d.SetType("aws_dx_gateway_association")
-		d.SetId(dxGatewayAssociationId(aws.StringValue(assoc.DirectConnectGatewayId), aws.StringValue(assoc.AssociatedGateway.Id)))
-		d.Set("dx_gateway_association_id", assoc.AssociationId)
-		results = append(results, d)
-	}
-
-	return results, nil
 }
 
 func dxGatewayStateRefresh(conn *directconnect.DirectConnect, dxgwId string) resource.StateRefreshFunc {

--- a/aws/resource_aws_dx_gateway_test.go
+++ b/aws/resource_aws_dx_gateway_test.go
@@ -140,13 +140,6 @@ func TestAccAwsDxGateway_basic(t *testing.T) {
 }
 
 func TestAccAwsDxGateway_complex(t *testing.T) {
-	checkFn := func(s []*terraform.InstanceState) error {
-		if len(s) != 3 {
-			return fmt.Errorf("Got %d resources, expected 3. State: %#v", len(s), s)
-		}
-		return nil
-	}
-
 	rName1 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
 	rName2 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
 	rBgpAsn := randIntRange(64512, 65534)
@@ -167,7 +160,6 @@ func TestAccAwsDxGateway_complex(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateCheck:  checkFn,
 				ImportStateVerify: true,
 			},
 		},

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -21,6 +21,7 @@ Upgrade topics:
 - [Provider Version Configuration](#provider-version-configuration)
 - [Data Source: aws_availability_zones](#data-source-aws_availability_zones)
 - [Data Source: aws_lambda_invocation](#data-source-aws_lambda_invocation)
+- [Resource: aws_dx_gateway](#resource-aws_dx_gateway)
 - [Resource: aws_emr_cluster](#resource-aws_emr_cluster)
 
 <!-- /TOC -->
@@ -120,6 +121,12 @@ output "lambda_result" {
   value = jsondecode(data.aws_lambda_invocation.example.result)["key1"]
 }
 ```
+
+## Resource: aws_dx_gateway
+
+### Removal of Automatic aws_dx_gateway_association Import
+
+Previously when importing the `aws_dx_gateway` resource with the [`terraform import` command](/docs/commands/import.html), the Terraform AWS Provider would automatically attempt to import an associated `aws_dx_gateway_association` resource(s) as well. This automatic resource import has been removed. Use the [`aws_dx_gateway_association` resource import](/docs/providers/aws/r/dx_gateway_association.html#import) to import those resources separately.
 
 ## Resource: aws_emr_cluster
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13408

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_dx_gateway: Remove automatic `aws_dx_gateway_association` resource import
```

Output from acceptance testing:

```
--- PASS: TestAccAwsDxGateway_basic (54.91s)
--- PASS: TestAccAwsDxGateway_complex (2018.49s)
```
