### PR TITLE
resource/aws_lambda_function: Increase IAM retry timeout for create to 2 minutes

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
 const awsMutexLambdaKey = `aws_lambda_function`
@@ -426,8 +427,8 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		params.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().LambdaTags()
 	}
 
-	// IAM changes can take 1 minute to propagate in AWS
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	// IAM changes can take some time to propagate in AWS
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 		_, err := conn.CreateFunction(params)
 		if err != nil {
 			log.Printf("[DEBUG] Error creating Lambda Function: %s", err)


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #14285

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_lambda_function: Increase retry on IAM eventual consistency errors for create from 1 to 2 minutes ([#14285](https://github.com/terraform-providers/terraform-provider-aws/issues/14285))
```

Increased the retry timeout for eventual consistency IAM errors during a lambda function create from 1 minute to 2 minute. The limit had been reduced to 1 minute in #3765 but the errors still appear frequently enough that increasing it to 2 minutes seems appropriate.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_'
...
--- PASS: TestAccAWSLambdaFunction_basic (28.86s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (34.46s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (160.32s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (208.54s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (567.54s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (596.13s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (49.02s)
--- PASS: TestAccAWSLambdaFunction_VPC (362.84s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (797.25s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (120.01s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (51.30s)
--- PASS: TestAccAWSLambdaFunction_envVariables (153.15s)
--- PASS: TestAccAWSLambdaFunction_versioned (39.16s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (61.80s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (31.16s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (51.77s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_dotnetcore31 (36.20s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby27 (40.86s)
--- PASS: TestAccAWSLambdaFunction_Layers (38.54s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (51.87s)
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (36.57s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (54.03s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (36.53s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (13.34s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python38 (28.27s)
--- PASS: TestAccAWSLambdaFunction_tags (51.19s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java11 (36.59s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (51.42s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (43.77s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (39.80s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (44.15s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (40.02s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (32.09s)
--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (721.87s)
--- PASS: TestAccAWSLambdaFunction_s3 (31.68s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (36.48s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (33.63s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x (38.17s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (0.91s)
--- PASS: TestAccAWSLambdaFunction_concurrency (46.63s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (38.38s)
--- PASS: TestAccAWSLambdaFunction_disappears (36.13s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs12x (38.47s)
```
