### PR TITLE
Remove hardcoded AMI IDs from launch_config data source

### DIFF
--- a/aws/data_source_aws_launch_configuration_test.go
+++ b/aws/data_source_aws_launch_configuration_test.go
@@ -52,10 +52,10 @@ func TestAccAWSLaunchConfigurationDataSource_securityGroups(t *testing.T) {
 }
 
 func testAccLaunchConfigurationDataSourceConfig_basic(rInt int) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foo" {
   name                        = "terraform-test-%d"
-  image_id                    = "ami-21f78e11"
+  image_id                    = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type               = "m1.small"
   associate_public_ip_address = true
   user_data                   = "foobar-user-data"
@@ -90,7 +90,7 @@ data "aws_launch_configuration" "foo" {
 }
 
 func testAccLaunchConfigurationDataSourceConfig_securityGroups(rInt int) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
@@ -102,7 +102,7 @@ resource "aws_security_group" "test" {
 
 resource "aws_launch_configuration" "test" {
   name            = "terraform-test-%d"
-  image_id        = "ami-21f78e11"
+  image_id        = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type   = "m1.small"
   security_groups = ["${aws_security_group.test.id}"]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Central management issue: #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TESTARGS='-run=TestAccAWSLaunchConfigurationDataSource_'  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSLaunchConfigurationDataSource_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLaunchConfigurationDataSource_basic
=== PAUSE TestAccAWSLaunchConfigurationDataSource_basic
=== RUN   TestAccAWSLaunchConfigurationDataSource_securityGroups
=== PAUSE TestAccAWSLaunchConfigurationDataSource_securityGroups
=== CONT  TestAccAWSLaunchConfigurationDataSource_basic
=== CONT  TestAccAWSLaunchConfigurationDataSource_securityGroups
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (37.22s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (49.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.688s
```

See [AWSAT002](https://github.com/terraform-providers/terraform-provider-aws/tree/master/awsproviderlint/passes/AWSAT002)

### Current stats of acceptance tests for this PR:

| Partition | Passing | Failing | Test |
| ---------|-------:|------:|:-----:|
| us-gov | 2 | 0 | With-PR |
| us-gov | 0 | 2 | Pre-PR |
| standard | 2 | 0 | With-PR |
| standard | 2 | 0 | Pre-PR |

