### PR TITLE
d/aws_s3_bucket_object: Don't crash when S3 HeadObject returns empty response

### DIFF
--- a/aws/data_source_aws_s3_bucket_object.go
+++ b/aws/data_source_aws_s3_bucket_object.go
@@ -149,7 +149,7 @@ func dataSourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return fmt.Errorf("Failed getting S3 object: %s Bucket: %q Object: %q", err, bucket, key)
 	}
-	if out.DeleteMarker != nil && *out.DeleteMarker {
+	if aws.BoolValue(out.DeleteMarker) {
 		return fmt.Errorf("Requested S3 object %q%s has been deleted",
 			bucket+key, versionText)
 	}
@@ -165,10 +165,14 @@ func dataSourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("content_length", out.ContentLength)
 	d.Set("content_type", out.ContentType)
 	// See https://forums.aws.amazon.com/thread.jspa?threadID=44003
-	d.Set("etag", strings.Trim(*out.ETag, `"`))
+	d.Set("etag", strings.Trim(aws.StringValue(out.ETag), `"`))
 	d.Set("expiration", out.Expiration)
 	d.Set("expires", out.Expires)
-	d.Set("last_modified", out.LastModified.Format(time.RFC1123))
+	if out.LastModified != nil {
+		d.Set("last_modified", out.LastModified.Format(time.RFC1123))
+	} else {
+		d.Set("last_modified", "")
+	}
 	d.Set("metadata", pointersMapToStringList(out.Metadata))
 	d.Set("object_lock_legal_hold_status", out.ObjectLockLegalHoldStatus)
 	d.Set("object_lock_mode", out.ObjectLockMode)

--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -360,9 +360,7 @@ func TestAccDataSourceAWSS3BucketObject_MultipleSlashes(t *testing.T) {
 }
 
 func TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey(t *testing.T) {
-	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
-	resourceName := "aws_s3_bucket_object.test"
 	dataSourceName := "data.aws_s3_bucket_object.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -374,11 +372,7 @@ func TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey(t *testing.T) {
 			{
 				Config: testAccAWSDataSourceS3ObjectConfigSingleSlashAsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
-					resource.TestCheckResourceAttr(dataSourceName, "content_length", "3"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
-					resource.TestCheckResourceAttr(dataSourceName, "body", "yes"),
 				),
 			},
 		},
@@ -684,15 +678,9 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_object" "test" {
-  bucket  = aws_s3_bucket.test.bucket
-  key     = "/"
-  content = "yes"
-}
-
 data "aws_s3_bucket_object" "test" {
   bucket = aws_s3_bucket.test.bucket
-  key    = aws_s3_bucket_object.test.key
+  key    = "/"
 }
 `, rName)
 }

--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -360,7 +360,9 @@ func TestAccDataSourceAWSS3BucketObject_MultipleSlashes(t *testing.T) {
 }
 
 func TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey(t *testing.T) {
+	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
+	resourceName := "aws_s3_bucket_object.test"
 	dataSourceName := "data.aws_s3_bucket_object.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -372,7 +374,11 @@ func TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey(t *testing.T) {
 			{
 				Config: testAccAWSDataSourceS3ObjectConfigSingleSlashAsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "3"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttr(dataSourceName, "body", "yes"),
 				),
 			},
 		},
@@ -678,9 +684,15 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_object" "test" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "/"
+  content = "yes"
+}
+
 data "aws_s3_bucket_object" "test" {
   bucket = aws_s3_bucket.test.bucket
-  key    = "/"
+  key    = aws_s3_bucket_object.test.key
 }
 `, rName)
 }

--- a/aws/internal/keyvaluetags/s3_tags.go
+++ b/aws/internal/keyvaluetags/s3_tags.go
@@ -88,7 +88,7 @@ func S3ObjectListTags(conn *s3.S3, bucket, key string) (KeyValueTags, error) {
 
 	output, err := conn.GetObjectTagging(input)
 
-	if awsbase.IsAWSErr(err, "NoSuchTagSet", "") {
+	if tfawserr.ErrCodeEquals(err, tfs3.NoSuchTagSet) {
 		return New(nil), nil
 	}
 

--- a/aws/internal/keyvaluetags/s3_tags.go
+++ b/aws/internal/keyvaluetags/s3_tags.go
@@ -88,6 +88,10 @@ func S3ObjectListTags(conn *s3.S3, bucket, key string) (KeyValueTags, error) {
 
 	output, err := conn.GetObjectTagging(input)
 
+	if awsbase.IsAWSErr(err, "NoSuchTagSet", "") {
+		return New(nil), nil
+	}
+
 	if err != nil {
 		return New(nil), err
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14151.
Relates #12992.
Relates #7584.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_s3_bucket_object: Don't crash when S3 `HeadObject` API returns empty response.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAWSS3BucketObject_' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 20 -run=TestAccDataSourceAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccDataSourceAWSS3BucketObject_basic
=== PAUSE TestAccDataSourceAWSS3BucketObject_basic
=== RUN   TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint
=== PAUSE TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint
=== RUN   TestAccDataSourceAWSS3BucketObject_readableBody
=== PAUSE TestAccDataSourceAWSS3BucketObject_readableBody
=== RUN   TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== PAUSE TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== RUN   TestAccDataSourceAWSS3BucketObject_allParams
=== PAUSE TestAccDataSourceAWSS3BucketObject_allParams
=== RUN   TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== PAUSE TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== RUN   TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== PAUSE TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== RUN   TestAccDataSourceAWSS3BucketObject_LeadingSlash
=== PAUSE TestAccDataSourceAWSS3BucketObject_LeadingSlash
=== RUN   TestAccDataSourceAWSS3BucketObject_MultipleSlashes
=== PAUSE TestAccDataSourceAWSS3BucketObject_MultipleSlashes
=== RUN   TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey
=== PAUSE TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey
=== CONT  TestAccDataSourceAWSS3BucketObject_basic
=== CONT  TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn
=== CONT  TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey
=== CONT  TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff
=== CONT  TestAccDataSourceAWSS3BucketObject_MultipleSlashes
=== CONT  TestAccDataSourceAWSS3BucketObject_allParams
=== CONT  TestAccDataSourceAWSS3BucketObject_LeadingSlash
=== CONT  TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== CONT  TestAccDataSourceAWSS3BucketObject_readableBody
=== CONT  TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint
--- PASS: TestAccDataSourceAWSS3BucketObject_SingleSlashAsKey (42.12s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basic (45.22s)
--- PASS: TestAccDataSourceAWSS3BucketObject_readableBody (47.39s)
--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (47.41s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff (48.20s)
--- PASS: TestAccDataSourceAWSS3BucketObject_kmsEncrypted (48.49s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint (48.81s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn (49.41s)
--- PASS: TestAccDataSourceAWSS3BucketObject_LeadingSlash (67.87s)
--- PASS: TestAccDataSourceAWSS3BucketObject_MultipleSlashes (68.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.374s
```
