### PR TITLE
service/directconnect: vpn_gateway_id Argument Removals and Increase aws_dx_gateway_association Default Timeouts

### DIFF
--- a/aws/resource_aws_dx_gateway_association.go
+++ b/aws/resource_aws_dx_gateway_association.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -49,7 +48,7 @@ func resourceAwsDxGatewayAssociation() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"associated_gateway_owner_account_id", "proposal_id", "vpn_gateway_id"},
+				ConflictsWith: []string{"associated_gateway_owner_account_id", "proposal_id"},
 			},
 
 			"associated_gateway_owner_account_id": {
@@ -58,7 +57,7 @@ func resourceAwsDxGatewayAssociation() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ValidateFunc:  validateAwsAccountId,
-				ConflictsWith: []string{"associated_gateway_id", "vpn_gateway_id"},
+				ConflictsWith: []string{"associated_gateway_id"},
 			},
 
 			"associated_gateway_type": {
@@ -86,15 +85,7 @@ func resourceAwsDxGatewayAssociation() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"associated_gateway_id", "vpn_gateway_id"},
-			},
-
-			"vpn_gateway_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
-				Deprecated:    "use 'associated_gateway_id' argument instead",
+				ConflictsWith: []string{"associated_gateway_id"},
 			},
 		},
 
@@ -111,7 +102,6 @@ func resourceAwsDxGatewayAssociationCreate(d *schema.ResourceData, meta interfac
 
 	dxgwId := d.Get("dx_gateway_id").(string)
 	gwIdRaw, gwIdOk := d.GetOk("associated_gateway_id")
-	vgwIdRaw, vgwIdOk := d.GetOk("vpn_gateway_id")
 	gwAcctIdRaw, gwAcctIdOk := d.GetOk("associated_gateway_owner_account_id")
 	proposalIdRaw, proposalIdOk := d.GetOk("proposal_id")
 
@@ -120,8 +110,8 @@ func resourceAwsDxGatewayAssociationCreate(d *schema.ResourceData, meta interfac
 		if !(gwAcctIdOk && proposalIdOk) {
 			return fmt.Errorf("associated_gateway_owner_account_id and proposal_id must be configured")
 		}
-	} else if !(gwIdOk || vgwIdOk) {
-		return fmt.Errorf("either associated_gateway_owner_account_id and proposal_id or one of associated_gateway_id or vpn_gateway_id must be configured")
+	} else if !gwIdOk {
+		return fmt.Errorf("either associated_gateway_owner_account_id and proposal_id, or associated_gateway_id, must be configured")
 	}
 
 	associationId := ""
@@ -143,17 +133,12 @@ func resourceAwsDxGatewayAssociationCreate(d *schema.ResourceData, meta interfac
 		associationId = aws.StringValue(resp.DirectConnectGatewayAssociation.AssociationId)
 		d.SetId(dxGatewayAssociationId(dxgwId, aws.StringValue(resp.DirectConnectGatewayAssociation.AssociatedGateway.Id)))
 	} else {
+		gwId := gwIdRaw.(string)
+
 		req := &directconnect.CreateDirectConnectGatewayAssociationInput{
 			AddAllowedPrefixesToDirectConnectGateway: expandDxRouteFilterPrefixes(d.Get("allowed_prefixes").(*schema.Set)),
 			DirectConnectGatewayId:                   aws.String(dxgwId),
-		}
-		gwId := ""
-		if gwIdOk {
-			gwId = gwIdRaw.(string)
-			req.GatewayId = aws.String(gwId)
-		} else {
-			gwId = vgwIdRaw.(string)
-			req.VirtualGatewayId = aws.String(gwId)
+			GatewayId:                                aws.String(gwId),
 		}
 
 		log.Printf("[DEBUG] Creating Direct Connect gateway association: %#v", req)
@@ -196,11 +181,7 @@ func resourceAwsDxGatewayAssociationRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error setting allowed_prefixes: %s", err)
 	}
 
-	if _, ok := d.GetOk("vpn_gateway_id"); ok {
-		d.Set("vpn_gateway_id", assoc.VirtualGatewayId)
-	} else {
-		d.Set("associated_gateway_id", assoc.AssociatedGateway.Id)
-	}
+	d.Set("associated_gateway_id", assoc.AssociatedGateway.Id)
 	d.Set("associated_gateway_owner_account_id", assoc.AssociatedGateway.OwnerAccount)
 	d.Set("associated_gateway_type", assoc.AssociatedGateway.Type)
 	d.Set("dx_gateway_association_id", assoc.AssociationId)
@@ -212,12 +193,6 @@ func resourceAwsDxGatewayAssociationRead(d *schema.ResourceData, meta interface{
 
 func resourceAwsDxGatewayAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dxconn
-
-	_, gwIdOk := d.GetOk("associated_gateway_id")
-	_, vgwIdOk := d.GetOk("vpn_gateway_id")
-	if !gwIdOk && !vgwIdOk {
-		return errors.New("one of associated_gateway_id or vpn_gateway_id must be configured")
-	}
 
 	if d.HasChange("allowed_prefixes") {
 		associationId := d.Get("dx_gateway_association_id").(string)

--- a/aws/resource_aws_dx_gateway_association.go
+++ b/aws/resource_aws_dx_gateway_association.go
@@ -99,9 +99,9 @@ func resourceAwsDxGatewayAssociation() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(15 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(15 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 	}
 }

--- a/aws/resource_aws_dx_gateway_association_migrate.go
+++ b/aws/resource_aws_dx_gateway_association_migrate.go
@@ -69,7 +69,6 @@ func resourceAwsDxGatewayAssociationResourceV0() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
-				Deprecated:    "use 'associated_gateway_id' argument instead",
 			},
 		},
 	}

--- a/aws/resource_aws_dx_gateway_association_proposal_test.go
+++ b/aws/resource_aws_dx_gateway_association_proposal_test.go
@@ -78,39 +78,6 @@ func testSweepDirectConnectGatewayAssociationProposals(region string) error {
 	return nil
 }
 
-func TestAccAwsDxGatewayAssociationProposal_VpnGatewayId(t *testing.T) {
-	var proposal1 directconnect.GatewayAssociationProposal
-	var providers []*schema.Provider
-	rBgpAsn := randIntRange(64512, 65534)
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_dx_gateway_association_proposal.test"
-	resourceNameDxGw := "aws_dx_gateway.test"
-	resourceNameVgw := "aws_vpn_gateway.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccAlternateAccountPreCheck(t)
-		},
-		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckAwsDxGatewayAssociationProposalDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDxGatewayAssociationProposalConfig_vpnGatewayId(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxGatewayAssociationProposalExists(resourceName, &proposal1),
-					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
-					resource.TestCheckNoResourceAttr(resourceName, "associated_gateway_id"),
-					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
-					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAwsDxGatewayAssociationProposal_basicVpnGateway(t *testing.T) {
 	var proposal1 directconnect.GatewayAssociationProposal
 	var providers []*schema.Provider
@@ -134,7 +101,6 @@ func TestAccAwsDxGatewayAssociationProposal_basicVpnGateway(t *testing.T) {
 					testAccCheckAwsDxGatewayAssociationProposalExists(resourceName, &proposal1),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
-					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
@@ -173,7 +139,6 @@ func TestAccAwsDxGatewayAssociationProposal_basicTransitGateway(t *testing.T) {
 					testAccCheckAwsDxGatewayAssociationProposalExists(resourceName, &proposal1),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameTgw, "id"),
-					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
@@ -356,16 +321,6 @@ resource "aws_vpn_gateway" "test" {
   }
 }
 `, rName, rBgpAsn)
-}
-
-func testAccDxGatewayAssociationProposalConfig_vpnGatewayId(rName string, rBgpAsn int) string {
-	return testAccDxGatewayAssociationProposalConfigBase_vpnGateway(rName, rBgpAsn) + `
-resource "aws_dx_gateway_association_proposal" "test" {
-  dx_gateway_id               = "${aws_dx_gateway.test.id}"
-  dx_gateway_owner_account_id = "${aws_dx_gateway.test.owner_account_id}"
-  vpn_gateway_id              = "${aws_vpn_gateway.test.id}"
-}
-`
 }
 
 func testAccDxGatewayAssociationProposalConfig_basicVpnGateway(rName string, rBgpAsn int) string {

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -182,38 +182,6 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 	return nil
 }
 
-func TestAccAwsDxGatewayAssociation_deprecatedSingleAccount(t *testing.T) {
-	resourceName := "aws_dx_gateway_association.test"
-	resourceNameDxGw := "aws_dx_gateway.test"
-	resourceNameVgw := "aws_vpn_gateway.test"
-	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDxGatewayAssociationConfig_deprecatedSingleAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxGatewayAssociationExists(resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
-					resource.TestCheckNoResourceAttr(resourceName, "associated_gateway_id"),
-					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
-					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
-					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/28"),
-					testAccCheckAwsDxGatewayAssociationStateUpgradeV0(resourceName),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount(t *testing.T) {
 	resourceName := "aws_dx_gateway_association.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
@@ -233,7 +201,6 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
-					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
@@ -281,7 +248,6 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
-					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					// dx_gateway_owner_account_id is the "aws.alternate" provider's account ID.
@@ -313,7 +279,6 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount(t *testing.
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameTgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
-					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
@@ -362,7 +327,6 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameTgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
-					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					// dx_gateway_owner_account_id is the "aws.alternate" provider's account ID.
@@ -613,15 +577,6 @@ resource "aws_dx_gateway" "test" {
   name            = %[1]q
 }
 `, rName, rBgpAsn)
-}
-
-func testAccDxGatewayAssociationConfig_deprecatedSingleAccount(rName string, rBgpAsn int) string {
-	return testAccDxGatewayAssociationConfigBase_vpnGatewaySingleAccount(rName, rBgpAsn) + `
-resource "aws_dx_gateway_association" "test" {
-  dx_gateway_id  = "${aws_dx_gateway.test.id}"
-  vpn_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
-}
-`
 }
 
 func testAccDxGatewayAssociationConfig_basicVpnGatewaySingleAccount(rName string, rBgpAsn int) string {

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -27,6 +27,8 @@ Upgrade topics:
 - [Resource: aws_autoscaling_group](#resource-aws_autoscaling_group)
 - [Resource: aws_cognito_user_pool](#resource-aws_cognito_user_pool)
 - [Resource: aws_dx_gateway](#resource-aws_dx_gateway)
+- [Resource: aws_dx_gateway_association](#resource-aws_dx_gateway_association)
+- [Resource: aws_dx_gateway_association_proposal](#resource-aws_dx_gateway_association_proposal)
 - [Resource: aws_ebs_volume](#resource-aws_ebs_volume)
 - [Resource: aws_elastic_transcoder_preset](#resource-aws_elastic_transcoder_preset)
 - [Resource: aws_emr_cluster](#resource-aws_emr_cluster)
@@ -615,6 +617,54 @@ resource "aws_cognito_user_pool" "example" {
 ### Removal of Automatic aws_dx_gateway_association Import
 
 Previously when importing the `aws_dx_gateway` resource with the [`terraform import` command](/docs/commands/import.html), the Terraform AWS Provider would automatically attempt to import an associated `aws_dx_gateway_association` resource(s) as well. This automatic resource import has been removed. Use the [`aws_dx_gateway_association` resource import](/docs/providers/aws/r/dx_gateway_association.html#import) to import those resources separately.
+
+## Resource: aws_dx_gateway_association
+
+### vpn_gateway_id Argument Removal
+
+Switch your Terraform configuration to the `associated_gateway_id` argument instead.
+
+For example, given this previous configuration:
+
+```hcl
+resource "aws_dx_gateway_association" "example" {
+  # ... other configuration ...
+  vpn_gateway_id = aws_vpn_gateway.example.id
+}
+```
+
+An updated configuration:
+
+```hcl
+resource "aws_dx_gateway_association" "example" {
+  # ... other configuration ...
+  associated_gateway_id = aws_vpn_gateway.example.id
+}
+```
+
+## Resource: aws_dx_gateway_association_proposal
+
+### vpn_gateway_id Argument Removal
+
+Switch your Terraform configuration to the `associated_gateway_id` argument instead.
+
+For example, given this previous configuration:
+
+```hcl
+resource "aws_dx_gateway_association_proposal" "example" {
+  # ... other configuration ...
+  vpn_gateway_id = aws_vpn_gateway.example.id
+}
+```
+
+An updated configuration:
+
+```hcl
+resource "aws_dx_gateway_association_proposal" "example" {
+  # ... other configuration ...
+  associated_gateway_id = aws_vpn_gateway.example.id
+}
+```
 
 ## Resource: aws_ebs_volume
 

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -90,14 +90,12 @@ A full example of how to create a VPN Gateway in one AWS account, create a Direc
 
 ## Argument Reference
 
-~> **NOTE:** `dx_gateway_id` plus one of `associated_gateway_id`, or `vpn_gateway_id` must be specified for single account Direct Connect gateway associations.
+~> **NOTE:** `dx_gateway_id` and `associated_gateway_id` must be specified for single account Direct Connect gateway associations.
 
 The following arguments are supported:
 
 * `dx_gateway_id` - (Required) The ID of the Direct Connect gateway.
 * `associated_gateway_id` - (Optional) The ID of the VGW or transit gateway with which to associate the Direct Connect gateway.
-Used for single account Direct Connect gateway associations.
-* `vpn_gateway_id` - (Optional) *Deprecated:* Use `associated_gateway_id` instead. The ID of the VGW with which to associate the gateway.
 Used for single account Direct Connect gateway associations.
 * `associated_gateway_owner_account_id` - (Optional) The ID of the AWS account that owns the VGW or transit gateway with which to associate the Direct Connect gateway.
 Used for cross-account Direct Connect gateway associations.

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -119,9 +119,9 @@ In addition to all arguments above, the following attributes are exported:
 `aws_dx_gateway_association` provides the following
 [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
-- `create` - (Default `15 minutes`) Used for creating the association
-- `update` - (Default `10 minutes`) Used for updating the association
-- `delete` - (Default `15 minutes`) Used for destroying the association
+- `create` - (Default `30 minutes`) Used for creating the association
+- `update` - (Default `30 minutes`) Used for updating the association
+- `delete` - (Default `30 minutes`) Used for destroying the association
 
 ## Import
 

--- a/website/docs/r/dx_gateway_association_proposal.html.markdown
+++ b/website/docs/r/dx_gateway_association_proposal.html.markdown
@@ -24,14 +24,11 @@ A full example of how to create a VPN Gateway in one AWS account, create a Direc
 
 ## Argument Reference
 
-~> **NOTE:** One of `associated_gateway_id`, or `vpn_gateway_id` must be specified.
-
 The following arguments are supported:
 
+* `associated_gateway_id` - (Required) The ID of the VGW or transit gateway with which to associate the Direct Connect gateway.
 * `dx_gateway_id` - (Required) Direct Connect Gateway identifier.
 * `dx_gateway_owner_account_id` - (Required) AWS Account identifier of the Direct Connect Gateway's owner.
-* `associated_gateway_id` - (Optional) The ID of the VGW or transit gateway with which to associate the Direct Connect gateway.
-* `vpn_gateway_id` - (Optional) *Deprecated:* Use `associated_gateway_id` instead. Virtual Gateway identifier to associate with the Direct Connect Gateway.
 * `allowed_prefixes` - (Optional) VPC prefixes (CIDRs) to advertise to the Direct Connect gateway. Defaults to the CIDR block of the VPC associated with the Virtual Gateway. To enable drift detection, must be configured.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: #13398

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BREAKING CHANGES

* resource/aws_dx_gateway_association: Remove `vpn_gateway_id` argument
* resource/aws_dx_gateway_association_proposal: Remove `vpn_gateway_id` argument

BUG FIXES

* resource/aws_dx_gateway_association: Increase default create/update/delete timeouts to 30 minutes
```

Previously, we were seeing consistent failures across many of acceptance tests:

```
    TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewaySingleAccount: testing.go:684: Step 1 error: errors during apply:

        Error: error waiting for Direct Connect gateway association (ga-a59d30b3-e6de-435e-bb17-cd7ed23f400evgw-06bccd6488d2b8d87) to become available: timeout while waiting for state to become 'associated' (last state: 'updating', timeout: 10m0s)

    TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount: testing.go:684: Step 1 error: errors during apply:

        Error: error waiting for Direct Connect gateway association (ga-a8b1b976-c0a1-4b64-8560-9d9cc45d11a3vgw-0a2e52679acf9c250) to become available: timeout while waiting for state to become 'associated' (last state: 'updating', timeout: 10m0s)

--- FAIL: TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount (989.81s)
testing.go:684: Step 0 error: errors during apply:
Error: error waiting for Direct Connect gateway association (ga-48d0e3d3-e131-443d-9693-e64eff519baatgw-0a2a0ea77f65ed202) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)

--- FAIL: TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount (991.80s)
testing.go:684: Step 0 error: errors during apply:
Error: error waiting for Direct Connect gateway association (ga-9f9c1ed2-97b6-41c5-8018-0724f6162b59tgw-06f7ce56df96282d7) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)

--- FAIL: TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount (1816.92s)
testing.go:684: Step 0 error: errors during apply:
Error: error waiting for Direct Connect gateway association (ga-76c9d0f4-b0aa-4b1b-96d9-10ce8c3ca025vgw-0c47a2c63baf7d4d8) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)

testing.go:745: Error destroying resource! WARNING: Dangling resources
may exist. The full state and error is shown below.
Error: errors during apply: error waiting for Direct Connect gateway association (ga-76c9d0f4-b0aa-4b1b-96d9-10ce8c3ca025vgw-0c47a2c63baf7d4d8) to be deleted: timeout while waiting for state to become 'disassociated, deleted' (last state: 'disassociating', timeout: 15m0s)

--- FAIL: TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewaySingleAccount (1816.89s)
testing.go:684: Step 0 error: errors during apply:
Error: error waiting for Direct Connect gateway association (ga-12a5c1e8-322e-4bc1-8a5a-f4b778a00db3vgw-09c811d121256131b) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)

testing.go:745: Error destroying resource! WARNING: Dangling resources
may exist. The full state and error is shown below.
Error: errors during apply: error waiting for Direct Connect gateway association (ga-12a5c1e8-322e-4bc1-8a5a-f4b778a00db3vgw-09c811d121256131b) to be deleted: timeout while waiting for state to become 'disassociated, deleted' (last state: 'disassociating', timeout: 15m0s)

--- FAIL: TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount (1819.25s)
testing.go:684: Step 0 error: errors during apply:
Error: error waiting for Direct Connect gateway association (ga-ccf678f2-5d51-441e-86c5-308c731f26abvgw-063e75f539bc3719c) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)

testing.go:745: Error destroying resource! WARNING: Dangling resources
may exist. The full state and error is shown below.
Error: errors during apply: error waiting for Direct Connect gateway association (ga-ccf678f2-5d51-441e-86c5-308c731f26abvgw-063e75f539bc3719c) to be deleted: timeout while waiting for state to become 'disassociated, deleted' (last state: 'disassociating', timeout: 15m0s)

--- FAIL: TestAccAwsDxGatewayAssociation_multiVpnGatewaysSingleAccount (2487.01s)
testing.go:684: Step 0 error: errors during apply:
Error: error waiting for Direct Connect gateway association (ga-5d93ccd0-8344-4ee6-95f8-58af27e01301vgw-054e2b0e7ecf45c8d) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)

Error: error waiting for Direct Connect gateway association (ga-5d93ccd0-8344-4ee6-95f8-58af27e01301vgw-057b39dbec7338ec1) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)

testing.go:745: Error destroying resource! WARNING: Dangling resources
may exist. The full state and error is shown below.
Error: errors during apply: error waiting for Direct Connect gateway association (ga-5d93ccd0-8344-4ee6-95f8-58af27e01301vgw-057b39dbec7338ec1) to be deleted: timeout while waiting for state to become 'disassociated, deleted' (last state: 'disassociating', timeout: 15m0s)

--- FAIL: TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount (2529.42s)
testing.go:684: Step 0 error: errors during apply:
Error: error waiting for Direct Connect gateway association (ga-ad8143a9-657e-4ed2-9ebb-a78dd2bee2c1vgw-0d552249edec48941) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)

testing.go:745: Error destroying resource! WARNING: Dangling resources
may exist. The full state and error is shown below.
Error: errors during apply: Error waiting for VPN Gateway "vgw-0d552249edec48941" to detach from VPC "vpc-0cbba5ddf6a4ec7ba": timeout while waiting for state to become 'detached' (last state: 'detaching', timeout: 15m0s)

--- FAIL: TestAccAwsDxGatewayAssociation_deprecatedSingleAccount (2551.41s)
testing.go:684: Step 0 error: errors during apply:
Error: error waiting for Direct Connect gateway association (ga-c1c37095-ab8d-4dcd-9f97-b369face1ad4vgw-0576f5ab3096ace51) to become available: timeout while waiting for state to become 'associated' (last state: 'associating', timeout: 15m0s)
```

Output from acceptance testing:

```
--- PASS: TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount (2063.56s)
--- PASS: TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount (2556.75s)
--- PASS: TestAccAwsDxGatewayAssociation_multiVpnGatewaysSingleAccount (2668.06s)
--- PASS: TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount (2674.09s)
--- PASS: TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount (2677.20s)
--- PASS: TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewaySingleAccount (3612.36s)
--- PASS: TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount (3856.32s)

--- PASS: TestAccAwsDxGatewayAssociationProposal_basicVpnGateway (88.64s)
--- PASS: TestAccAwsDxGatewayAssociationProposal_disappears (96.50s)
--- PASS: TestAccAwsDxGatewayAssociationProposal_AllowedPrefixes (121.18s)
--- PASS: TestAccAwsDxGatewayAssociationProposal_basicTransitGateway (182.42s)
```
