### PR TITLE
Removed hardcoded AMI IDs from AutoscalingAttachment

### DIFF
--- a/aws/resource_aws_autoscaling_attachment_test.go
+++ b/aws/resource_aws_autoscaling_attachment_test.go
@@ -176,7 +176,16 @@ func testAccCheckAWSAutocalingAlbAttachmentExists(asgname string, targetGroupCou
 }
 
 func testAccAWSAutoscalingAttachment_alb(rInt int) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+	state            = "available"
+	
+	filter {
+		name   = "opt-in-status"
+		values = ["opt-in-not-required"]
+	}
+}	
+	
 resource "aws_lb_target_group" "test" {
   name     = "test-alb-%d"
   port     = 443
@@ -236,7 +245,7 @@ resource "aws_lb_target_group" "another_test" {
 }
 
 resource "aws_autoscaling_group" "asg" {
-  availability_zones        = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones        = data.aws_availability_zones.available.names
   name                      = "asg-lb-assoc-terraform-test_%d"
   max_size                  = 1
   min_size                  = 0
@@ -254,7 +263,7 @@ resource "aws_autoscaling_group" "asg" {
 
 resource "aws_launch_configuration" "as_conf" {
   name          = "test_config_%d"
-  image_id      = "ami-f34032c3"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
@@ -269,9 +278,18 @@ resource "aws_vpc" "test" {
 }
 
 func testAccAWSAutoscalingAttachment_elb(rInt int) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+	state            = "available"
+	
+	filter {
+		name   = "opt-in-status"
+		values = ["opt-in-not-required"]
+	}
+}	
+
 resource "aws_elb" "foo" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = data.aws_availability_zones.available.names
 
   listener {
     instance_port     = 8000
@@ -282,7 +300,7 @@ resource "aws_elb" "foo" {
 }
 
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = data.aws_availability_zones.available.names
 
   listener {
     instance_port     = 8000
@@ -294,12 +312,12 @@ resource "aws_elb" "bar" {
 
 resource "aws_launch_configuration" "as_conf" {
   name          = "test_config_%d"
-  image_id      = "ami-f34032c3"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
 resource "aws_autoscaling_group" "asg" {
-  availability_zones        = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones        = data.aws_availability_zones.available.names
   name                      = "asg-lb-assoc-terraform-test_%d"
   max_size                  = 1
   min_size                  = 0


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Central management issue: #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user-facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% make testacc TESTARGS='-run=TestAccAWSAutoscalingAttachment_'        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run=TestAccAWSAutoscalingAttachment_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAutoscalingAttachment_elb
=== PAUSE TestAccAWSAutoscalingAttachment_elb
=== RUN   TestAccAWSAutoscalingAttachment_albTargetGroup
=== PAUSE TestAccAWSAutoscalingAttachment_albTargetGroup
=== CONT  TestAccAWSAutoscalingAttachment_elb
=== CONT  TestAccAWSAutoscalingAttachment_albTargetGroup
--- PASS: TestAccAWSAutoscalingAttachment_elb (140.94s)
--- PASS: TestAccAWSAutoscalingAttachment_albTargetGroup (182.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	183.611s
```

See [AWSAT002](https://github.com/terraform-providers/terraform-provider-aws/tree/master/awsproviderlint/passes/AWSAT002)

### Current stats of acceptance tests for this PR:

| Partition | Passing | Failing | Test |
| ---------|-------:|------:|:-----:|
| us-gov | 2 | 0 | With-PR |
| us-gov | 0 | 2 | Pre-PR |
| standard | 2 | 0 | With-PR |
| standard | 2 | 0 | Pre-PR |