### PR TITLE
resource/aws_msk_cluster: Update encryption_info.encryption_in_transit.client_broker default to match API default

### DIFF
--- a/aws/data_source_aws_msk_cluster_test.go
+++ b/aws/data_source_aws_msk_cluster_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -22,8 +23,8 @@ func TestAccAWSMskClusterDataSource_Name(t *testing.T) {
 				Config: testAccMskClusterDataSourceConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "bootstrap_brokers"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "bootstrap_brokers_tls"),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap_brokers", ""),
+					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers_tls", regexp.MustCompile(`^(([-\w]+\.){1,}[\w]+:\d+,){2,}([-\w]+\.){1,}[\w]+:\d+$`)), // Ordering not guaranteed
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_name", dataSourceName, "cluster_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "kafka_version", dataSourceName, "kafka_version"),
 					resource.TestCheckResourceAttrPair(resourceName, "number_of_broker_nodes", dataSourceName, "number_of_broker_nodes"),

--- a/aws/data_source_aws_msk_cluster_test.go
+++ b/aws/data_source_aws_msk_cluster_test.go
@@ -24,7 +24,7 @@ func TestAccAWSMskClusterDataSource_Name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "bootstrap_brokers", ""),
-					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers_tls", regexp.MustCompile(`^(([-\w]+\.){1,}[\w]+:\d+,){2,}([-\w]+\.){1,}[\w]+:\d+$`)), // Ordering not guaranteed
+					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers_tls", regexp.MustCompile(`^(([-\w]+\.){1,}[\w]+:\d+,){2,}([-\w]+\.){1,}[\w]+:\d+$`)), // Hostname ordering not guaranteed between resource and data source reads
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_name", dataSourceName, "cluster_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "kafka_version", dataSourceName, "kafka_version"),
 					resource.TestCheckResourceAttrPair(resourceName, "number_of_broker_nodes", dataSourceName, "number_of_broker_nodes"),

--- a/aws/resource_aws_msk_cluster.go
+++ b/aws/resource_aws_msk_cluster.go
@@ -166,7 +166,7 @@ func resourceAwsMskCluster() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										ForceNew: true,
-										Default:  kafka.ClientBrokerTlsPlaintext,
+										Default:  kafka.ClientBrokerTls,
 										ValidateFunc: validation.StringInSlice([]string{
 											kafka.ClientBrokerPlaintext,
 											kafka.ClientBrokerTlsPlaintext,

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -25,6 +25,7 @@ Upgrade topics:
 - [Resource: aws_elastic_transcoder_preset](#resource-aws_elastic_transcoder_preset)
 - [Resource: aws_emr_cluster](#resource-aws_emr_cluster)
 - [Resource: aws_lb_listener_rule](#resource-aws_lb_listener_rule)
+- [Resource: aws_msk_cluster](#resource-aws_msk_cluster)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
 - [Resource: aws_sns_platform_application](#resource-aws_sns_platform_application)
 - [Resource: aws_spot_fleet_request](#resource-aws_spot_fleet_request)
@@ -395,6 +396,30 @@ resource "aws_lb_listener_rule" "example" {
   condition {
     path_pattern {
       values = ["/static/*"]
+    }
+  }
+}
+```
+
+## Resource: aws_msk_cluster
+
+### encryption_info.encryption_in_transit.client_broker Default Updated to Match API
+
+A few weeks after general availability launch and initial release of the `aws_msk_cluster` resource, the MSK API default for client broker encryption switched from `TLS_PLAINTEXT` to `TLS`. The attribute default has now been updated to match the more secure API default, however existing Terraform configurations may show a difference if this setting is not configured.
+
+To continue using the old default when it was previously not configured, add or modify this configuration:
+
+```hcl
+resource "aws_msk_cluster" "example" {
+  # ... other configuration ...
+
+  encryption_info {
+    # ... potentially other configuration ...
+
+    encryption_in_transit {
+      # ... potentially other configuration ...
+
+      client_broker = "TLS_PLAINTEXT"
     }
   }
 }

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -155,11 +155,6 @@ output "zookeeper_connect_string" {
   value = aws_msk_cluster.example.zookeeper_connect_string
 }
 
-output "bootstrap_brokers" {
-  description = "Plaintext connection host:port pairs"
-  value       = aws_msk_cluster.example.bootstrap_brokers
-}
-
 output "bootstrap_brokers_tls" {
   description = "TLS connection host:port pairs"
   value       = aws_msk_cluster.example.bootstrap_brokers_tls
@@ -210,7 +205,7 @@ The following arguments are supported:
 
 #### encryption_info encryption_in_transit Argument Reference
 
-* `client_broker` - (Optional) Encryption setting for data in transit between clients and brokers. Valid values: `TLS`, `TLS_PLAINTEXT`, and `PLAINTEXT`. Default value is `TLS_PLAINTEXT` when `encryption_in_transit` block defined, but `TLS` when `encryption_in_transit` block omitted.
+* `client_broker` - (Optional) Encryption setting for data in transit between clients and brokers. Valid values: `TLS`, `TLS_PLAINTEXT`, and `PLAINTEXT`. Default value is `TLS`.
 * `in_cluster` - (Optional) Whether data communication among broker nodes is encrypted. Default value: `true`.
 
 #### open_monitoring Argument Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10673

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_msk_cluster: Update `encryption_info` `encryption_in_transit` `client_broker` argument default to match API default
```

Output from acceptance testing:

```
--- PASS: TestAccAWSMskCluster_basic (1595.73s)
--- PASS: TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize (1760.04s)
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn (1603.40s)
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker (1603.85s)
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster (1598.02s)
--- PASS: TestAccAWSMskCluster_EnhancedMonitoring (1603.10s)
--- PASS: TestAccAWSMskCluster_LoggingInfo (1806.72s)
--- PASS: TestAccAWSMskCluster_NumberOfBrokerNodes (2036.98s)
--- PASS: TestAccAWSMskCluster_OpenMonitoring (1722.68s)
--- PASS: TestAccAWSMskCluster_Tags (1605.63s)

--- PASS: TestAccAWSMskClusterDataSource_Name (1608.30s)
```
