### PR TITLE
Corrects name of Workspaces Workspace sweeper

### DIFF
--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -16,13 +16,13 @@ import (
 )
 
 func init() {
-	resource.AddTestSweepers("aws_workspace", &resource.Sweeper{
-		Name: "aws_workspace",
-		F:    testSweepWorkspaces,
+	resource.AddTestSweepers("aws_workspaces_workspace", &resource.Sweeper{
+		Name: "aws_workspaces_workspace",
+		F:    testSweepWorkspacesWorkspace,
 	})
 }
 
-func testSweepWorkspaces(region string) error {
+func testSweepWorkspacesWorkspace(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)


### PR DESCRIPTION
The Workspaces Workspace sweeper had the wrong name, so it was not being called. This was causing some sweepers and tests to fail.

Extracted from #14146

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14146

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make sweep SWEEPARGS='-sweep-run=aws_workspaces_workspace'

Sweeper Tests ran successfully:
	- aws_workspaces_workspace
```
