### PR TITLE
Add new maintainers to issues.yml so needs-triage label does not get applied.

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   comment:
-    if: github.event_name == 'pull_request' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "maryelizbeth", "renovate[bot]"]'), github.actor)
+    if: github.event_name == 'pull_request' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "maryelizbeth", "YakDriver", "renovate[bot]"]'), github.actor)
     name: Comment
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v1.0.0
     - name: Apply Issue Triage Label
       uses: actions/github@v1.0.0
-      if: github.event.action == 'opened' && !contains(fromJSON('["bflad", "breathingdust", "ewbankkit", "gdavison", "maryelizbeth"]'), github.actor)
+      if: github.event.action == 'opened' && !contains(fromJSON('["bflad", "breathingdust", "ewbankkit", "gdavison", "maryelizbeth", "YakDriver", "anGie44"]'), github.actor)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v1.0.0
     - name: Apply Issue Triage Label
       uses: actions/github@v1.0.0
-      if: github.event.action == 'opened' && !contains(fromJSON('["bflad", "breathingdust", "ewbankkit", "gdavison", "maryelizbeth", "YakDriver", "anGie44"]'), github.actor)
+      if: github.event.action == 'opened' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "maryelizbeth", "YakDriver"]'), github.actor)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Adds `anGie44` and `YakDriver` to `.github/issues.yml` to avoid `needs-triage` label being applied for their issues/prs