### PR TITLE
resource/aws_codepipeline: Only retry CreatePipeline errors for IAM eventual consistency

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
 func resourceAwsCodePipeline() *schema.Resource {
@@ -190,14 +190,19 @@ func resourceAwsCodePipelineCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	var resp *codepipeline.CreatePipelineOutput
-	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 		var err error
 
 		resp, err = conn.CreatePipeline(params)
 
-		if err != nil {
+		if isAWSErr(err, codepipeline.ErrCodeInvalidStructureException, "not authorized") {
 			return resource.RetryableError(err)
 		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
 		return nil
 	})
 	if isResourceTimeoutError(err) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13409

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCodePipeline_emptyStageArtifacts (33.11s)
--- PASS: TestAccAWSCodePipeline_WithNamespace (35.13s)
--- PASS: TestAccAWSCodePipeline_multiregion_basic (36.83s)
--- PASS: TestAccAWSCodePipeline_deployWithServiceRole (42.85s)
--- PASS: TestAccAWSCodePipeline_basic (57.83s)
--- PASS: TestAccAWSCodePipeline_multiregion_Update (61.32s)
--- PASS: TestAccAWSCodePipeline_tags (76.28s)
--- PASS: TestAccAWSCodePipeline_multiregion_ConvertSingleRegion (79.20s)
```
