### PR TITLE
resource/aws_lb_listener_rule: Remove deprecated condition configuration block field and values arguments

### DIFF
--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -86,16 +86,15 @@ func TestAccAWSLBListenerRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.0.authenticate_oidc.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                 "path-pattern",
-						"host_header.#":         "0",
-						"http_header.#":         "0",
-						"http_request_method.#": "0",
-						"path_pattern.#":        "1",
-						"query_string.#":        "0",
-						"source_ip.#":           "0",
-						"values.#":              "1",
-						"values.0":              "/static/*",
+						"host_header.#":           "0",
+						"http_header.#":           "0",
+						"http_request_method.#":   "0",
+						"path_pattern.#":          "1",
+						"path_pattern.0.values.#": "1",
+						"query_string.#":          "0",
+						"source_ip.#":             "0",
 					}),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/static/*"),
 				),
 			},
 		},
@@ -212,16 +211,15 @@ func TestAccAWSLBListenerRule_BackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.0.authenticate_oidc.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                 "path-pattern",
-						"host_header.#":         "0",
-						"http_header.#":         "0",
-						"http_request_method.#": "0",
-						"path_pattern.#":        "1",
-						"query_string.#":        "0",
-						"source_ip.#":           "0",
-						"values.#":              "1",
-						"values.0":              "/static/*",
+						"host_header.#":           "0",
+						"http_header.#":           "0",
+						"http_request_method.#":   "0",
+						"path_pattern.#":          "1",
+						"path_pattern.0.values.#": "1",
+						"query_string.#":          "0",
+						"source_ip.#":             "0",
 					}),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/static/*"),
 				),
 			},
 		},
@@ -389,23 +387,6 @@ func TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew(t *testing.T) {
 					testAccCheckAWSLBListenerRuleExists(resourceName, &after),
 					testAccCheckAWSLbListenerRuleRecreated(t, &before, &after),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAWSLBListenerRule_multipleConditionThrowsError(t *testing.T) {
-	lbName := fmt.Sprintf("testrule-basic-%s", acctest.RandString(13))
-	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandString(10))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLBListenerRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSLBListenerRuleConfig_multipleConditions(lbName, targetGroupName),
-				ExpectError: regexp.MustCompile(`attribute supports 1 item maximum`),
 			},
 		},
 	})
@@ -624,27 +605,13 @@ func TestAccAWSLBListenerRule_Action_Order_Recreates(t *testing.T) {
 }
 
 func TestAccAWSLBListenerRule_conditionAttributesCount(t *testing.T) {
-	err_zero := regexp.MustCompile("One of host_header, http_header, http_request_method, path_pattern, query_string or source_ip must be set in a condition block")
-	err_many := regexp.MustCompile("Only one of field, host_header, http_header, http_request_method, path_pattern, query_string or source_ip can be set in a condition block")
-	err_deprecated := regexp.MustCompile("Both field and values must be set in a condition block")
+	err_many := regexp.MustCompile("Only one of host_header, http_header, http_request_method, path_pattern, query_string or source_ip can be set in a condition block")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLBListenerRuleDestroy,
 		Steps: []resource.TestStep{
-			{
-				Config:      testAccAWSLBListenerRuleConfig_conditionAttributesCount_empty(),
-				ExpectError: err_zero,
-			},
-			{
-				Config:      testAccAWSLBListenerRuleConfig_conditionAttributesCount_field(),
-				ExpectError: err_deprecated,
-			},
-			{
-				Config:      testAccAWSLBListenerRuleConfig_conditionAttributesCount_values(),
-				ExpectError: err_zero,
-			},
 			{
 				Config:      testAccAWSLBListenerRuleConfig_conditionAttributesCount_http_header(),
 				ExpectError: err_many,
@@ -663,10 +630,6 @@ func TestAccAWSLBListenerRule_conditionAttributesCount(t *testing.T) {
 			},
 			{
 				Config:      testAccAWSLBListenerRuleConfig_conditionAttributesCount_source_ip(),
-				ExpectError: err_many,
-			},
-			{
-				Config:      testAccAWSLBListenerRuleConfig_conditionAttributesCount_classic(),
 				ExpectError: err_many,
 			},
 		},
@@ -695,7 +658,6 @@ func TestAccAWSLBListenerRule_conditionHostHeader(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                  "host-header",
 						"host_header.#":          "1",
 						"host_header.0.values.#": "2",
 						"http_header.#":          "0",
@@ -703,52 +665,9 @@ func TestAccAWSLBListenerRule_conditionHostHeader(t *testing.T) {
 						"path_pattern.#":         "0",
 						"query_string.#":         "0",
 						"source_ip.#":            "0",
-						"values.#":               "2",
-						"values.0":               "example.com",
-						"values.1":               "www.example.com",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "www.example.com"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSLBListenerRule_conditionHostHeader_deprecated(t *testing.T) {
-	var conf elbv2.Rule
-	lbName := fmt.Sprintf("testrule-hostHeader-%s", acctest.RandString(12))
-
-	resourceName := "aws_lb_listener_rule.static"
-	frontEndListenerResourceName := "aws_lb_listener.front_end"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLBListenerRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLBListenerRuleConfig_conditionHostHeader_deprecated(lbName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLBListenerRuleExists(resourceName, &conf),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
-					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                  "host-header",
-						"host_header.#":          "1",
-						"host_header.0.values.#": "1",
-						"http_header.#":          "0",
-						"http_request_method.#":  "0",
-						"path_pattern.#":         "0",
-						"query_string.#":         "0",
-						"source_ip.#":            "0",
-						"values.#":               "1",
-						"values.0":               "example.com",
-					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
 				),
 			},
 		},
@@ -777,7 +696,6 @@ func TestAccAWSLBListenerRule_conditionHttpHeader(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                          "http-header",
 						"host_header.#":                  "0",
 						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "X-Forwarded-For",
@@ -786,12 +704,10 @@ func TestAccAWSLBListenerRule_conditionHttpHeader(t *testing.T) {
 						"path_pattern.#":                 "0",
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
-						"values.#":                       "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "10.0.0.*"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                          "http-header",
 						"host_header.#":                  "0",
 						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "Zz9~|_^.-+*'&%$#!0aA",
@@ -800,7 +716,6 @@ func TestAccAWSLBListenerRule_conditionHttpHeader(t *testing.T) {
 						"path_pattern.#":                 "0",
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
-						"values.#":                       "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "RFC7230 Validity"),
 				),
@@ -845,7 +760,6 @@ func TestAccAWSLBListenerRule_conditionHttpRequestMethod(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                          "http-request-method",
 						"host_header.#":                  "0",
 						"http_header.#":                  "0",
 						"http_request_method.#":          "1",
@@ -853,7 +767,6 @@ func TestAccAWSLBListenerRule_conditionHttpRequestMethod(t *testing.T) {
 						"path_pattern.#":                 "0",
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
-						"values.#":                       "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "POST"),
@@ -885,7 +798,6 @@ func TestAccAWSLBListenerRule_conditionPathPattern(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                   "path-pattern",
 						"host_header.#":           "0",
 						"http_header.#":           "0",
 						"http_request_method.#":   "0",
@@ -893,116 +805,6 @@ func TestAccAWSLBListenerRule_conditionPathPattern(t *testing.T) {
 						"path_pattern.0.values.#": "2",
 						"query_string.#":          "0",
 						"source_ip.#":             "0",
-						"values.#":                "2",
-						"values.0":                "/cgi-bin/*",
-						"values.1":                "/public/*",
-					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSLBListenerRule_conditionPathPattern_deprecated(t *testing.T) {
-	var conf elbv2.Rule
-	lbName := fmt.Sprintf("testrule-pathPattern-%s", acctest.RandString(11))
-
-	resourceName := "aws_lb_listener_rule.static"
-	frontEndListenerResourceName := "aws_lb_listener.front_end"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLBListenerRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLBListenerRuleConfig_conditionPathPattern_deprecated(lbName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLBListenerRuleExists(resourceName, &conf),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
-					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
-					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                   "path-pattern",
-						"host_header.#":           "0",
-						"http_header.#":           "0",
-						"http_request_method.#":   "0",
-						"path_pattern.#":          "1",
-						"path_pattern.0.values.#": "1",
-						"query_string.#":          "0",
-						"source_ip.#":             "0",
-						"values.#":                "1",
-						"values.0":                "/public/*",
-					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSLBListenerRule_conditionUpdatePathPattern_deprecated(t *testing.T) {
-	var conf elbv2.Rule
-	lbName := fmt.Sprintf("testrule-pathPattern-%s", acctest.RandString(11))
-
-	resourceName := "aws_lb_listener_rule.static"
-	frontEndListenerResourceName := "aws_lb_listener.front_end"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLBListenerRuleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLBListenerRuleConfig_conditionPathPattern_deprecated(lbName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLBListenerRuleExists(resourceName, &conf),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
-					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":    "path-pattern",
-						"values.0": "/public/*",
-					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
-				),
-			},
-			{
-				Config: testAccAWSLBListenerRuleConfig_conditionPathPattern_deprecatedUpdated(lbName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLBListenerRuleExists(resourceName, &conf),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
-					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"values.0": "/cgi-bin/*",
-					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
-				),
-			},
-			{
-				Config: testAccAWSLBListenerRuleConfig_conditionPathPattern_migrated(lbName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLBListenerRuleExists(resourceName, &conf),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
-					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"values.0": "/cgi-bin/*",
-					}),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
-				),
-			},
-			{
-				Config: testAccAWSLBListenerRuleConfig_conditionPathPattern(lbName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLBListenerRuleExists(resourceName, &conf),
-					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
-					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"values.0": "/cgi-bin/*",
-						"values.1": "/public/*",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
@@ -1034,14 +836,12 @@ func TestAccAWSLBListenerRule_conditionQueryString(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                 "query-string",
 						"host_header.#":         "0",
 						"http_header.#":         "0",
 						"http_request_method.#": "0",
 						"path_pattern.#":        "0",
 						"query_string.#":        "2",
 						"source_ip.#":           "0",
-						"values.#":              "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
 						"key":   "",
@@ -1055,14 +855,12 @@ func TestAccAWSLBListenerRule_conditionQueryString(t *testing.T) {
 					// because we had to write a new check for the "downstream" nested set
 					// a distinguishing attribute on the outer set would be solve this.
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                 "query-string",
 						"host_header.#":         "0",
 						"http_header.#":         "0",
 						"http_request_method.#": "0",
 						"path_pattern.#":        "0",
 						"query_string.#":        "2",
 						"source_ip.#":           "0",
-						"values.#":              "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*.query_string.*", map[string]string{
 						"key":   "foo",
@@ -1100,7 +898,6 @@ func TestAccAWSLBListenerRule_conditionSourceIp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                 "source-ip",
 						"host_header.#":         "0",
 						"http_header.#":         "0",
 						"http_request_method.#": "0",
@@ -1108,7 +905,6 @@ func TestAccAWSLBListenerRule_conditionSourceIp(t *testing.T) {
 						"query_string.#":        "0",
 						"source_ip.#":           "1",
 						"source_ip.0.values.#":  "2",
-						"values.#":              "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
@@ -1139,14 +935,11 @@ func TestAccAWSLBListenerRule_conditionUpdateMixed(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                   "path-pattern",
 						"path_pattern.#":          "1",
 						"path_pattern.0.values.#": "1",
-						"values.0":                "/public/*",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                "source-ip",
 						"source_ip.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
@@ -1161,14 +954,11 @@ func TestAccAWSLBListenerRule_conditionUpdateMixed(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                   "path-pattern",
 						"path_pattern.#":          "1",
 						"path_pattern.0.values.#": "1",
-						"values.0":                "/public/*",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                "source-ip",
 						"source_ip.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
@@ -1183,14 +973,11 @@ func TestAccAWSLBListenerRule_conditionUpdateMixed(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "2"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                   "path-pattern",
 						"path_pattern.#":          "1",
 						"path_pattern.0.values.#": "1",
-						"values.0":                "/cgi-bin/*",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/cgi-bin/*"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                "source-ip",
 						"source_ip.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "dead:cafe::/64"),
@@ -1222,7 +1009,6 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "5"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                          "http-header",
 						"host_header.#":                  "0",
 						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "X-Forwarded-For",
@@ -1231,12 +1017,10 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"path_pattern.#":                 "0",
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
-						"values.#":                       "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                 "source-ip",
 						"host_header.#":         "0",
 						"http_header.#":         "0",
 						"http_request_method.#": "0",
@@ -1244,12 +1028,10 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"query_string.#":        "0",
 						"source_ip.#":           "1",
 						"source_ip.0.values.#":  "1",
-						"values.#":              "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                          "http-request-method",
 						"host_header.#":                  "0",
 						"http_header.#":                  "0",
 						"http_request_method.#":          "1",
@@ -1257,12 +1039,10 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"path_pattern.#":                 "0",
 						"query_string.#":                 "0",
 						"source_ip.#":                    "0",
-						"values.#":                       "0",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                   "path-pattern",
 						"host_header.#":           "0",
 						"http_header.#":           "0",
 						"http_request_method.#":   "0",
@@ -1270,13 +1050,10 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"path_pattern.0.values.#": "1",
 						"query_string.#":          "0",
 						"source_ip.#":             "0",
-						"values.#":                "1",
-						"values.0":                "/public/*",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                  "host-header",
 						"host_header.#":          "1",
 						"host_header.0.values.#": "1",
 						"http_header.#":          "0",
@@ -1284,8 +1061,6 @@ func TestAccAWSLBListenerRule_conditionMultiple(t *testing.T) {
 						"path_pattern.#":         "0",
 						"query_string.#":         "0",
 						"source_ip.#":            "0",
-						"values.#":               "1",
-						"values.0":               "example.com",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
 				),
@@ -1315,30 +1090,33 @@ func TestAccAWSLBListenerRule_conditionUpdateMultiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "5"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                          "http-header",
+						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "X-Forwarded-For",
+						"http_header.0.values.#":         "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.1.*"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field": "source-ip",
+						"source_ip.#":          "1",
+						"source_ip.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/16"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field": "http-request-method",
+						"http_request_method.#":          "1",
+						"http_request_method.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "GET"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":    "path-pattern",
-						"values.0": "/public/*",
+						"path_pattern.#":          "1",
+						"path_pattern.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/*"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":    "host-header",
-						"values.0": "example.com",
+						"host_header.#":          "1",
+						"host_header.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "example.com"),
 				),
@@ -1352,30 +1130,33 @@ func TestAccAWSLBListenerRule_conditionUpdateMultiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "condition.#", "5"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":                          "http-header",
+						"http_header.#":                  "1",
 						"http_header.0.http_header_name": "X-Forwarded-For",
+						"http_header.0.values.#":         "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_header.0.values.*", "192.168.2.*"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field": "source-ip",
+						"source_ip.#":          "1",
+						"source_ip.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.source_ip.0.values.*", "192.168.0.0/24"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field": "http-request-method",
+						"http_request_method.#":          "1",
+						"http_request_method.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.http_request_method.0.values.*", "POST"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":    "path-pattern",
-						"values.0": "/public/2/*",
+						"path_pattern.#":          "1",
+						"path_pattern.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.path_pattern.0.values.*", "/public/2/*"),
 
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "condition.*", map[string]string{
-						"field":    "host-header",
-						"values.0": "foobar.com",
+						"host_header.#":          "1",
+						"host_header.0.values.#": "1",
 					}),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "condition.*.host_header.0.values.*", "foobar.com"),
 				),
@@ -1483,126 +1264,6 @@ func testAccCheckAWSLBListenerRuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSLBListenerRuleConfig_multipleConditions(lbName, targetGroupName string) string {
-	return fmt.Sprintf(`
-resource "aws_lb_listener_rule" "static" {
-  listener_arn = "${aws_lb_listener.front_end.arn}"
-  priority     = 100
-
-  action {
-    type             = "forward"
-    target_group_arn = "${aws_lb_target_group.test.arn}"
-  }
-
-  condition {
-    field  = "path-pattern"
-    values = ["/static/*", "static"]
-  }
-}
-
-resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = "${aws_lb.alb_test.id}"
-  protocol          = "HTTP"
-  port              = "80"
-
-  default_action {
-    target_group_arn = "${aws_lb_target_group.test.id}"
-    type             = "forward"
-  }
-}
-
-resource "aws_lb" "alb_test" {
-  name            = "%s"
-  internal        = true
-  security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
-
-  idle_timeout               = 30
-  enable_deletion_protection = false
-
-  tags = {
-    Name = "TestAccAWSALB_basic"
-  }
-}
-
-resource "aws_lb_target_group" "test" {
-  name     = "%s"
-  port     = 8080
-  protocol = "HTTP"
-  vpc_id   = "${aws_vpc.alb_test.id}"
-
-  health_check {
-    path                = "/health"
-    interval            = 60
-    port                = 8081
-    protocol            = "HTTP"
-    timeout             = 3
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    matcher             = "200-299"
-  }
-}
-
-variable "subnets" {
-  default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "alb_test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-lb-listener-rule-multiple-conditions"
-  }
-}
-
-resource "aws_subnet" "alb_test" {
-  count                   = 2
-  vpc_id                  = "${aws_vpc.alb_test.id}"
-  cidr_block              = "${element(var.subnets, count.index)}"
-  map_public_ip_on_launch = true
-  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
-
-  tags = {
-    Name = "tf-acc-lb-listener-rule-multiple-conditions-${count.index}"
-  }
-}
-
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
-  description = "Used for ALB Testing"
-  vpc_id      = "${aws_vpc.alb_test.id}"
-
-  ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = "TestAccAWSALB_basic"
-  }
-}
-`, lbName, targetGroupName)
-}
-
 func testAccAWSLBListenerRuleConfig_basic(lbName, targetGroupName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_listener_rule" "static" {
@@ -1615,8 +1276,9 @@ resource "aws_lb_listener_rule" "static" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -1744,8 +1406,9 @@ resource "aws_lb_listener_rule" "weighted" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/weighted/*"]
+    path_pattern {
+      values = ["/weighted/*"]
+    }
   }
 }
 
@@ -1895,8 +1558,9 @@ resource "aws_lb_listener_rule" "weighted" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/weighted/*"]
+    path_pattern {
+      values = ["/weighted/*"]
+    }
   }
 }
 
@@ -2033,8 +1697,9 @@ resource "aws_lb_listener_rule" "weighted" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/weighted/*"]
+    path_pattern {
+      values = ["/weighted/*"]
+    }
   }
 }
 
@@ -2171,8 +1836,9 @@ resource "aws_alb_listener_rule" "static" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -2296,8 +1962,9 @@ resource "aws_lb_listener_rule" "static" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -2408,8 +2075,9 @@ resource "aws_lb_listener_rule" "static" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -2515,8 +2183,9 @@ resource "aws_lb_listener_rule" "static" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -2635,8 +2304,9 @@ resource "aws_lb_listener_rule" "static" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -2870,8 +2540,9 @@ resource "aws_lb_listener_rule" "first" {
   }
 
   condition {
-    field = "path-pattern"
-    values = ["/first/*"]
+    path_pattern {
+      values = ["/first/*"]
+    }
   }
 }
 
@@ -2885,8 +2556,9 @@ resource "aws_lb_listener_rule" "third" {
   }
 
   condition {
-    field = "path-pattern"
-    values = ["/third/*"]
+    path_pattern {
+      values = ["/third/*"]
+    }
   }
 
   depends_on = ["aws_lb_listener_rule.first"]
@@ -2905,8 +2577,9 @@ resource "aws_lb_listener_rule" "last" {
   }
 
   condition {
-    field = "path-pattern"
-    values = ["/last/*"]
+    path_pattern {
+      values = ["/last/*"]
+    }
   }
 }
 `
@@ -2924,8 +2597,9 @@ resource "aws_lb_listener_rule" "last" {
   }
 
   condition {
-    field = "path-pattern"
-    values = ["/last/*"]
+    path_pattern {
+      values = ["/last/*"]
+    }
   }
 }
 `
@@ -2944,8 +2618,9 @@ resource "aws_lb_listener_rule" "parallelism" {
   }
 
   condition {
-    field = "path-pattern"
-    values = ["/${count.index}/*"]
+    path_pattern {
+      values = ["/${count.index}/*"]
+    }
   }
 }
 `
@@ -2963,8 +2638,9 @@ resource "aws_lb_listener_rule" "priority50000" {
   }
 
   condition {
-    field = "path-pattern"
-    values = ["/50000/*"]
+    path_pattern {
+      values = ["/50000/*"]
+    }
   }
 }
 `
@@ -2982,8 +2658,9 @@ resource "aws_lb_listener_rule" "priority50001" {
   }
 
   condition {
-    field = "path-pattern"
-    values = ["/50001/*"]
+    path_pattern {
+      values = ["/50001/*"]
+    }
   }
 }
 `
@@ -3001,8 +2678,9 @@ resource "aws_lb_listener_rule" "priority50000_in_use" {
   }
 
   condition {
-    field = "path-pattern"
-    values = ["/50000_in_use/*"]
+    path_pattern {
+      values = ["/50000_in_use/*"]
+    }
   }
 }
 `
@@ -3034,8 +2712,9 @@ resource "aws_lb_listener_rule" "cognito" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -3200,8 +2879,9 @@ resource "aws_lb_listener_rule" "oidc" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -3359,8 +3039,9 @@ resource "aws_lb_listener_rule" "test" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 
@@ -3475,18 +3156,6 @@ resource "aws_lb_listener_rule" "error" {
 `, condition)
 }
 
-func testAccAWSLBListenerRuleConfig_conditionAttributesCount_empty() string {
-	return testAccAWSLBListenerRuleConfig_condition_error("condition {}")
-}
-
-func testAccAWSLBListenerRuleConfig_conditionAttributesCount_field() string {
-	return testAccAWSLBListenerRuleConfig_condition_error(`condition { field = "host-header" }`)
-}
-
-func testAccAWSLBListenerRuleConfig_conditionAttributesCount_values() string {
-	return testAccAWSLBListenerRuleConfig_condition_error(`condition { values = ["example.com"] }`)
-}
-
 func testAccAWSLBListenerRuleConfig_conditionAttributesCount_http_header() string {
 	return testAccAWSLBListenerRuleConfig_condition_error(`
 condition {
@@ -3546,17 +3215,6 @@ condition {
   source_ip {
     values = ["192.168.0.0/16"]
   }
-}`)
-}
-
-func testAccAWSLBListenerRuleConfig_conditionAttributesCount_classic() string {
-	return testAccAWSLBListenerRuleConfig_condition_error(`
-condition {
-  host_header {
-    values = ["example.com"]
-  }
-  field  = "host-header"
-  values = ["example2.com"]
 }`)
 }
 
@@ -3679,15 +3337,6 @@ condition {
 `, "HostHeader", lbName)
 }
 
-func testAccAWSLBListenerRuleConfig_conditionHostHeader_deprecated(lbName string) string {
-	return testAccAWSLBListenerRuleConfig_condition_base(`
-condition {
-  field  = "host-header"
-  values = ["example.com"]
-}
-`, "HostHeaderDep", lbName)
-}
-
 func testAccAWSLBListenerRuleConfig_conditionHttpHeader(lbName string) string {
 	return testAccAWSLBListenerRuleConfig_condition_base(`
 condition {
@@ -3752,34 +3401,6 @@ condition {
 `, "PathPattern", lbName)
 }
 
-func testAccAWSLBListenerRuleConfig_conditionPathPattern_deprecated(lbName string) string {
-	return testAccAWSLBListenerRuleConfig_condition_base(`
-condition {
-  field = "path-pattern"
-  values = ["/public/*"]
-}
-`, "PathPattern", lbName)
-}
-
-func testAccAWSLBListenerRuleConfig_conditionPathPattern_deprecatedUpdated(lbName string) string {
-	return testAccAWSLBListenerRuleConfig_condition_base(`
-condition {
-  field = "path-pattern"
-  values = ["/cgi-bin/*"]
-}
-`, "PathPattern", lbName)
-}
-
-func testAccAWSLBListenerRuleConfig_conditionPathPattern_migrated(lbName string) string {
-	return testAccAWSLBListenerRuleConfig_condition_base(`
-condition {
-  path_pattern {
-    values = ["/cgi-bin/*"]
-  }
-}
-`, "PathPattern", lbName)
-}
-
 func testAccAWSLBListenerRuleConfig_conditionQueryString(lbName string) string {
 	return testAccAWSLBListenerRuleConfig_condition_base(`
 condition {
@@ -3821,8 +3442,9 @@ condition {
 func testAccAWSLBListenerRuleConfig_conditionMixed(lbName string) string {
 	return testAccAWSLBListenerRuleConfig_condition_base(`
 condition {
-  field  = "path-pattern"
-  values = ["/public/*"]
+  path_pattern {
+    values = ["/public/*"]
+  }
 }
 
 condition {
@@ -3839,8 +3461,9 @@ condition {
 func testAccAWSLBListenerRuleConfig_conditionMixed_updated(lbName string) string {
 	return testAccAWSLBListenerRuleConfig_condition_base(`
 condition {
-  field  = "path-pattern"
-  values = ["/public/*"]
+  path_pattern {
+    values = ["/public/*"]
+  }
 }
 
 condition {
@@ -3857,8 +3480,9 @@ condition {
 func testAccAWSLBListenerRuleConfig_conditionMixed_updated2(lbName string) string {
 	return testAccAWSLBListenerRuleConfig_condition_base(`
 condition {
-  field  = "path-pattern"
-  values = ["/cgi-bin/*"]
+  path_pattern {
+    values = ["/cgi-bin/*"]
+  }
 }
 
 condition {

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -295,8 +295,6 @@ One or more condition blocks can be set per rule. Most condition types can only 
 
 Condition Blocks (for `condition`) support the following:
 
-* `field` - (Optional, **DEPRECATED**) The type of condition. Valid values are `host-header` or `path-pattern`. Must also set `values`.
-* `values` - (Optional, **DEPRECATED**) List of exactly one pattern to match. Required when `field` is set.
 * `host_header` - (Optional) Contains a single `values` item which is a list of host header patterns to match. The maximum size of each pattern is 128 characters. Comparison is case insensitive. Wildcard characters supported: * (matches 0 or more characters) and ? (matches exactly 1 character). Only one pattern needs to match for the condition to be satisfied.
 * `http_header` - (Optional) HTTP headers to match. [HTTP Header block](#http-header-blocks) fields documented below.
 * `http_request_method` - (Optional) Contains a single `values` item which is a list of HTTP request methods or verbs to match. Maximum size is 40 characters. Only allowed characters are A-Z, hyphen (-) and underscore (\_). Comparison is case sensitive. Wildcards are not supported. Only one needs to match for the condition to be satisfied. AWS recommends that GET and HEAD requests are routed in the same way because the response to a HEAD request may be cached.
@@ -304,7 +302,7 @@ Condition Blocks (for `condition`) support the following:
 * `query_string` - (Optional) Query strings to match. [Query String block](#query-string-blocks) fields documented below.
 * `source_ip` - (Optional) Contains a single `values` item which is a list of source IP CIDR notations to match. You can use both IPv4 and IPv6 addresses. Wildcards are not supported. Condition is satisfied if the source IP address of the request matches one of the CIDR blocks. Condition is not satisfied by the addresses in the `X-Forwarded-For` header, use `http_header` condition instead.
 
-~> **NOTE::** Exactly one of `field`, `host_header`, `http_header`, `http_request_method`, `path_pattern`, `query_string` or `source_ip` must be set per condition.
+~> **NOTE::** Exactly one of `host_header`, `http_header`, `http_request_method`, `path_pattern`, `query_string` or `source_ip` must be set per condition.
 
 #### HTTP Header Blocks
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/8268
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13398

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_lb_listener_rule: Remove deprecated `condition` configuration block `field` and `values` arguments
```

Already documented in the version 3 upgrade guide.

Output from acceptance testing:

```
--- PASS: TestAccAWSLBListenerRule_Action_Order (242.39s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (172.01s)
--- PASS: TestAccAWSLBListenerRule_BackwardsCompatibility (192.52s)
--- PASS: TestAccAWSLBListenerRule_basic (205.77s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (234.49s)
--- PASS: TestAccAWSLBListenerRule_cognito (190.75s)
--- PASS: TestAccAWSLBListenerRule_conditionAttributesCount (10.86s)
--- PASS: TestAccAWSLBListenerRule_conditionHostHeader (227.40s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader (194.36s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpHeader_invalid (1.43s)
--- PASS: TestAccAWSLBListenerRule_conditionHttpRequestMethod (195.55s)
--- PASS: TestAccAWSLBListenerRule_conditionMultiple (269.78s)
--- PASS: TestAccAWSLBListenerRule_conditionPathPattern (199.17s)
--- PASS: TestAccAWSLBListenerRule_conditionQueryString (195.57s)
--- PASS: TestAccAWSLBListenerRule_conditionSourceIp (186.73s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMixed (274.24s)
--- PASS: TestAccAWSLBListenerRule_conditionUpdateMultiple (267.11s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (213.36s)
--- PASS: TestAccAWSLBListenerRule_forwardWeighted (213.62s)
--- PASS: TestAccAWSLBListenerRule_oidc (206.04s)
--- PASS: TestAccAWSLBListenerRule_priority (377.75s)
--- PASS: TestAccAWSLBListenerRule_redirect (248.43s)
--- PASS: TestAccAWSLBListenerRule_updateFixedResponse (189.01s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (206.44s)
```
