### PR TITLE
resource/s3_bucket_metric: add atleastoneof property to filter attributes

### DIFF
--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -36,10 +36,16 @@ func resourceAwsS3BucketMetric() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"prefix": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							AtLeastOneOf: filterAtLeastOneOfKeys,
 						},
-						"tags": tagsSchema(),
+						"tags": {
+							Type:         schema.TypeMap,
+							Optional:     true,
+							Elem:         &schema.Schema{Type: schema.TypeString},
+							AtLeastOneOf: filterAtLeastOneOfKeys,
+						},
 					},
 				},
 			},

--- a/aws/resource_aws_s3_bucket_metric_test.go
+++ b/aws/resource_aws_s3_bucket_metric_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"regexp"
 	"sort"
 	"testing"
 	"time"
@@ -292,6 +293,8 @@ func TestAccAWSS3BucketMetric_basic(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11813
+// Disallow Empty filter block
 func TestAccAWSS3BucketMetric_WithEmptyFilter(t *testing.T) {
 	var conf s3.MetricsConfiguration
 	rInt := acctest.RandInt()
@@ -310,6 +313,7 @@ func TestAccAWSS3BucketMetric_WithEmptyFilter(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketMetricsConfigExists(resourceName, &conf),
 				),
+				ExpectError: regexp.MustCompile(`config is invalid`),
 			},
 		},
 	})

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -32,6 +32,7 @@ Upgrade topics:
 - [Resource: aws_lb_listener_rule](#resource-aws_lb_listener_rule)
 - [Resource: aws_msk_cluster](#resource-aws_msk_cluster)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
+- [Resource: aws_s3_bucket_metric](#resource-aws_s3_bucket_metric)
 - [Resource: aws_security_group](#resource-aws_security_group)
 - [Resource: aws_sns_platform_application](#resource-aws_sns_platform_application)
 - [Resource: aws_spot_fleet_request](#resource-aws_spot_fleet_request)
@@ -499,6 +500,30 @@ An updated configuration:
 
 ```hcl
 resource "aws_s3_bucket" "example" {
+  # ... other configuration ...
+}
+```
+
+## Resource: aws_s3_bucket_metric
+
+### filter configuration block Plan-Time Validation Change
+
+The `filter` configuration block no longer supports the empty block `{}` and requires at least one of the `prefix` or `tags` attributes to be specified.   
+
+For example, given this previous configuration:
+
+```hcl
+resource "aws_s3_bucket_metric" "example" {
+  # ... other configuration ...
+
+  filter {}
+}
+```
+
+An updated configuration:
+
+```hcl
+resource "aws_s3_bucket_metric" "example" {
   # ... other configuration ...
 }
 ```

--- a/website/docs/r/s3_bucket_metric.html.markdown
+++ b/website/docs/r/s3_bucket_metric.html.markdown
@@ -57,6 +57,8 @@ The following arguments are supported:
 
 The `filter` metric configuration supports the following:
 
+~> **NOTE**: At least one of `prefix` or `tags` is required when specifying a `filter`
+
 * `prefix` - (Optional) Object prefix for filtering (singular).
 * `tags` - (Optional) Object tags for filtering (up to 10).
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11813 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/s3_bucket_metric: add atleastoneof property to filter attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (1.50s)
--- PASS: TestAccAWSS3BucketMetric_basic (30.31s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (46.73s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (46.93s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (47.32s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (47.36s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (47.71s)
```
