### PR TITLE
data-source/aws_lambda_invocation: Remove result_map attribute

### DIFF
--- a/aws/data_source_aws_lambda_invocation.go
+++ b/aws/data_source_aws_lambda_invocation.go
@@ -2,9 +2,7 @@ package aws
 
 import (
 	"crypto/md5"
-	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
@@ -38,15 +36,6 @@ func dataSourceAwsLambdaInvocation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"result_map": {
-				Type:       schema.TypeMap,
-				Computed:   true,
-				Deprecated: "use `result` attribute with jsondecode() function",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 		},
 	}
 }
@@ -75,16 +64,6 @@ func dataSourceAwsLambdaInvocationRead(d *schema.ResourceData, meta interface{})
 
 	if err = d.Set("result", string(res.Payload)); err != nil {
 		return err
-	}
-
-	var result map[string]interface{}
-
-	if err = json.Unmarshal(res.Payload, &result); err != nil {
-		return err
-	}
-
-	if err = d.Set("result_map", result); err != nil {
-		log.Printf("[WARN] Cannot use the result invocation as a string map: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s_%s_%x", functionName, qualifier, md5.Sum(input)))

--- a/aws/data_source_aws_lambda_invocation_test.go
+++ b/aws/data_source_aws_lambda_invocation_test.go
@@ -45,10 +45,6 @@ func TestAccDataSourceAwsLambdaInvocation_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsLambdaInvocation_basic_config(rName, testData),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map.%", "3"),
-					resource.TestCheckResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map.key1", "value1"),
-					resource.TestCheckResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map.key2", "value2"),
-					resource.TestCheckResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map.key3", testData),
 					testAccCheckLambdaInvocationResult("data.aws_lambda_invocation.invocation_test", `{"key1":"value1","key2":"value2","key3":"`+testData+`"}`),
 				),
 			},
@@ -67,10 +63,7 @@ func TestAccDataSourceAwsLambdaInvocation_qualifier(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsLambdaInvocation_qualifier_config(rName, testData),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map.%", "3"),
-					resource.TestCheckResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map.key1", "value1"),
-					resource.TestCheckResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map.key2", "value2"),
-					resource.TestCheckResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map.key3", testData),
+					testAccCheckLambdaInvocationResult("data.aws_lambda_invocation.invocation_test", `{"key1":"value1","key2":"value2","key3":"`+testData+`"}`),
 				),
 			},
 		},
@@ -88,7 +81,6 @@ func TestAccDataSourceAwsLambdaInvocation_complex(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsLambdaInvocation_complex_config(rName, testData),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("data.aws_lambda_invocation.invocation_test", "result_map"),
 					testAccCheckLambdaInvocationResult("data.aws_lambda_invocation.invocation_test", `{"key1":{"subkey1":"subvalue1"},"key2":{"subkey2":"subvalue2","subkey3":{"a": "b"}},"key3":"`+testData+`"}`),
 				),
 			},

--- a/website/docs/d/lambda_invocation.html.markdown
+++ b/website/docs/d/lambda_invocation.html.markdown
@@ -26,20 +26,7 @@ data "aws_lambda_invocation" "example" {
 JSON
 }
 
-output "result" {
-  description = "String result of Lambda execution"
-  value       = "${data.aws_lambda_invocation.example.result}"
-}
-
-# In Terraform 0.11 and earlier, the result_map attribute can be used
-# to convert a result JSON string to a map of string keys to string values.
-output "result_entry_tf011" {
-  value = "${data.aws_lambda_invocation.example.result_map["key1"]}"
-}
-
-# In Terraform 0.12 and later, the jsondecode() function can be used
-# to convert a result JSON string to native Terraform types.
-output "result_entry_tf012" {
+output "result_entry" {
   value = jsondecode(data.aws_lambda_invocation.example.result)["key1"]
 }
 ```
@@ -54,4 +41,3 @@ output "result_entry_tf012" {
 ## Attributes Reference
 
 * `result` - String result of the lambda function invocation.
-* `result_map` - (**DEPRECATED**) This field is set only if result is a map of primitive types, where the map is string keys and string values. In Terraform 0.12 and later, use the [`jsondecode()` function](/docs/configuration/functions/jsondecode.html) with the `result` attribute instead to convert the result to all supported native Terraform types.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9189

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_lambda_invocation: Remove `result_map` attribute
```

Already documented in the version 3 upgrade guide.

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsLambdaInvocation_basic (37.41s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_complex (43.39s)
--- PASS: TestAccDataSourceAwsLambdaInvocation_qualifier (52.03s)
```
