### PR TITLE
resource/aws_launch_configuration: Remove DescribeLaunchConfigurations retries on all errors

### DIFF
--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -503,24 +503,8 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 	}
 
 	d.SetId(lcName)
-	log.Printf("[INFO] launch configuration ID: %s", d.Id())
 
-	// We put a Retry here since sometimes eventual consistency bites
-	// us and we need to retry a few times to get the LC to load properly
-	err = resource.Retry(30*time.Second, func() *resource.RetryError {
-		err := resourceAwsLaunchConfigurationRead(d, meta)
-		if err != nil {
-			return resource.RetryableError(err)
-		}
-		return nil
-	})
-	if isResourceTimeoutError(err) {
-		err = resourceAwsLaunchConfigurationRead(d, meta)
-	}
-	if err != nil {
-		return fmt.Errorf("Error reading launch configuration: %s", err)
-	}
-	return nil
+	return resourceAwsLaunchConfigurationRead(d, meta)
 }
 
 func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform/issues/302
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13409

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Does not seem to be occurring anymore, but could require additional load to manifest. Can re-add explicit retries as necessary.

Output from acceptance testing:

```
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (11.31s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (13.17s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (13.44s)
--- PASS: TestAccAWSLaunchConfiguration_withInstanceStoreAMI (13.67s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (14.02s)
--- PASS: TestAccAWSLaunchConfiguration_basic (22.34s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (24.19s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (25.59s)
--- PASS: TestAccAWSLaunchConfiguration_userData (28.60s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_VolumeSize (28.91s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (30.96s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (32.72s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears (353.93s)
```
