### PR TITLE
resource/aws_iam_server_certificate: Remove state hashing from certificate_body, certificate_chain, and private_key arguments

### DIFF
--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -29,17 +29,19 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"certificate_body": {
-				Type:      schema.TypeString,
-				Required:  true,
-				ForceNew:  true,
-				StateFunc: normalizeCert,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressNormalizeCertRemoval,
+				StateFunc:        StateTrimSpace,
 			},
 
 			"certificate_chain": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  true,
-				StateFunc: normalizeCert,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressNormalizeCertRemoval,
+				StateFunc:        StateTrimSpace,
 			},
 
 			"path": {
@@ -50,11 +52,12 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 			},
 
 			"private_key": {
-				Type:      schema.TypeString,
-				Required:  true,
-				ForceNew:  true,
-				StateFunc: normalizeCert,
-				Sensitive: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				Sensitive:        true,
+				DiffSuppressFunc: suppressNormalizeCertRemoval,
+				StateFunc:        StateTrimSpace,
 			},
 
 			"name": {
@@ -112,13 +115,10 @@ func resourceAwsIAMServerCertificateCreate(d *schema.ResourceData, meta interfac
 	log.Printf("[DEBUG] Creating IAM Server Certificate with opts: %s", createOpts)
 	resp, err := conn.UploadServerCertificate(createOpts)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			return fmt.Errorf("Error uploading server certificate, error: %s: %s", awsErr.Code(), awsErr.Message())
-		}
-		return fmt.Errorf("Error uploading server certificate, error: %s", err)
+		return fmt.Errorf("error uploading server certificate: %w", err)
 	}
 
-	d.SetId(*resp.ServerCertificateMetadata.ServerCertificateId)
+	d.SetId(aws.StringValue(resp.ServerCertificateMetadata.ServerCertificateId))
 	d.Set("name", sslCertName)
 
 	return resourceAwsIAMServerCertificateRead(d, meta)
@@ -130,29 +130,20 @@ func resourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interface{
 		ServerCertificateName: aws.String(d.Get("name").(string)),
 	})
 
+	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		log.Printf("[WARN] IAM Server Certificate (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "NoSuchEntity" {
-				log.Printf("[WARN] IAM Server Cert (%s) not found, removing from state", d.Id())
-				d.SetId("")
-				return nil
-			}
-			return fmt.Errorf("Error reading IAM Server Certificate: %s: %s", awsErr.Code(), awsErr.Message())
-		}
-		return fmt.Errorf("Error reading IAM Server Certificate: %s", err)
+		return fmt.Errorf("error reading IAM Server Certificate (%s): %w", d.Id(), err)
 	}
 
-	d.SetId(*resp.ServerCertificate.ServerCertificateMetadata.ServerCertificateId)
+	d.SetId(aws.StringValue(resp.ServerCertificate.ServerCertificateMetadata.ServerCertificateId))
 
-	// these values should always be present, and have a default if not set in
-	// configuration, and so safe to reference with nil checks
-	d.Set("certificate_body", normalizeCert(resp.ServerCertificate.CertificateBody))
-
-	c := normalizeCert(resp.ServerCertificate.CertificateChain)
-	if c != "" {
-		d.Set("certificate_chain", c)
-	}
-
+	d.Set("certificate_body", resp.ServerCertificate.CertificateBody)
+	d.Set("certificate_chain", resp.ServerCertificate.CertificateChain)
 	d.Set("path", resp.ServerCertificate.ServerCertificateMetadata.Path)
 	d.Set("arn", resp.ServerCertificate.ServerCertificateMetadata.Arn)
 
@@ -246,4 +237,10 @@ func stripCR(b []byte) []byte {
 		}
 	}
 	return c[:i]
+}
+
+// Terraform AWS Provider version 3.0.0 removed state hash storage.
+// This DiffSuppressFunc prevents the resource from triggering needless recreation.
+func suppressNormalizeCertRemoval(k, old, new string, d *schema.ResourceData) bool {
+	return normalizeCert(new) == old
 }

--- a/aws/state_funcs.go
+++ b/aws/state_funcs.go
@@ -1,0 +1,17 @@
+package aws
+
+import "strings"
+
+// StateTrimSpace is a StateFunc that trims extraneous whitespace from strings.
+//
+// This prevents differences caused by an API canonicalizing a string with a
+// trailing newline character removed.
+func StateTrimSpace(v interface{}) string {
+	s, ok := v.(string)
+
+	if !ok {
+		return ""
+	}
+
+	return strings.TrimSpace(s)
+}

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -36,6 +36,7 @@ Upgrade topics:
 - [Resource: aws_glue_job](#resource-aws_glue_job)
 - [Resource: aws_iam_access_key](#resource-aws_iam_access_key)
 - [Resource: aws_iam_instance_profile](#resource-aws_iam_instance_profile)
+- [Resource: aws_iam_server_certificate](#resource-aws_iam_server_certificate)
 - [Resource: aws_instance](#resource-aws_instance)
 - [Resource: aws_lambda_alias](#resource-aws_lambda_alias)
 - [Resource: aws_launch_template](#resource-aws_launch_template)
@@ -909,6 +910,12 @@ resource "aws_iam_instance_profile" "example" {
   role = aws_iam_role.example.id
 }
 ```
+
+## Resource: aws_iam_server_certificate
+
+### certificate_body, certificate_chain, and private_key Arguments No Longer Stored as Hash
+
+Previously when the `certificate_body`, `certificate_chain`, and `private_key` arguments were stored in state, they were stored as a hash of the actual value. This hashing has been removed for new or recreated resources to prevent lifecycle issues.
 
 ## Resource: aws_instance
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13406

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_iam_server_certificate: Remove state hashing from `certificate_body`, `certificate_chain`, and `private_key` arguments for new or recreated resources
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIAMServerCertificate_name_prefix (6.05s)
--- PASS: TestAccAWSIAMServerCertificate_disappears (6.10s)
--- PASS: TestAccAWSIAMServerCertificate_Path (6.48s)
--- PASS: TestAccAWSIAMServerCertificate_basic (6.54s)
--- PASS: TestAccAWSIAMServerCertificate_file (10.07s)
```