### PR TITLE
r/sagemaker_notebook_instance: Root access to Sagemaker notebook instance

### DIFF
--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -79,10 +79,8 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Default:  sagemaker.RootAccessEnabled,
-				ValidateFunc: validation.StringInSlice([]string{
-					sagemaker.RootAccessDisabled,
-					sagemaker.RootAccessEnabled,
-				}, false),
+				ValidateFunc: validation.StringInSlice(
+					sagemaker.RootAccess_Values(), false),
 			},
 
 			"direct_internet_access": {

--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -74,6 +74,17 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"root_access": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  sagemaker.RootAccessEnabled,
+				ValidateFunc: validation.StringInSlice([]string{
+					sagemaker.RootAccessDisabled,
+					sagemaker.RootAccessEnabled,
+				}, false),
+			},
+
 			"direct_internet_access": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -100,6 +111,10 @@ func resourceAwsSagemakerNotebookInstanceCreate(d *schema.ResourceData, meta int
 		NotebookInstanceName: aws.String(name),
 		RoleArn:              aws.String(d.Get("role_arn").(string)),
 		InstanceType:         aws.String(d.Get("instance_type").(string)),
+	}
+
+	if v, ok := d.GetOk("root_access"); ok {
+		createOpts.RootAccess = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("direct_internet_access"); ok {
@@ -193,6 +208,10 @@ func resourceAwsSagemakerNotebookInstanceRead(d *schema.ResourceData, meta inter
 
 	if err := d.Set("arn", notebookInstance.NotebookInstanceArn); err != nil {
 		return fmt.Errorf("error setting arn for sagemaker notebook instance (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("root_access", notebookInstance.RootAccess); err != nil {
+		return fmt.Errorf("error setting root_access for sagemaker notebook instance (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("direct_internet_access", notebookInstance.DirectInternetAccess); err != nil {

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -325,6 +325,38 @@ func testAccCheckAWSSagemakerNotebookInstanceName(notebook *sagemaker.DescribeNo
 	}
 }
 
+func TestAccAWSSagemakerNotebookInstance_root_access(t *testing.T) {
+	var notebook sagemaker.DescribeNotebookInstanceOutput
+	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
+	var resourceName = "aws_sagemaker_notebook_instance.foo"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerNotebookInstanceConfigRootAccess(notebookName, "Disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerNotebookRootAccess(&notebook, "Disabled"),
+				),
+			},
+			{
+				Config: testAccAWSSagemakerNotebookInstanceConfigRootAccess(notebookName, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerNotebookRootAccess(&notebook, "Enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 	var notebook sagemaker.DescribeNotebookInstanceOutput
 	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
@@ -355,6 +387,17 @@ func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSSagemakerNotebookRootAccess(notebook *sagemaker.DescribeNotebookInstanceOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rootAccess := notebook.RootAccess
+		if *rootAccess != expected {
+			return fmt.Errorf("root_access setting is incorrect: %s", *notebook.RootAccess)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckAWSSagemakerNotebookDirectInternetAccess(notebook *sagemaker.DescribeNotebookInstanceOutput, expected string) resource.TestCheckFunc {
@@ -542,6 +585,33 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 `, notebookName, notebookName)
+}
+
+func testAccAWSSagemakerNotebookInstanceConfigRootAccess(notebookName string, rootAccess string) string {
+	return fmt.Sprintf(`
+resource "aws_sagemaker_notebook_instance" "foo" {
+	name = %[1]q
+	role_arn = "${aws_iam_role.foo.arn}"
+	instance_type = "ml.t2.medium"
+	root_access = %[2]q
+}
+
+resource "aws_iam_role" "foo" {
+	name = %[1]q
+	path = "/"
+	assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+	statement {
+		actions = [ "sts:AssumeRole" ]
+		principals {
+			type = "Service"
+			identifiers = [ "sagemaker.amazonaws.com" ]
+		}
+	}
+}
+`, notebookName, rootAccess)
 }
 
 func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(notebookName string, directInternetAccess string) string {

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -591,7 +591,7 @@ func testAccAWSSagemakerNotebookInstanceConfigRootAccess(notebookName string, ro
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
 	name = %[1]q
-	role_arn = "${aws_iam_role.foo.arn}"
+	role_arn = aws_iam_role.foo.arn
 	instance_type = "ml.t2.medium"
 	root_access = %[2]q
 }
@@ -599,7 +599,7 @@ resource "aws_sagemaker_notebook_instance" "foo" {
 resource "aws_iam_role" "foo" {
 	name = %[1]q
 	path = "/"
-	assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+	assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `security_groups` - (Optional) The associated security groups.
 * `kms_key_id` - (Optional) The AWS Key Management Service (AWS KMS) key that Amazon SageMaker uses to encrypt the model artifacts at rest using Amazon S3 server-side encryption.
 * `lifecycle_config_name` - (Optional) The name of a lifecycle configuration to associate with the notebook instance.
+* `root_access` - (Optional) Whether root access is `Enabled` or `Disabled` for users of the notebook instance. The default value is `Enabled`.
 * `direct_internet_access` - (Optional) Set to `Disabled` to disable internet access to notebook. Requires `security_groups` and `subnet_id` to be set. Supported values: `Enabled` (Default) or `Disabled`. If set to `Disabled`, the notebook instance will be able to access resources only in your VPC, and will not be able to connect to Amazon SageMaker training and endpoint services unless your configure a NAT Gateway in your VPC.
 * `tags` - (Optional) A map of tags to assign to the resource.
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #NA

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
Ability to configure root access for Sagemaker notebook instances
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance_root_access'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSagemakerNotebookInstance_root_access -timeout 120m
=== RUN   TestAccAWSSagemakerNotebookInstance_root_access
=== PAUSE TestAccAWSSagemakerNotebookInstance_root_access
=== CONT  TestAccAWSSagemakerNotebookInstance_root_access
--- PASS: TestAccAWSSagemakerNotebookInstance_root_access (652.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	653.837s
```
