### PR TITLE
resource/elasticsearch_domain: update method to set advanced_security_options 

### DIFF
--- a/aws/elasticsearch_domain_structure.go
+++ b/aws/elasticsearch_domain_structure.go
@@ -50,8 +50,8 @@ func flattenAdvancedSecurityOptions(advancedSecurityOptions *elasticsearch.Advan
 	}
 
 	m := map[string]interface{}{}
+	m["enabled"] = aws.BoolValue(advancedSecurityOptions.Enabled)
 	if aws.BoolValue(advancedSecurityOptions.Enabled) {
-		m["enabled"] = aws.BoolValue(advancedSecurityOptions.Enabled)
 		m["internal_user_database_enabled"] = aws.BoolValue(advancedSecurityOptions.InternalUserDatabaseEnabled)
 	}
 
@@ -69,4 +69,17 @@ func getMasterUserOptions(d *schema.ResourceData) []interface{} {
 		}
 	}
 	return []interface{}{}
+}
+
+func getUserDBEnabled(d *schema.ResourceData) bool {
+	if v, ok := d.GetOk("advanced_security_options"); ok {
+		options := v.([]interface{})
+		if len(options) > 0 && options[0] != nil {
+			m := options[0].(map[string]interface{})
+			if enabled, ok := m["internal_user_database_enabled"]; ok {
+				return enabled.(bool)
+			}
+		}
+	}
+	return false
 }

--- a/aws/elasticsearch_domain_structure.go
+++ b/aws/elasticsearch_domain_structure.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func expandAdvancedSecurityOptions(m []interface{}) *elasticsearch.AdvancedSecurityOptionsInput {
@@ -48,10 +49,24 @@ func flattenAdvancedSecurityOptions(advancedSecurityOptions *elasticsearch.Advan
 		return []map[string]interface{}{}
 	}
 
-	m := map[string]interface{}{
-		"enabled":                        aws.BoolValue(advancedSecurityOptions.Enabled),
-		"internal_user_database_enabled": aws.BoolValue(advancedSecurityOptions.InternalUserDatabaseEnabled),
+	m := map[string]interface{}{}
+	if aws.BoolValue(advancedSecurityOptions.Enabled) {
+		m["enabled"] = aws.BoolValue(advancedSecurityOptions.Enabled)
+		m["internal_user_database_enabled"] = aws.BoolValue(advancedSecurityOptions.InternalUserDatabaseEnabled)
 	}
 
 	return []map[string]interface{}{m}
+}
+
+func getMasterUserOptions(d *schema.ResourceData) []interface{} {
+	if v, ok := d.GetOk("advanced_security_options"); ok {
+		options := v.([]interface{})
+		if len(options) > 0 && options[0] != nil {
+			m := options[0].(map[string]interface{})
+			if opts, ok := m["master_user_options"]; ok {
+				return opts.([]interface{})
+			}
+		}
+	}
+	return []interface{}{}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/elasticsearch_domain: update method to set advanced_security_options
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSElasticSearchDomain_duplicate (501.34s)
--- PASS: TestAccAWSElasticSearchDomain_complex (847.78s)
--- PASS: TestAccAWSElasticSearchDomain_basic (885.08s)
--- PASS: TestAccAWSElasticSearchDomain_policy (1018.34s)
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions (1019.78s)
--- PASS: TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_UserDB (1066.63s)
--- PASS: TestAccAWSElasticSearchDomain_v23 (1317.74s)
--- PASS: TestAccAWSElasticSearchDomain_vpc (1397.84s)
--- PASS: TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_Disabled (1632.41s)
--- PASS: TestAccAWSElasticSearchDomain_RequireHTTPS (1651.93s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_default_key (1722.04s)
--- PASS: TestAccAWSElasticSearchDomain_NodeToNodeEncryption (886.06s)
--- PASS: TestAccAWSElasticSearchDomain_internetToVpcEndpoint (1807.26s)
--- PASS: TestAccAWSElasticSearchDomainPolicy_basic (1810.02s)
--- PASS: TestAccAWSElasticSearchDomain_AdvancedSecurityOptions_IAM (1815.24s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsCreateAndRemove (1985.83s)
--- PASS: TestAccAWSElasticSearchDomain_tags (1114.47s)
--- PASS: TestAccAWSElasticSearchDomain_encrypt_at_rest_specify_key (1521.66s)
--- PASS: TestAccAWSElasticSearchDomain_WithVolumeType_Missing (1073.25s)
--- PASS: TestAccAWSElasticSearchDomain_CognitoOptionsUpdate (2162.89s)
--- PASS: TestAccAWSElasticSearchDomain_vpc_update (2686.80s)
--- PASS: TestAccAWSElasticSearchDomain_withDedicatedMaster (3178.74s)
--- PASS: TestAccAWSElasticSearchDomain_update (2290.92s)
--- PASS: TestAccAWSElasticSearchDomain_update_volume_type (3056.45s)
--- PASS: TestAccAWSElasticSearchDomain_warm (4197.91s)
--- PASS: TestAccAWSElasticSearchDomain_update_version (3223.32s)
--- PASS: TestAccAWSElasticSearchDomain_ClusterConfig_ZoneAwarenessConfig (5663.74s)```
