### PR TITLE
resource/aws_ssm_activation: Only retry CreateActivation on IAM eventual consistency error, allow retries for standard 2 minutes

### DIFF
--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
 func resourceAwsSsmActivation() *schema.Resource {
@@ -102,13 +103,17 @@ func resourceAwsSsmActivationCreate(d *schema.ResourceData, meta interface{}) er
 
 	// Retry to allow iam_role to be created and policy attachment to take place
 	var resp *ssm.CreateActivationOutput
-	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 		var err error
 
 		resp, err = ssmconn.CreateActivation(activationInput)
 
-		if err != nil {
+		if isAWSErr(err, "ValidationException", "Not existing role") {
 			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
 		}
 
 		return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13409

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

API does not seem to validate IAM Role permissions on creation.

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMActivation_expirationDate (19.17s)
--- PASS: TestAccAWSSSMActivation_disappears (25.22s)
--- PASS: TestAccAWSSSMActivation_basic (27.39s)
--- PASS: TestAccAWSSSMActivation_update (37.23s)
```
