### PR TITLE
Remove CodePipeline GitHub environment variable

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -1,9 +1,12 @@
 package aws
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
@@ -106,11 +109,10 @@ func resourceAwsCodePipeline() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"configuration": {
-										Type:     schema.TypeMap,
-										Optional: true,
-										// Some configuration types can contain sensitive values, such as a GitHub OAuthToken
-										Sensitive: true,
-										Elem:      &schema.Schema{Type: schema.TypeString},
+										Type:             schema.TypeMap,
+										Optional:         true,
+										Elem:             &schema.Schema{Type: schema.TypeString},
+										DiffSuppressFunc: suppressCodePipelineStageActionConfiguration,
 									},
 									"category": {
 										Type:     schema.TypeString,
@@ -423,7 +425,8 @@ func flattenAwsCodePipelineStageActions(si int, actions []*codepipeline.ActionDe
 				if _, ok := config[CodePipelineGitHubActionConfigurationOAuthToken]; ok {
 					// The AWS API returns "****" for the OAuthToken value. Pull the value from the configuration.
 					addr := fmt.Sprintf("stage.%d.action.%d.configuration.OAuthToken", si, ai)
-					config[CodePipelineGitHubActionConfigurationOAuthToken] = d.Get(addr).(string)
+					hash := hashCodePipelineGitHubToken(d.Get(addr).(string))
+					config[CodePipelineGitHubActionConfigurationOAuthToken] = hash
 				}
 			}
 
@@ -615,4 +618,29 @@ func resourceAwsCodePipelineDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	return err
+}
+
+func suppressCodePipelineStageActionConfiguration(k, old, new string, d *schema.ResourceData) bool {
+	parts := strings.Split(k, ".")
+	parts = parts[:len(parts)-2]
+	providerAddr := strings.Join(append(parts, "provider"), ".")
+	provider := d.Get(providerAddr).(string)
+
+	if provider == CodePipelineProviderGitHub && strings.HasSuffix(k, CodePipelineGitHubActionConfigurationOAuthToken) {
+		hash := hashCodePipelineGitHubToken(new)
+		return old == hash
+	}
+
+	return false
+}
+
+const codePipelineGitHubTokenHashPrefix = "hash-"
+
+func hashCodePipelineGitHubToken(token string) string {
+	// Without this check, the value was getting encoded twice
+	if strings.HasPrefix(token, codePipelineGitHubTokenHashPrefix) {
+		return token
+	}
+	sum := sha256.Sum256([]byte(token))
+	return codePipelineGitHubTokenHashPrefix + hex.EncodeToString(sum[:])
 }

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -15,6 +15,11 @@ import (
 )
 
 func TestAccAWSCodePipeline_basic(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
 	var p1, p2 codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
 	resourceName := "aws_codepipeline.test"
@@ -25,7 +30,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineConfig_basic(name),
+				Config: testAccAWSCodePipelineConfig_basic(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p1),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.codepipeline_role", "arn"),
@@ -44,10 +49,11 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "test"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "4"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Owner", "lifesum-terraform"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Repo", "test"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Branch", "master"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", hashCodePipelineGitHubToken(githubToken)),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.run_order", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.region", ""),
@@ -73,9 +79,13 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 			{
-				Config: testAccAWSCodePipelineConfig_basicUpdated(name),
+				Config: testAccAWSCodePipelineConfig_basicUpdated(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p2),
 
@@ -87,10 +97,11 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "artifacts"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "4"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Owner", "test-terraform"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Repo", "test-repo"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Branch", "stable"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", hashCodePipelineGitHubToken(githubToken)),
 
 					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
@@ -105,12 +116,21 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 		},
 	})
 }
 
 func TestAccAWSCodePipeline_emptyStageArtifacts(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
 	var p codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
 	resourceName := "aws_codepipeline.test"
@@ -121,7 +141,7 @@ func TestAccAWSCodePipeline_emptyStageArtifacts(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineConfig_emptyStageArtifacts(name),
+				Config: testAccAWSCodePipelineConfig_emptyStageArtifacts(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codepipeline", regexp.MustCompile(fmt.Sprintf("test-pipeline-%s$", name))),
@@ -142,12 +162,21 @@ func TestAccAWSCodePipeline_emptyStageArtifacts(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 		},
 	})
 }
 
 func TestAccAWSCodePipeline_deployWithServiceRole(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
 	var p codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
 	resourceName := "aws_codepipeline.test"
@@ -158,7 +187,7 @@ func TestAccAWSCodePipeline_deployWithServiceRole(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineConfig_deployWithServiceRole(name),
+				Config: testAccAWSCodePipelineConfig_deployWithServiceRole(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p),
 					resource.TestCheckResourceAttr(resourceName, "stage.2.name", "Deploy"),
@@ -170,12 +199,21 @@ func TestAccAWSCodePipeline_deployWithServiceRole(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 		},
 	})
 }
 
 func TestAccAWSCodePipeline_tags(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
 	var p1, p2, p3 codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
 	resourceName := "aws_codepipeline.test"
@@ -186,7 +224,7 @@ func TestAccAWSCodePipeline_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineConfigWithTags(name, "tag1value", "tag2value"),
+				Config: testAccAWSCodePipelineConfigWithTags(name, githubToken, "tag1value", "tag2value"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -199,9 +237,13 @@ func TestAccAWSCodePipeline_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 			{
-				Config: testAccAWSCodePipelineConfigWithTags(name, "tag1valueUpdate", "tag2valueUpdate"),
+				Config: testAccAWSCodePipelineConfigWithTags(name, githubToken, "tag1valueUpdate", "tag2valueUpdate"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -214,9 +256,13 @@ func TestAccAWSCodePipeline_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 			{
-				Config: testAccAWSCodePipelineConfig_basic(name),
+				Config: testAccAWSCodePipelineConfig_basic(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -227,6 +273,11 @@ func TestAccAWSCodePipeline_tags(t *testing.T) {
 }
 
 func TestAccAWSCodePipeline_multiregion_basic(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
 	var p codepipeline.PipelineDeclaration
 	resourceName := "aws_codepipeline.test"
 	var providers []*schema.Provider
@@ -244,7 +295,7 @@ func TestAccAWSCodePipeline_multiregion_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineConfig_multiregion(name),
+				Config: testAccAWSCodePipelineConfig_multiregion(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "2"),
@@ -258,16 +309,25 @@ func TestAccAWSCodePipeline_multiregion_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:            testAccAWSCodePipelineConfig_multiregion(name),
+				Config:            testAccAWSCodePipelineConfig_multiregion(name, githubToken),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 		},
 	})
 }
 
 func TestAccAWSCodePipeline_multiregion_Update(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
 	var p1, p2 codepipeline.PipelineDeclaration
 	resourceName := "aws_codepipeline.test"
 	var providers []*schema.Provider
@@ -285,7 +345,7 @@ func TestAccAWSCodePipeline_multiregion_Update(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineConfig_multiregion(name),
+				Config: testAccAWSCodePipelineConfig_multiregion(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p1),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "2"),
@@ -299,7 +359,7 @@ func TestAccAWSCodePipeline_multiregion_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCodePipelineConfig_multiregionUpdated(name),
+				Config: testAccAWSCodePipelineConfig_multiregionUpdated(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p2),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "2"),
@@ -313,16 +373,25 @@ func TestAccAWSCodePipeline_multiregion_Update(t *testing.T) {
 				),
 			},
 			{
-				Config:            testAccAWSCodePipelineConfig_multiregionUpdated(name),
+				Config:            testAccAWSCodePipelineConfig_multiregionUpdated(name, githubToken),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 		},
 	})
 }
 
 func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
 	var p1, p2 codepipeline.PipelineDeclaration
 	resourceName := "aws_codepipeline.test"
 	var providers []*schema.Provider
@@ -340,7 +409,7 @@ func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineConfig_basic(name),
+				Config: testAccAWSCodePipelineConfig_basic(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p1),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
@@ -352,7 +421,7 @@ func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCodePipelineConfig_multiregion(name),
+				Config: testAccAWSCodePipelineConfig_multiregion(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p2),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "2"),
@@ -366,7 +435,7 @@ func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCodePipelineConfig_backToBasic(name),
+				Config: testAccAWSCodePipelineConfig_backToBasic(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p1),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
@@ -378,17 +447,22 @@ func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
 				),
 			},
 			{
-				Config:            testAccAWSCodePipelineConfig_backToBasic(name),
+				Config:            testAccAWSCodePipelineConfig_backToBasic(name, githubToken),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 		},
 	})
 }
 
 func TestAccAWSCodePipeline_WithNamespace(t *testing.T) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
 		t.Skip("Environment variable GITHUB_TOKEN is not set")
 	}
 
@@ -402,7 +476,7 @@ func TestAccAWSCodePipeline_WithNamespace(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineConfigWithNamespace(name),
+				Config: testAccAWSCodePipelineConfigWithNamespace(name, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists(resourceName, &p1),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codepipeline", regexp.MustCompile(fmt.Sprintf("test-pipeline-%s", name))),
@@ -413,6 +487,10 @@ func TestAccAWSCodePipeline_WithNamespace(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stage.0.action.0.configuration.%",
+					"stage.0.action.0.configuration.OAuthToken",
+				},
 			},
 		},
 	})
@@ -469,10 +547,6 @@ func testAccCheckAWSCodePipelineDestroy(s *terraform.State) error {
 }
 
 func testAccPreCheckAWSCodePipeline(t *testing.T) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
-
 	conn := testAccProvider.Meta().(*AWSClient).codepipelineconn
 
 	input := &codepipeline.ListPipelinesInput{}
@@ -607,13 +681,13 @@ EOF
 `, rName)
 }
 
-func testAccAWSCodePipelineConfig_basic(rName string) string {
+func testAccAWSCodePipelineConfig_basic(rName, githubToken string) string {
 	return composeConfig(
 		testAccAWSCodePipelineS3DefaultBucket(rName),
 		testAccAWSCodePipelineServiceIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
-  name     = "test-pipeline-%s"
+  name     = "test-pipeline-%[1]s"
   role_arn = "${aws_iam_role.codepipeline_role.arn}"
 
   artifact_store {
@@ -638,9 +712,10 @@ resource "aws_codepipeline" "test" {
       output_artifacts = ["test"]
 
       configuration = {
-        Owner  = "lifesum-terraform"
-        Repo   = "test"
-        Branch = "master"
+        Owner      = "lifesum-terraform"
+        Repo       = "test"
+        Branch     = "master"
+        OAuthToken = %[2]q
       }
     }
   }
@@ -662,10 +737,10 @@ resource "aws_codepipeline" "test" {
     }
   }
 }
-`, rName))
+`, rName, githubToken))
 }
 
-func testAccAWSCodePipelineConfig_basicUpdated(rName string) string {
+func testAccAWSCodePipelineConfig_basicUpdated(rName, githubToken string) string {
 	return composeConfig(
 		testAccAWSCodePipelineS3DefaultBucket(rName),
 		testAccAWSCodePipelineS3Bucket("updated", rName),
@@ -697,9 +772,10 @@ resource "aws_codepipeline" "test" {
       output_artifacts = ["artifacts"]
 
       configuration = {
-        Owner  = "test-terraform"
-        Repo   = "test-repo"
-        Branch = "stable"
+        Owner      = "test-terraform"
+        Repo       = "test-repo"
+        Branch     = "stable"
+        OAuthToken = %[2]q
       }
     }
   }
@@ -721,16 +797,16 @@ resource "aws_codepipeline" "test" {
     }
   }
 }
-`, rName))
+`, rName, githubToken))
 }
 
-func testAccAWSCodePipelineConfig_emptyStageArtifacts(rName string) string {
+func testAccAWSCodePipelineConfig_emptyStageArtifacts(rName, githubToken string) string {
 	return composeConfig(
 		testAccAWSCodePipelineS3DefaultBucket(rName),
 		testAccAWSCodePipelineServiceIAMRole(rName),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
-  name     = "test-pipeline-%s"
+  name     = "test-pipeline-%[1]s"
   role_arn = "${aws_iam_role.codepipeline_role.arn}"
 
   artifact_store {
@@ -750,9 +826,10 @@ resource "aws_codepipeline" "test" {
       output_artifacts = ["test"]
 
       configuration = {
-        Owner  = "lifesum-terraform"
-        Repo   = "test"
-        Branch = "master"
+        Owner      = "lifesum-terraform"
+        Repo       = "test"
+        Branch     = "master"
+        OAuthToken = %[2]q
       }
     }
   }
@@ -775,7 +852,7 @@ resource "aws_codepipeline" "test" {
     }
   }
 }
-`, rName))
+`, rName, githubToken))
 }
 
 func testAccAWSCodePipelineDeployActionIAMRole(rName string) string {
@@ -828,7 +905,7 @@ EOF
 `, rName)
 }
 
-func testAccAWSCodePipelineConfig_deployWithServiceRole(rName string) string {
+func testAccAWSCodePipelineConfig_deployWithServiceRole(rName, githubToken string) string {
 	return composeConfig(
 		testAccAWSCodePipelineS3DefaultBucket(rName),
 		testAccAWSCodePipelineServiceIAMRoleWithAssumeRole(rName),
@@ -860,9 +937,10 @@ resource "aws_codepipeline" "test" {
       output_artifacts = ["artifacts"]
 
       configuration = {
-        Owner  = "test-terraform"
-        Repo   = "test-repo"
-        Branch = "stable"
+        Owner      = "test-terraform"
+        Repo       = "test-repo"
+        Branch     = "stable"
+        OAuthToken = %[2]q
       }
     }
   }
@@ -906,10 +984,10 @@ resource "aws_codepipeline" "test" {
     }
   }
 }
-`, rName))
+`, rName, githubToken))
 }
 
-func testAccAWSCodePipelineConfigWithTags(rName, tag1, tag2 string) string {
+func testAccAWSCodePipelineConfigWithTags(rName, githubToken, tag1, tag2 string) string {
 	return composeConfig(
 		testAccAWSCodePipelineS3DefaultBucket(rName),
 		testAccAWSCodePipelineServiceIAMRole(rName),
@@ -940,9 +1018,10 @@ resource "aws_codepipeline" "test" {
       output_artifacts = ["test"]
 
       configuration = {
-        Owner  = "lifesum-terraform"
-        Repo   = "test"
-        Branch = "master"
+        Owner      = "lifesum-terraform"
+        Repo       = "test"
+        Branch     = "master"
+        OAuthToken = %[4]q
       }
     }
   }
@@ -970,10 +1049,10 @@ resource "aws_codepipeline" "test" {
     tag2 = %[3]q
   }
 }
-`, rName, tag1, tag2))
+`, rName, tag1, tag2, githubToken))
 }
 
-func testAccAWSCodePipelineConfig_multiregion(rName string) string {
+func testAccAWSCodePipelineConfig_multiregion(rName, githubToken string) string {
 	return composeConfig(
 		testAccAlternateRegionProviderConfig(),
 		testAccAWSCodePipelineS3DefaultBucket(rName),
@@ -1068,9 +1147,10 @@ resource "aws_codepipeline" "test" {
       output_artifacts = ["test"]
 
       configuration = {
-        Owner  = "lifesum-terraform"
-        Repo   = "test"
-        Branch = "master"
+        Owner      = "lifesum-terraform"
+        Repo       = "test"
+        Branch     = "master"
+        OAuthToken = %[4]q
       }
     }
   }
@@ -1105,10 +1185,10 @@ resource "aws_codepipeline" "test" {
     }
   }
 }
-`, rName, testAccGetRegion(), testAccGetAlternateRegion()))
+`, rName, testAccGetRegion(), testAccGetAlternateRegion(), githubToken))
 }
 
-func testAccAWSCodePipelineConfig_multiregionUpdated(rName string) string {
+func testAccAWSCodePipelineConfig_multiregionUpdated(rName, githubToken string) string {
 	return composeConfig(
 		testAccAlternateRegionProviderConfig(),
 		testAccAWSCodePipelineS3DefaultBucket(rName),
@@ -1203,9 +1283,10 @@ resource "aws_codepipeline" "test" {
       output_artifacts = ["test"]
 
       configuration = {
-        Owner  = "lifesum-terraform"
-        Repo   = "test"
-        Branch = "master"
+        Owner      = "lifesum-terraform"
+        Repo       = "test"
+        Branch     = "master"
+        OAuthToken = %[4]q
       }
     }
   }
@@ -1240,13 +1321,13 @@ resource "aws_codepipeline" "test" {
     }
   }
 }
-`, rName, testAccGetRegion(), testAccGetAlternateRegion()))
+`, rName, testAccGetRegion(), testAccGetAlternateRegion(), githubToken))
 }
 
-func testAccAWSCodePipelineConfig_backToBasic(rName string) string {
+func testAccAWSCodePipelineConfig_backToBasic(rName, githubToken string) string {
 	return composeConfig(
 		testAccAlternateRegionProviderConfig(),
-		testAccAWSCodePipelineConfig_basic(rName),
+		testAccAWSCodePipelineConfig_basic(rName, githubToken),
 	)
 }
 
@@ -1266,14 +1347,14 @@ resource "aws_s3_bucket" "%[1]s" {
 func testAccAWSCodePipelineS3BucketWithProvider(bucket, rName, provider string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "%[1]s" {
-  bucket = "tf-test-pipeline-%[1]s-%[2]s"
-  acl    = "private"
+  bucket   = "tf-test-pipeline-%[1]s-%[2]s"
+  acl      = "private"
   provider = %[3]s
 }
 `, bucket, rName, provider)
 }
 
-func testAccAWSCodePipelineConfigWithNamespace(rName string) string {
+func testAccAWSCodePipelineConfigWithNamespace(rName, githubToken string) string {
 	return fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
   name     = "test-pipeline-%[1]s"
@@ -1302,9 +1383,10 @@ resource "aws_codepipeline" "test" {
       namespace        = "SourceVariables"
 
       configuration = {
-        Owner  = "lifesum-terraform"
-        Repo   = "test"
-        Branch = "master"
+        Owner      = "lifesum-terraform"
+        Repo       = "test"
+        Branch     = "master"
+        OAuthToken = %[2]q
       }
     }
   }
@@ -1383,7 +1465,7 @@ resource "aws_iam_role_policy" "codepipeline_policy" {
 }
 EOF
 }
-`, rName)
+`, rName, githubToken)
 }
 
 func TestResourceAWSCodePipelineExpandArtifactStoresValidation(t *testing.T) {
@@ -1492,14 +1574,14 @@ func TestResourceAWSCodePipelineExpandArtifactStoresValidation(t *testing.T) {
 		_, err := expandAwsCodePipelineArtifactStores(tc.Input)
 		if tc.ExpectedError == "" {
 			if err != nil {
-				t.Errorf("%s: Did not expect an error, but got: %q", tc.Name, err)
+				t.Errorf("%s: Did not expect an error, but got: %w", tc.Name, err)
 			}
 		} else {
 			if err == nil {
 				t.Errorf("%s: Expected an error, but did not get one", tc.Name)
 			} else {
 				if err.Error() != tc.ExpectedError {
-					t.Errorf("%s: Expected error %q, got %q", tc.Name, tc.ExpectedError, err.Error())
+					t.Errorf("%s: Expected error %q, got %w", tc.Name, tc.ExpectedError, err)
 				}
 			}
 		}

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -53,7 +53,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Owner", "lifesum-terraform"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Repo", "test"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Branch", "master"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", hashCodePipelineGitHubToken(githubToken)),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", githubToken),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.run_order", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.region", ""),
@@ -101,7 +101,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Owner", "test-terraform"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Repo", "test-repo"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Branch", "stable"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", hashCodePipelineGitHubToken(githubToken)),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", githubToken),
 
 					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -53,7 +53,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Owner", "lifesum-terraform"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Repo", "test"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Branch", "master"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", githubToken),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", hashCodePipelineGitHubToken(githubToken)),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.run_order", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.region", ""),
@@ -101,7 +101,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Owner", "test-terraform"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Repo", "test-repo"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.Branch", "stable"),
-					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", githubToken),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.OAuthToken", hashCodePipelineGitHubToken(githubToken)),
 
 					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -16,9 +16,6 @@ import (
 
 func TestAccAWSCodePipeline_basic(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p1, p2 codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
@@ -127,9 +124,6 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 
 func TestAccAWSCodePipeline_disappears(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
@@ -154,9 +148,6 @@ func TestAccAWSCodePipeline_disappears(t *testing.T) {
 
 func TestAccAWSCodePipeline_emptyStageArtifacts(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
@@ -200,9 +191,6 @@ func TestAccAWSCodePipeline_emptyStageArtifacts(t *testing.T) {
 
 func TestAccAWSCodePipeline_deployWithServiceRole(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
@@ -237,9 +225,6 @@ func TestAccAWSCodePipeline_deployWithServiceRole(t *testing.T) {
 
 func TestAccAWSCodePipeline_tags(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p1, p2, p3 codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
@@ -301,9 +286,6 @@ func TestAccAWSCodePipeline_tags(t *testing.T) {
 
 func TestAccAWSCodePipeline_multiregion_basic(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p codepipeline.PipelineDeclaration
 	resourceName := "aws_codepipeline.test"
@@ -351,9 +333,6 @@ func TestAccAWSCodePipeline_multiregion_basic(t *testing.T) {
 
 func TestAccAWSCodePipeline_multiregion_Update(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p1, p2 codepipeline.PipelineDeclaration
 	resourceName := "aws_codepipeline.test"
@@ -415,9 +394,6 @@ func TestAccAWSCodePipeline_multiregion_Update(t *testing.T) {
 
 func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p1, p2 codepipeline.PipelineDeclaration
 	resourceName := "aws_codepipeline.test"
@@ -489,9 +465,6 @@ func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
 
 func TestAccAWSCodePipeline_WithNamespace(t *testing.T) {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	if githubToken == "" {
-		t.Skip("Environment variable GITHUB_TOKEN is not set")
-	}
 
 	var p1 codepipeline.PipelineDeclaration
 	name := acctest.RandString(10)
@@ -574,8 +547,11 @@ func testAccCheckAWSCodePipelineDestroy(s *terraform.State) error {
 }
 
 func testAccPreCheckAWSCodePipeline(t *testing.T, regions ...string) {
-	regions = append(regions, testAccGetRegion())
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
 
+	regions = append(regions, testAccGetRegion())
 	for _, region := range regions {
 		conf := &Config{
 			Region: region,
@@ -1095,7 +1071,7 @@ func testAccAWSCodePipelineConfig_multiregion(rName, githubToken string) string 
 		testAccAlternateRegionProviderConfig(),
 		testAccAWSCodePipelineS3DefaultBucket(rName),
 		testAccAWSCodePipelineServiceIAMRole(rName),
-		testAccAWSCodePipelineS3BucketWithProvider("alternate", rName, "aws.alternate"),
+		testAccAWSCodePipelineS3BucketWithProvider("alternate", rName, "awsalternate"),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
   name     = "test-pipeline-%[1]s"
@@ -1178,7 +1154,7 @@ func testAccAWSCodePipelineConfig_multiregionUpdated(rName, githubToken string) 
 		testAccAlternateRegionProviderConfig(),
 		testAccAWSCodePipelineS3DefaultBucket(rName),
 		testAccAWSCodePipelineServiceIAMRole(rName),
-		testAccAWSCodePipelineS3BucketWithProvider("alternate", rName, "aws.alternate"),
+		testAccAWSCodePipelineS3BucketWithProvider("alternate", rName, "awsalternate"),
 		fmt.Sprintf(`
 resource "aws_codepipeline" "test" {
   name     = "test-pipeline-%[1]s"

--- a/aws/resource_aws_codepipeline_webhook_test.go
+++ b/aws/resource_aws_codepipeline_webhook_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -22,7 +25,7 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineWebhookConfig_basic(rName),
+				Config: testAccAWSCodePipelineWebhookConfig_basic(rName, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -41,6 +44,8 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -51,7 +56,7 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineWebhookConfig_ipAuth(rName),
+				Config: testAccAWSCodePipelineWebhookConfig_ipAuth(rName, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -70,6 +75,8 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+
 	var v codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -80,7 +87,7 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineWebhookConfig_unauthenticated(rName),
+				Config: testAccAWSCodePipelineWebhookConfig_unauthenticated(rName, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -97,6 +104,8 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+
 	var v1, v2, v3 codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -107,7 +116,7 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineWebhookConfigWithTags(rName, "tag1value", "tag2value"),
+				Config: testAccAWSCodePipelineWebhookConfigWithTags(rName, "tag1value", "tag2value", githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -117,7 +126,7 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCodePipelineWebhookConfigWithTags(rName, "tag1valueUpdate", "tag2valueUpdate"),
+				Config: testAccAWSCodePipelineWebhookConfigWithTags(rName, "tag1valueUpdate", "tag2valueUpdate", githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
@@ -138,7 +147,7 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSCodePipelineWebhookConfig_basic(rName),
+				Config: testAccAWSCodePipelineWebhookConfig_basic(rName, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -155,6 +164,8 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 }
 
 func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken(t *testing.T) {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+
 	var v1, v2 codepipeline.ListWebhookItem
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codepipeline_webhook.test"
@@ -165,7 +176,7 @@ func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodePipelineWebhookConfig_basic(rName),
+				Config: testAccAWSCodePipelineWebhookConfig_basic(rName, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v1),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -175,7 +186,7 @@ func TestAccAWSCodePipelineWebhook_UpdateAuthenticationConfiguration_SecretToken
 				),
 			},
 			{
-				Config: testAccAWSCodePipelineWebhookConfig_secretTokenUpdated(rName),
+				Config: testAccAWSCodePipelineWebhookConfig_secretTokenUpdated(rName, githubToken),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineWebhookExists(resourceName, &v2),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -219,8 +230,8 @@ func testAccCheckAWSCodePipelineWebhookExists(n string, webhook *codepipeline.Li
 	}
 }
 
-func testAccAWSCodePipelineWebhookConfig_basic(rName string) string {
-	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName) + fmt.Sprintf(`
+func testAccAWSCodePipelineWebhookConfig_basic(rName, githubToken string) string {
+	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName, githubToken) + fmt.Sprintf(`
 resource "aws_codepipeline_webhook" "test" {
   name            = %[1]q
   authentication  = "GITHUB_HMAC"
@@ -239,8 +250,8 @@ resource "aws_codepipeline_webhook" "test" {
 `, rName)
 }
 
-func testAccAWSCodePipelineWebhookConfig_ipAuth(rName string) string {
-	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName) + fmt.Sprintf(`
+func testAccAWSCodePipelineWebhookConfig_ipAuth(rName, githubToken string) string {
+	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName, githubToken) + fmt.Sprintf(`
 resource "aws_codepipeline_webhook" "test" {
   name            = %[1]q
   authentication  = "IP"
@@ -259,8 +270,8 @@ resource "aws_codepipeline_webhook" "test" {
 `, rName)
 }
 
-func testAccAWSCodePipelineWebhookConfig_unauthenticated(rName string) string {
-	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName) + fmt.Sprintf(`
+func testAccAWSCodePipelineWebhookConfig_unauthenticated(rName, githubToken string) string {
+	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName, githubToken) + fmt.Sprintf(`
 resource "aws_codepipeline_webhook" "test" {
   name            = %[1]q
   authentication  = "UNAUTHENTICATED"
@@ -275,8 +286,8 @@ resource "aws_codepipeline_webhook" "test" {
 `, rName)
 }
 
-func testAccAWSCodePipelineWebhookConfigWithTags(rName, tag1, tag2 string) string {
-	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName) + fmt.Sprintf(`
+func testAccAWSCodePipelineWebhookConfigWithTags(rName, tag1, tag2, githubToken string) string {
+	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName, githubToken) + fmt.Sprintf(`
 resource "aws_codepipeline_webhook" "test" {
   name            = %[1]q
   authentication  = "GITHUB_HMAC"
@@ -301,8 +312,8 @@ resource "aws_codepipeline_webhook" "test" {
 `, rName, tag1, tag2)
 }
 
-func testAccAWSCodePipelineWebhookConfig_secretTokenUpdated(rName string) string {
-	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName) + fmt.Sprintf(`
+func testAccAWSCodePipelineWebhookConfig_secretTokenUpdated(rName, githubToken string) string {
+	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName, githubToken) + fmt.Sprintf(`
 resource "aws_codepipeline_webhook" "test" {
   name            = %[1]q
   authentication  = "GITHUB_HMAC"
@@ -321,7 +332,7 @@ resource "aws_codepipeline_webhook" "test" {
 `, rName)
 }
 
-func testAccAWSCodePipelineWebhookConfig_codePipeline(rName string) string {
+func testAccAWSCodePipelineWebhookConfig_codePipeline(rName, githubToken string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -408,7 +419,8 @@ resource "aws_codepipeline" "test" {
       configuration = {
         Owner  = "lifesum-terraform"
         Repo   = "test"
-        Branch = "master"
+		Branch = "master"
+		OAuthToken = %[2]q
       }
     }
   }
@@ -430,5 +442,5 @@ resource "aws_codepipeline" "test" {
     }
   }
 }
-`, rName)
+`, rName, githubToken)
 }

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -30,6 +30,7 @@ Upgrade topics:
 - [Resource: aws_autoscaling_group](#resource-aws_autoscaling_group)
 - [Resource: aws_cloudfront_distribution](#resource-aws_cloudfront_distribution)
 - [Resource: aws_cloudwatch_log_group](#resource-aws_cloudwatch_log_group)
+- [Resource: aws_codepipeline](#resource-aws_codepipeline)
 - [Resource: aws_cognito_user_pool](#resource-aws_cognito_user_pool)
 - [Resource: aws_dx_gateway](#resource-aws_dx_gateway)
 - [Resource: aws_dx_gateway_association](#resource-aws_dx_gateway_association)
@@ -713,6 +714,75 @@ data "aws_iam_policy_document" "ad-log-policy" {
     }
     resources = ["${aws_cloudwatch_log_group.example.arn}:*"]
     effect = "Allow"
+  }
+}
+```
+
+## Resource: aws_codepipeline
+
+### GITHUB_TOKEN environment variable removal
+
+Switch your Terraform configuration to the `OAuthToken` element in the `action` `configuration` map instead.
+
+For example, given this previous configuration:
+
+```bash
+$ GITHUB_TOKEN=<token> terraform apply
+```
+
+```hcl
+resource "aws_codepipeline" "example" {
+  # ... other configuration ...
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["example"]
+
+      configuration = {
+        Owner  = "lifesum-terraform"
+        Repo   = "example"
+        Branch = "main"
+      }
+    }
+  }
+}
+```
+
+```bash
+$ TF_VAR_github_token=<token> terraform apply
+```
+
+```hcl
+variable "github_token" {}
+
+resource "aws_codepipeline" "example" {
+  # ... other configuration ...
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["example"]
+
+      configuration = {
+        Owner      = "lifesum-terraform"
+        Repo       = "example"
+        Branch     = "main"
+        OAuthToken = var.github_token
+      }
+    }
   }
 }
 ```

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -109,11 +109,12 @@ resource "aws_iam_role" "codepipeline_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "codepipeline_policy" {
   name = "codepipeline_policy"
-  role = "${aws_iam_role.codepipeline_role.id}"
+  role = aws_iam_role.codepipeline_role.id
 
   policy = <<EOF
 {

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -10,73 +10,9 @@ description: |-
 
 Provides a CodePipeline.
 
-~> **NOTE on `aws_codepipeline`:** - the `GITHUB_TOKEN` environment variable must be set if the GitHub provider is specified.
-
 ## Example Usage
 
 ```hcl
-resource "aws_s3_bucket" "codepipeline_bucket" {
-  bucket = "test-bucket"
-  acl    = "private"
-}
-
-resource "aws_iam_role" "codepipeline_role" {
-  name = "test-role"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "codepipeline.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "codepipeline_policy" {
-  name = "codepipeline_policy"
-  role = aws_iam_role.codepipeline_role.id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect":"Allow",
-      "Action": [
-        "s3:GetObject",
-        "s3:GetObjectVersion",
-        "s3:GetBucketVersioning",
-        "s3:PutObject"
-      ],
-      "Resource": [
-        "${aws_s3_bucket.codepipeline_bucket.arn}",
-        "${aws_s3_bucket.codepipeline_bucket.arn}/*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "codebuild:BatchGetBuilds",
-        "codebuild:StartBuild"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
-data "aws_kms_alias" "s3kmskey" {
-  name = "alias/myKmsKey"
-}
-
 resource "aws_codepipeline" "codepipeline" {
   name     = "tf-test-pipeline"
   role_arn = aws_iam_role.codepipeline_role.arn
@@ -103,9 +39,10 @@ resource "aws_codepipeline" "codepipeline" {
       output_artifacts = ["source_output"]
 
       configuration = {
-        Owner  = "my-organization"
-        Repo   = "test"
-        Branch = "master"
+        Owner      = "my-organization"
+        Repo       = "test"
+        Branch     = "master"
+        OAuthToken = var.github_token
       }
     }
   }
@@ -149,6 +86,68 @@ resource "aws_codepipeline" "codepipeline" {
     }
   }
 }
+
+resource "aws_s3_bucket" "codepipeline_bucket" {
+  bucket = "test-bucket"
+  acl    = "private"
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name = "test-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name = "codepipeline_policy"
+  role = "${aws_iam_role.codepipeline_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.codepipeline_bucket.arn}",
+        "${aws_s3_bucket.codepipeline_bucket.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:BatchGetBuilds",
+        "codebuild:StartBuild"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_kms_alias" "s3kmskey" {
+  name = "alias/myKmsKey"
+}
 ```
 
 ## Argument Reference
@@ -186,7 +185,7 @@ An `action` block supports the following arguments:
 * `name` - (Required) The action declaration's name.
 * `provider` - (Required) The provider of the service being called by the action. Valid providers are determined by the action category. For example, an action in the Deploy category type might have a provider of AWS CodeDeploy, which would be specified as CodeDeploy.
 * `version` - (Required) A string that identifies the action type.
-* `configuration` - (Optional) A Map of the action declaration's configuration. Find out more about configuring action configurations in the [Reference Pipeline Structure documentation](http://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#action-requirements).
+* `configuration` - (Optional) A map of the action declaration's configuration. Configurations options for action types and providers can be found in the [Pipeline Structure Reference](http://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#action-requirements) and [Action Structure Reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference.html) documentation.
 * `input_artifacts` - (Optional) A list of artifact names to be worked on.
 * `output_artifacts` - (Optional) A list of artifact names to output. Output artifact names must be unique within a pipeline.
 * `role_arn` - (Optional) The ARN of the IAM service role that will perform the declared action. This is assumed through the roleArn for the pipeline.


### PR DESCRIPTION
Removes the previously required `GITHUB_TOKEN` environment variable for CodePipeline. The authentication token is now passed as the `OAuthToken` field in the action configuration.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2796 
Closes #4768

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_codepipeline: Removes `GITHUB_TOKEN` environment variable
```

Output from acceptance testing in commercial partition:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodePipeline_'

--- PASS: TestAccAWSCodePipeline_disappears (35.93s)
--- PASS: TestAccAWSCodePipeline_emptyStageArtifacts (40.89s)
--- PASS: TestAccAWSCodePipeline_multiregion_basic (48.58s)
--- PASS: TestAccAWSCodePipeline_deployWithServiceRole (55.08s)
--- PASS: TestAccAWSCodePipeline_WithNamespace (58.69s)
--- PASS: TestAccAWSCodePipeline_basic (63.80s)
--- PASS: TestAccAWSCodePipeline_tags (75.56s)
--- PASS: TestAccAWSCodePipeline_multiregion_Update (79.32s)
--- PASS: TestAccAWSCodePipeline_multiregion_ConvertSingleRegion (94.63s)
```

Output from acceptance testing in GovCloud partition:

```
--- SKIP: TestAccAWSCodePipeline_multiregion_ConvertSingleRegion (2.37s)
--- SKIP: TestAccAWSCodePipeline_multiregion_basic (2.38s)
--- SKIP: TestAccAWSCodePipeline_multiregion_Update (2.39s)
--- PASS: TestAccAWSCodePipeline_disappears (24.64s)
--- PASS: TestAccAWSCodePipeline_emptyStageArtifacts (30.55s)
--- PASS: TestAccAWSCodePipeline_WithNamespace (32.72s)
--- PASS: TestAccAWSCodePipeline_deployWithServiceRole (35.85s)
--- PASS: TestAccAWSCodePipeline_basic (46.98s)
--- PASS: TestAccAWSCodePipeline_tags (57.72s)
```