### PR TITLE
resource/aws_glue_job: Remove deprecated allocated_capacity argument

### DIFF
--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -90,44 +90,6 @@ func TestAccAWSGlueJob_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSGlueJob_AllocatedCapacity(t *testing.T) {
-	var job glue.Job
-
-	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceName := "aws_glue_job.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSGlueJobDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSGlueJobConfig_AllocatedCapacity(rName, 1),
-				ExpectError: regexp.MustCompile(`expected allocated_capacity to be at least`),
-			},
-			{
-				Config: testAccAWSGlueJobConfig_AllocatedCapacity(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGlueJobExists(resourceName, &job),
-					resource.TestCheckResourceAttr(resourceName, "allocated_capacity", "2"),
-				),
-			},
-			{
-				Config: testAccAWSGlueJobConfig_AllocatedCapacity(rName, 3),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSGlueJobExists(resourceName, &job),
-					resource.TestCheckResourceAttr(resourceName, "allocated_capacity", "3"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSGlueJob_Command(t *testing.T) {
 	var job glue.Job
 
@@ -730,32 +692,14 @@ resource "aws_iam_role_policy_attachment" "test" {
 `, rName)
 }
 
-func testAccAWSGlueJobConfig_AllocatedCapacity(rName string, allocatedCapacity int) string {
-	return fmt.Sprintf(`
-%s
-
-resource "aws_glue_job" "test" {
-  allocated_capacity = %d
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-
-  command {
-    script_location = "testscriptlocation"
-  }
-
-  depends_on = ["aws_iam_role_policy_attachment.test"]
-}
-`, testAccAWSGlueJobConfig_Base(rName), allocatedCapacity, rName)
-}
-
 func testAccAWSGlueJobConfig_Command(rName, scriptLocation string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "aws_glue_job" "test" {
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  allocated_capacity = 10
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
 
   command {
     script_location = "%s"
@@ -771,9 +715,9 @@ func testAccAWSGlueJobConfig_DefaultArguments(rName, jobBookmarkOption, jobLangu
 %s
 
 resource "aws_glue_job" "test" {
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  allocated_capacity = 10
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
 
   command {
     script_location = "testscriptlocation"
@@ -794,10 +738,10 @@ func testAccAWSGlueJobConfig_Description(rName, description string) string {
 %s
 
 resource "aws_glue_job" "test" {
-  description        = "%s"
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  allocated_capacity = 10
+  description  = "%s"
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
 
   command {
     script_location = "testscriptlocation"
@@ -813,10 +757,10 @@ func testAccAWSGlueJobConfig_GlueVersion(rName, glueVersion string) string {
 %s
 
 resource "aws_glue_job" "test" {
-  glue_version       = "%s"
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  allocated_capacity = 10
+  glue_version = "%s"
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
 
   command {
     script_location = "testscriptlocation"
@@ -832,9 +776,9 @@ func testAccAWSGlueJobConfig_ExecutionProperty(rName string, maxConcurrentRuns i
 %s
 
 resource "aws_glue_job" "test" {
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  allocated_capacity = 10
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
 
   command {
     script_location = "testscriptlocation"
@@ -854,10 +798,10 @@ func testAccAWSGlueJobConfig_MaxRetries(rName string, maxRetries int) string {
 %s
 
 resource "aws_glue_job" "test" {
-  max_retries        = %d
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  allocated_capacity = 10
+  max_capacity = 10
+  max_retries  = %d
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
 
   command {
     script_location = "testscriptlocation"
@@ -873,9 +817,9 @@ func testAccAWSGlueJobConfig_NotificationProperty(rName string, notifyDelayAfter
 %s
 
 resource "aws_glue_job" "test" {
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  allocated_capacity = 10
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
 
   command {
     script_location = "testscriptlocation"
@@ -895,9 +839,9 @@ func testAccAWSGlueJobConfig_Required(rName string) string {
 %s
 
 resource "aws_glue_job" "test" {
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  allocated_capacity = 10
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
 
   command {
     script_location = "testscriptlocation"
@@ -956,10 +900,10 @@ func testAccAWSGlueJobConfig_Timeout(rName string, timeout int) string {
 %s
 
 resource "aws_glue_job" "test" {
-  name               = "%s"
-  role_arn           = "${aws_iam_role.test.arn}"
-  timeout            = %d
-  allocated_capacity = 10
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
+  timeout      = %d
 
   command {
     script_location = "testscriptlocation"
@@ -975,10 +919,10 @@ func testAccAWSGlueJobConfig_SecurityConfiguration(rName string, securityConfigu
 %s
 
 resource "aws_glue_job" "test" {
+  max_capacity           = 10
   name                   = "%s"
-  role_arn               = "${aws_iam_role.test.arn}"
+  role_arn               = aws_iam_role.test.arn
   security_configuration = "%s"
-  allocated_capacity     = 10
 
   command {
     script_location = "testscriptlocation"

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -30,6 +30,7 @@ Upgrade topics:
 - [Resource: aws_ebs_volume](#resource-aws_ebs_volume)
 - [Resource: aws_elastic_transcoder_preset](#resource-aws_elastic_transcoder_preset)
 - [Resource: aws_emr_cluster](#resource-aws_emr_cluster)
+- [Resource: aws_glue_job](#resource-aws_glue_job)
 - [Resource: aws_iam_access_key](#resource-aws_iam_access_key)
 - [Resource: aws_instance](#resource-aws_instance)
 - [Resource: aws_lambda_alias](#resource-aws_lambda_alias)
@@ -760,6 +761,32 @@ resource "aws_emr_cluster" "example" {
   master_instance_group {
     instance_type = "m4.large"
   }
+}
+```
+
+## Resource: aws_glue_job
+
+### allocated_capacity Argument Removal
+
+The Glue API has deprecated the `allocated_capacity` argument. Switch your Terraform configuration to the `max_capacity` argument instead.
+
+For example, given this previous configuration:
+
+```hcl
+resource "aws_glue_job" "example" {
+  # ... other configuration ...
+
+  allocated_capacity = 2
+}
+```
+
+An updated configuration:
+
+```hcl
+resource "aws_glue_job" "example" {
+  # ... other configuration ...
+
+  max_capacity = 2
 }
 ```
 

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -69,10 +69,6 @@ resource "aws_glue_job" "example" {
 
 The following arguments are supported:
 
-~> **NOTE:** The `allocated_capacity` attribute has been deprecated and might
-be removed in future releases, please use `max_capacity` instead.
-
-* `allocated_capacity` – **DEPRECATED** (Optional) The number of AWS Glue data processing units (DPUs) to allocate to this Job. At least 2 DPUs need to be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory.
 * `command` – (Required) The command of the job. Defined below.
 * `connections` – (Optional) The list of connections used for this job.
 * `default_arguments` – (Optional) The map of default arguments for this job. You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes. For information about how to specify and consume your own Job arguments, see the [Calling AWS Glue APIs in Python](http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html) topic in the developer guide. For information about the key-value pairs that AWS Glue consumes to set up your job, see the [Special Parameters Used by AWS Glue](http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html) topic in the developer guide.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/7340
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13398

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_glue_job: Remove deprecated `allocated_capacity` argument
```

Output from acceptance testing:

```
--- PASS: TestAccAWSGlueJob_basic (14.45s)
--- PASS: TestAccAWSGlueJob_Description (21.70s)
--- PASS: TestAccAWSGlueJob_GlueVersion (21.74s)
--- PASS: TestAccAWSGlueJob_MaxRetries (21.92s)
--- PASS: TestAccAWSGlueJob_Command (21.95s)
--- PASS: TestAccAWSGlueJob_DefaultArguments (22.08s)
--- PASS: TestAccAWSGlueJob_NotificationProperty (22.10s)
--- PASS: TestAccAWSGlueJob_Timeout (22.13s)
--- PASS: TestAccAWSGlueJob_ExecutionProperty (22.43s)
--- PASS: TestAccAWSGlueJob_MaxCapacity (22.43s)
--- PASS: TestAccAWSGlueJob_SecurityConfiguration (22.48s)
--- PASS: TestAccAWSGlueJob_WorkerType (29.22s)
--- PASS: TestAccAWSGlueJob_Tags (29.29s)
--- PASS: TestAccAWSGlueJob_PythonShell (30.12s)
```
