### PR TITLE
Add underscore to acceptance test names

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,6 +76,7 @@ awsproviderlint:
 		-c 1 \
 		-AT001 \
 		-AT002 \
+		-AT003 \
 		-AT005 \
 		-AT006 \
 		-AT007 \

--- a/aws/data_source_aws_acmpca_certificate_authority_test.go
+++ b/aws/data_source_aws_acmpca_certificate_authority_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsAcmpcaCertificateAuthority_Basic(t *testing.T) {
+func TestAccDataSourceAwsAcmpcaCertificateAuthority_basic(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	datasourceName := "data.aws_acmpca_certificate_authority.test"
 

--- a/aws/data_source_aws_api_gateway_api_key_test.go
+++ b/aws/data_source_aws_api_gateway_api_key_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsApiGatewayApiKey(t *testing.T) {
+func TestAccDataSourceAwsApiGatewayApiKey_basic(t *testing.T) {
 	rName := acctest.RandString(8)
 	resourceName1 := "aws_api_gateway_api_key.example_key"
 	dataSourceName1 := "data.aws_api_gateway_api_key.test_key"

--- a/aws/data_source_aws_api_gateway_resource_test.go
+++ b/aws/data_source_aws_api_gateway_resource_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsApiGatewayResource(t *testing.T) {
+func TestAccDataSourceAwsApiGatewayResource_basic(t *testing.T) {
 	rName := acctest.RandString(8)
 	resourceName1 := "aws_api_gateway_resource.example_v1"
 	dataSourceName1 := "data.aws_api_gateway_resource.example_v1"

--- a/aws/data_source_aws_api_gateway_vpc_link_test.go
+++ b/aws/data_source_aws_api_gateway_vpc_link_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsApiGatewayVpcLink(t *testing.T) {
+func TestAccDataSourceAwsApiGatewayVpcLink_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 	resourceName := "aws_api_gateway_vpc_link.vpc_link"
 	dataSourceName := "data.aws_api_gateway_vpc_link.vpc_link"

--- a/aws/data_source_aws_batch_compute_environment_test.go
+++ b/aws/data_source_aws_batch_compute_environment_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsBatchComputeEnvironment(t *testing.T) {
+func TestAccDataSourceAwsBatchComputeEnvironment_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf_acc_test_")
 	resourceName := "aws_batch_compute_environment.test"
 	datasourceName := "data.aws_batch_compute_environment.by_name"

--- a/aws/data_source_aws_batch_job_queue_test.go
+++ b/aws/data_source_aws_batch_job_queue_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsBatchJobQueue(t *testing.T) {
+func TestAccDataSourceAwsBatchJobQueue_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf_acc_test_")
 	resourceName := "aws_batch_job_queue.test"
 	datasourceName := "data.aws_batch_job_queue.by_name"

--- a/aws/data_source_aws_dx_gateway_test.go
+++ b/aws/data_source_aws_dx_gateway_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsDxGateway_Basic(t *testing.T) {
+func TestAccDataSourceAwsDxGateway_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_dx_gateway.test"
 	datasourceName := "data.aws_dx_gateway.test"

--- a/aws/data_source_aws_ebs_volumes_test.go
+++ b/aws/data_source_aws_ebs_volumes_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsEbsVolumes(t *testing.T) {
+func TestAccDataSourceAwsEbsVolumes_basic(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsEfsMountTargetByMountTargetId(t *testing.T) {
+func TestAccDataSourceAwsEfsMountTarget_basic(t *testing.T) {
 	rName := acctest.RandString(10)
 	dataSourceName := "data.aws_efs_mount_target.test"
 	resourceName := "aws_efs_mount_target.test"

--- a/aws/data_source_aws_elastic_beanstalk_solution_stack_test.go
+++ b/aws/data_source_aws_elastic_beanstalk_solution_stack_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSElasticBeanstalkSolutionStackDataSource(t *testing.T) {
+func TestAccAWSElasticBeanstalkSolutionStackDataSource_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_kinesis_stream_test.go
+++ b/aws/data_source_aws_kinesis_stream_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAWSKinesisStreamDataSource(t *testing.T) {
+func TestAccAWSKinesisStreamDataSource_basic(t *testing.T) {
 	var stream kinesis.StreamDescription
 
 	sn := fmt.Sprintf("terraform-kinesis-test-%d", acctest.RandInt())

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -68,7 +68,7 @@ func TestAccDataSourceAWSALBTargetGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAWSLBTargetGroupBackwardsCompatibility(t *testing.T) {
+func TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 	lbName := fmt.Sprintf("testlb-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resourceNameArn := "data.aws_alb_target_group.alb_tg_test_with_arn"

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -52,7 +52,7 @@ func TestAccDataSourceAWSLB_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAWSLBBackwardsCompatibility(t *testing.T) {
+func TestAccDataSourceAWSLB_BackwardsCompatibility(t *testing.T) {
 	lbName := fmt.Sprintf("testaccawsalb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	dataSourceName1 := "data.aws_alb.alb_test_with_arn"
 	dataSourceName2 := "data.aws_alb.alb_test_with_name"

--- a/aws/data_source_aws_nat_gateway_test.go
+++ b/aws/data_source_aws_nat_gateway_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsNatGateway(t *testing.T) {
+func TestAccDataSourceAwsNatGateway_basic(t *testing.T) {
 	// This is used as a portion of CIDR network addresses.
 	rInt := acctest.RandIntRange(4, 254)
 

--- a/aws/data_source_aws_qldb_ledger_test.go
+++ b/aws/data_source_aws_qldb_ledger_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsQLDBLedger(t *testing.T) {
+func TestAccDataSourceAwsQLDBLedger_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(7)) // QLDB name cannot be longer than 32 characters
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/data_source_aws_ram_resource_share_test.go
+++ b/aws/data_source_aws_ram_resource_share_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsRamResourceShare_Basic(t *testing.T) {
+func TestAccDataSourceAwsRamResourceShare_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ram_resource_share.test"
 	datasourceName := "data.aws_ram_resource_share.test"

--- a/aws/data_source_aws_regions_test.go
+++ b/aws/data_source_aws_regions_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsRegions_Basic(t *testing.T) {
+func TestAccDataSourceAwsRegions_basic(t *testing.T) {
 	resourceName := "data.aws_regions.empty"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/data_source_aws_route_tables_test.go
+++ b/aws/data_source_aws_route_tables_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsRouteTables(t *testing.T) {
+func TestAccDataSourceAwsRouteTables_basic(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/data_source_aws_secretsmanager_secret_rotation_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_rotation_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsSecretsManagerSecretRotation_Basic(t *testing.T) {
+func TestAccDataSourceAwsSecretsManagerSecretRotation_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_secretsmanager_secret_rotation.test"
 	datasourceName := "data.aws_secretsmanager_secret_rotation.test"

--- a/aws/data_source_aws_secretsmanager_secret_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsSecretsManagerSecret_Basic(t *testing.T) {
+func TestAccDataSourceAwsSecretsManagerSecret_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_secretsmanager_secret_version_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_version_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsSecretsManagerSecretVersion_Basic(t *testing.T) {
+func TestAccDataSourceAwsSecretsManagerSecretVersion_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_secretsmanager_secret_version.test"
 	datasourceName := "data.aws_secretsmanager_secret_version.test"

--- a/aws/data_source_aws_sfn_activity_test.go
+++ b/aws/data_source_aws_sfn_activity_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAWSStepFunctionsActivityDataSource(t *testing.T) {
+func TestAccAWSStepFunctionsActivityDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sfn_activity.test"
 	dataName := "data.aws_sfn_activity.test"

--- a/aws/data_source_aws_sfn_state_machine_test.go
+++ b/aws/data_source_aws_sfn_state_machine_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsSfnStateMachine(t *testing.T) {
+func TestAccDataSourceAwsSfnStateMachine_basic(t *testing.T) {
 	rName := acctest.RandString(5)
 	dataSourceName := "data.aws_sfn_state_machine.test"
 	resourceName := "aws_sfn_state_machine.test"

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccDataSourceAwsSnsTopic(t *testing.T) {
+func TestAccDataSourceAwsSnsTopic_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_subnet_ids_test.go
+++ b/aws/data_source_aws_subnet_ids_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsSubnetIDs(t *testing.T) {
+func TestAccDataSourceAwsSubnetIDs_basic(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/data_source_aws_waf_ipset_test.go
+++ b/aws/data_source_aws_waf_ipset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafIPSet_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafIPSet_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_ipset.ipset"
 	datasourceName := "data.aws_waf_ipset.ipset"

--- a/aws/data_source_aws_waf_rate_based_rule_test.go
+++ b/aws/data_source_aws_waf_rate_based_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafRateBasedRule_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafRateBasedRule_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 	datasourceName := "data.aws_waf_rate_based_rule.wafrule"

--- a/aws/data_source_aws_waf_rule_test.go
+++ b/aws/data_source_aws_waf_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafRule_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafRule_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_rule.wafrule"
 	datasourceName := "data.aws_waf_rule.wafrule"

--- a/aws/data_source_aws_waf_web_acl_test.go
+++ b/aws/data_source_aws_waf_web_acl_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafWebAcl_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafWebAcl_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_waf_web_acl.web_acl"
 	datasourceName := "data.aws_waf_web_acl.web_acl"

--- a/aws/data_source_aws_wafregional_ipset_test.go
+++ b/aws/data_source_aws_wafregional_ipset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafRegionalIPSet_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafRegionalIPSet_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_ipset.ipset"
 	datasourceName := "data.aws_wafregional_ipset.ipset"

--- a/aws/data_source_aws_wafregional_rate_based_rule_test.go
+++ b/aws/data_source_aws_wafregional_rate_based_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafRegionalRateBasedRule_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafRegionalRateBasedRule_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_rate_based_rule.wafrule"
 	datasourceName := "data.aws_wafregional_rate_based_rule.wafrule"

--- a/aws/data_source_aws_wafregional_rule_test.go
+++ b/aws/data_source_aws_wafregional_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafRegionalRule_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafRegionalRule_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_rule.wafrule"
 	datasourceName := "data.aws_wafregional_rule.wafrule"

--- a/aws/data_source_aws_wafregional_web_acl_test.go
+++ b/aws/data_source_aws_wafregional_web_acl_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafRegionalWebAcl_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafRegionalWebAcl_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafregional_web_acl.web_acl"
 	datasourceName := "data.aws_wafregional_web_acl.web_acl"

--- a/aws/data_source_aws_wafv2_ip_set_test.go
+++ b/aws/data_source_aws_wafv2_ip_set_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafv2IPSet_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafv2IPSet_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_ip_set.test"
 	datasourceName := "data.aws_wafv2_ip_set.test"

--- a/aws/data_source_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/data_source_aws_wafv2_regex_pattern_set_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafv2RegexPatternSet_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafv2RegexPatternSet_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_regex_pattern_set.test"
 	datasourceName := "data.aws_wafv2_regex_pattern_set.test"

--- a/aws/data_source_aws_wafv2_rule_group_test.go
+++ b/aws/data_source_aws_wafv2_rule_group_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafv2RuleGroup_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafv2RuleGroup_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_rule_group.test"
 	datasourceName := "data.aws_wafv2_rule_group.test"

--- a/aws/data_source_aws_wafv2_web_acl_test.go
+++ b/aws/data_source_aws_wafv2_web_acl_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceAwsWafv2WebACL_Basic(t *testing.T) {
+func TestAccDataSourceAwsWafv2WebACL_basic(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"
 	datasourceName := "data.aws_wafv2_web_acl.test"

--- a/aws/resource_aws_accessanalyzer_test.go
+++ b/aws/resource_aws_accessanalyzer_test.go
@@ -8,7 +8,7 @@ import (
 
 // AccessAnalyzer is limited to one per region, so run serially
 // locally and in TeamCity.
-func TestAccAWSAccessAnalyzer(t *testing.T) {
+func TestAccAWSAccessAnalyzer_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Analyzer": {
 			"basic":      testAccAWSAccessAnalyzerAnalyzer_basic,

--- a/aws/resource_aws_acmpca_certificate_authority_test.go
+++ b/aws/resource_aws_acmpca_certificate_authority_test.go
@@ -60,7 +60,7 @@ func testSweepAcmpcaCertificateAuthorities(region string) error {
 	return nil
 }
 
-func TestAccAwsAcmpcaCertificateAuthority_Basic(t *testing.T) {
+func TestAccAwsAcmpcaCertificateAuthority_basic(t *testing.T) {
 	var certificateAuthority acmpca.CertificateAuthority
 	resourceName := "aws_acmpca_certificate_authority.test"
 

--- a/aws/resource_aws_ami_launch_permission_test.go
+++ b/aws/resource_aws_ami_launch_permission_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSAMILaunchPermission_Basic(t *testing.T) {
+func TestAccAWSAMILaunchPermission_basic(t *testing.T) {
 	resourceName := "aws_ami_launch_permission.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 

--- a/aws/resource_aws_apigatewayv2_api_mapping_test.go
+++ b/aws/resource_aws_apigatewayv2_api_mapping_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // These tests need to be serialized, else resources get orphaned after "TooManyRequests" errors.
-func TestAccAWSAPIGatewayV2ApiMapping(t *testing.T) {
+func TestAccAWSAPIGatewayV2ApiMapping_basic(t *testing.T) {
 	var certificateArn string
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 

--- a/aws/resource_aws_appmesh_test.go
+++ b/aws/resource_aws_appmesh_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestAccAWSAppmesh(t *testing.T) {
+func TestAccAWSAppmesh_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Mesh": {
 			"basic":        testAccAwsAppmeshMesh_basic,

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -91,7 +91,7 @@ func testSweepCloudTrails(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestAccAWSCloudTrail(t *testing.T) {
+func TestAccAWSCloudTrail_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Trail": {
 			"basic":                      testAccAWSCloudTrail_basic,

--- a/aws/resource_aws_cloudwatch_event_permission_test.go
+++ b/aws/resource_aws_cloudwatch_event_permission_test.go
@@ -67,7 +67,7 @@ func testSweepCloudWatchEventPermissions(region string) error {
 	return nil
 }
 
-func TestAccAWSCloudWatchEventPermission_Basic(t *testing.T) {
+func TestAccAWSCloudWatchEventPermission_basic(t *testing.T) {
 	principal1 := "111111111111"
 	principal2 := "*"
 	statementID := acctest.RandomWithPrefix(t.Name())

--- a/aws/resource_aws_codebuild_source_credential_test.go
+++ b/aws/resource_aws_codebuild_source_credential_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCodeBuildSourceCredential_Basic(t *testing.T) {
+func TestAccAWSCodeBuildSourceCredential_basic(t *testing.T) {
 	var sourceCredentialsInfo codebuild.SourceCredentialsInfo
 	token := acctest.RandomWithPrefix("token")
 	resourceName := "aws_codebuild_source_credential.test"

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -387,7 +387,7 @@ func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
 	})
 }
 
-func TestAccAWSCodePipelineWithNamespace(t *testing.T) {
+func TestAccAWSCodePipeline_WithNamespace(t *testing.T) {
 	if os.Getenv("GITHUB_TOKEN") == "" {
 		t.Skip("Environment variable GITHUB_TOKEN is not set")
 	}

--- a/aws/resource_aws_codestarnotifications_notification_rule_test.go
+++ b/aws/resource_aws_codestarnotifications_notification_rule_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSCodeStarNotificationsNotificationRule_Basic(t *testing.T) {
+func TestAccAWSCodeStarNotificationsNotificationRule_basic(t *testing.T) {
 	resourceName := "aws_codestarnotifications_notification_rule.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 

--- a/aws/resource_aws_config_test.go
+++ b/aws/resource_aws_config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestAccAWSConfig(t *testing.T) {
+func TestAccAWSConfig_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Config": {
 			"basic":            testAccConfigConfigRule_basic,

--- a/aws/resource_aws_dlm_lifecycle_policy_test.go
+++ b/aws/resource_aws_dlm_lifecycle_policy_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDlmLifecyclePolicy_Basic(t *testing.T) {
+func TestAccAWSDlmLifecyclePolicy_basic(t *testing.T) {
 	resourceName := "aws_dlm_lifecycle_policy.basic"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 

--- a/aws/resource_aws_dms_certificate_test.go
+++ b/aws/resource_aws_dms_certificate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDmsCertificateBasic(t *testing.T) {
+func TestAccAWSDmsCertificate_basic(t *testing.T) {
 	resourceName := "aws_dms_certificate.dms_certificate"
 	randId := acctest.RandString(8)
 

--- a/aws/resource_aws_dms_endpoint_test.go
+++ b/aws/resource_aws_dms_endpoint_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAwsDmsEndpoint_Basic(t *testing.T) {
+func TestAccAwsDmsEndpoint_basic(t *testing.T) {
 	resourceName := "aws_dms_endpoint.dms_endpoint"
 	randId := acctest.RandString(8) + "-basic"
 

--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -77,7 +77,7 @@ func testSweepDmsReplicationInstances(region string) error {
 	return nil
 }
 
-func TestAccAWSDmsReplicationInstance_Basic(t *testing.T) {
+func TestAccAWSDmsReplicationInstance_basic(t *testing.T) {
 	// NOTE: Using larger dms.c4.large here for AWS GovCloud (US) support
 	replicationInstanceClass := "dms.c4.large"
 	resourceName := "aws_dms_replication_instance.test"

--- a/aws/resource_aws_dms_replication_subnet_group_test.go
+++ b/aws/resource_aws_dms_replication_subnet_group_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDmsReplicationSubnetGroupBasic(t *testing.T) {
+func TestAccAWSDmsReplicationSubnetGroup_basic(t *testing.T) {
 	resourceName := "aws_dms_replication_subnet_group.dms_replication_subnet_group"
 	randId := acctest.RandString(8)
 

--- a/aws/resource_aws_dms_replication_task_test.go
+++ b/aws/resource_aws_dms_replication_task_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSDmsReplicationTaskBasic(t *testing.T) {
+func TestAccAWSDmsReplicationTask_basic(t *testing.T) {
 	resourceName := "aws_dms_replication_task.dms_replication_task"
 	randId := acctest.RandString(8)
 

--- a/aws/resource_aws_dx_hosted_transit_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_transit_virtual_interface_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAwsDxHostedTransitVirtualInterface(t *testing.T) {
+func TestAccAwsDxHostedTransitVirtualInterface_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"basic":        testAccAwsDxHostedTransitVirtualInterface_basic,
 		"accepterTags": testAccAwsDxHostedTransitVirtualInterface_accepterTags,

--- a/aws/resource_aws_dx_transit_virtual_interface_test.go
+++ b/aws/resource_aws_dx_transit_virtual_interface_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAwsDxTransitVirtualInterface(t *testing.T) {
+func TestAccAwsDxTransitVirtualInterface_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"basic": testAccAwsDxTransitVirtualInterface_basic,
 		"tags":  testAccAwsDxTransitVirtualInterface_Tags,

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -77,7 +77,7 @@ func testSweepEc2ClientVpnEndpoints(region string) error {
 //   "This place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.
 //   What is here was dangerous and repulsive to us. This message is a warning about danger."
 //   --  https://hyperallergic.com/312318/a-nuclear-warning-designed-to-last-10000-years/
-func TestAccAwsEc2ClientVpn(t *testing.T) {
+func TestAccAwsEc2ClientVpn_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Endpoint": {
 			"basic":             testAccAwsEc2ClientVpnEndpoint_basic,

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -57,7 +57,7 @@ func testSweepGlueConnections(region string) error {
 	return nil
 }
 
-func TestAccAWSGlueConnection_Basic(t *testing.T) {
+func TestAccAWSGlueConnection_basic(t *testing.T) {
 	var connection glue.Connection
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -55,7 +55,7 @@ func testSweepGlueJobs(region string) error {
 	return nil
 }
 
-func TestAccAWSGlueJob_Basic(t *testing.T) {
+func TestAccAWSGlueJob_basic(t *testing.T) {
 	var job glue.Job
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))

--- a/aws/resource_aws_glue_security_configuration_test.go
+++ b/aws/resource_aws_glue_security_configuration_test.go
@@ -60,7 +60,7 @@ func testSweepGlueSecurityConfigurations(region string) error {
 	return nil
 }
 
-func TestAccAWSGlueSecurityConfiguration_Basic(t *testing.T) {
+func TestAccAWSGlueSecurityConfiguration_basic(t *testing.T) {
 	var securityConfiguration glue.SecurityConfiguration
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/aws/resource_aws_glue_trigger_test.go
+++ b/aws/resource_aws_glue_trigger_test.go
@@ -54,7 +54,7 @@ func testSweepGlueTriggers(region string) error {
 	return nil
 }
 
-func TestAccAWSGlueTrigger_Basic(t *testing.T) {
+func TestAccAWSGlueTrigger_basic(t *testing.T) {
 	var trigger glue.Trigger
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))

--- a/aws/resource_aws_glue_workflow_test.go
+++ b/aws/resource_aws_glue_workflow_test.go
@@ -44,7 +44,7 @@ func testSweepGlueWorkflow(region string) error {
 	return nil
 }
 
-func TestAccAWSGlueWorkflow_Basic(t *testing.T) {
+func TestAccAWSGlueWorkflow_basic(t *testing.T) {
 	var workflow glue.Workflow
 
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))

--- a/aws/resource_aws_guardduty_test.go
+++ b/aws/resource_aws_guardduty_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestAccAWSGuardDuty(t *testing.T) {
+func TestAccAWSGuardDuty_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Detector": {
 			"basic":            testAccAwsGuardDutyDetector_basic,

--- a/aws/resource_aws_iam_account_alias_test.go
+++ b/aws/resource_aws_iam_account_alias_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSIAMAccountAlias(t *testing.T) {
+func TestAccAWSIAMAccountAlias_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Basic": {
 			"basic": testAccAWSIAMAccountAlias_basic_with_datasource,

--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
-func TestAccAWSKmsGrant_Basic(t *testing.T) {
+func TestAccAWSKmsGrant_basic(t *testing.T) {
 	resourceName := "aws_kms_grant.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -181,7 +181,7 @@ func TestAccAWSLBListenerRule_forwardWeighted(t *testing.T) {
 	})
 }
 
-func TestAccAWSLBListenerRuleBackwardsCompatibility(t *testing.T) {
+func TestAccAWSLBListenerRule_BackwardsCompatibility(t *testing.T) {
 	var conf elbv2.Rule
 	lbName := fmt.Sprintf("testrule-basic-%s", acctest.RandString(13))
 	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandString(10))

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -421,7 +421,7 @@ func TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck(t *testing.T) {
 	})
 }
 
-func TestAccAWSLBTargetGroupBackwardsCompatibility(t *testing.T) {
+func TestAccAWSLBTargetGroup_BackwardsCompatibility(t *testing.T) {
 	var conf elbv2.TargetGroup
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resourceName := "aws_alb_target_group.test"

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -191,7 +191,7 @@ func TestAccAWSLB_networkLoadbalancerEIP(t *testing.T) {
 	})
 }
 
-func TestAccAWSLBBackwardsCompatibility(t *testing.T) {
+func TestAccAWSLB_BackwardsCompatibility(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	lbName := fmt.Sprintf("testaccawslb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resourceName := "aws_alb.lb_test"

--- a/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
+func TestAccAWSOpsworksRdsDbInstance_basic(t *testing.T) {
 	sName := fmt.Sprintf("test-db-instance-%d", acctest.RandInt())
 	var opsdb opsworks.RdsDbInstance
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_opsworks_user_profile_test.go
+++ b/aws/resource_aws_opsworks_user_profile_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSOpsworksUserProfile(t *testing.T) {
+func TestAccAWSOpsworksUserProfile_basic(t *testing.T) {
 	rName := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	updateRName := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestAccAWSOrganizations(t *testing.T) {
+func TestAccAWSOrganizations_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Organization": {
 			"basic":                      testAccAwsOrganizationsOrganization_basic,

--- a/aws/resource_aws_redshift_snapshot_copy_grant_test.go
+++ b/aws/resource_aws_redshift_snapshot_copy_grant_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSRedshiftSnapshotCopyGrant_Basic(t *testing.T) {
+func TestAccAWSRedshiftSnapshotCopyGrant_basic(t *testing.T) {
 	resourceName := "aws_redshift_snapshot_copy_grant.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 

--- a/aws/resource_aws_route53_query_log_test.go
+++ b/aws/resource_aws_route53_query_log_test.go
@@ -68,7 +68,7 @@ func testSweepRoute53QueryLogs(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func TestAccAWSRoute53QueryLog_Basic(t *testing.T) {
+func TestAccAWSRoute53QueryLog_basic(t *testing.T) {
 	// The underlying resources are sensitive to where they are located
 	// Use us-east-1 for testing
 	oldRegion := os.Getenv("AWS_DEFAULT_REGION")

--- a/aws/resource_aws_s3_account_public_access_block_test.go
+++ b/aws/resource_aws_s3_account_public_access_block_test.go
@@ -13,7 +13,7 @@ import (
 
 // S3 account-level settings must run serialized
 // for TeamCity environment
-func TestAccAWSS3Account(t *testing.T) {
+func TestAccAWSS3Account_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"PublicAccessBlock": {
 			"basic":                 testAccAWSS3AccountPublicAccessBlock_basic,

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -57,7 +57,7 @@ func testSweepSagemakerEndpointConfigurations(region string) error {
 	return nil
 }
 
-func TestAccAWSSagemakerEndpointConfiguration_Basic(t *testing.T) {
+func TestAccAWSSagemakerEndpointConfiguration_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_endpoint_configuration.foo"
 

--- a/aws/resource_aws_sagemaker_notebook_instance_lifecycle_configuration_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_lifecycle_configuration_test.go
@@ -68,7 +68,7 @@ func testSweepSagemakerNotebookInstanceLifecycleConfiguration(region string) err
 	return nil
 }
 
-func TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_Basic(t *testing.T) {
+func TestAccAWSSagemakerNotebookInstanceLifecycleConfiguration_basic(t *testing.T) {
 	var lifecycleConfig sagemaker.DescribeNotebookInstanceLifecycleConfigOutput
 	rName := acctest.RandomWithPrefix(SagemakerNotebookInstanceLifecycleConfigurationResourcePrefix)
 	resourceName := "aws_sagemaker_notebook_instance_lifecycle_configuration.test"

--- a/aws/resource_aws_secretsmanager_secret_rotation_test.go
+++ b/aws/resource_aws_secretsmanager_secret_rotation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAwsSecretsManagerSecretRotation(t *testing.T) {
+func TestAccAwsSecretsManagerSecretRotation_basic(t *testing.T) {
 	var secret secretsmanager.DescribeSecretOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_secretsmanager_secret_rotation.test"

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -65,7 +65,7 @@ func testSweepSecretsManagerSecrets(region string) error {
 	return nil
 }
 
-func TestAccAwsSecretsManagerSecret_Basic(t *testing.T) {
+func TestAccAwsSecretsManagerSecret_basic(t *testing.T) {
 	var secret secretsmanager.DescribeSecretOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_secretsmanager_secret.test"

--- a/aws/resource_aws_securityhub_test.go
+++ b/aws/resource_aws_securityhub_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestAccAWSSecurityHub(t *testing.T) {
+func TestAccAWSSecurityHub_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Account": {
 			"basic": testAccAWSSecurityHubAccount_basic,

--- a/aws/resource_aws_servicecatalog_portfolio_test.go
+++ b/aws/resource_aws_servicecatalog_portfolio_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestAccAWSServiceCatalogPortfolio_Basic(t *testing.T) {
+func TestAccAWSServiceCatalogPortfolio_basic(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	name := acctest.RandString(5)
 	var dpo servicecatalog.DescribePortfolioOutput

--- a/aws/resource_aws_ses_template_test.go
+++ b/aws/resource_aws_ses_template_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSSesTemplate_Basic(t *testing.T) {
+func TestAccAWSSesTemplate_basic(t *testing.T) {
 	resourceName := "aws_ses_template.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	var template ses.Template

--- a/aws/resource_aws_snapshot_create_volume_permission_test.go
+++ b/aws/resource_aws_snapshot_create_volume_permission_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSSnapshotCreateVolumePermission_Basic(t *testing.T) {
+func TestAccAWSSnapshotCreateVolumePermission_basic(t *testing.T) {
 	var snapshotId string
 	accountId := "111122223333"
 

--- a/aws/resource_aws_sns_sms_preferences_test.go
+++ b/aws/resource_aws_sns_sms_preferences_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // The preferences are account-wide, so the tests must be serialized
-func TestAccAWSSNSSMSPreferences(t *testing.T) {
+func TestAccAWSSNSSMSPreferences_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"almostAll":      testAccAWSSNSSMSPreferences_almostAll,
 		"defaultSMSType": testAccAWSSNSSMSPreferences_defaultSMSType,

--- a/aws/resource_aws_spot_datafeed_subscription_test.go
+++ b/aws/resource_aws_spot_datafeed_subscription_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSSpotDatafeedSubscription(t *testing.T) {
+func TestAccAWSSpotDatafeedSubscription_serial(t *testing.T) {
 	cases := map[string]func(t *testing.T){
 		"basic":      testAccAWSSpotDatafeedSubscription_basic,
 		"disappears": testAccAWSSpotDatafeedSubscription_disappears,

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -459,7 +459,7 @@ func testAccCheckAWSSpotInstanceRequestAttributesVPC(
 	}
 }
 
-func TestAccAWSSpotInstanceRequestInterruptStop(t *testing.T) {
+func TestAccAWSSpotInstanceRequest_InterruptStop(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -484,7 +484,7 @@ func TestAccAWSSpotInstanceRequestInterruptStop(t *testing.T) {
 	})
 }
 
-func TestAccAWSSpotInstanceRequestInterruptHibernate(t *testing.T) {
+func TestAccAWSSpotInstanceRequest_InterruptHibernate(t *testing.T) {
 	var sir ec2.SpotInstanceRequest
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
@@ -68,7 +68,7 @@ func TestParseStorageGatewayVolumeGatewayARNAndTargetNameFromARN(t *testing.T) {
 	}
 }
 
-func TestAccAWSStorageGatewayCachedIscsiVolume_Basic(t *testing.T) {
+func TestAccAWSStorageGatewayCachedIscsiVolume_basic(t *testing.T) {
 	var cachedIscsiVolume storagegateway.CachediSCSIVolume
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_storagegateway_cached_iscsi_volume.test"

--- a/aws/resource_aws_storagegateway_upload_buffer_test.go
+++ b/aws/resource_aws_storagegateway_upload_buffer_test.go
@@ -67,7 +67,7 @@ func TestDecodeStorageGatewayUploadBufferID(t *testing.T) {
 	}
 }
 
-func TestAccAWSStorageGatewayUploadBuffer_Basic(t *testing.T) {
+func TestAccAWSStorageGatewayUploadBuffer_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_storagegateway_upload_buffer.test"
 	localDiskDataSourceName := "data.aws_storagegateway_local_disk.test"

--- a/aws/resource_aws_storagegateway_working_storage_test.go
+++ b/aws/resource_aws_storagegateway_working_storage_test.go
@@ -67,7 +67,7 @@ func TestDecodeStorageGatewayWorkingStorageID(t *testing.T) {
 	}
 }
 
-func TestAccAWSStorageGatewayWorkingStorage_Basic(t *testing.T) {
+func TestAccAWSStorageGatewayWorkingStorage_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_storagegateway_working_storage.test"
 	localDiskDataSourceName := "data.aws_storagegateway_local_disk.test"

--- a/aws/resource_aws_waf_regex_match_set_test.go
+++ b/aws/resource_aws_waf_regex_match_set_test.go
@@ -78,7 +78,7 @@ func testSweepWafRegexMatchSet(region string) error {
 
 // Serialized acceptance tests due to WAF account limits
 // https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
-func TestAccAWSWafRegexMatchSet(t *testing.T) {
+func TestAccAWSWafRegexMatchSet_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"basic":          testAccAWSWafRegexMatchSet_basic,
 		"changePatterns": testAccAWSWafRegexMatchSet_changePatterns,

--- a/aws/resource_aws_waf_regex_pattern_set_test.go
+++ b/aws/resource_aws_waf_regex_pattern_set_test.go
@@ -15,7 +15,7 @@ import (
 
 // Serialized acceptance tests due to WAF account limits
 // https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
-func TestAccAWSWafRegexPatternSet(t *testing.T) {
+func TestAccAWSWafRegexPatternSet_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"basic":          testAccAWSWafRegexPatternSet_basic,
 		"changePatterns": testAccAWSWafRegexPatternSet_changePatterns,

--- a/aws/resource_aws_wafregional_regex_match_set_test.go
+++ b/aws/resource_aws_wafregional_regex_match_set_test.go
@@ -78,7 +78,7 @@ func testSweepWafRegionalRegexMatchSet(region string) error {
 
 // Serialized acceptance tests due to WAF account limits
 // https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
-func TestAccAWSWafRegionalRegexMatchSet(t *testing.T) {
+func TestAccAWSWafRegionalRegexMatchSet_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"basic":          testAccAWSWafRegionalRegexMatchSet_basic,
 		"changePatterns": testAccAWSWafRegionalRegexMatchSet_changePatterns,

--- a/aws/resource_aws_wafregional_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafregional_regex_pattern_set_test.go
@@ -15,7 +15,7 @@ import (
 
 // Serialized acceptance tests due to WAF account limits
 // https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
-func TestAccAWSWafRegionalRegexPatternSet(t *testing.T) {
+func TestAccAWSWafRegionalRegexPatternSet_serial(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"basic":          testAccAWSWafRegionalRegexPatternSet_basic,
 		"changePatterns": testAccAWSWafRegionalRegexPatternSet_changePatterns,

--- a/aws/resource_aws_wafv2_ip_set_test.go
+++ b/aws/resource_aws_wafv2_ip_set_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
-func TestAccAwsWafv2IPSet_Basic(t *testing.T) {
+func TestAccAwsWafv2IPSet_basic(t *testing.T) {
 	var v wafv2.IPSet
 	ipSetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
 	resourceName := "aws_wafv2_ip_set.ip_set"

--- a/aws/resource_aws_wafv2_regex_pattern_set_test.go
+++ b/aws/resource_aws_wafv2_regex_pattern_set_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
-func TestAccAwsWafv2RegexPatternSet_Basic(t *testing.T) {
+func TestAccAwsWafv2RegexPatternSet_basic(t *testing.T) {
 	var v wafv2.RegexPatternSet
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_regex_pattern_set.test"

--- a/aws/resource_aws_wafv2_rule_group_test.go
+++ b/aws/resource_aws_wafv2_rule_group_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
-func TestAccAwsWafv2RuleGroup_Basic(t *testing.T) {
+func TestAccAwsWafv2RuleGroup_basic(t *testing.T) {
 	var v wafv2.RuleGroup
 	ruleGroupName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_rule_group.test"

--- a/aws/resource_aws_wafv2_web_acl_association_test.go
+++ b/aws/resource_aws_wafv2_web_acl_association_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAwsWafv2WebACLAssociation_Basic(t *testing.T) {
+func TestAccAwsWafv2WebACLAssociation_basic(t *testing.T) {
 	testName := fmt.Sprintf("web-acl-association-%s", acctest.RandString(5))
 	resourceName := "aws_wafv2_web_acl_association.test"
 

--- a/aws/resource_aws_wafv2_web_acl_test.go
+++ b/aws/resource_aws_wafv2_web_acl_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAwsWafv2WebACL_Basic(t *testing.T) {
+func TestAccAwsWafv2WebACL_basic(t *testing.T) {
 	var v wafv2.WebACL
 	webACLName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_wafv2_web_acl.test"

--- a/aws/resource_aws_worklink_fleet_test.go
+++ b/aws/resource_aws_worklink_fleet_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSWorkLinkFleet_Basic(t *testing.T) {
+func TestAccAWSWorkLinkFleet_basic(t *testing.T) {
 	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
 

--- a/aws/resource_aws_worklink_website_certificate_authority_association_test.go
+++ b/aws/resource_aws_worklink_website_certificate_authority_association_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic(t *testing.T) {
+func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_basic(t *testing.T) {
 	suffix := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9950

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

<details>
<summary>

Hit some flakey errors, `You have imported the maximum number of 8000 certificates in the last year.`

```
--- PASS: TestAccAWSAccessAnalyzer_serial (43.73s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_basic (16.67s)
--- PASS: TestAccAWSAMILaunchPermission_basic (334.20s)
--- PASS: TestAccAWSAppmesh_serial (634.72s)
--- PASS: TestAccAWSCloudTrail_serial (725.83s)
--- PASS: TestAccAWSCloudWatchEventPermission_basic (23.08s)
--- PASS: TestAccAWSCodeBuildSourceCredential_basic (23.08s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_basic (16.37s)
--- PASS: TestAccAWSDlmLifecyclePolicy_basic (18.43s)
--- PASS: TestAccAWSDmsCertificate_basic (9.84s)
--- PASS: TestAccAwsDmsEndpoint_basic (20.54s)
--- PASS: TestAccAWSDmsReplicationInstance_basic (294.96s)
--- PASS: TestAccAWSDmsReplicationSubnetGroup_basic (50.75s)
--- PASS: TestAccAWSEcrDataSource_nonExistent (2.25s)
--- PASS: TestAccAWSElasticBeanstalkSolutionStackDataSource_basic (10.02s)
--- PASS: TestAccAWSKinesisStreamDataSource_basic (165.92s)
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (2.10s)
--- PASS: TestAccAWSStepFunctionsActivityDataSource_basic (21.30s)
--- PASS: TestAccDataSourceAwsAcmpcaCertificateAuthority_basic (22.72s)
--- PASS: TestAccDataSourceAwsApiGatewayApiKey_basic (11.09s)
--- PASS: TestAccDataSourceAwsApiGatewayResource_basic (17.07s)
--- PASS: TestAccDataSourceAwsApiGatewayVpcLink_basic (688.65s)
--- PASS: TestAccDataSourceAwsBatchComputeEnvironment_basic (59.67s)
--- PASS: TestAccDataSourceAwsBatchJobQueue_basic (92.09s)
--- PASS: TestAccDataSourceAwsDxGateway_basic (34.22s)
--- PASS: TestAccDataSourceAwsEbsVolumes_basic (37.86s)
--- PASS: TestAccDataSourceAwsEfsMountTargetByMountTargetId_basic (144.42s)
--- PASS: TestAccDataSourceAWSLB_BackwardsCompatibility (194.88s)
--- PASS: TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility (186.24s)
--- PASS: TestAccDataSourceAwsNatGateway_basic (235.62s)
--- PASS: TestAccDataSourceAwsQLDBLedger_basic (48.20s)
--- PASS: TestAccDataSourceAwsRamResourceShare_basic (15.21s)
--- PASS: TestAccDataSourceAwsRegions_basic (9.66s)
--- PASS: TestAccDataSourceAwsRouteTables_basic (46.12s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_basic (4.29s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecretRotation_basic (48.54s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecretVersion_basic (15.98s)
--- PASS: TestAccDataSourceAwsSfnStateMachine_basic (30.52s)
--- PASS: TestAccDataSourceAwsSnsTopic_basic (12.49s)
--- PASS: TestAccDataSourceAwsSubnetIDs_basic (39.91s)
--- PASS: TestAccDataSourceAwsWafIPSet_basic (11.26s)
--- PASS: TestAccDataSourceAwsWafRateBasedRule_basic (12.50s)
--- PASS: TestAccDataSourceAwsWafRegionalIPSet_basic (15.33s)
--- PASS: TestAccDataSourceAwsWafRegionalRateBasedRule_basic (17.84s)
--- PASS: TestAccDataSourceAwsWafRegionalRule_basic (16.55s)
--- PASS: TestAccDataSourceAwsWafRegionalWebAcl_basic (19.36s)
--- PASS: TestAccDataSourceAwsWafRule_basic (11.35s)
--- PASS: TestAccDataSourceAwsWafv2IPSet_basic (16.24s)
--- PASS: TestAccDataSourceAwsWafv2RegexPatternSet_basic (16.71s)
--- PASS: TestAccDataSourceAwsWafv2RuleGroup_basic (25.10s)
--- PASS: TestAccDataSourceAwsWafv2WebACL_basic (229.72s)
--- PASS: TestAccDataSourceAwsWafWebAcl_basic (11.69s)
--- SKIP: TestAccAWSCodePipeline_WithNamespace (0.00s)
```

</summary>

```


TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsAcmpcaCertificateAuthority_basic -timeout 120m
=== RUN   TestAccDataSourceAwsAcmpcaCertificateAuthority_basic
=== PAUSE TestAccDataSourceAwsAcmpcaCertificateAuthority_basic
=== CONT  TestAccDataSourceAwsAcmpcaCertificateAuthority_basic
--- PASS: TestAccDataSourceAwsAcmpcaCertificateAuthority_basic (22.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	22.764s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsApiGatewayApiKey_basic -timeout 120m
=== RUN   TestAccDataSourceAwsApiGatewayApiKey_basic
=== PAUSE TestAccDataSourceAwsApiGatewayApiKey_basic
=== CONT  TestAccDataSourceAwsApiGatewayApiKey_basic
--- PASS: TestAccDataSourceAwsApiGatewayApiKey_basic (11.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.135s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsApiGatewayResource_basic -timeout 120m
=== RUN   TestAccDataSourceAwsApiGatewayResource_basic
=== PAUSE TestAccDataSourceAwsApiGatewayResource_basic
=== CONT  TestAccDataSourceAwsApiGatewayResource_basic
--- PASS: TestAccDataSourceAwsApiGatewayResource_basic (17.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	17.127s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsApiGatewayVpcLink_basic -timeout 120m
=== RUN   TestAccDataSourceAwsApiGatewayVpcLink_basic
=== PAUSE TestAccDataSourceAwsApiGatewayVpcLink_basic
=== CONT  TestAccDataSourceAwsApiGatewayVpcLink_basic
--- PASS: TestAccDataSourceAwsApiGatewayVpcLink_basic (688.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	688.704s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsBatchComputeEnvironment_basic -timeout 120m
=== RUN   TestAccDataSourceAwsBatchComputeEnvironment_basic
=== PAUSE TestAccDataSourceAwsBatchComputeEnvironment_basic
=== CONT  TestAccDataSourceAwsBatchComputeEnvironment_basic
--- PASS: TestAccDataSourceAwsBatchComputeEnvironment_basic (59.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.719s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsBatchJobQueue_basic -timeout 120m
=== RUN   TestAccDataSourceAwsBatchJobQueue_basic
=== PAUSE TestAccDataSourceAwsBatchJobQueue_basic
=== CONT  TestAccDataSourceAwsBatchJobQueue_basic
--- PASS: TestAccDataSourceAwsBatchJobQueue_basic (92.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	92.141s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsDxGateway_basic -timeout 120m
=== RUN   TestAccDataSourceAwsDxGateway_basic
=== PAUSE TestAccDataSourceAwsDxGateway_basic
=== CONT  TestAccDataSourceAwsDxGateway_basic
--- PASS: TestAccDataSourceAwsDxGateway_basic (34.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.270s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsEbsVolumes_basic -timeout 120m
=== RUN   TestAccDataSourceAwsEbsVolumes_basic
=== PAUSE TestAccDataSourceAwsEbsVolumes_basic
=== CONT  TestAccDataSourceAwsEbsVolumes_basic
--- PASS: TestAccDataSourceAwsEbsVolumes_basic (37.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.914s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEcrDataSource_nonExistent -timeout 120m
=== RUN   TestAccAWSEcrDataSource_nonExistent
=== PAUSE TestAccAWSEcrDataSource_nonExistent
=== CONT  TestAccAWSEcrDataSource_nonExistent
--- PASS: TestAccAWSEcrDataSource_nonExistent (2.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.290s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsEfsMountTargetByMountTargetId_basic -timeout 120m
=== RUN   TestAccDataSourceAwsEfsMountTargetByMountTargetId_basic
=== PAUSE TestAccDataSourceAwsEfsMountTargetByMountTargetId_basic
=== CONT  TestAccDataSourceAwsEfsMountTargetByMountTargetId_basic
--- PASS: TestAccDataSourceAwsEfsMountTargetByMountTargetId_basic (144.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	144.471s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSElasticBeanstalkSolutionStackDataSource_basic -timeout 120m
=== RUN   TestAccAWSElasticBeanstalkSolutionStackDataSource_basic
=== PAUSE TestAccAWSElasticBeanstalkSolutionStackDataSource_basic
=== CONT  TestAccAWSElasticBeanstalkSolutionStackDataSource_basic
--- PASS: TestAccAWSElasticBeanstalkSolutionStackDataSource_basic (10.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.076s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSKinesisStreamDataSource_basic -timeout 120m
=== RUN   TestAccAWSKinesisStreamDataSource_basic
=== PAUSE TestAccAWSKinesisStreamDataSource_basic
=== CONT  TestAccAWSKinesisStreamDataSource_basic
--- PASS: TestAccAWSKinesisStreamDataSource_basic (165.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	165.966s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource_NonExistent -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_NonExistent
=== PAUSE TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_NonExistent
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (2.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.146s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility -timeout 120m
=== RUN   TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
=== PAUSE TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
=== CONT  TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility (186.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	186.285s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSLB_BackwardsCompatibility -timeout 120m
=== RUN   TestAccDataSourceAWSLB_BackwardsCompatibility
=== PAUSE TestAccDataSourceAWSLB_BackwardsCompatibility
=== CONT  TestAccDataSourceAWSLB_BackwardsCompatibility
--- PASS: TestAccDataSourceAWSLB_BackwardsCompatibility (194.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	194.935s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsNatGateway_basic -timeout 120m
=== RUN   TestAccDataSourceAwsNatGateway_basic
=== PAUSE TestAccDataSourceAwsNatGateway_basic
=== CONT  TestAccDataSourceAwsNatGateway_basic
--- PASS: TestAccDataSourceAwsNatGateway_basic (235.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	235.667s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsQLDBLedger_basic -timeout 120m
=== RUN   TestAccDataSourceAwsQLDBLedger_basic
=== PAUSE TestAccDataSourceAwsQLDBLedger_basic
=== CONT  TestAccDataSourceAwsQLDBLedger_basic
--- PASS: TestAccDataSourceAwsQLDBLedger_basic (48.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.258s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRamResourceShare_basic -timeout 120m
=== RUN   TestAccDataSourceAwsRamResourceShare_basic
=== PAUSE TestAccDataSourceAwsRamResourceShare_basic
=== CONT  TestAccDataSourceAwsRamResourceShare_basic
--- PASS: TestAccDataSourceAwsRamResourceShare_basic (15.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	15.256s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRegions_basic -timeout 120m
=== RUN   TestAccDataSourceAwsRegions_basic
=== PAUSE TestAccDataSourceAwsRegions_basic
=== CONT  TestAccDataSourceAwsRegions_basic
--- PASS: TestAccDataSourceAwsRegions_basic (9.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	9.712s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRouteTables_basic -timeout 120m
=== RUN   TestAccDataSourceAwsRouteTables_basic
=== PAUSE TestAccDataSourceAwsRouteTables_basic
=== CONT  TestAccDataSourceAwsRouteTables_basic
--- PASS: TestAccDataSourceAwsRouteTables_basic (46.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.168s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSecretsManagerSecretRotation_basic -timeout 120m
=== RUN   TestAccDataSourceAwsSecretsManagerSecretRotation_basic
=== PAUSE TestAccDataSourceAwsSecretsManagerSecretRotation_basic
=== CONT  TestAccDataSourceAwsSecretsManagerSecretRotation_basic
--- PASS: TestAccDataSourceAwsSecretsManagerSecretRotation_basic (48.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.591s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSecretsManagerSecret_basic -timeout 120m
=== RUN   TestAccDataSourceAwsSecretsManagerSecret_basic
=== PAUSE TestAccDataSourceAwsSecretsManagerSecret_basic
=== CONT  TestAccDataSourceAwsSecretsManagerSecret_basic
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_basic (4.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.348s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSecretsManagerSecretVersion_basic -timeout 120m
=== RUN   TestAccDataSourceAwsSecretsManagerSecretVersion_basic
=== PAUSE TestAccDataSourceAwsSecretsManagerSecretVersion_basic
=== CONT  TestAccDataSourceAwsSecretsManagerSecretVersion_basic
--- PASS: TestAccDataSourceAwsSecretsManagerSecretVersion_basic (15.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.027s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSStepFunctionsActivityDataSource_basic -timeout 120m
=== RUN   TestAccAWSStepFunctionsActivityDataSource_basic
=== PAUSE TestAccAWSStepFunctionsActivityDataSource_basic
=== CONT  TestAccAWSStepFunctionsActivityDataSource_basic
--- PASS: TestAccAWSStepFunctionsActivityDataSource_basic (21.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	21.349s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSfnStateMachine_basic -timeout 120m
=== RUN   TestAccDataSourceAwsSfnStateMachine_basic
=== PAUSE TestAccDataSourceAwsSfnStateMachine_basic
=== CONT  TestAccDataSourceAwsSfnStateMachine_basic
--- PASS: TestAccDataSourceAwsSfnStateMachine_basic (30.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	30.564s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSnsTopic_basic -timeout 120m
=== RUN   TestAccDataSourceAwsSnsTopic_basic
=== PAUSE TestAccDataSourceAwsSnsTopic_basic
=== CONT  TestAccDataSourceAwsSnsTopic_basic
--- PASS: TestAccDataSourceAwsSnsTopic_basic (12.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.538s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSubnetIDs_basic -timeout 120m
=== RUN   TestAccDataSourceAwsSubnetIDs_basic
=== PAUSE TestAccDataSourceAwsSubnetIDs_basic
=== CONT  TestAccDataSourceAwsSubnetIDs_basic
--- PASS: TestAccDataSourceAwsSubnetIDs_basic (39.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.957s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafIPSet_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafIPSet_basic
=== PAUSE TestAccDataSourceAwsWafIPSet_basic
=== CONT  TestAccDataSourceAwsWafIPSet_basic
--- PASS: TestAccDataSourceAwsWafIPSet_basic (11.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.303s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafRateBasedRule_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafRateBasedRule_basic
=== PAUSE TestAccDataSourceAwsWafRateBasedRule_basic
=== CONT  TestAccDataSourceAwsWafRateBasedRule_basic
--- PASS: TestAccDataSourceAwsWafRateBasedRule_basic (12.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.548s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafRule_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafRule_basic
=== PAUSE TestAccDataSourceAwsWafRule_basic
=== CONT  TestAccDataSourceAwsWafRule_basic
--- PASS: TestAccDataSourceAwsWafRule_basic (11.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.398s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafWebAcl_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafWebAcl_basic
=== PAUSE TestAccDataSourceAwsWafWebAcl_basic
=== CONT  TestAccDataSourceAwsWafWebAcl_basic
--- PASS: TestAccDataSourceAwsWafWebAcl_basic (11.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.746s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafRegionalIPSet_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafRegionalIPSet_basic
=== PAUSE TestAccDataSourceAwsWafRegionalIPSet_basic
=== CONT  TestAccDataSourceAwsWafRegionalIPSet_basic
--- PASS: TestAccDataSourceAwsWafRegionalIPSet_basic (15.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	15.374s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafRegionalRateBasedRule_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafRegionalRateBasedRule_basic
=== PAUSE TestAccDataSourceAwsWafRegionalRateBasedRule_basic
=== CONT  TestAccDataSourceAwsWafRegionalRateBasedRule_basic
--- PASS: TestAccDataSourceAwsWafRegionalRateBasedRule_basic (17.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	17.883s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafRegionalRule_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafRegionalRule_basic
=== PAUSE TestAccDataSourceAwsWafRegionalRule_basic
=== CONT  TestAccDataSourceAwsWafRegionalRule_basic
--- PASS: TestAccDataSourceAwsWafRegionalRule_basic (16.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.595s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafRegionalWebAcl_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafRegionalWebAcl_basic
=== PAUSE TestAccDataSourceAwsWafRegionalWebAcl_basic
=== CONT  TestAccDataSourceAwsWafRegionalWebAcl_basic
--- PASS: TestAccDataSourceAwsWafRegionalWebAcl_basic (19.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.409s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2IPSet_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2IPSet_basic
=== PAUSE TestAccDataSourceAwsWafv2IPSet_basic
=== CONT  TestAccDataSourceAwsWafv2IPSet_basic
--- PASS: TestAccDataSourceAwsWafv2IPSet_basic (16.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.289s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2RegexPatternSet_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2RegexPatternSet_basic
=== PAUSE TestAccDataSourceAwsWafv2RegexPatternSet_basic
=== CONT  TestAccDataSourceAwsWafv2RegexPatternSet_basic
--- PASS: TestAccDataSourceAwsWafv2RegexPatternSet_basic (16.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.751s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2RuleGroup_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2RuleGroup_basic
=== PAUSE TestAccDataSourceAwsWafv2RuleGroup_basic
=== CONT  TestAccDataSourceAwsWafv2RuleGroup_basic
--- PASS: TestAccDataSourceAwsWafv2RuleGroup_basic (25.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.147s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsWafv2WebACL_basic -timeout 120m
=== RUN   TestAccDataSourceAwsWafv2WebACL_basic
=== PAUSE TestAccDataSourceAwsWafv2WebACL_basic
=== CONT  TestAccDataSourceAwsWafv2WebACL_basic
--- PASS: TestAccDataSourceAwsWafv2WebACL_basic (229.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	229.777s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAccessAnalyzer_serial -timeout 120m
=== RUN   TestAccAWSAccessAnalyzer_serial
=== RUN   TestAccAWSAccessAnalyzer_serial/Analyzer
=== RUN   TestAccAWSAccessAnalyzer_serial/Analyzer/basic
=== RUN   TestAccAWSAccessAnalyzer_serial/Analyzer/disappears
=== RUN   TestAccAWSAccessAnalyzer_serial/Analyzer/Tags
--- PASS: TestAccAWSAccessAnalyzer_serial (43.73s)
    --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer (43.73s)
        --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/basic (11.61s)
        --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/disappears (7.88s)
        --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/Tags (24.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	43.784s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAcmpcaCertificateAuthority_basic -timeout 120m
=== RUN   TestAccAwsAcmpcaCertificateAuthority_basic
=== PAUSE TestAccAwsAcmpcaCertificateAuthority_basic
=== CONT  TestAccAwsAcmpcaCertificateAuthority_basic
--- PASS: TestAccAwsAcmpcaCertificateAuthority_basic (16.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.720s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAMILaunchPermission_basic -timeout 120m
=== RUN   TestAccAWSAMILaunchPermission_basic
=== PAUSE TestAccAWSAMILaunchPermission_basic
=== CONT  TestAccAWSAMILaunchPermission_basic
--- PASS: TestAccAWSAMILaunchPermission_basic (334.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	334.247s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAppmesh_serial -timeout 120m
=== RUN   TestAccAWSAppmesh_serial
=== RUN   TestAccAWSAppmesh_serial/Mesh
=== RUN   TestAccAWSAppmesh_serial/Mesh/basic
=== RUN   TestAccAWSAppmesh_serial/Mesh/egressFilter
=== RUN   TestAccAWSAppmesh_serial/Mesh/tags
=== RUN   TestAccAWSAppmesh_serial/Route
=== RUN   TestAccAWSAppmesh_serial/Route/httpRoute
=== RUN   TestAccAWSAppmesh_serial/Route/tcpRoute
=== RUN   TestAccAWSAppmesh_serial/Route/routePriority
=== RUN   TestAccAWSAppmesh_serial/Route/tags
=== RUN   TestAccAWSAppmesh_serial/Route/httpHeader
=== RUN   TestAccAWSAppmesh_serial/VirtualNode
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/listenerHealthChecks
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/logging
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/tags
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/basic
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/cloudMapServiceDiscovery
=== RUN   TestAccAWSAppmesh_serial/VirtualRouter
=== RUN   TestAccAWSAppmesh_serial/VirtualRouter/tags
=== RUN   TestAccAWSAppmesh_serial/VirtualRouter/basic
=== RUN   TestAccAWSAppmesh_serial/VirtualService
=== RUN   TestAccAWSAppmesh_serial/VirtualService/virtualRouter
=== RUN   TestAccAWSAppmesh_serial/VirtualService/tags
=== RUN   TestAccAWSAppmesh_serial/VirtualService/virtualNode
--- PASS: TestAccAWSAppmesh_serial (634.72s)
    --- PASS: TestAccAWSAppmesh_serial/Mesh (68.39s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/basic (12.67s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/egressFilter (26.10s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/tags (29.62s)
    --- PASS: TestAccAWSAppmesh_serial/Route (199.55s)
        --- PASS: TestAccAWSAppmesh_serial/Route/httpRoute (45.87s)
        --- PASS: TestAccAWSAppmesh_serial/Route/tcpRoute (42.92s)
        --- PASS: TestAccAWSAppmesh_serial/Route/routePriority (32.51s)
        --- PASS: TestAccAWSAppmesh_serial/Route/tags (47.56s)
        --- PASS: TestAccAWSAppmesh_serial/Route/httpHeader (30.70s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualNode (203.68s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/listenerHealthChecks (25.54s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/logging (25.26s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/tags (37.57s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/basic (16.77s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/cloudMapServiceDiscovery (98.54s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualRouter (61.20s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualRouter/tags (36.36s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualRouter/basic (24.84s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualService (101.89s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/virtualRouter (29.57s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/tags (42.67s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/virtualNode (29.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	634.776s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudTrail_serial -timeout 120m
=== RUN   TestAccAWSCloudTrail_serial
=== RUN   TestAccAWSCloudTrail_serial/Trail
=== RUN   TestAccAWSCloudTrail_serial/Trail/basic
=== RUN   TestAccAWSCloudTrail_serial/Trail/isOrganization
    TestAccAWSCloudTrail_serial/Trail/isOrganization: provider_test.go:532: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccAWSCloudTrail_serial/Trail/logValidation
=== RUN   TestAccAWSCloudTrail_serial/Trail/kmsKey
=== RUN   TestAccAWSCloudTrail_serial/Trail/eventSelector
=== RUN   TestAccAWSCloudTrail_serial/Trail/cloudwatch
=== RUN   TestAccAWSCloudTrail_serial/Trail/enableLogging
=== RUN   TestAccAWSCloudTrail_serial/Trail/includeGlobalServiceEvents
=== RUN   TestAccAWSCloudTrail_serial/Trail/isMultiRegion
=== RUN   TestAccAWSCloudTrail_serial/Trail/tags
--- PASS: TestAccAWSCloudTrail_serial (725.83s)
    --- PASS: TestAccAWSCloudTrail_serial/Trail (725.83s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/basic (65.97s)
        --- SKIP: TestAccAWSCloudTrail_serial/Trail/isOrganization (1.82s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/logValidation (67.50s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/kmsKey (42.18s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/eventSelector (141.62s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/cloudwatch (80.59s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/enableLogging (92.46s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/includeGlobalServiceEvents (42.74s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/isMultiRegion (93.81s)
        --- PASS: TestAccAWSCloudTrail_serial/Trail/tags (97.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	725.881s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventPermission_basic -timeout 120m
=== RUN   TestAccAWSCloudWatchEventPermission_basic
=== PAUSE TestAccAWSCloudWatchEventPermission_basic
=== CONT  TestAccAWSCloudWatchEventPermission_basic
--- PASS: TestAccAWSCloudWatchEventPermission_basic (23.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	23.132s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeBuildSourceCredential_basic -timeout 120m
=== RUN   TestAccAWSCodeBuildSourceCredential_basic
=== PAUSE TestAccAWSCodeBuildSourceCredential_basic
=== CONT  TestAccAWSCodeBuildSourceCredential_basic
--- PASS: TestAccAWSCodeBuildSourceCredential_basic (23.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	23.129s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodePipeline_WithNamespace -timeout 120m
=== RUN   TestAccAWSCodePipeline_WithNamespace
    TestAccAWSCodePipeline_WithNamespace: resource_aws_codepipeline_test.go:392: Environment variable GITHUB_TOKEN is not set
--- SKIP: TestAccAWSCodePipeline_WithNamespace (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.049s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCodeStarNotificationsNotificationRule_basic -timeout 120m
=== RUN   TestAccAWSCodeStarNotificationsNotificationRule_basic
=== PAUSE TestAccAWSCodeStarNotificationsNotificationRule_basic
=== CONT  TestAccAWSCodeStarNotificationsNotificationRule_basic
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_basic (16.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.426s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDlmLifecyclePolicy_basic -timeout 120m
=== RUN   TestAccAWSDlmLifecyclePolicy_basic
=== PAUSE TestAccAWSDlmLifecyclePolicy_basic
=== CONT  TestAccAWSDlmLifecyclePolicy_basic
--- PASS: TestAccAWSDlmLifecyclePolicy_basic (18.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.488s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDmsCertificate_basic -timeout 120m
=== RUN   TestAccAWSDmsCertificate_basic
=== PAUSE TestAccAWSDmsCertificate_basic
=== CONT  TestAccAWSDmsCertificate_basic
--- PASS: TestAccAWSDmsCertificate_basic (9.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	9.887s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsDmsEndpoint_basic -timeout 120m
=== RUN   TestAccAwsDmsEndpoint_basic
=== PAUSE TestAccAwsDmsEndpoint_basic
=== CONT  TestAccAwsDmsEndpoint_basic
--- PASS: TestAccAwsDmsEndpoint_basic (20.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	20.588s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDmsReplicationInstance_basic -timeout 120m
=== RUN   TestAccAWSDmsReplicationInstance_basic
=== PAUSE TestAccAWSDmsReplicationInstance_basic
=== CONT  TestAccAWSDmsReplicationInstance_basic
--- PASS: TestAccAWSDmsReplicationInstance_basic (294.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	295.016s

TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDmsReplicationSubnetGroup_basic -timeout 120m
=== RUN   TestAccAWSDmsReplicationSubnetGroup_basic
=== PAUSE TestAccAWSDmsReplicationSubnetGroup_basic
=== CONT  TestAccAWSDmsReplicationSubnetGroup_basic
--- PASS: TestAccAWSDmsReplicationSubnetGroup_basic (50.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	50.806s

```

</details>
