### PR TITLE
resource/aws_iam_access_key: Remove deprecated ses_smtp_password attribute

### DIFF
--- a/aws/resource_aws_iam_access_key_test.go
+++ b/aws/resource_aws_iam_access_key_test.go
@@ -256,23 +256,3 @@ func TestSesSmtpPasswordFromSecretKeySigV4(t *testing.T) {
 		}
 	}
 }
-
-func TestSesSmtpPasswordFromSecretKeySigV2(t *testing.T) {
-	cases := []struct {
-		Input    string
-		Expected string
-	}{
-		{"some+secret+key", "AnkqhOiWEcszZZzTMCQbOY1sPGoLFgMH9zhp4eNgSjo4"},
-		{"another+secret+key", "Akwqr0Giwi8FsQFgW3DXWCC2DiiQ/jZjqLDWK8TeTBgL"},
-	}
-
-	for _, tc := range cases {
-		actual, err := sesSmtpPasswordFromSecretKeySigV2(&tc.Input)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		if actual != tc.Expected {
-			t.Fatalf("%q: expected %q, got %q", tc.Input, tc.Expected, actual)
-		}
-	}
-}

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -29,6 +29,7 @@ Upgrade topics:
 - [Resource: aws_ebs_volume](#resource-aws_ebs_volume)
 - [Resource: aws_elastic_transcoder_preset](#resource-aws_elastic_transcoder_preset)
 - [Resource: aws_emr_cluster](#resource-aws_emr_cluster)
+- [Resource: aws_iam_access_key](#resource-aws_iam_access_key)
 - [Resource: aws_instance](#resource-aws_instance)
 - [Resource: aws_lambda_alias](#resource-aws_lambda_alias)
 - [Resource: aws_launch_template](#resource-aws_launch_template)
@@ -726,6 +727,12 @@ resource "aws_emr_cluster" "example" {
   }
 }
 ```
+
+## Resource: aws_iam_access_key
+
+### ses_smtp_password Attribute Removal
+
+In many regions today and in all regions after October 1, 2020, the [SES API will only accept version 4 signatures](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-ses-api-authentication.html). If referencing the `ses_smtp_password` attribute, switch your Terraform configuration to the `ses_smtp_password_v4` attribute instead. Please note that this signature is based on the region of the Terraform AWS Provider. If you need the SES v4 password in multiple regions, it may require using [multiple provider instances](/docs/configuration/providers.html#alias-multiple-provider-instances).
 
 ## Resource: aws_instance
 

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -90,8 +90,6 @@ the use of the secret key in automation.
 * `encrypted_secret` - The encrypted secret, base64 encoded, if `pgp_key` was specified.
 ~> **NOTE:** The encrypted secret may be decrypted using the command line,
    for example: `terraform output encrypted_secret | base64 --decode | keybase pgp decrypt`.
-* `ses_smtp_password` - **DEPRECATED** The secret access key converted into an SES SMTP
-  password by applying AWS's SigV2 conversion algorithm
 * `ses_smtp_password_v4` - The secret access key converted into an SES SMTP
   password by applying [AWS's documented Sigv4 conversion
   algorithm](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/11144
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13398

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_iam_access_key: Remove deprecated `ses_smtp_password` attribute
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAccessKey_basic (5.87s)
--- PASS: TestAccAWSAccessKey_encrypted (5.97s)
--- PASS: TestAccAWSAccessKey_inactive (9.72s)
```
