### PR TITLE
provider: Remove deprecated kinesis_analytics and r53 custom endpoint arguments

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -589,14 +589,6 @@ func (c *Config) Client() (interface{}, error) {
 	s3Config.DisableRestProtocolURICleaning = aws.Bool(true)
 	client.s3connUriCleaningDisabled = s3.New(sess.Copy(s3Config))
 
-	// Handle deprecated endpoint configurations
-	if c.Endpoints["kinesis_analytics"] != "" {
-		client.kinesisanalyticsconn = kinesisanalytics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["kinesis_analytics"])}))
-	}
-	if c.Endpoints["r53"] != "" {
-		route53Config.Endpoint = aws.String(c.Endpoints["r53"])
-	}
-
 	// Force "global" services to correct regions
 	switch partition {
 	case endpoints.AwsPartitionID:

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1095,7 +1095,6 @@ func init() {
 		"iotanalytics",
 		"iotevents",
 		"kafka",
-		"kinesis_analytics",
 		"kinesis",
 		"kinesisanalytics",
 		"kinesisanalyticsv2",
@@ -1126,7 +1125,6 @@ func init() {
 		"pricing",
 		"qldb",
 		"quicksight",
-		"r53",
 		"ram",
 		"rds",
 		"redshift",
@@ -1344,10 +1342,6 @@ func endpointsSchema() *schema.Schema {
 			Description: descriptions["endpoint"],
 		}
 	}
-
-	// Since the endpoints attribute is a TypeSet we cannot use ConflictsWith
-	endpointsAttributes["kinesis_analytics"].Deprecated = "use `endpoints` configuration block `kinesisanalytics` argument instead"
-	endpointsAttributes["r53"].Deprecated = "use `endpoints` configuration block `route53` argument instead"
 
 	return &schema.Schema{
 		Type:     schema.TypeSet,

--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -128,7 +128,6 @@ The Terraform AWS Provider allows the following endpoints to be customized:
   <li><code>iotanalytics</code></li>
   <li><code>iotevents</code></li>
   <li><code>kafka</code></li>
-  <li><code>kinesis_analytics</code> (<b>DEPRECATED</b> Use <code>kinesisanalytics</code> instead)</li>
   <li><code>kinesis</code></li>
   <li><code>kinesisanalytics</code></li>
   <li><code>kinesisanalyticsv2</code></li>
@@ -159,7 +158,6 @@ The Terraform AWS Provider allows the following endpoints to be customized:
   <li><code>pricing</code></li>
   <li><code>qldb</code></li>
   <li><code>quicksight</code></li>
-  <li><code>r53</code></li> (<b>DEPRECATED</b> Use <code>route53</code> instead)</li>
   <li><code>ram</code></li>
   <li><code>rds</code></li>
   <li><code>redshift</code></li>

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -20,6 +20,7 @@ Upgrade topics:
 
 - [Provider Version Configuration](#provider-version-configuration)
 - [Provider Authentication Updates](#provider-authentication-updates)
+- [Provider Custom Service Endpoint Updates](#provider-custom-service-endpoint-updates)
 - [Data Source: aws_availability_zones](#data-source-aws_availability_zones)
 - [Data Source: aws_lambda_invocation](#data-source-aws_lambda_invocation)
 - [Resource: aws_acm_certificate](#resource-aws_acm_certificate)
@@ -92,6 +93,42 @@ The `AWS_SDK_LOAD_CONFIG` environment variable is no longer necessary for the pr
 ### Removal of AWS_METADATA_TIMEOUT Environment Variable Usage
 
 The provider now relies on the default AWS Go SDK timeouts for interacting with the EC2 Instance Metadata Service.
+
+## Provider Custom Service Endpoint Updates
+
+### Removal of kinesis_analytics and r53 Arguments
+
+The [custom service endpoints](custom-service-endpoints.html) for Kinesis Analytics and Route 53 now use the `kinesisanalytics` and `route53` argument names in the provider configuration.
+
+For example, given this previous configuration:
+
+```hcl
+provider "aws" {
+  # ... potentially other configuration ...
+
+  endpoints {
+    # ... potentially other configuration ...
+
+    kinesis_analytics = "https://example.com"
+    r53               = "https://example.com"
+  }
+}
+```
+
+An updated configuration:
+
+```hcl
+provider "aws" {
+  # ... potentially other configuration ...
+
+  endpoints {
+    # ... potentially other configuration ...
+
+    kinesisanalytics = "https://example.com"
+    route53          = "https://example.com"
+  }
+}
+```
 
 ## Data Source: aws_availability_zones
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13398

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* provider: Remove deprecated `kinesis_analytics` and `r53` custom service endpoint arguments
```

Output from acceptance testing:

```
--- PASS: TestAccAWSProvider_Region_AwsCommercial (3.64s)
--- PASS: TestAccAWSProvider_Region_AwsChina (3.64s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (3.65s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (4.00s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (4.00s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (4.01s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (4.01s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (4.01s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (4.02s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (4.01s)
--- PASS: TestAccAWSProvider_Endpoints (4.08s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (7.80s)
```
