### PR TITLE
Fix TestAccAWSRDSCluster_EngineVersion

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -1026,7 +1026,7 @@ func TestAccAWSRDSCluster_EngineVersion(t *testing.T) {
 			},
 			{
 				Config:      testAccAWSClusterConfig_EngineVersion(rInt, "aurora-postgresql", "9.6.6"),
-				ExpectError: regexp.MustCompile(`Cannot modify engine version without a primary instance in DB cluster`),
+				ExpectError: regexp.MustCompile(`Cannot modify engine version without a healthy primary instance in DB cluster`),
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14274

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
This PR does is not user-facing
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSRDSCluster_EngineVersion'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRDSCluster_EngineVersion -timeout 120m
=== RUN   TestAccAWSRDSCluster_EngineVersion
=== PAUSE TestAccAWSRDSCluster_EngineVersion
=== RUN   TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== PAUSE TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== CONT  TestAccAWSRDSCluster_EngineVersion
=== CONT  TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
--- PASS: TestAccAWSRDSCluster_EngineVersion (459.31s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1133.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1134.965s

...
```

Fixed `TestAccAWSRDSCluster_EngineVersion` to reflect the recent API change. Thank you for creating the issue. It was a great chance for me to interact with acceptance tests.
