### PR TITLE
resource/aws_iam_instance_profile: Remove deprecated roles argument

### DIFF
--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -566,8 +566,8 @@ EOT
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "emr_profile_%d"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  name = "emr_profile_%d"
+  role = aws_iam_role.iam_emr_profile_role.name
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -3677,8 +3677,8 @@ resource "aws_iam_role" "test" {
 }
 
 resource "aws_iam_instance_profile" "test" {
-  name  = %q
-  roles = ["${aws_iam_role.test.name}"]
+  name = %q
+  role = aws_iam_role.test.name
 }
 
 resource "aws_launch_template" "test" {

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -927,8 +927,8 @@ resource "aws_elastic_beanstalk_environment" "test" {
 func testAccBeanstalkWorkerEnvConfig(rName string) string {
 	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
 resource "aws_iam_instance_profile" "test" {
-  name  = %[1]q
-  roles = [aws_iam_role.test.name]
+  name = %[1]q
+  role = aws_iam_role.test.name
 }
 
 resource "aws_iam_role" "test" {

--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -37,32 +37,6 @@ func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSIAMInstanceProfile_withRoleNotRoles(t *testing.T) {
-	var conf iam.GetInstanceProfileOutput
-	resourceName := "aws_iam_instance_profile.test"
-
-	rName := acctest.RandString(5)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSInstanceProfileDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSInstanceProfileWithRoleSpecified(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSInstanceProfileExists(resourceName, &conf),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name_prefix"},
-			},
-		},
-	})
-}
-
 func TestAccAWSIAMInstanceProfile_withoutRole(t *testing.T) {
 	var conf iam.GetInstanceProfileOutput
 	resourceName := "aws_iam_instance_profile.test"
@@ -195,8 +169,8 @@ resource "aws_iam_role" "test" {
 }
 
 resource "aws_iam_instance_profile" "test" {
-  name  = "test"
-  roles = ["${aws_iam_role.test.name}"]
+  name = "test-%[1]s"
+  role = aws_iam_role.test.name
 }
 `, rName)
 }
@@ -218,21 +192,7 @@ resource "aws_iam_role" "test" {
 
 resource "aws_iam_instance_profile" "test" {
   name_prefix = "test-"
-  roles       = ["${aws_iam_role.test.name}"]
-}
-`, rName)
-}
-
-func testAccAWSInstanceProfileWithRoleSpecified(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "test" {
-  name               = "test-%s"
-  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
-}
-
-resource "aws_iam_instance_profile" "test" {
-  name_prefix = "test-"
-  role        = "${aws_iam_role.test.name}"
+  role        = aws_iam_role.test.name
 }
 `, rName)
 }

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -745,9 +745,9 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "role_update_test" {
-  name  = "role_update_test_%s"
-  path  = "/test/"
-  roles = ["${aws_iam_role.test.name}"]
+  name = "role_update_test_%s"
+  path = "/test/"
+  role = aws_iam_role.test.name
 }
 `, rName, rName, rName)
 }
@@ -799,9 +799,9 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "role_update_test" {
-  name  = "role_update_test_%s"
-  path  = "/test/"
-  roles = ["${aws_iam_role.test.name}"]
+  name = "role_update_test_%s"
+  path = "/test/"
+  role = aws_iam_role.test.name
 }
 `, rName, rName, rName)
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -4134,8 +4134,8 @@ resource "aws_iam_role" "test" {
 }
 
 resource "aws_iam_instance_profile" "test" {
-  name  = %[1]q
-  roles = ["${aws_iam_role.test.name}"]
+  name = %[1]q
+  role = aws_iam_role.test.name
 }
 
 resource "aws_instance" "test" {

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -888,8 +888,8 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "profile" {
-  name  = "tf-acc-test-%[1]d"
-  roles = ["${aws_iam_role.role.name}"]
+  name = "tf-acc-test-%[1]d"
+  role = aws_iam_role.role.name
 }
 
 resource "aws_launch_configuration" "test" {

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -31,6 +31,7 @@ Upgrade topics:
 - [Resource: aws_elastic_transcoder_preset](#resource-aws_elastic_transcoder_preset)
 - [Resource: aws_emr_cluster](#resource-aws_emr_cluster)
 - [Resource: aws_iam_access_key](#resource-aws_iam_access_key)
+- [Resource: aws_iam_instance_profile](#resource-aws_iam_instance_profile)
 - [Resource: aws_instance](#resource-aws_instance)
 - [Resource: aws_lambda_alias](#resource-aws_lambda_alias)
 - [Resource: aws_launch_template](#resource-aws_launch_template)
@@ -768,6 +769,32 @@ resource "aws_emr_cluster" "example" {
 ### ses_smtp_password Attribute Removal
 
 In many regions today and in all regions after October 1, 2020, the [SES API will only accept version 4 signatures](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-ses-api-authentication.html). If referencing the `ses_smtp_password` attribute, switch your Terraform configuration to the `ses_smtp_password_v4` attribute instead. Please note that this signature is based on the region of the Terraform AWS Provider. If you need the SES v4 password in multiple regions, it may require using [multiple provider instances](/docs/configuration/providers.html#alias-multiple-provider-instances).
+
+## Resource: aws_iam_instance_profile
+
+### roles Argument Removal
+
+Switch your Terraform configuration to the `role` argument instead.
+
+For example, given this previous configuration:
+
+```hcl
+resource "aws_iam_instance_profile" "example" {
+  # ... other configuration ...
+
+  roles = [aws_iam_role.example.id]
+}
+```
+
+An updated configuration:
+
+```hcl
+resource "aws_iam_instance_profile" "example" {
+  # ... other configuration ...
+
+  role = aws_iam_role.example.id
+}
+```
 
 ## Resource: aws_instance
 

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -642,8 +642,8 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "emr_profile"
-  roles = ["${aws_iam_role.iam_emr_profile_role.name}"]
+  name = "emr_profile"
+  role = aws_iam_role.iam_emr_profile_role.name
 }
 
 resource "aws_iam_role_policy" "iam_emr_profile_policy" {

--- a/website/docs/r/iam_instance_profile.html.markdown
+++ b/website/docs/r/iam_instance_profile.html.markdown
@@ -47,9 +47,6 @@ The following arguments are supported:
 * `name` - (Optional, Forces new resource) The profile's name. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path in which to create the profile.
-* `roles` - (**Deprecated**)
-A list of role names to include in the profile.  The current default is 1.  If you see an error message similar to `Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1`, then you must contact AWS support and ask for a limit increase.
- WARNING: This is deprecated since [version 0.9.3 (April 12, 2017)](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#093-april-12-2017), as >= 2 roles are not possible. See [issue #11575](https://github.com/hashicorp/terraform/issues/11575).
 * `role` - (Optional) The role name to include in the profile.
 
 ## Attribute Reference
@@ -60,7 +57,6 @@ A list of role names to include in the profile.  The current default is 1.  If y
 * `name` - The instance profile's name.
 * `path` - The path of the instance profile in IAM.
 * `role` - The role assigned to the instance profile.
-* `roles` - The list of roles assigned to the instance profile. (**Deprecated**)
 * `unique_id` - The [unique ID][1] assigned by AWS.
 
   [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html#GUIDs


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/hashicorp/terraform/pull/13130
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13398

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_iam_instance_profile: Remove deprecated `roles` argument
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIAMInstanceProfile_withoutRole (6.44s)
--- PASS: TestAccAWSIAMInstanceProfile_basic (6.92s)
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (6.94s)

--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (53.25s)

--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (790.81s)

--- PASS: TestAccAWSBeanstalkEnv_tier (518.46s)

--- PASS: TestAccAWSIAMRole_testNameChange (12.80s)

--- PASS: TestAccAWSInstance_instanceProfileChange (204.32s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (115.26s)

--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (21.61s)
```
