### PR TITLE
Removed hardcoded AMIs and AZs

### DIFF
--- a/aws/resource_aws_elb_attachment_test.go
+++ b/aws/resource_aws_elb_attachment_test.go
@@ -29,7 +29,7 @@ func TestAccAWSELBAttachment_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSELBAttachmentConfig1,
+				Config: testAccAWSELBAttachmentConfig1(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
 					testCheckInstanceAttached(1),
@@ -37,7 +37,7 @@ func TestAccAWSELBAttachment_basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccAWSELBAttachmentConfig2,
+				Config: testAccAWSELBAttachmentConfig2(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
 					testCheckInstanceAttached(2),
@@ -45,7 +45,7 @@ func TestAccAWSELBAttachment_basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccAWSELBAttachmentConfig3,
+				Config: testAccAWSELBAttachmentConfig3(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
 					testCheckInstanceAttached(2),
@@ -53,7 +53,7 @@ func TestAccAWSELBAttachment_basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccAWSELBAttachmentConfig4,
+				Config: testAccAWSELBAttachmentConfig4(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
 					testCheckInstanceAttached(0),
@@ -100,7 +100,7 @@ func TestAccAWSELBAttachment_drift(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSELBAttachmentConfig1,
+				Config: testAccAWSELBAttachmentConfig1(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
 					testCheckInstanceAttached(1),
@@ -109,7 +109,7 @@ func TestAccAWSELBAttachment_drift(t *testing.T) {
 
 			// remove an instance from the ELB, and make sure it gets re-added
 			{
-				Config:    testAccAWSELBAttachmentConfig1,
+				Config:    testAccAWSELBAttachmentConfig1(),
 				PreConfig: deregInstance,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSELBExists("aws_elb.bar", &conf),
@@ -121,9 +121,23 @@ func TestAccAWSELBAttachment_drift(t *testing.T) {
 }
 
 // add one attachment
-const testAccAWSELBAttachmentConfig1 = `
+func testAccAWSELBAttachmentConfig1() string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
 
   listener {
     instance_port     = 8000
@@ -134,8 +148,7 @@ resource "aws_elb" "bar" {
 }
 
 resource "aws_instance" "foo1" {
-  # us-west-2
-  ami           = "ami-043a5034"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
@@ -143,12 +156,27 @@ resource "aws_elb_attachment" "foo1" {
   elb      = "${aws_elb.bar.id}"
   instance = "${aws_instance.foo1.id}"
 }
-`
+`)
+}
 
 // add a second attachment
-const testAccAWSELBAttachmentConfig2 = `
+func testAccAWSELBAttachmentConfig2() string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
 
   listener {
     instance_port     = 8000
@@ -159,14 +187,12 @@ resource "aws_elb" "bar" {
 }
 
 resource "aws_instance" "foo1" {
-  # us-west-2
-  ami           = "ami-043a5034"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
 resource "aws_instance" "foo2" {
-  # us-west-2
-  ami           = "ami-043a5034"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
@@ -179,12 +205,27 @@ resource "aws_elb_attachment" "foo2" {
   elb      = "${aws_elb.bar.id}"
   instance = "${aws_instance.foo2.id}"
 }
-`
+`)
+}
 
 // swap attachments between resources
-const testAccAWSELBAttachmentConfig3 = `
+func testAccAWSELBAttachmentConfig3() string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
 
   listener {
     instance_port     = 8000
@@ -195,14 +236,12 @@ resource "aws_elb" "bar" {
 }
 
 resource "aws_instance" "foo1" {
-  # us-west-2
-  ami           = "ami-043a5034"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
 resource "aws_instance" "foo2" {
-  # us-west-2
-  ami           = "ami-043a5034"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
@@ -215,12 +254,27 @@ resource "aws_elb_attachment" "foo2" {
   elb      = "${aws_elb.bar.id}"
   instance = "${aws_instance.foo1.id}"
 }
-`
+`)
+}
 
 // destroy attachments
-const testAccAWSELBAttachmentConfig4 = `
+func testAccAWSELBAttachmentConfig4() string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_elb" "bar" {
-  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
 
   listener {
     instance_port     = 8000
@@ -229,4 +283,5 @@ resource "aws_elb" "bar" {
     lb_protocol       = "http"
   }
 }
-`
+`)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from GovCloud partition acceptance testing:

```
% testacc TestAccAWSELBAttachment_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSELBAttachment_ -timeout 120m
=== RUN   TestAccAWSELBAttachment_basic
=== PAUSE TestAccAWSELBAttachment_basic
=== RUN   TestAccAWSELBAttachment_drift
=== PAUSE TestAccAWSELBAttachment_drift
=== CONT  TestAccAWSELBAttachment_basic
=== CONT  TestAccAWSELBAttachment_drift
--- PASS: TestAccAWSELBAttachment_drift (104.01s)
--- PASS: TestAccAWSELBAttachment_basic (161.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	161.099s
```

The output from start partition acceptance testing:

```
% testacc TestAccAWSELBAttachment_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSELBAttachment_ -timeout 120m
=== RUN   TestAccAWSELBAttachment_basic
=== PAUSE TestAccAWSELBAttachment_basic
=== RUN   TestAccAWSELBAttachment_drift
=== PAUSE TestAccAWSELBAttachment_drift
=== CONT  TestAccAWSELBAttachment_basic
=== CONT  TestAccAWSELBAttachment_drift
--- PASS: TestAccAWSELBAttachment_drift (93.49s)
--- PASS: TestAccAWSELBAttachment_basic (173.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	173.074s
```