### PR TITLE
resource/aws_spot_fleet_request: Only retry RequestSpotFleet on IAM eventual consistency errors, use standard 2 minute timeout

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
 func resourceAwsSpotFleetRequest() *schema.Resource {
@@ -950,19 +951,18 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	// Since IAM is eventually consistent, we retry creation as a newly created role may not
 	// take effect immediately, resulting in an InvalidSpotFleetRequestConfig error
 	var resp *ec2.RequestSpotFleetOutput
-	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 		var err error
 		resp, err = conn.RequestSpotFleet(spotFleetOpts)
 
-		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "Duplicate: Parameter combination") {
-			return resource.NonRetryableError(fmt.Errorf("Error creating Spot fleet request: %s", err))
+		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "Parameter: SpotFleetRequestConfig.IamFleetRole is invalid") {
+			return resource.RetryableError(err)
 		}
-		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "") {
-			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))
-		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
+
 		return nil
 	})
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #7740
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13409

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (251.97s)
--- PASS: TestAccAWSSpotFleetRequest_basic (314.23s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (612.33s)
--- PASS: TestAccAWSSpotFleetRequest_disappears (261.47s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (403.92s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (316.94s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (251.69s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (253.29s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (112.90s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (142.33s)
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (467.97s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (253.11s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (254.84s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (468.45s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (253.43s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (274.51s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (314.01s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (276.90s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (486.46s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (406.36s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (231.26s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (295.29s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (57.48s)
--- PASS: TestAccAWSSpotFleetRequest_tags (342.55s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (597.13s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (753.34s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (255.16s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (277.96s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (232.56s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (282.39s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (427.61s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (335.33s)
```
