### PR TITLE
r/aws_instance: Remove hardcoded AMI IDs from acceptance tests

### DIFF
--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -473,11 +473,7 @@ func TestAccAWSInstanceDataSource_metadataOptions(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		// No subnet_id specified requires default VPC or EC2-Classic.
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckHasDefaultVpcOrEc2Classic(t)
-		},
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -900,11 +896,13 @@ data "aws_instance" "test" {
 func testAccInstanceDataSourceConfig_metadataOptions(rName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(rName, false),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
 
   tags = {
     Name = %[1]q

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1288,16 +1288,19 @@ func testAccCheckAWSProviderPartition(providers *[]*schema.Provider, expectedPar
 	}
 }
 
-// testAccPreCheckHasDefaultVpcOrEc2Classic checks that the test region has a default VPC or has the EC2-Classic platform.
+// testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets checks that the test region has either
+// - The EC2-Classic platform available, or
+// - A default VPC with default subnets.
 // This check is useful to ensure that an instance can be launched without specifying a subnet.
-func testAccPreCheckHasDefaultVpcOrEc2Classic(t *testing.T) {
+func testAccPreCheckEc2ClassicOrHasDefaultVpcWithDefaultSubnets(t *testing.T) {
 	client := testAccProvider.Meta().(*AWSClient)
 
-	if !testAccHasDefaultVpc(t) && !hasEc2Classic(client.supportedplatforms) {
-		t.Skipf("skipping tests; %s does not have a default VPC or EC2-Classic", client.region)
+	if !hasEc2Classic(client.supportedplatforms) && !(testAccHasDefaultVpc(t) && testAccDefaultSubnetCount(t) > 0) {
+		t.Skipf("skipping tests; %s does not have EC2-Classic or a default VPC with default subnets", client.region)
 	}
 }
 
+// testAccHasDefaultVpc returns whether the current AWS region has a default VPC.
 func testAccHasDefaultVpc(t *testing.T) bool {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -1315,6 +1318,26 @@ func testAccHasDefaultVpc(t *testing.T) bool {
 	}
 
 	return true
+}
+
+// testAccDefaultSubnetCount returns the number of default subnets in the current region's default VPC.
+func testAccDefaultSubnetCount(t *testing.T) int {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	input := &ec2.DescribeSubnetsInput{
+		Filters: buildEC2AttributeFilterList(map[string]string{
+			"defaultForAz": "true",
+		}),
+	}
+	output, err := conn.DescribeSubnets(input)
+	if testAccPreCheckSkipError(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("error describing default subnets: %s", err)
+	}
+
+	return len(output.Subnets)
 }
 
 func testAccAWSProviderConfigEndpoints(endpoints string) string {

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -538,6 +538,13 @@ func testAccRegionPreCheck(t *testing.T, region string) {
 	}
 }
 
+// testAccPartitionPreCheck checks that the test partition is the specified partition.
+func testAccPartitionPreCheck(t *testing.T, partition string) {
+	if testAccGetPartition() != partition {
+		t.Skipf("skipping tests; partition (%s) does not equal %s", testAccGetPartition(), partition)
+	}
+}
+
 func testAccOrganizationsAccountPreCheck(t *testing.T) {
 	conn := testAccProvider.Meta().(*AWSClient).organizationsconn
 	input := &organizations.DescribeOrganizationInput{}

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -531,6 +531,13 @@ func testAccMultipleRegionsPreCheck(t *testing.T) {
 	}
 }
 
+// testAccRegionPreCheck checks that the test region is the specified region.
+func testAccRegionPreCheck(t *testing.T, region string) {
+	if testAccGetRegion() != region {
+		t.Skipf("skipping tests; AWS_DEFAULT_REGION (%s) does not equal %s", testAccGetRegion(), region)
+	}
+}
+
 func testAccOrganizationsAccountPreCheck(t *testing.T) {
 	conn := testAccProvider.Meta().(*AWSClient).organizationsconn
 	input := &organizations.DescribeOrganizationInput{}

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1062,7 +1062,7 @@ func TestAccAWSInstance_tags(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckInstanceConfigTags,
+				Config: testAccCheckInstanceConfigTags(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -1075,7 +1075,7 @@ func TestAccAWSInstance_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckInstanceConfigTagsUpdate,
+				Config: testAccCheckInstanceConfigTagsUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -3830,15 +3830,17 @@ resource "aws_instance" "test2" {
 }
 `
 
-const testAccCheckInstanceConfigTags = `
+func testAccCheckInstanceConfigTags() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-4fccb37f"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 	instance_type = "m1.small"
 	tags = {
 		test = "test2"
 	}
 }
-`
+`))
+}
 
 func testAccInstanceConfigEbsBlockDeviceKmsKeyArn() string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
@@ -4076,15 +4078,17 @@ resource "aws_instance" "test" {
 }
 `
 
-const testAccCheckInstanceConfigTagsUpdate = `
+func testAccCheckInstanceConfigTagsUpdate() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-4fccb37f"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 	instance_type = "m1.small"
 	tags = {
 		test2 = "test3"
 	}
 }
-`
+`))
+}
 
 func testAccInstanceConfigWithoutInstanceProfile(rName string) string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -934,7 +934,7 @@ func TestAccAWSInstance_multipleRegions(t *testing.T) {
 	var providers []*schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPartitionPreCheck(t, "aws") },
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckInstanceDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -3390,25 +3390,9 @@ resource "aws_instance" "test" {
 }
 
 func testAccInstanceConfigInEc2Classic(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 provider "aws" {
   region = "us-east-1"
-}
-
-data "aws_ami" "ubuntu" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/ubuntu-trusty-14.04-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["paravirtual"]
-  }
-
-  owners = ["099720109477"] # Canonical
 }
 
 resource "aws_security_group" "sg" {
@@ -3417,11 +3401,11 @@ resource "aws_security_group" "sg" {
 }
 
 resource "aws_instance" "test" {
-  ami             = "${data.aws_ami.ubuntu.id}"
+  ami             = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type   = "m3.medium"
   security_groups = ["${aws_security_group.sg.name}"]
 }
-`, rInt)
+`, rInt))
 }
 
 func testAccInstanceConfig_pre(rInt int) string {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -936,30 +936,6 @@ func TestAccAWSInstance_ipv6_supportAddressCountWithIpv4(t *testing.T) {
 	})
 }
 
-func TestAccAWSInstance_multipleRegions(t *testing.T) {
-	var v ec2.Instance
-	resourceName := "aws_instance.test"
-
-	// record the initialized providers so that we can use them to
-	// check for the instances in each region
-	var providers []*schema.Provider
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckWithProviders(testAccCheckInstanceDestroyWithProvider, &providers),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstanceConfigMultipleRegions,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExistsWithProvider(resourceName, &v, testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					testAccCheckInstanceExistsWithProvider("aws_instance.test2", &v, testAccAwsRegionProviderFunc("us-east-1", &providers)),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
@@ -4849,26 +4825,6 @@ data "aws_ami" "amzn-ami-minimal-hvm-instance-store" {
   }
 }
 `
-}
-
-// testAccLatestAmazonLinuxHvmInstanceStoreAmiConfig returns the configuration for a data source that
-// describes the latest Amazon Linux AMI using HVM virtualization and an instance store root device.
-// The data source is named 'amzn-ami-minimal-hvm-instance-store'.
-func testAccLatestAmazonLinuxHvmInstanceStoreAmiConfig() string {
-	return fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-instance-store" {
-  most_recent = true
-  owners      = ["amazon"]
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-  filter {
-    name   = "root-device-type"
-    values = ["instance-store"]
-  }
-}
-`)
 }
 
 // testAccLatestAmazonLinuxPvEbsAmiConfig returns the configuration for a data source that

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -330,7 +330,7 @@ func TestAccAWSInstance_EbsBlockDevice_KmsKeyArn(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigEbsBlockDeviceKmsKeyArn,
+				Config: testAccInstanceConfigEbsBlockDeviceKmsKeyArn(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "ebs_block_device.#", "1"),
@@ -3831,14 +3831,14 @@ resource "aws_instance" "test" {
 }
 `
 
-const testAccInstanceConfigEbsBlockDeviceKmsKeyArn = `
+func testAccInstanceConfigEbsBlockDeviceKmsKeyArn() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 }
 
 resource "aws_instance" "test" {
-  # us-west-2
-  ami = "ami-55a7ea65"
+  ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 
   # In order to attach an encrypted volume to an instance you need to have an
   # m3.medium or larger. See "Supported Instance Types" in:
@@ -3858,7 +3858,8 @@ resource "aws_instance" "test" {
     volume_size = 12
   }
 }
-`
+`))
+}
 
 const testAccInstanceConfigRootBlockDeviceKmsKeyArn = `
 resource "aws_vpc" "test" {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -432,8 +432,8 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 			}
 
 			// Check if the root block device exists.
-			if _, ok := blockDevices["/dev/sda1"]; !ok {
-				return fmt.Errorf("block device doesn't exist: /dev/sda1")
+			if _, ok := blockDevices["/dev/xvda"]; !ok {
+				return fmt.Errorf("block device doesn't exist: /dev/xvda")
 			}
 
 			return nil
@@ -448,7 +448,7 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceGP2IopsDevice,
+				Config: testAccInstanceGP2IopsDevice(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "root_block_device.#", "1"),
@@ -3491,10 +3491,10 @@ resource "aws_instance" "test" {
 }
 `
 
-const testAccInstanceGP2IopsDevice = `
+func testAccInstanceGP2IopsDevice() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-55a7ea65"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 
 	# In order to attach an encrypted volume to an instance you need to have an
 	# m3.medium or larger. See "Supported Instance Types" in:
@@ -3506,7 +3506,8 @@ resource "aws_instance" "test" {
 		volume_size = 11
 	}
 }
-`
+`))
+}
 
 const testAccInstanceGP2WithIopsValue = `
 resource "aws_instance" "test" {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1096,7 +1096,7 @@ func TestAccAWSInstance_volumeTags(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckInstanceConfigNoVolumeTags,
+				Config: testAccCheckInstanceConfigNoVolumeTags(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckNoResourceAttr(resourceName, "volume_tags"),
@@ -1109,7 +1109,7 @@ func TestAccAWSInstance_volumeTags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ephemeral_block_device"},
 			},
 			{
-				Config: testAccCheckInstanceConfigWithVolumeTags,
+				Config: testAccCheckInstanceConfigWithVolumeTags(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "1"),
@@ -1117,7 +1117,7 @@ func TestAccAWSInstance_volumeTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckInstanceConfigWithVolumeTagsUpdate,
+				Config: testAccCheckInstanceConfigWithVolumeTagsUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "volume_tags.%", "2"),
@@ -1126,7 +1126,7 @@ func TestAccAWSInstance_volumeTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckInstanceConfigNoVolumeTags,
+				Config: testAccCheckInstanceConfigNoVolumeTags(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 					resource.TestCheckNoResourceAttr(resourceName, "volume_tags"),
@@ -1146,7 +1146,7 @@ func TestAccAWSInstance_volumeTagsComputed(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckInstanceConfigWithAttachedVolume,
+				Config: testAccCheckInstanceConfigWithAttachedVolume(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
 				),
@@ -3892,35 +3892,10 @@ resource "aws_instance" "test" {
 `))
 }
 
-const testAccCheckInstanceConfigWithAttachedVolume = `
-data "aws_ami" "debian_jessie_latest" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["debian-jessie-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-
-  owners = ["379101102735"] # Debian
-}
-
+func testAccCheckInstanceConfigWithAttachedVolume() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami           = "${data.aws_ami.debian_jessie_latest.id}"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.medium"
 
   root_block_device {
@@ -3949,11 +3924,13 @@ resource "aws_volume_attachment" "test" {
   volume_id   = "${aws_ebs_volume.test.id}"
   instance_id = "${aws_instance.test.id}"
 }
-`
+`))
+}
 
-const testAccCheckInstanceConfigNoVolumeTags = `
+func testAccCheckInstanceConfigNoVolumeTags() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-55a7ea65"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 
 	instance_type = "m3.medium"
 
@@ -3983,7 +3960,8 @@ resource "aws_instance" "test" {
 		virtual_name = "ephemeral0"
 	}
 }
-`
+`))
+}
 
 var testAccCheckInstanceConfigEBSBlockDeviceInvalidIops = composeConfig(testAccAwsEc2InstanceAmiWithEbsRootVolume,
 	`
@@ -4001,9 +3979,10 @@ resource "aws_instance" "test" {
 }
 `)
 
-const testAccCheckInstanceConfigWithVolumeTags = `
+func testAccCheckInstanceConfigWithVolumeTags() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-55a7ea65"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 
 	instance_type = "m3.medium"
 
@@ -4037,11 +4016,13 @@ resource "aws_instance" "test" {
 		Name = "acceptance-test-volume-tag"
 	}
 }
-`
+`))
+}
 
-const testAccCheckInstanceConfigWithVolumeTagsUpdate = `
+func testAccCheckInstanceConfigWithVolumeTagsUpdate() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	ami = "ami-55a7ea65"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 
 	instance_type = "m3.medium"
 
@@ -4076,7 +4057,8 @@ resource "aws_instance" "test" {
 		Environment = "dev"
 	}
 }
-`
+`))
+}
 
 func testAccCheckInstanceConfigTagsUpdate() string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -925,6 +925,30 @@ func TestAccAWSInstance_ipv6_supportAddressCountWithIpv4(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstance_multipleRegions(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+
+	// record the initialized providers so that we can use them to
+	// check for the instances in each region
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckWithProviders(testAccCheckInstanceDestroyWithProvider, &providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfigMultipleRegions,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExistsWithProvider(resourceName, &v, testAccAwsRegionProviderFunc("us-west-2", &providers)),
+					testAccCheckInstanceExistsWithProvider("aws_instance.test2", &v, testAccAwsRegionProviderFunc("us-east-1", &providers)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -3364,7 +3364,7 @@ func testAccInstanceConfigAtLeastOneOtherEbsVolume(rName string) string {
 # Ensure that there is at least 1 EBS volume in the current region.
 # See https://github.com/hashicorp/terraform/issues/1249.
 resource "aws_ebs_volume" "test" {
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
   size              = 5
 
   tags = {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1385,10 +1385,10 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 func TestAccAWSInstance_rootBlockDeviceMismatch(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
-	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRegionPreCheck(t, "us-west-2") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -4213,7 +4213,7 @@ resource "aws_instance" "test" {
 func testAccInstanceConfigRootBlockDeviceMismatch(rName string) string {
 	return testAccAwsInstanceVpcConfig(rName, false) + `
 resource "aws_instance" "test" {
-  // This is an AMI with RootDeviceName: "/dev/sda1"; actual root: "/dev/sda"
+  // This is an AMI in us-west-2 with RootDeviceName: "/dev/sda1"; actual root: "/dev/sda"
   ami           = "ami-ef5b69df"
   instance_type = "t1.micro"
   subnet_id     = "${aws_subnet.test.id}"

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1480,6 +1480,7 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 	var before ec2.Instance
 	var after ec2.Instance
 	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1487,7 +1488,7 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigWithSmallInstanceType,
+				Config: testAccInstanceConfigWithSmallInstanceType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
 				),
@@ -1498,7 +1499,7 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfigUpdateInstanceType,
+				Config: testAccInstanceConfigUpdateInstanceType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckInstanceNotRecreated(t, &before, &after),
@@ -3430,11 +3431,11 @@ resource "aws_instance" "test" {
 `))
 }
 
-const testAccInstanceConfigWithSmallInstanceType = `
+func testAccInstanceConfigWithSmallInstanceType(rName string) string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), testAccAwsInstanceVpcConfig(rName, false), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-55a7ea65"
-	availability_zone = "us-west-2a"
+	ami       = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+	subnet_id = "${aws_subnet.test.id}"
 
 	instance_type = "m3.medium"
 
@@ -3442,13 +3443,14 @@ resource "aws_instance" "test" {
 	    Name = "tf-acctest"
 	}
 }
-`
+`))
+}
 
-const testAccInstanceConfigUpdateInstanceType = `
+func testAccInstanceConfigUpdateInstanceType(rName string) string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), testAccAwsInstanceVpcConfig(rName, false), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-55a7ea65"
-	availability_zone = "us-west-2a"
+	ami       = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+	subnet_id = "${aws_subnet.test.id}"
 
 	instance_type = "m3.large"
 
@@ -3456,7 +3458,8 @@ resource "aws_instance" "test" {
 	    Name = "tf-acctest"
 	}
 }
-`
+`))
+}
 
 func testAccInstanceGP2IopsDevice() string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -478,7 +478,7 @@ func TestAccAWSInstance_GP2WithIopsValue(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccInstanceGP2WithIopsValue,
+				Config:      testAccInstanceGP2WithIopsValue(),
 				ExpectError: regexp.MustCompile(`error creating resource: iops attribute not supported for root_block_device with volume_type gp2`),
 			},
 		},
@@ -3509,10 +3509,10 @@ resource "aws_instance" "test" {
 `))
 }
 
-const testAccInstanceGP2WithIopsValue = `
+func testAccInstanceGP2WithIopsValue() string {
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-55a7ea65"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 
 	# In order to attach an encrypted volume to an instance you need to have an
 	# m3.medium or larger. See "Supported Instance Types" in:
@@ -3526,7 +3526,8 @@ resource "aws_instance" "test" {
 		iops        = 10
 	}
 }
-`
+`))
+}
 
 func testAccAwsEc2InstanceEbsRootDeviceBasic() string {
 	return composeConfig(testAccAwsEc2InstanceAmiWithEbsRootVolume, `

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -499,8 +499,8 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 			}
 
 			// Check if the root block device exists.
-			if _, ok := blockDevices["/dev/sda1"]; !ok {
-				return fmt.Errorf("block device doesn't exist: /dev/sda1")
+			if _, ok := blockDevices["/dev/xvda"]; !ok {
+				return fmt.Errorf("block device doesn't exist: /dev/xvda")
 			}
 
 			// Check if the secondary block device exists.
@@ -3592,10 +3592,10 @@ func testAccAwsEc2InstanceConfigBlockDevicesWithDeleteOnTerminate(size, delete s
 	if delete == "" {
 		delete = "null"
 	}
-	return fmt.Sprintf(`
+
+	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-	# us-west-2
-	ami = "ami-55a7ea65"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
 
 	# In order to attach an encrypted volume to an instance you need to have an
 	# m3.medium or larger. See "Supported Instance Types" in:
@@ -3632,7 +3632,7 @@ resource "aws_instance" "test" {
 		virtual_name = "ephemeral0"
 	}
 }
-`, size, delete)
+`, size, delete))
 }
 
 func testAccInstanceConfigSourceDestEnable(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14082.
Relates #14083.
Relates #14145.
Relates #14147.
Relates #14148.
Relates #11126.
Relates #12994.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
##### Default test region (`us-west-2`):

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -count 1 -parallel 2 -run=TestAccAWSInstance_ -timeout 120m
=== RUN   TestAccAWSInstance_inDefaultVpcBySgName
=== PAUSE TestAccAWSInstance_inDefaultVpcBySgName
=== RUN   TestAccAWSInstance_inDefaultVpcBySgId
=== PAUSE TestAccAWSInstance_inDefaultVpcBySgId
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== RUN   TestAccAWSInstance_atLeastOneOtherEbsVolume
=== PAUSE TestAccAWSInstance_atLeastOneOtherEbsVolume
=== RUN   TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
=== PAUSE TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
=== RUN   TestAccAWSInstance_RootBlockDevice_KmsKeyArn
=== PAUSE TestAccAWSInstance_RootBlockDevice_KmsKeyArn
=== RUN   TestAccAWSInstance_userDataBase64
=== PAUSE TestAccAWSInstance_userDataBase64
=== RUN   TestAccAWSInstance_GP2IopsDevice
=== PAUSE TestAccAWSInstance_GP2IopsDevice
=== RUN   TestAccAWSInstance_GP2WithIopsValue
=== PAUSE TestAccAWSInstance_GP2WithIopsValue
=== RUN   TestAccAWSInstance_blockDevices
=== PAUSE TestAccAWSInstance_blockDevices
=== RUN   TestAccAWSInstance_rootInstanceStore
=== PAUSE TestAccAWSInstance_rootInstanceStore
=== RUN   TestAccAWSInstance_noAMIEphemeralDevices
=== PAUSE TestAccAWSInstance_noAMIEphemeralDevices
=== RUN   TestAccAWSInstance_sourceDestCheck
=== PAUSE TestAccAWSInstance_sourceDestCheck
=== RUN   TestAccAWSInstance_disableApiTermination
=== PAUSE TestAccAWSInstance_disableApiTermination
=== RUN   TestAccAWSInstance_vpc
=== PAUSE TestAccAWSInstance_vpc
=== RUN   TestAccAWSInstance_outpost
=== PAUSE TestAccAWSInstance_outpost
=== RUN   TestAccAWSInstance_placementGroup
=== PAUSE TestAccAWSInstance_placementGroup
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
=== PAUSE TestAccAWSInstance_ipv6_supportAddressCount
=== RUN   TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
=== PAUSE TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
=== RUN   TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
=== PAUSE TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
=== PAUSE TestAccAWSInstance_NetworkInstanceSecurityGroups
=== RUN   TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
=== PAUSE TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
=== PAUSE TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
=== RUN   TestAccAWSInstance_tags
=== PAUSE TestAccAWSInstance_tags
=== RUN   TestAccAWSInstance_volumeTags
=== PAUSE TestAccAWSInstance_volumeTags
=== RUN   TestAccAWSInstance_volumeTagsComputed
=== PAUSE TestAccAWSInstance_volumeTagsComputed
=== RUN   TestAccAWSInstance_instanceProfileChange
=== PAUSE TestAccAWSInstance_instanceProfileChange
=== RUN   TestAccAWSInstance_withIamInstanceProfile
=== PAUSE TestAccAWSInstance_withIamInstanceProfile
=== RUN   TestAccAWSInstance_privateIP
=== PAUSE TestAccAWSInstance_privateIP
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
=== PAUSE TestAccAWSInstance_associatePublicIPAndPrivateIP
=== RUN   TestAccAWSInstance_Empty_PrivateIP
=== PAUSE TestAccAWSInstance_Empty_PrivateIP
=== RUN   TestAccAWSInstance_keyPairCheck
=== PAUSE TestAccAWSInstance_keyPairCheck
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
=== PAUSE TestAccAWSInstance_rootBlockDeviceMismatch
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
=== PAUSE TestAccAWSInstance_forceNewAndTagsDrift
=== RUN   TestAccAWSInstance_changeInstanceType
=== PAUSE TestAccAWSInstance_changeInstanceType
=== RUN   TestAccAWSInstance_EbsRootDevice_basic
=== PAUSE TestAccAWSInstance_EbsRootDevice_basic
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifySize
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifySize
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyType
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyType
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyIOPS
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyIOPS
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyAll
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyAll
=== RUN   TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize
=== PAUSE TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize
=== RUN   TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination
=== PAUSE TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination
=== RUN   TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices
=== PAUSE TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices
=== RUN   TestAccAWSInstance_primaryNetworkInterface
=== PAUSE TestAccAWSInstance_primaryNetworkInterface
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
=== PAUSE TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
=== RUN   TestAccAWSInstance_addSecondaryInterface
=== PAUSE TestAccAWSInstance_addSecondaryInterface
=== RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
=== PAUSE TestAccAWSInstance_addSecurityGroupNetworkInterface
=== RUN   TestAccAWSInstance_associatePublic_defaultPrivate
=== PAUSE TestAccAWSInstance_associatePublic_defaultPrivate
=== RUN   TestAccAWSInstance_associatePublic_defaultPublic
=== PAUSE TestAccAWSInstance_associatePublic_defaultPublic
=== RUN   TestAccAWSInstance_associatePublic_explicitPublic
=== PAUSE TestAccAWSInstance_associatePublic_explicitPublic
=== RUN   TestAccAWSInstance_associatePublic_explicitPrivate
=== PAUSE TestAccAWSInstance_associatePublic_explicitPrivate
=== RUN   TestAccAWSInstance_associatePublic_overridePublic
=== PAUSE TestAccAWSInstance_associatePublic_overridePublic
=== RUN   TestAccAWSInstance_associatePublic_overridePrivate
=== PAUSE TestAccAWSInstance_associatePublic_overridePrivate
=== RUN   TestAccAWSInstance_getPasswordData_falseToTrue
=== PAUSE TestAccAWSInstance_getPasswordData_falseToTrue
=== RUN   TestAccAWSInstance_getPasswordData_trueToFalse
=== PAUSE TestAccAWSInstance_getPasswordData_trueToFalse
=== RUN   TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
=== PAUSE TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
=== RUN   TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
=== PAUSE TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
=== RUN   TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
=== PAUSE TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
=== RUN   TestAccAWSInstance_creditSpecification_standardCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_standardCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
=== PAUSE TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
=== RUN   TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
=== PAUSE TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
=== RUN   TestAccAWSInstance_creditSpecification_updateCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_updateCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
=== PAUSE TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
=== RUN   TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
=== PAUSE TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
=== RUN   TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
=== RUN   TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
=== RUN   TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
=== PAUSE TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
=== RUN   TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
=== PAUSE TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
=== RUN   TestAccAWSInstance_disappears
=== PAUSE TestAccAWSInstance_disappears
=== RUN   TestAccAWSInstance_UserData_EmptyStringToUnspecified
=== PAUSE TestAccAWSInstance_UserData_EmptyStringToUnspecified
=== RUN   TestAccAWSInstance_UserData_UnspecifiedToEmptyString
=== PAUSE TestAccAWSInstance_UserData_UnspecifiedToEmptyString
=== RUN   TestAccAWSInstance_hibernation
=== PAUSE TestAccAWSInstance_hibernation
=== RUN   TestAccAWSInstance_metadataOptions
=== PAUSE TestAccAWSInstance_metadataOptions
=== CONT  TestAccAWSInstance_inDefaultVpcBySgName
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination
=== CONT  TestAccAWSInstance_metadataOptions
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (97.63s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (127.11s)
=== CONT  TestAccAWSInstance_hibernation
--- PASS: TestAccAWSInstance_metadataOptions (143.94s)
=== CONT  TestAccAWSInstance_UserData_UnspecifiedToEmptyString
--- PASS: TestAccAWSInstance_hibernation (214.57s)
=== CONT  TestAccAWSInstance_UserData_EmptyStringToUnspecified
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (134.65s)
=== CONT  TestAccAWSInstance_disappears
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (154.63s)
=== CONT  TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
--- PASS: TestAccAWSInstance_disappears (219.40s)
=== CONT  TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (227.81s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (226.12s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (183.32s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (159.96s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (117.51s)
=== CONT  TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (110.42s)
=== CONT  TestAccAWSInstance_creditSpecification_updateCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (137.86s)
=== CONT  TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (97.30s)
=== CONT  TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (184.03s)
=== CONT  TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (107.59s)
=== CONT  TestAccAWSInstance_creditSpecification_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (149.72s)
=== CONT  TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (137.71s)
=== CONT  TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (117.72s)
=== CONT  TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (126.18s)
=== CONT  TestAccAWSInstance_getPasswordData_trueToFalse
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (182.66s)
=== CONT  TestAccAWSInstance_getPasswordData_falseToTrue
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (184.88s)
=== CONT  TestAccAWSInstance_associatePublic_overridePrivate
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (171.68s)
=== CONT  TestAccAWSInstance_associatePublic_overridePublic
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (107.00s)
=== CONT  TestAccAWSInstance_associatePublic_explicitPrivate
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (118.01s)
=== CONT  TestAccAWSInstance_associatePublic_explicitPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (106.18s)
=== CONT  TestAccAWSInstance_associatePublic_defaultPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (117.28s)
=== CONT  TestAccAWSInstance_associatePublic_defaultPrivate
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (116.86s)
=== CONT  TestAccAWSInstance_addSecurityGroupNetworkInterface
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (117.21s)
=== CONT  TestAccAWSInstance_addSecondaryInterface
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (167.32s)
=== CONT  TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_addSecondaryInterface (166.13s)
=== CONT  TestAccAWSInstance_primaryNetworkInterface
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (112.14s)
=== CONT  TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices
--- PASS: TestAccAWSInstance_primaryNetworkInterface (112.11s)
=== CONT  TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (125.10s)
=== CONT  TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (224.62s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyAll
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (167.34s)
=== CONT  TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (157.15s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyIOPS
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (121.72s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyType
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS (166.98s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifySize
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (167.95s)
=== CONT  TestAccAWSInstance_EbsRootDevice_basic
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (145.38s)
=== CONT  TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (130.60s)
=== CONT  TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_changeInstanceType (186.02s)
=== CONT  TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (163.17s)
=== CONT  TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (90.50s)
=== CONT  TestAccAWSInstance_Empty_PrivateIP
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (105.05s)
=== CONT  TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_Empty_PrivateIP (106.76s)
=== CONT  TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (106.93s)
=== CONT  TestAccAWSInstance_withIamInstanceProfile
--- PASS: TestAccAWSInstance_privateIP (108.34s)
=== CONT  TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_withIamInstanceProfile (142.17s)
=== CONT  TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (149.82s)
=== CONT  TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_instanceProfileChange (221.21s)
=== CONT  TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (149.82s)
=== CONT  TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_volumeTags (190.35s)
=== CONT  TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (122.22s)
=== CONT  TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (139.89s)
=== CONT  TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
--- PASS: TestAccAWSInstance_rootInstanceStore (118.90s)
=== CONT  TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (30.87s)
=== CONT  TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (117.89s)
=== CONT  TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_placementGroup (98.78s)
=== CONT  TestAccAWSInstance_outpost
--- SKIP: TestAccAWSInstance_outpost (4.75s)
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts Outpost found
=== CONT  TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (107.04s)
=== CONT  TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_vpc (125.35s)
=== CONT  TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_disableApiTermination (170.21s)
=== CONT  TestAccAWSInstance_noAMIEphemeralDevices
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (103.57s)
=== CONT  TestAccAWSInstance_RootBlockDevice_KmsKeyArn
--- PASS: TestAccAWSInstance_sourceDestCheck (194.48s)
=== CONT  TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (128.31s)
=== CONT  TestAccAWSInstance_GP2WithIopsValue
--- PASS: TestAccAWSInstance_blockDevices (112.01s)
=== CONT  TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2WithIopsValue (122.13s)
=== CONT  TestAccAWSInstance_userDataBase64
--- PASS: TestAccAWSInstance_GP2IopsDevice (99.54s)
=== CONT  TestAccAWSInstance_atLeastOneOtherEbsVolume
--- PASS: TestAccAWSInstance_userDataBase64 (136.21s)
=== CONT  TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
--- PASS: TestAccAWSInstance_atLeastOneOtherEbsVolume (190.06s)
=== CONT  TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (104.13s)
=== CONT  TestAccAWSInstance_inDefaultVpcBySgId
--- PASS: TestAccAWSInstance_basic (133.61s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (149.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5324.969s
```
