### PR TITLE
resource/instance and resource/ebs_volume: error when iops provided for unsupported volume type

### DIFF
--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -114,27 +114,30 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 		request.OutpostArn = aws.String(value.(string))
 	}
 
-	// IOPs are only valid, and required for, storage type io1. The current minimu
-	// is 100. Instead of a hard validation we we only apply the IOPs to the
-	// request if the type is io1, and log a warning otherwise. This allows users
-	// to "disable" iops. See https://github.com/hashicorp/terraform/pull/4146
+	// IOPs are only valid, and required for, storage type io1. The current minimum
+	// is 100. Hard validation in place to return an error if IOPs are provided
+	// for an unsupported storage type.
+	// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12667
 	var t string
 	if value, ok := d.GetOk("type"); ok {
 		t = value.(string)
 		request.VolumeType = aws.String(t)
 	}
 
-	iops := d.Get("iops").(int)
-	if t != ec2.VolumeTypeIo1 && iops > 0 {
-		log.Printf("[WARN] IOPs is only valid on IO1 storage type for EBS Volumes")
-	} else if t == ec2.VolumeTypeIo1 {
+	if iops := d.Get("iops").(int); iops > 0 {
+		if t != ec2.VolumeTypeIo1 {
+			if t == "" {
+				// Volume creation would default to gp2
+				t = ec2.VolumeTypeGp2
+			}
+			return fmt.Errorf("error creating ebs_volume: iops attribute not supported for type %s", t)
+		}
 		// We add the iops value without validating it's size, to allow AWS to
 		// enforce a size requirement (currently 100)
 		request.Iops = aws.Int64(int64(iops))
 	}
 
-	log.Printf(
-		"[DEBUG] EBS Volume create opts: %s", request)
+	log.Printf("[DEBUG] EBS Volume create opts: %s", request)
 	result, err := conn.CreateVolume(request)
 	if err != nil {
 		return fmt.Errorf("Error creating EC2 volume: %s", err)

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -592,11 +592,11 @@ func resourceAwsInstance() *schema.Resource {
 }
 
 func iopsDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	// Suppress diff if volume_type is not io1
+	// Suppress diff if volume_type is not io1 and iops is unset or configured as 0
 	i := strings.LastIndexByte(k, '.')
 	vt := k[:i+1] + "volume_type"
 	v := d.Get(vt).(string)
-	return strings.ToLower(v) != ec2.VolumeTypeIo1
+	return strings.ToLower(v) != ec2.VolumeTypeIo1 && new == "0"
 }
 
 func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
@@ -1367,6 +1367,15 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		if d.HasChange("root_block_device.0.iops") {
 			if v, ok := d.Get("root_block_device.0.iops").(int); ok && v != 0 {
+				// Enforce IOPs usage with a valid volume type
+				// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12667
+				if t, ok := d.Get("root_block_device.0.volume_type").(string); ok && t != ec2.VolumeTypeIo1 {
+					if t == "" {
+						// Volume defaults to gp2
+						t = ec2.VolumeTypeGp2
+					}
+					return fmt.Errorf("error updating instance: iops attribute not supported for type %s", t)
+				}
 				modifyVolume = true
 				input.Iops = aws.Int64(int64(v))
 			}
@@ -1823,13 +1832,17 @@ func readBlockDeviceMappingsFromConfig(d *schema.ResourceData, conn *ec2.EC2) ([
 
 			if v, ok := bd["volume_type"].(string); ok && v != "" {
 				ebs.VolumeType = aws.String(v)
-				if ec2.VolumeTypeIo1 == strings.ToLower(v) {
-					// Condition: This parameter is required for requests to create io1
-					// volumes; it is not used in requests to create gp2, st1, sc1, or
-					// standard volumes.
-					// See: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html
-					if v, ok := bd["iops"].(int); ok && v > 0 {
-						ebs.Iops = aws.Int64(int64(v))
+				if iops, ok := bd["iops"].(int); ok && iops > 0 {
+					if ec2.VolumeTypeIo1 == strings.ToLower(v) {
+						// Condition: This parameter is required for requests to create io1
+						// volumes; it is not used in requests to create gp2, st1, sc1, or
+						// standard volumes.
+						// See: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html
+						ebs.Iops = aws.Int64(int64(iops))
+					} else {
+						// Enforce IOPs usage with a valid volume type
+						// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12667
+						return nil, fmt.Errorf("error creating resource: iops attribute not supported for ebs_block_device with volume_type %s", v)
 					}
 				}
 			}
@@ -1885,18 +1898,20 @@ func readBlockDeviceMappingsFromConfig(d *schema.ResourceData, conn *ec2.EC2) ([
 
 			if v, ok := bd["volume_type"].(string); ok && v != "" {
 				ebs.VolumeType = aws.String(v)
-			}
-
-			if v, ok := bd["iops"].(int); ok && v > 0 && aws.StringValue(ebs.VolumeType) == ec2.VolumeTypeIo1 {
-				// Only set the iops attribute if the volume type is io1. Setting otherwise
-				// can trigger a refresh/plan loop based on the computed value that is given
-				// from AWS, and prevent us from specifying 0 as a valid iops.
-				//   See https://github.com/hashicorp/terraform/pull/4146
-				//   See https://github.com/hashicorp/terraform/issues/7765
-				ebs.Iops = aws.Int64(int64(v))
-			} else if v, ok := bd["iops"].(int); ok && v > 0 && aws.StringValue(ebs.VolumeType) != ec2.VolumeTypeIo1 {
-				// Message user about incompatibility
-				log.Print("[WARN] IOPs is only valid on IO1 storage type for EBS Volumes")
+				if iops, ok := bd["iops"].(int); ok && iops > 0 {
+					if ec2.VolumeTypeIo1 == strings.ToLower(v) {
+						// Only set the iops attribute if the volume type is io1. Setting otherwise
+						// can trigger a refresh/plan loop based on the computed value that is given
+						// from AWS, and prevent us from specifying 0 as a valid iops.
+						//   See https://github.com/hashicorp/terraform/pull/4146
+						//   See https://github.com/hashicorp/terraform/issues/7765
+						ebs.Iops = aws.Int64(int64(iops))
+					} else {
+						// Enforce IOPs usage with a valid volume type
+						// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12667
+						return nil, fmt.Errorf("error creating resource: iops attribute not supported for root_block_device with volume_type %s", v)
+					}
+				}
 			}
 
 			if dn, err := fetchRootDeviceName(d.Get("ami").(string), conn); err == nil {
@@ -2064,8 +2079,7 @@ type awsInstanceOpts struct {
 	MetadataOptions                   *ec2.InstanceMetadataOptionsRequest
 }
 
-func buildAwsInstanceOpts(
-	d *schema.ResourceData, meta interface{}) (*awsInstanceOpts, error) {
+func buildAwsInstanceOpts(d *schema.ResourceData, meta interface{}) (*awsInstanceOpts, error) {
 	conn := meta.(*AWSClient).ec2conn
 
 	instanceType := d.Get("instance_type").(string)

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -344,6 +344,22 @@ func TestAccAWSInstance_EbsBlockDevice_KmsKeyArn(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12667
+func TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType(t *testing.T) {
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckInstanceConfigEBSBlockDeviceInvalidIops,
+				ExpectError: regexp.MustCompile(`error creating resource: iops attribute not supported for ebs_block_device with volume_type gp2`),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_RootBlockDevice_KmsKeyArn(t *testing.T) {
 	var instance ec2.Instance
 	kmsKeyResourceName := "aws_kms_key.test"
@@ -449,30 +465,19 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 	})
 }
 
+// TestAccAWSInstance_GP2WithIopsValue updated in v3.0.0
+// to account for apply-time validation of the root_block_device.iops attribute for supported volume types
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/14310
 func TestAccAWSInstance_GP2WithIopsValue(t *testing.T) {
-	var v ec2.Instance
-	resourceName := "aws_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   resourceName,
-		IDRefreshIgnore: []string{"ephemeral_block_device", "user_data"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckInstanceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceGP2WithIopsValue,
-				Check:  testAccCheckInstanceExists(resourceName, &v),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config:             testAccInstanceGP2WithIopsValue,
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
+				Config:      testAccInstanceGP2WithIopsValue,
+				ExpectError: regexp.MustCompile(`error creating resource: iops attribute not supported for root_block_device with volume_type gp2`),
 			},
 		},
 	})
@@ -3999,6 +4004,22 @@ resource "aws_instance" "test" {
 	}
 }
 `
+
+var testAccCheckInstanceConfigEBSBlockDeviceInvalidIops = composeConfig(testAccAwsEc2InstanceAmiWithEbsRootVolume,
+	`
+resource "aws_instance" "test" {
+  ami = data.aws_ami.ami.id
+
+  instance_type = "m3.medium"
+
+  ebs_block_device {
+    device_name = "/dev/sdc"
+    volume_size = 10
+    volume_type = "gp2"
+    iops        = 100
+  }
+}
+`)
 
 const testAccCheckInstanceConfigWithVolumeTags = `
 resource "aws_instance" "test" {

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -252,7 +252,8 @@ Previously when importing the `aws_dx_gateway` resource with the [`terraform imp
 
 ### iops Argument Apply-Time Validation
 
-Previously when the `iops` argument was configured with a `type` other than `io1` (either explicitly or omitted, indicating the default type `gp2`), the Terraform AWS Provider would automatically disregard the value provided to `iops` as it is only configurable for the `io1` volume type per the AWS EC2 API. This behavior has changed such that the Terraform AWS Provider will instead return an error at apply time indicating an `iops` value is invalid for types other than `io1`.
+Previously when the `iops` argument was configured with a `type` other than `io1` (either explicitly or omitted, indicating the default type `gp2`), the Terraform AWS Provider would automatically disregard the value provided to `iops` as it is only configurable for the `io1` volume type per the AWS EC2 API. This behavior has changed such that the Terraform AWS Provider will instead return an error at apply time indicating an `iops` value is invalid for types other than `io1`. 
+Exceptions to this are in cases where `iops` is set to `null` or `0` such that the Terraform AWS Provider will continue to accept the value regardless of `type`. 
 
 ## Resource: aws_elastic_transcoder_preset
 
@@ -399,6 +400,7 @@ resource "aws_emr_cluster" "example" {
 ### ebs_block_device.iops and root_block_device.iops Argument Apply-Time Validations
 
 Previously when the `iops` argument was configured in either the `ebs_block_device` or `root_block_device` configuration block, the Terraform AWS Provider would automatically disregard the value provided to `iops` if the `type` argument was also configured with a value other than `io1` (either explicitly or omitted, indicating the default type `gp2`) as `iops` are only configurable for the `io1` volume type per the AWS EC2 API. This behavior has changed such that the Terraform AWS Provider will instead return an error at apply time indicating an `iops` value is invalid for volume types other than `io1`.
+Exceptions to this are in cases where `iops` is set to `null` or `0` such that the Terraform AWS Provider will continue to accept the value regardless of `type`. 
 
 ## Resource: aws_lambda_alias
 

--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -26,8 +26,10 @@ Upgrade topics:
 - [Resource: aws_api_gateway_method_settings](#resource-aws_api_gateway_method_settings)
 - [Resource: aws_autoscaling_group](#resource-aws_autoscaling_group)
 - [Resource: aws_dx_gateway](#resource-aws_dx_gateway)
+- [Resource: aws_ebs_volume](#resource-aws_ebs_volume)
 - [Resource: aws_elastic_transcoder_preset](#resource-aws_elastic_transcoder_preset)
 - [Resource: aws_emr_cluster](#resource-aws_emr_cluster)
+- [Resource: aws_instance](#resource-aws_instance)
 - [Resource: aws_lambda_alias](#resource-aws_lambda_alias)
 - [Resource: aws_launch_template](#resource-aws_launch_template)
 - [Resource: aws_lb_listener_rule](#resource-aws_lb_listener_rule)
@@ -246,6 +248,12 @@ resource "aws_autoscaling_group" "example"{
 
 Previously when importing the `aws_dx_gateway` resource with the [`terraform import` command](/docs/commands/import.html), the Terraform AWS Provider would automatically attempt to import an associated `aws_dx_gateway_association` resource(s) as well. This automatic resource import has been removed. Use the [`aws_dx_gateway_association` resource import](/docs/providers/aws/r/dx_gateway_association.html#import) to import those resources separately.
 
+## Resource: aws_ebs_volume
+
+### iops Argument Apply-Time Validation
+
+Previously when the `iops` argument was configured with a `type` other than `io1` (either explicitly or omitted, indicating the default type `gp2`), the Terraform AWS Provider would automatically disregard the value provided to `iops` as it is only configurable for the `io1` volume type per the AWS EC2 API. This behavior has changed such that the Terraform AWS Provider will instead return an error at apply time indicating an `iops` value is invalid for types other than `io1`.
+
 ## Resource: aws_elastic_transcoder_preset
 
 ### video Configuration Block max_frame_rate Argument No Longer Uses 30 Default
@@ -385,6 +393,12 @@ resource "aws_emr_cluster" "example" {
   }
 }
 ```
+
+## Resource: aws_instance
+
+### ebs_block_device.iops and root_block_device.iops Argument Apply-Time Validations
+
+Previously when the `iops` argument was configured in either the `ebs_block_device` or `root_block_device` configuration block, the Terraform AWS Provider would automatically disregard the value provided to `iops` if the `type` argument was also configured with a value other than `io1` (either explicitly or omitted, indicating the default type `gp2`) as `iops` are only configurable for the `io1` volume type per the AWS EC2 API. This behavior has changed such that the Terraform AWS Provider will instead return an error at apply time indicating an `iops` value is invalid for volume types other than `io1`.
 
 ## Resource: aws_lambda_alias
 

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `availability_zone` - (Required) The AZ where the EBS volume will exist.
 * `encrypted` - (Optional) If true, the disk will be encrypted.
-* `iops` - (Optional) The amount of IOPS to provision for the disk.
+* `iops` - (Optional) The amount of IOPS to provision for the disk. Only valid for `type` of `io1`.
 * `multi_attach_enabled` - (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported exclusively on `io1` volumes.
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12667 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/instance and resource/ebs_volume: error when iops provided for unsupported volume type
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEBSVolume_basic (20.13s)
--- PASS: TestAccAWSEBSVolume_InvalidIopsForType (6.23s)
--- SKIP: TestAccAWSEBSVolume_outpost (1.73s)
--- PASS: TestAccAWSEBSVolume_updateSize (36.70s)
--- PASS: TestAccAWSEBSVolume_kmsKey (20.93s)
--- PASS: TestAccAWSEBSVolume_NoIops (20.76s)
--- PASS: TestAccAWSEBSVolume_withTags (20.31s)
--- PASS: TestAccAWSEBSVolume_multiAttach (20.14s)
--- PASS: TestAccAWSEBSVolume_updateType (36.84s)
--- PASS: TestAccAWSEBSVolume_disappears (20.44s)
--- PASS: TestAccAWSEBSVolume_updateIops (36.60s)
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (140.93s)
```
```
--- SKIP: TestAccAWSInstance_inEc2Classic (0.93s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType (8.88s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (3.21s)
--- PASS: TestAccAWSInstance_RootBlockDevice_InvalidIopsForVolumeType (10.40s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (74.15s)
--- SKIP: TestAccAWSInstance_outpost (1.68s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (79.71s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (95.11s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (10.36s)
--- PASS: TestAccAWSInstance_blockDevices (90.34s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (104.75s)
--- PASS: TestAccAWSInstance_rootInstanceStore (89.92s)
--- PASS: TestAccAWSInstance_placementGroup (58.79s)
--- PASS: TestAccAWSInstance_vpc (85.15s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (76.46s)
--- PASS: TestAccAWSInstance_sourceDestCheck (124.58s)
--- PASS: TestAccAWSInstance_disableApiTermination (127.27s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (73.02s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (180.76s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (78.42s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (85.25s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (175.30s)
--- PASS: TestAccAWSInstance_basic (200.55s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (65.00s)
--- PASS: TestAccAWSInstance_volumeTags (112.21s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (76.44s)
--- PASS: TestAccAWSInstance_privateIP (85.73s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (74.64s)
--- PASS: TestAccAWSInstance_userDataBase64 (233.29s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (63.76s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (146.57s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (188.32s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (108.67s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (153.33s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (102.87s)
--- PASS: TestAccAWSInstance_instanceProfileChange (167.39s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS (111.94s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (124.74s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (82.10s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (80.37s)
--- PASS: TestAccAWSInstance_keyPairCheck (185.32s)
--- PASS: TestAccAWSInstance_tags (237.77s)
--- PASS: TestAccAWSInstance_multipleRegions (261.12s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (147.13s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs (83.29s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (78.80s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (114.79s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate (102.39s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate (106.91s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (87.53s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (85.54s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (90.97s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (90.17s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (181.91s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (77.64s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (202.68s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (90.53s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (90.62s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (106.33s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (91.01s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (159.00s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (93.65s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (195.43s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (105.27s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (104.30s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (99.33s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (182.96s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (115.48s)
--- PASS: TestAccAWSInstance_changeInstanceType (353.22s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (135.66s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (94.56s)
--- PASS: TestAccAWSInstance_disappears (98.96s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (96.48s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs (331.70s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (310.95s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (309.68s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (355.33s)
--- PASS: TestAccAWSInstance_hibernation (388.94s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs (622.90s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (491.04s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (105.32s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (117.49s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (147.10s)
--- PASS: TestAccAWSInstance_metadataOptions (95.34s)
```