### PR TITLE
Add function to check TypeSet pairs

### DIFF
--- a/aws/internal/tfawsresource/testing_test.go
+++ b/aws/internal/tfawsresource/testing_test.go
@@ -419,6 +419,562 @@ func TestTestCheckTypeSetElemAttr(t *testing.T) {
 	}
 }
 
+func TestTestCheckTypeSetElemAttrPair(t *testing.T) {
+	testCases := []struct {
+		Description             string
+		FirstResourceAddress    string
+		FirstResourceAttribute  string
+		SecondResourceAddress   string
+		SecondResourceAttribute string
+		TerraformState          *terraform.State
+		ExpectedError           func(err error) bool
+	}{
+		{
+			Description:             "first resource no primary instance",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+							},
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":       "1",
+										"id":      "3579",
+										"names.#": "3",
+										"names.0": "uswst3",
+										"names.1": "uswst2",
+										"names.3": "uswst1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "No primary instance")
+			},
+		},
+		{
+			Description:             "second resource no primary instance",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":        "1",
+										"id":       "11111",
+										"az.%":     "2",
+										"az.12345": "uswst2",
+										"az.23456": "uswst3",
+									},
+								},
+							},
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "No primary instance")
+			},
+		},
+		{
+			Description:             "no resources",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:         []string{"root"},
+						Outputs:      map[string]*terraform.OutputState{},
+						Resources:    map[string]*terraform.ResourceState{},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "Not found: asg.bar")
+			},
+		},
+		{
+			Description:             "first resource not found",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":       "1",
+										"id":      "3579",
+										"names.#": "3",
+										"names.0": "uswst3",
+										"names.1": "uswst2",
+										"names.3": "uswst1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "Not found: asg.bar")
+			},
+		},
+		{
+			Description:             "second resource not found",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":        "1",
+										"id":       "11111",
+										"az.%":     "2",
+										"az.12345": "uswst2",
+										"az.23456": "uswst3",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "Not found")
+			},
+		},
+		{
+			Description:             "first resource attribute not found",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":       "1",
+										"id":      "3579",
+										"names.#": "3",
+										"names.0": "uswst3",
+										"names.1": "uswst2",
+										"names.3": "uswst1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "no TypeSet element \"az.*\", with value \"uswst3\" in state")
+			},
+		},
+		{
+			Description:             "second resource attribute not found",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":        "1",
+										"id":       "11111",
+										"az.%":     "2",
+										"az.12345": "uswst2",
+										"az.23456": "uswst3",
+									},
+								},
+							},
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "3579",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), `Attribute "names.0" not set`)
+			},
+		},
+		{
+			Description:             "first resource attribute does not end with sentinel",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.34812",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":        "1",
+										"id":       "11111",
+										"az.%":     "2",
+										"az.12345": "uswst2",
+										"az.23456": "uswst3",
+									},
+								},
+							},
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":       "1",
+										"id":      "3579",
+										"names.#": "3",
+										"names.0": "uswst3",
+										"names.1": "uswst2",
+										"names.3": "uswst1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "does not end with the special value")
+			},
+		},
+		{
+			Description:             "second resource attribute ends with sentinel",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.*",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":        "1",
+										"id":       "11111",
+										"az.%":     "2",
+										"az.12345": "uswst2",
+										"az.23456": "uswst3",
+									},
+								},
+							},
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":       "1",
+										"id":      "3579",
+										"names.#": "3",
+										"names.0": "uswst3",
+										"names.1": "uswst2",
+										"names.3": "uswst1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), `data.az.available: Attribute "names.*" not set`)
+			},
+		},
+		{
+			Description:             "match zero attribute",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.0",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":        "1",
+										"id":       "11111",
+										"az.%":     "2",
+										"az.12345": "uswst2",
+										"az.23456": "uswst3",
+									},
+								},
+							},
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":       "1",
+										"id":      "3579",
+										"names.#": "3",
+										"names.0": "uswst3",
+										"names.1": "uswst2",
+										"names.3": "uswst1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:             "match non-zero attribute",
+			FirstResourceAddress:    "asg.bar",
+			FirstResourceAttribute:  "az.*",
+			SecondResourceAddress:   "data.az.available",
+			SecondResourceAttribute: "names.2",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"asg.bar": {
+								Type:     "asg",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":        "1",
+										"id":       "11111",
+										"az.%":     "2",
+										"az.12345": "uswst1",
+										"az.23456": "uswst3",
+									},
+								},
+							},
+							"data.az.available": {
+								Type:     "data.az",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":       "1",
+										"id":      "3579",
+										"names.#": "3",
+										"names.0": "uswst3",
+										"names.1": "uswst2",
+										"names.2": "uswst1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			err := TestCheckTypeSetElemAttrPair(
+				testCase.FirstResourceAddress,
+				testCase.FirstResourceAttribute,
+				testCase.SecondResourceAddress,
+				testCase.SecondResourceAttribute)(testCase.TerraformState)
+
+			if err != nil {
+				if testCase.ExpectedError == nil {
+					t.Fatalf("expected no error, got error: %s", err)
+				}
+
+				if !testCase.ExpectedError(err) {
+					t.Fatalf("unexpected error: %s", err)
+				}
+
+				t.Logf("received expected error: %s", err)
+				return
+			}
+
+			if err == nil && testCase.ExpectedError != nil {
+				t.Fatalf("expected error, got no error")
+			}
+		})
+	}
+}
+
 func TestTestCheckTypeSetElemNestedAttrs(t *testing.T) {
 	testCases := []struct {
 		Description       string

--- a/aws/internal/tfawsresource/testing_test.go
+++ b/aws/internal/tfawsresource/testing_test.go
@@ -175,7 +175,7 @@ func TestTestCheckTypeSetElemAttr(t *testing.T) {
 				},
 			},
 			ExpectedError: func(err error) bool {
-				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.*\"")
+				return strings.Contains(err.Error(), "\"example_thing.test\" error: no TypeSet element \"test.*\"")
 			},
 		},
 		{
@@ -246,7 +246,7 @@ func TestTestCheckTypeSetElemAttr(t *testing.T) {
 				},
 			},
 			ExpectedError: func(err error) bool {
-				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.*\"")
+				return strings.Contains(err.Error(), "\"example_thing.test\" error: no TypeSet element \"test.*\"")
 			},
 		},
 		{
@@ -319,7 +319,7 @@ func TestTestCheckTypeSetElemAttr(t *testing.T) {
 				},
 			},
 			ExpectedError: func(err error) bool {
-				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.*\"")
+				return strings.Contains(err.Error(), "\"example_thing.test\" error: no TypeSet element \"test.*\"")
 			},
 		},
 		{
@@ -390,7 +390,7 @@ func TestTestCheckTypeSetElemAttr(t *testing.T) {
 				},
 			},
 			ExpectedError: func(err error) bool {
-				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.0.nested_test.*\"")
+				return strings.Contains(err.Error(), "\"example_thing.test\" error: no TypeSet element \"test.0.nested_test.*\"")
 			},
 		},
 	}

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -98,7 +98,7 @@ func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupHealthyCapacity(&group, 2),
 					testAccCheckAWSAutoScalingGroupAttributes(&group, randName),
 					testAccMatchResourceAttrRegionalARN("aws_autoscaling_group.bar", "arn", "autoscaling", regexp.MustCompile(`autoScalingGroup:.+`)),
-					tfawsresource.TestCheckTypeSetElemAttr("aws_autoscaling_group.bar", "availability_zones.*", "us-west-2a"),
+					tfawsresource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "default_cooldown", "300"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "desired_capacity", "4"),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "enabled_metrics.#", "0"),
@@ -391,7 +391,7 @@ func TestAccAWSAutoScalingGroup_VpcUpdates(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "availability_zones.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr("aws_autoscaling_group.bar", "availability_zones.*", "us-west-2a"),
+					tfawsresource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "0"),
 				),
@@ -417,7 +417,7 @@ func TestAccAWSAutoScalingGroup_VpcUpdates(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupAttributesVPCZoneIdentifier(&group),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "availability_zones.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr("aws_autoscaling_group.bar", "availability_zones.*", "us-west-2a"),
+					tfawsresource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "1"),
 				),
@@ -2260,6 +2260,16 @@ resource "aws_autoscaling_group" "bar" {
 
 func testAccAWSAutoScalingGroupConfig(name string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 data "aws_ami" "test_ami" {
   most_recent = true
   owners      = ["amazon"]
@@ -2281,7 +2291,7 @@ resource "aws_placement_group" "test" {
 }
 
 resource "aws_autoscaling_group" "bar" {
-  availability_zones   = ["us-west-2a"]
+  availability_zones   = [data.aws_availability_zones.available.names[0]]
   name                 = "%s"
   max_size             = 5
   min_size             = 2
@@ -2586,6 +2596,16 @@ resource "aws_autoscaling_group" "bar" {
 `
 
 const testAccAWSAutoScalingGroupConfigWithAZ = `
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+  
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
   tags = {
@@ -2596,7 +2616,7 @@ resource "aws_vpc" "default" {
 resource "aws_subnet" "main" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "10.0.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
     Name = "tf-acc-autoscaling-group-with-az"
   }
@@ -2619,7 +2639,7 @@ resource "aws_launch_configuration" "foobar" {
 
 resource "aws_autoscaling_group" "bar" {
   availability_zones = [
-	  "us-west-2a"
+	data.aws_availability_zones.available.names[0]
   ]
   desired_capacity = 0
   max_size = 0
@@ -2629,6 +2649,16 @@ resource "aws_autoscaling_group" "bar" {
 `
 
 const testAccAWSAutoScalingGroupConfigWithVPCIdent = `
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+  
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
   tags = {
@@ -2639,7 +2669,7 @@ resource "aws_vpc" "default" {
 resource "aws_subnet" "main" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "10.0.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
     Name = "tf-acc-autoscaling-group-with-vpc-id"
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12994 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
NONE
```

The output from acceptance testing.

This modifies `tfawsresource.TestCheckTypeSetElemAttr()` so that the new function, `tfawsresource.TestCheckTypeSetElemAttrPair()`, can share its guts. As such, I ran some general acc tests that show is `tfawsresource.TestCheckTypeSetElemAttr()` is still working.

This uses the **new** function `tfawsresource.TestCheckTypeSetElemAttrPair()`:
```
% testacc TestAccAWSAutoScalingGroup_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoScalingGroup_basic -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_basic
=== PAUSE TestAccAWSAutoScalingGroup_basic
=== CONT  TestAccAWSAutoScalingGroup_basic
--- PASS: TestAccAWSAutoScalingGroup_basic (342.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	342.549s
```

This uses the **new** function `tfawsresource.TestCheckTypeSetElemAttrPair()`:
```
% testacc TestAccAWSAutoScalingGroup_VpcUpdates
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoScalingGroup_VpcUpdates -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
=== PAUSE TestAccAWSAutoScalingGroup_VpcUpdates
=== CONT  TestAccAWSAutoScalingGroup_VpcUpdates
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (73.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	73.148s
```

This uses the _existing and modified_ function `tfawsresource.TestCheckTypeSetElemAttr()`:
```
% testacc TestAccAWSAutoScalingGroup_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAutoScalingGroup_basic -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_basic
=== PAUSE TestAccAWSAutoScalingGroup_basic
=== CONT  TestAccAWSAutoScalingGroup_basic
--- PASS: TestAccAWSAutoScalingGroup_basic (342.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	342.549s
```

This uses the _existing and modified_ function `tfawsresource.TestCheckTypeSetElemAttr()`:
```
% testacc TestAccAwsWafv2IPSet_IPv6
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsWafv2IPSet_IPv6 -timeout 120m
=== RUN   TestAccAwsWafv2IPSet_IPv6
=== PAUSE TestAccAwsWafv2IPSet_IPv6
=== CONT  TestAccAwsWafv2IPSet_IPv6
--- PASS: TestAccAwsWafv2IPSet_IPv6 (12.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.386s
```
