### PR TITLE
resource/rds_cluster: update default value for min_capacity in scaling_configuration block

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	rdsClusterScalingConfiguration_DefaultMinCapacity = 2
+	rdsClusterScalingConfiguration_DefaultMinCapacity = 1
 	rdsClusterScalingConfiguration_DefaultMaxCapacity = 16
 )
 
@@ -452,7 +452,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			DeletionProtection:   aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:               aws.String(d.Get("engine").(string)),
 			EngineMode:           aws.String(d.Get("engine_mode").(string)),
-			ScalingConfiguration: expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string)),
+			ScalingConfiguration: expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{})),
 			SnapshotIdentifier:   aws.String(d.Get("snapshot_identifier").(string)),
 			Tags:                 tags,
 		}
@@ -548,7 +548,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			Engine:                      aws.String(d.Get("engine").(string)),
 			EngineMode:                  aws.String(d.Get("engine_mode").(string)),
 			ReplicationSourceIdentifier: aws.String(d.Get("replication_source_identifier").(string)),
-			ScalingConfiguration:        expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string)),
+			ScalingConfiguration:        expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{})),
 			Tags:                        tags,
 		}
 
@@ -767,7 +767,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			DeletionProtection:   aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:               aws.String(d.Get("engine").(string)),
 			EngineMode:           aws.String(d.Get("engine_mode").(string)),
-			ScalingConfiguration: expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string)),
+			ScalingConfiguration: expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{})),
 			Tags:                 tags,
 		}
 
@@ -1140,7 +1140,7 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("scaling_configuration") {
-		req.ScalingConfiguration = expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}), d.Get("engine_mode").(string))
+		req.ScalingConfiguration = expandRdsClusterScalingConfiguration(d.Get("scaling_configuration").([]interface{}))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -1356,6 +1356,46 @@ func TestAccAWSRDSCluster_ScalingConfiguration(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11698
+func TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity(t *testing.T) {
+	var dbCluster rds.DBCluster
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_rds_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRDSClusterConfig_ScalingConfiguration_DefaultMinCapacity(rName, false, 128, 301, "RollbackCapacityChange"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterExists(resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.auto_pause", "false"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.max_capacity", "128"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.min_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.seconds_until_auto_pause", "301"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.0.timeout_action", "RollbackCapacityChange"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
+			},
+		},
+	})
+}
+
 func TestAccAWSRDSCluster_SnapshotIdentifier(t *testing.T) {
 	var dbCluster, sourceDbCluster rds.DBCluster
 	var dbClusterSnapshot rds.DBClusterSnapshot
@@ -3118,6 +3158,25 @@ resource "aws_rds_cluster" "test" {
   }
 }
 `, rName, autoPause, maxCapacity, minCapacity, secondsUntilAutoPause, timeoutAction)
+}
+
+func testAccAWSRDSClusterConfig_ScalingConfiguration_DefaultMinCapacity(rName string, autoPause bool, maxCapacity, secondsUntilAutoPause int, timeoutAction string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier  = %q
+  engine_mode         = "serverless"
+  master_password     = "barbarbarbar"
+  master_username     = "foo"
+  skip_final_snapshot = true
+
+  scaling_configuration {
+    auto_pause               = %t
+    max_capacity             = %d
+    seconds_until_auto_pause = %d
+    timeout_action           = "%s"
+  }
+}
+`, rName, autoPause, maxCapacity, secondsUntilAutoPause, timeoutAction)
 }
 
 func testAccAWSRDSClusterConfig_SnapshotIdentifier(rName string) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4532,17 +4532,9 @@ func flattenDaxEncryptAtRestOptions(options *dax.SSEDescription) []map[string]in
 	return []map[string]interface{}{m}
 }
 
-func expandRdsClusterScalingConfiguration(l []interface{}, engineMode string) *rds.ScalingConfiguration {
+func expandRdsClusterScalingConfiguration(l []interface{}) *rds.ScalingConfiguration {
 	if len(l) == 0 || l[0] == nil {
-		// Our default value for MinCapacity is different from AWS's.
-		// We need to override it here to avoid a non-empty plan with an empty ScalingConfiguration.
-		if engineMode == "serverless" {
-			return &rds.ScalingConfiguration{
-				MinCapacity: aws.Int64(int64(rdsClusterScalingConfiguration_DefaultMinCapacity)),
-			}
-		} else {
-			return nil
-		}
+		return nil
 	}
 
 	m := l[0].(map[string]interface{})

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -1611,57 +1611,10 @@ const testExampleXML_from_msdn_flawed = `
 </purchaseOrder>
 `
 
-func TestExpandRdsClusterScalingConfiguration_serverless(t *testing.T) {
-	type testCase struct {
-		EngineMode string
-		Input      []interface{}
-		Expected   *rds.ScalingConfiguration
-	}
-	cases := []testCase{
-		{
-			EngineMode: "serverless",
-			Input: []interface{}{
-				map[string]interface{}{
-					"auto_pause":               false,
-					"max_capacity":             32,
-					"min_capacity":             4,
-					"seconds_until_auto_pause": 600,
-					"timeout_action":           "ForceApplyCapacityChange",
-				},
-			},
-			Expected: &rds.ScalingConfiguration{
-				AutoPause:             aws.Bool(false),
-				MaxCapacity:           aws.Int64(32),
-				MinCapacity:           aws.Int64(4),
-				SecondsUntilAutoPause: aws.Int64(600),
-				TimeoutAction:         aws.String("ForceApplyCapacityChange"),
-			},
-		},
-		{
-			EngineMode: "serverless",
-			Input:      []interface{}{},
-			Expected: &rds.ScalingConfiguration{
-				MinCapacity: aws.Int64(2),
-			},
-		},
-		{
-			EngineMode: "serverless",
-			Input: []interface{}{
-				nil,
-			},
-			Expected: &rds.ScalingConfiguration{
-				MinCapacity: aws.Int64(2),
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		output := expandRdsClusterScalingConfiguration(tc.Input, tc.EngineMode)
-		if !reflect.DeepEqual(output, tc.Expected) {
-			t.Errorf("EngineMode: %s\nExpected: %v,\nGot: %v", tc.EngineMode, tc.Expected, output)
-		}
-	}
-}
+// TestExpandRdsClusterScalingConfiguration_serverless removed in v3.0.0
+// as all engine_modes are treated equal when expanding scaling_configuration
+// and an override of min_capacity is no longer needed
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/11698
 
 func TestExpandRdsClusterScalingConfiguration_basic(t *testing.T) {
 	type testCase struct {
@@ -1673,7 +1626,7 @@ func TestExpandRdsClusterScalingConfiguration_basic(t *testing.T) {
 
 	// RDS Cluster Scaling Configuration is only valid for serverless, but we're relying on AWS errors.
 	// If Terraform adds whole-resource validation, we can do our own validation at plan time.
-	for _, engineMode := range []string{"global", "multimaster", "parallelquery", "provisioned"} {
+	for _, engineMode := range []string{"global", "multimaster", "parallelquery", "provisioned", "serverless"} {
 		cases = append(cases, []testCase{
 			{
 				EngineMode: engineMode,
@@ -1703,7 +1656,7 @@ func TestExpandRdsClusterScalingConfiguration_basic(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output := expandRdsClusterScalingConfiguration(tc.Input, tc.EngineMode)
+		output := expandRdsClusterScalingConfiguration(tc.Input)
 		if tc.ExpectNil != (output == nil) {
 			t.Errorf("EngineMode %q: Expected nil: %t, Got: %v", tc.EngineMode, tc.ExpectNil, output)
 		}

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -31,6 +31,7 @@ Upgrade topics:
 - [Resource: aws_launch_template](#resource-aws_launch_template)
 - [Resource: aws_lb_listener_rule](#resource-aws_lb_listener_rule)
 - [Resource: aws_msk_cluster](#resource-aws_msk_cluster)
+- [Resource: aws_rds_cluster](#resource-aws_rds_cluster)
 - [Resource: aws_s3_bucket](#resource-aws_s3_bucket)
 - [Resource: aws_security_group](#resource-aws_security_group)
 - [Resource: aws_sns_platform_application](#resource-aws_sns_platform_application)
@@ -474,6 +475,12 @@ resource "aws_msk_cluster" "example" {
   }
 }
 ```
+
+## Resource: aws_rds_cluster
+
+### scaling_configuration.min_capacity Now Defaults to 1
+
+Previously when the `min_capacity` argument in a `scaling_configuration` block was not configured, the resource would default to 2. This behavior has been updated to align with the AWS RDS Cluster API default of 1. 
 
 ## Resource: aws_s3_bucket
 

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -185,7 +185,7 @@ resource "aws_rds_cluster" "example" {
 
 * `auto_pause` - (Optional) Whether to enable automatic pause. A DB cluster can be paused only when it's idle (it has no connections). If a DB cluster is paused for more than seven days, the DB cluster might be backed up with a snapshot. In this case, the DB cluster is restored when there is a request to connect to it. Defaults to `true`.
 * `max_capacity` - (Optional) The maximum capacity. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, and `256`. Defaults to `16`.
-* `min_capacity` - (Optional) The minimum capacity. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, and `256`. Defaults to `2`.
+* `min_capacity` - (Optional) The minimum capacity. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, and `256`. Defaults to `1`.
 * `seconds_until_auto_pause` - (Optional) The time, in seconds, before an Aurora DB cluster in serverless mode is paused. Valid values are `300` through `86400`. Defaults to `300`.
 * `timeout_action` - (Optional) The action to take when the timeout is reached. Valid values: `ForceApplyCapacityChange`, `RollbackCapacityChange`. Defaults to `RollbackCapacityChange`. See [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.how-it-works.html#aurora-serverless.how-it-works.timeout-action).
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11698

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/rds_cluster: update default value for min_capacity in scaling_configuration block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSRDSClusterInstance_disappears (697.21s)
--- PASS: TestAccAWSRDSClusterInstance_generatedName (698.35s)
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (709.21s)
--- PASS: TestAccAWSRDSClusterInstance_isAlreadyBeingDeleted (753.40s)
--- PASS: TestAccAWSRDSClusterInstance_az (766.74s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_DefaultKeyToCustomKey (767.89s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (768.64s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql (773.96s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1 (817.00s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2 (824.06s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (3.92s)
--- PASS: TestAccAWSRDSCluster_basic (120.66s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1 (854.17s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (857.71s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (114.71s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (131.49s)
--- PASS: TestAccAWSRDSCluster_generatedName (120.54s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (140.63s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (166.20s)
--- PASS: TestAccAWSRDSCluster_kmsKey (101.16s)
--- PASS: TestAccAWSRDSCluster_Tags (132.29s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (161.52s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2 (768.84s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_DefaultKeyToCustomKey (781.94s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (147.06s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql (737.88s)
--- PASS: TestAccAWSRDSCluster_encrypted (161.02s)
--- PASS: TestAccAWSRDSCluster_iamAuth (130.39s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (155.86s)
--- PASS: TestAccAWSRDSClusterEndpoint_basic (1064.88s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (201.61s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (124.71s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (150.86s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (176.18s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (160.21s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (329.74s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global (155.90s)
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned (135.15s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add (158.47s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update (160.81s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove (185.84s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (1274.69s)
--- PASS: TestAccAWSRDSClusterInstance_CACertificateIdentifier (585.56s)
--- PASS: TestAccAWSRDSClusterEndpoint_tags (1338.50s)
--- PASS: TestAccAWSRDSCluster_EngineMode (461.81s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_DefaultKeyToCustomKey (752.98s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (368.50s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity (363.38s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (349.06s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1524.51s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (339.04s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (318.44s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (318.55s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (388.97s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (405.76s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (359.65s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (308.53s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (338.92s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (339.89s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (399.48s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (360.40s)
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (328.74s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (369.06s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1101.48s)
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1512.32s)
```

_Seem_ unrelated to changes when run in TC:
```
--- FAIL: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToRemoved (215.86s)
--- FAIL: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToDisabled (217.09s)
--- FAIL: TestAccAWSRDSClusterInstance_MonitoringInterval (264.20s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1.01s)
--- FAIL: TestAccAWSRDSCluster_Port (4.69s)
--- FAIL: TestAccAWSRDSClusterInstance_MonitoringRoleArn_RemovedToEnabled (1166.73s)
--- FAIL: TestAccAWSRDSCluster_EngineVersion (423.09s)
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier (156.90s)
```