### PR TITLE
tests/resource/aws_rds_cluster: Remove aws_s3_bucket region argument from TestAccAWSRDSCluster_s3Restore

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -2265,11 +2265,8 @@ data "aws_availability_zones" "available" {
   }
 }
 
-data "aws_region" "current" {}
-
 resource "aws_s3_bucket" "xtrabackup" {
   bucket = %[1]q
-  region = "${data.aws_region.current.name}"
 }
 
 resource "aws_s3_bucket_object" "xtrabackup_db" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/14127

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Missed during test configuration cleanup after the referenced argument removal. Fixes the initial configuration issue, but does not fix the (still) broken test which is presumably something to do with the backup file or engine version.

Previously:

```
--- FAIL: TestAccAWSRDSCluster_s3Restore (0.99s)
testing.go:684: Step 0 error: config is invalid: "region": this field cannot be set
```

Output from acceptance testing:

```
=== CONT  TestAccAWSRDSCluster_s3Restore
    TestAccAWSRDSCluster_s3Restore: testing.go:684: Step 0 error: errors during apply:

        Error: Error waiting for RDS Cluster state to be "available": unexpected state 'migration-failed', wanted target 'available'. last error: %!s(<nil>)
```
