### PR TITLE
Remove hardcoded AMI from eip association

### DIFF
--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -22,7 +22,7 @@ func TestAccAWSEIPAssociation_instance(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEIPAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEIPAssociationConfig_instance,
+				Config: testAccAWSEIPAssociationConfig_instance(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEIPExists(
 						"aws_eip.test", &a),
@@ -464,10 +464,10 @@ resource "aws_eip_association" "test" {
 `, testAccAWSSpotInstanceRequestConfig(rInt))
 }
 
-const testAccAWSEIPAssociationConfig_instance = `
+func testAccAWSEIPAssociationConfig_instance() string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_instance" "test" {
-  # us-west-2
-  ami = "ami-4fccb37f"
+  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "m1.small"
 }
 
@@ -477,7 +477,8 @@ resource "aws_eip_association" "test" {
   allocation_id = "${aws_eip.test.id}"
   instance_id = "${aws_instance.test.id}"
 }
-`
+`)
+}
 
 const testAccAWSEIPAssociationConfig_networkInterface = `
 resource "aws_vpc" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from GovCloud acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% testacc TestAccAWSEIPAssociation_instance
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEIPAssociation_instance -timeout 120m
=== RUN   TestAccAWSEIPAssociation_instance
=== PAUSE TestAccAWSEIPAssociation_instance
=== CONT  TestAccAWSEIPAssociation_instance
--- PASS: TestAccAWSEIPAssociation_instance (106.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	106.177s
```

Output from standard partition acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
% testacc TestAccAWSEIPAssociation_instance
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEIPAssociation_instance -timeout 120m
=== RUN   TestAccAWSEIPAssociation_instance
=== PAUSE TestAccAWSEIPAssociation_instance
=== CONT  TestAccAWSEIPAssociation_instance
--- PASS: TestAccAWSEIPAssociation_instance (122.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	122.619s
```