### PR TITLE
awsproviderlint: go fmt -s -w and go mod vendor

### DIFF
--- a/awsproviderlint/passes/AWSAT003/AWSAT003.go
+++ b/awsproviderlint/passes/AWSAT003/AWSAT003.go
@@ -46,7 +46,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	var regions []string
 
 	for _, p := range partitions {
-		for id, _ := range p.Regions() {
+		for id := range p.Regions() {
 			regions = append(regions, id)
 		}
 	}

--- a/vendor/github.com/bflad/tfproviderlint/passes/helper/resource/testcheckresourceattrcallexpr/testcheckresourceattrcallexpr.go
+++ b/vendor/github.com/bflad/tfproviderlint/passes/helper/resource/testcheckresourceattrcallexpr/testcheckresourceattrcallexpr.go
@@ -1,0 +1,13 @@
+package testcheckresourceattrcallexpr
+
+import (
+	"github.com/bflad/tfproviderlint/helper/analysisutils"
+	"github.com/bflad/tfproviderlint/helper/terraformtype/helper/resource"
+)
+
+var Analyzer = analysisutils.FunctionCallExprAnalyzer(
+	"testcheckresourceattrcallexpr",
+	resource.IsFunc,
+	resource.PackagePath,
+	resource.FuncNameTestCheckResourceAttr,
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -306,6 +306,7 @@ github.com/bflad/tfproviderlint/passes/V008
 github.com/bflad/tfproviderlint/passes/commentignore
 github.com/bflad/tfproviderlint/passes/helper/resource/retryfuncinfo
 github.com/bflad/tfproviderlint/passes/helper/resource/testcaseinfo
+github.com/bflad/tfproviderlint/passes/helper/resource/testcheckresourceattrcallexpr
 github.com/bflad/tfproviderlint/passes/helper/resource/testmatchresourceattrcallexpr
 github.com/bflad/tfproviderlint/passes/helper/schema/crudfuncinfo
 github.com/bflad/tfproviderlint/passes/helper/schema/resourcedatagetchangeassignstmt


### PR DESCRIPTION
To fix `make fmtcheck` and `GOFLAGS='-mod=vendor'` errors.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A (unit testing)
