### PR TITLE
Fix AWS MSK Cluster documentation: Kafka ver. and some warns

### DIFF
--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -23,25 +23,25 @@ data "aws_availability_zones" "azs" {
 }
 
 resource "aws_subnet" "subnet_az1" {
-  availability_zone = "${data.aws_availability_zones.azs.names[0]}"
+  availability_zone = data.aws_availability_zones.azs.names[0]
   cidr_block        = "192.168.0.0/24"
-  vpc_id            = "${aws_vpc.vpc.id}"
+  vpc_id            = aws_vpc.vpc.id
 }
 
 resource "aws_subnet" "subnet_az2" {
-  availability_zone = "${data.aws_availability_zones.azs.names[1]}"
+  availability_zone = data.aws_availability_zones.azs.names[1]
   cidr_block        = "192.168.1.0/24"
-  vpc_id            = "${aws_vpc.vpc.id}"
+  vpc_id            = aws_vpc.vpc.id
 }
 
 resource "aws_subnet" "subnet_az3" {
-  availability_zone = "${data.aws_availability_zones.azs.names[2]}"
+  availability_zone = data.aws_availability_zones.azs.names[2]
   cidr_block        = "192.168.2.0/24"
-  vpc_id            = "${aws_vpc.vpc.id}"
+  vpc_id            = aws_vpc.vpc.id
 }
 
 resource "aws_security_group" "sg" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 }
 
 resource "aws_kms_key" "kms" {
@@ -82,8 +82,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   destination = "s3"
 
   s3_configuration {
-    role_arn   = "${aws_iam_role.firehose_role.arn}"
-    bucket_arn = "${aws_s3_bucket.bucket.arn}"
+    role_arn   = aws_iam_role.firehose_role.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
   }
 
   tags = {
@@ -99,22 +99,22 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
 
 resource "aws_msk_cluster" "example" {
   cluster_name           = "example"
-  kafka_version          = "2.1.0"
+  kafka_version          = "2.4.1"
   number_of_broker_nodes = 3
 
   broker_node_group_info {
     instance_type   = "kafka.m5.large"
     ebs_volume_size = 1000
     client_subnets = [
-      "${aws_subnet.subnet_az1.id}",
-      "${aws_subnet.subnet_az2.id}",
-      "${aws_subnet.subnet_az3.id}",
+      aws_subnet.subnet_az1.id,
+      aws_subnet.subnet_az2.id,
+      aws_subnet.subnet_az3.id,
     ]
-    security_groups = ["${aws_security_group.sg.id}"]
+    security_groups = [aws_security_group.sg.id]
   }
 
   encryption_info {
-    encryption_at_rest_kms_key_arn = "${aws_kms_key.kms.arn}"
+    encryption_at_rest_kms_key_arn = aws_kms_key.kms.arn
   }
 
   open_monitoring {
@@ -132,15 +132,15 @@ resource "aws_msk_cluster" "example" {
     broker_logs {
       cloudwatch_logs {
         enabled   = true
-        log_group = "${aws_cloudwatch_log_group.test.name}"
+        log_group = aws_cloudwatch_log_group.test.name
       }
       firehose {
         enabled         = true
-        delivery_stream = "${aws_kinesis_firehose_delivery_stream.test_stream.name}"
+        delivery_stream = aws_kinesis_firehose_delivery_stream.test_stream.name
       }
       s3 {
         enabled = true
-        bucket  = "${aws_s3_bucket.bucket.id}"
+        bucket  = aws_s3_bucket.bucket.id
         prefix  = "logs/msk-"
       }
     }
@@ -152,17 +152,17 @@ resource "aws_msk_cluster" "example" {
 }
 
 output "zookeeper_connect_string" {
-  value = "${aws_msk_cluster.example.zookeeper_connect_string}"
+  value = aws_msk_cluster.example.zookeeper_connect_string
 }
 
 output "bootstrap_brokers" {
   description = "Plaintext connection host:port pairs"
-  value       = "${aws_msk_cluster.example.bootstrap_brokers}"
+  value       = aws_msk_cluster.example.bootstrap_brokers
 }
 
 output "bootstrap_brokers_tls" {
   description = "TLS connection host:port pairs"
-  value       = "${aws_msk_cluster.example.bootstrap_brokers_tls}"
+  value       = aws_msk_cluster.example.bootstrap_brokers_tls
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The current "Example usage" section for AWS MSK runs with errors on the last Terraform version.

1. Kafka version is not supported by AWS anymore:
```
Error: error creating MSK cluster: BadRequestException: Unsupported KafkaVersion [2.1.0]. Valid values: [2.3.1, 2.4.1, 1.1.1, 2.2.1]
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "c59f40b8-1776-4feb-a6ed-63928c2bafba"
  },
  InvalidParameter: "kafkaVersion",
  Message_: "Unsupported KafkaVersion [2.1.0]. Valid values: [2.3.1, 2.4.1, 1.1.1, 2.2.1]"
}
```
Changed to the `2.4.1`.

2. Syntax related warnings:
```
Warning: Interpolation-only expressions are deprecated
```
Fixed all occurrences in this file.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 NONE
```
