### PR TITLE
Fix schema set errors

### DIFF
--- a/aws/data_source_aws_lb.go
+++ b/aws/data_source_aws_lb.go
@@ -97,6 +97,11 @@ func dataSourceAwsLb() *schema.Resource {
 				Computed: true,
 			},
 
+			"enable_http2": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"idle_timeout": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/aws/resource_aws_api_gateway_resource.go
+++ b/aws/resource_aws_api_gateway_resource.go
@@ -25,7 +25,6 @@ func resourceAwsApiGatewayResource() *schema.Resource {
 				}
 				restApiID := idParts[0]
 				resourceID := idParts[1]
-				d.Set("request_validator_id", resourceID)
 				d.Set("rest_api_id", restApiID)
 				d.SetId(resourceID)
 				return []*schema.ResourceData{d}, nil

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -709,22 +709,19 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	// Use AdvancedSecurityOptions from resource if possible
-	// because DescribeElasticsearchDomainConfig does not return MasterUserOptions
+	// Populate AdvancedSecurityOptions with values returned from
+	// DescribeElasticsearchDomainConfig, if enabled, else use
+	// values from resource; additionally, append MasterUserOptions
+	// from resource as they are not returned from the API
 	if ds.AdvancedSecurityOptions != nil {
-		if _, ok := d.GetOk("advanced_security_options"); ok {
-			if err := d.Set("advanced_security_options", []interface{}{
-				map[string]interface{}{
-					"enabled":                        ds.AdvancedSecurityOptions.Enabled,
-					"internal_user_database_enabled": ds.AdvancedSecurityOptions.InternalUserDatabaseEnabled,
-				},
-			}); err != nil {
-				return fmt.Errorf("error setting advanced_security_options: %w", err)
-			}
-		} else {
-			if err := d.Set("advanced_security_options", flattenAdvancedSecurityOptions(ds.AdvancedSecurityOptions)); err != nil {
-				return fmt.Errorf("error setting advanced_security_options: %w", err)
-			}
+		advSecOpts := flattenAdvancedSecurityOptions(ds.AdvancedSecurityOptions)
+		if !aws.BoolValue(ds.AdvancedSecurityOptions.Enabled) {
+			advSecOpts[0]["internal_user_database_enabled"] = getUserDBEnabled(d)
+		}
+		advSecOpts[0]["master_user_options"] = getMasterUserOptions(d)
+
+		if err := d.Set("advanced_security_options", advSecOpts); err != nil {
+			return fmt.Errorf("error setting advanced_security_options: %w", err)
 		}
 	}
 

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -713,8 +713,14 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 	// because DescribeElasticsearchDomainConfig does not return MasterUserOptions
 	if ds.AdvancedSecurityOptions != nil {
 		if _, ok := d.GetOk("advanced_security_options"); ok {
-			d.Set("advanced_security_options.0.enabled", ds.AdvancedSecurityOptions.Enabled)
-			d.Set("advanced_security_options.0.internal_user_database_enabled", ds.AdvancedSecurityOptions.InternalUserDatabaseEnabled)
+			if err := d.Set("advanced_security_options", []interface{}{
+				map[string]interface{}{
+					"enabled":                        ds.AdvancedSecurityOptions.Enabled,
+					"internal_user_database_enabled": ds.AdvancedSecurityOptions.InternalUserDatabaseEnabled,
+				},
+			}); err != nil {
+				return fmt.Errorf("error setting advanced_security_options: %w", err)
+			}
 		} else {
 			if err := d.Set("advanced_security_options", flattenAdvancedSecurityOptions(ds.AdvancedSecurityOptions)); err != nil {
 				return fmt.Errorf("error setting advanced_security_options: %w", err)

--- a/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -138,7 +138,11 @@ func resourceAwsLBCookieStickinessPolicyRead(d *schema.ResourceData, meta interf
 
 	d.Set("name", policyName)
 	d.Set("load_balancer", lbName)
-	d.Set("lb_port", lbPort)
+	lbPortInt, err := strconv.Atoi(lbPort)
+	if err != nil {
+		return err
+	}
+	d.Set("lb_port", lbPortInt)
 
 	return nil
 }

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -349,7 +349,7 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 			for _, ni := range instance.NetworkInterfaces {
 				if *ni.Attachment.DeviceIndex == 0 {
 					d.Set("subnet_id", ni.SubnetId)
-					d.Set("network_interface_id", ni.NetworkInterfaceId)
+					d.Set("primary_network_interface_id", ni.NetworkInterfaceId)
 					d.Set("associate_public_ip_address", ni.Association != nil)
 					d.Set("ipv6_address_count", len(ni.Ipv6Addresses))
 
@@ -360,7 +360,7 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 			}
 		} else {
 			d.Set("subnet_id", instance.SubnetId)
-			d.Set("network_interface_id", "")
+			d.Set("primary_network_interface_id", "")
 		}
 
 		if err := d.Set("ipv6_addresses", ipv6Addresses); err != nil {

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -218,7 +218,6 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("association_name", association.AssociationName)
 	d.Set("instance_id", association.InstanceId)
 	d.Set("name", association.Name)
-	d.Set("parameters", association.Parameters)
 	d.Set("association_id", association.AssociationId)
 	d.Set("schedule_expression", association.ScheduleExpression)
 	d.Set("document_version", association.DocumentVersion)
@@ -226,6 +225,10 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("max_concurrency", association.MaxConcurrency)
 	d.Set("max_errors", association.MaxErrors)
 	d.Set("automation_target_parameter_name", association.AutomationTargetParameterName)
+
+	if err := d.Set("parameters", flattenAwsSsmParameters(association.Parameters)); err != nil {
+		return err
+	}
 
 	if err := d.Set("targets", flattenAwsSsmTargets(association.Targets)); err != nil {
 		return fmt.Errorf("Error setting targets error: %#v", err)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3262,6 +3262,20 @@ func expandAwsSsmTargets(in []interface{}) []*ssm.Target {
 	return targets
 }
 
+func flattenAwsSsmParameters(parameters map[string][]*string) map[string]string {
+	result := make(map[string]string)
+	for p, values := range parameters {
+		var vs []string
+		for _, vPtr := range values {
+			if v := aws.StringValue(vPtr); v != "" {
+				vs = append(vs, v)
+			}
+		}
+		result[p] = strings.Join(vs, ",")
+	}
+	return result
+}
+
 func flattenAwsSsmTargets(targets []*ssm.Target) []map[string]interface{} {
 	if len(targets) == 0 {
 		return nil


### PR DESCRIPTION
A few schema panics seemed to have slipped through the cracks

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/lb: `enable_http2` now properly set
* resource/lb_cookie_stickiness_policy: `lb_port` now properly set
* resource/spot_instance_request: `primary_network_interface_id` now properly set
* resource/ssm_association: `parameters` now properly set
* resource/elasticsearch_domain: update method to set advanced_security_options
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
