### PR TITLE
Switch multiregion/account testing to SDK V2 compatible pattern

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway_peering_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_peering_attachment_test.go
@@ -189,7 +189,7 @@ func testAccAWSEc2TransitGatewayPeeringAttachmentDataSourceConfigFilter_differen
 		testAccAWSEc2TransitGatewayPeeringAttachmentConfigBasic_differentAccount(rName),
 		`
 data "aws_ec2_transit_gateway_peering_attachment" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
   filter {
     name   = "transit-gateway-attachment-id"
     values = ["${aws_ec2_transit_gateway_peering_attachment.test.id}"]
@@ -203,7 +203,7 @@ func testAccAWSEc2TransitGatewayPeeringAttachmentDataSourceConfigID_differentAcc
 		testAccAWSEc2TransitGatewayPeeringAttachmentConfigBasic_differentAccount(rName),
 		`
 data "aws_ec2_transit_gateway_peering_attachment" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
   id = "${aws_ec2_transit_gateway_peering_attachment.test.id}"
 }
 `)

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -293,7 +293,7 @@ resource "aws_ram_principal_association" "test" {
 }
 
 data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   resolver_endpoint_id = "${aws_route53_resolver_rule.example.resolver_endpoint_id}"
 

--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -860,7 +860,7 @@ resource "aws_backup_vault" "test" {
 }
 
 resource "aws_backup_vault" "test2" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
   name     = "%[1]s-2"
 }
 

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -2400,7 +2400,7 @@ func testAccAWSCloudFrontDistributionConfigViewerCertificateAcmCertificateArnBas
 
 	return testAccUsEast1RegionProviderConfig() + fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
-  provider = "aws.us-east-1"
+  provider = "awsus-east-1"
 
   certificate_body = "%[1]s"
   private_key      = "%[2]s"

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -977,7 +977,7 @@ func testAccAWSCodePipelineConfig_multiregion(rName string) string {
 	return composeConfig(
 		testAccAlternateRegionProviderConfig(),
 		testAccAWSCodePipelineS3DefaultBucket(rName),
-		testAccAWSCodePipelineS3BucketWithProvider("alternate", rName, "aws.alternate"),
+		testAccAWSCodePipelineS3BucketWithProvider("alternate", rName, "awsalternate"),
 		fmt.Sprintf(`
 resource "aws_iam_role" "codepipeline_role" {
   name = "codepipeline-role-%[1]s"
@@ -1112,7 +1112,7 @@ func testAccAWSCodePipelineConfig_multiregionUpdated(rName string) string {
 	return composeConfig(
 		testAccAlternateRegionProviderConfig(),
 		testAccAWSCodePipelineS3DefaultBucket(rName),
-		testAccAWSCodePipelineS3BucketWithProvider("alternate", rName, "aws.alternate"),
+		testAccAWSCodePipelineS3BucketWithProvider("alternate", rName, "awsalternate"),
 		fmt.Sprintf(`
 resource "aws_iam_role" "codepipeline_role" {
   name = "codepipeline-role-%[1]s"

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -4662,7 +4662,7 @@ resource "aws_db_instance" "test" {
 func testAccAWSDBInstanceConfig_DbSubnetGroupName_RamShared(rName string) string {
 	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   state = "available"
 
@@ -4675,7 +4675,7 @@ data "aws_availability_zones" "available" {
 data "aws_organizations_organization" "test" {}
 
 resource "aws_vpc" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.0.0.0/16"
 
@@ -4686,7 +4686,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   count    = 2
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
@@ -4698,13 +4698,13 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_ram_resource_share" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   name = %[1]q
 }
 
 resource "aws_ram_principal_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   principal          = data.aws_organizations_organization.test.arn
   resource_share_arn = aws_ram_resource_share.test.arn
@@ -4712,7 +4712,7 @@ resource "aws_ram_principal_association" "test" {
 
 resource "aws_ram_resource_association" "test" {
   count    = 2
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   resource_arn       = aws_subnet.test[count.index].arn
   resource_share_arn = aws_ram_resource_share.test.id
@@ -5066,7 +5066,7 @@ resource "aws_db_instance" "test" {
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName(rName string) string {
 	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   state = "available"
 
@@ -5086,7 +5086,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.1.0.0/16"
 
@@ -5105,7 +5105,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "alternate" {
   count    = 2
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   availability_zone = data.aws_availability_zones.alternate.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
@@ -5129,7 +5129,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_db_subnet_group" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   name       = %[1]q
   subnet_ids = aws_subnet.alternate[*].id
@@ -5141,7 +5141,7 @@ resource "aws_db_subnet_group" "test" {
 }
 
 resource "aws_db_instance" "source" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   allocated_storage       = 5
   backup_retention_period = 1
@@ -5167,7 +5167,7 @@ resource "aws_db_instance" "test" {
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName_RamShared(rName string) string {
 	return testAccAlternateAccountAndAlternateRegionProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternateaccountsameregion" {
-  provider = "aws.alternateaccountsameregion"
+  provider = "awsalternateaccountsameregion"
 
   state = "available"
 
@@ -5178,7 +5178,7 @@ data "aws_availability_zones" "alternateaccountsameregion" {
 }
 
 data "aws_availability_zones" "sameaccountalternateregion" {
-  provider = "aws.sameaccountalternateregion"
+  provider = "awssameaccountalternateregion"
 
   state = "available"
 
@@ -5191,7 +5191,7 @@ data "aws_availability_zones" "sameaccountalternateregion" {
 data "aws_organizations_organization" "test" {}
 
 resource "aws_vpc" "sameaccountalternateregion" {
-  provider = "aws.sameaccountalternateregion"
+  provider = "awssameaccountalternateregion"
 
   cidr_block = "10.1.0.0/16"
 
@@ -5201,7 +5201,7 @@ resource "aws_vpc" "sameaccountalternateregion" {
 }
 
 resource "aws_vpc" "alternateaccountsameregion" {
-  provider = "aws.alternateaccountsameregion"
+  provider = "awsalternateaccountsameregion"
 
   cidr_block = "10.0.0.0/16"
 
@@ -5212,7 +5212,7 @@ resource "aws_vpc" "alternateaccountsameregion" {
 
 resource "aws_subnet" "sameaccountalternateregion" {
   count    = 2
-  provider = "aws.sameaccountalternateregion"
+  provider = "awssameaccountalternateregion"
 
   availability_zone = data.aws_availability_zones.sameaccountalternateregion.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
@@ -5225,7 +5225,7 @@ resource "aws_subnet" "sameaccountalternateregion" {
 
 resource "aws_subnet" "alternateaccountsameregion" {
   count    = 2
-  provider = "aws.alternateaccountsameregion"
+  provider = "awsalternateaccountsameregion"
 
   availability_zone = data.aws_availability_zones.alternateaccountsameregion.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
@@ -5237,13 +5237,13 @@ resource "aws_subnet" "alternateaccountsameregion" {
 }
 
 resource "aws_ram_resource_share" "alternateaccountsameregion" {
-  provider = "aws.alternateaccountsameregion"
+  provider = "awsalternateaccountsameregion"
 
   name = %[1]q
 }
 
 resource "aws_ram_principal_association" "alternateaccountsameregion" {
-  provider = "aws.alternateaccountsameregion"
+  provider = "awsalternateaccountsameregion"
 
   principal          = data.aws_organizations_organization.test.arn
   resource_share_arn = aws_ram_resource_share.alternateaccountsameregion.arn
@@ -5251,14 +5251,14 @@ resource "aws_ram_principal_association" "alternateaccountsameregion" {
 
 resource "aws_ram_resource_association" "alternateaccountsameregion" {
   count    = 2
-  provider = "aws.alternateaccountsameregion"
+  provider = "awsalternateaccountsameregion"
 
   resource_arn       = aws_subnet.alternateaccountsameregion[count.index].arn
   resource_share_arn = aws_ram_resource_share.alternateaccountsameregion.id
 }
 
 resource "aws_db_subnet_group" "sameaccountalternateregion" {
-  provider = "aws.sameaccountalternateregion"
+  provider = "awssameaccountalternateregion"
 
   name       = %[1]q
   subnet_ids = aws_subnet.sameaccountalternateregion[*].id
@@ -5279,7 +5279,7 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_db_instance" "source" {
-  provider = "aws.sameaccountalternateregion"
+  provider = "awssameaccountalternateregion"
 
   allocated_storage       = 5
   backup_retention_period = 1
@@ -5306,7 +5306,7 @@ resource "aws_db_instance" "test" {
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
 	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   state = "available"
 
@@ -5326,7 +5326,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.1.0.0/16"
 
@@ -5350,7 +5350,7 @@ resource "aws_security_group" "test" {
 
 resource "aws_subnet" "alternate" {
   count    = 2
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   availability_zone = data.aws_availability_zones.alternate.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
@@ -5374,7 +5374,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_db_subnet_group" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   name       = %[1]q
   subnet_ids = aws_subnet.alternate[*].id
@@ -5386,7 +5386,7 @@ resource "aws_db_subnet_group" "test" {
 }
 
 resource "aws_db_instance" "source" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   allocated_storage       = 5
   backup_retention_period = 1
@@ -6017,7 +6017,7 @@ resource "aws_db_instance" "test" {
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName_RamShared(rName string) string {
 	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   state = "available"
 
@@ -6030,7 +6030,7 @@ data "aws_availability_zones" "available" {
 data "aws_organizations_organization" "test" {}
 
 resource "aws_vpc" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.0.0.0/16"
 
@@ -6041,7 +6041,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   count    = 2
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
@@ -6053,13 +6053,13 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_ram_resource_share" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   name = %[1]q
 }
 
 resource "aws_ram_principal_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   principal          = data.aws_organizations_organization.test.arn
   resource_share_arn = aws_ram_resource_share.test.arn
@@ -6067,7 +6067,7 @@ resource "aws_ram_principal_association" "test" {
 
 resource "aws_ram_resource_association" "test" {
   count    = 2
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   resource_arn       = aws_subnet.test[count.index].arn
   resource_share_arn = aws_ram_resource_share.test.id

--- a/aws/resource_aws_dx_gateway_association_proposal_test.go
+++ b/aws/resource_aws_dx_gateway_association_proposal_test.go
@@ -299,7 +299,7 @@ func testAccCheckAwsDxGatewayAssociationProposalRecreated(i, j *directconnect.Ga
 func testAccDxGatewayAssociationProposalConfigBase_vpnGateway(rName string, rBgpAsn int) string {
 	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   amazon_side_asn = %[2]d
   name            = %[1]q
@@ -336,7 +336,7 @@ resource "aws_dx_gateway_association_proposal" "test" {
 func testAccDxGatewayAssociationProposalConfig_basicTransitGateway(rName string, rBgpAsn int) string {
 	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   amazon_side_asn = %[2]d
   name            = %[1]q

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -272,7 +272,7 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
-					// dx_gateway_owner_account_id is the "aws.alternate" provider's account ID.
+					// dx_gateway_owner_account_id is the "awsalternate" provider's account ID.
 					// testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/28"),
@@ -351,7 +351,7 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
-					// dx_gateway_owner_account_id is the "aws.alternate" provider's account ID.
+					// dx_gateway_owner_account_id is the "awsalternate" provider's account ID.
 					// testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/30"),
@@ -593,7 +593,7 @@ resource "aws_vpn_gateway_attachment" "test" {
 
 # Accepter
 resource "aws_dx_gateway" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   amazon_side_asn = %[2]d
   name            = %[1]q
@@ -621,7 +621,7 @@ resource "aws_dx_gateway_association_proposal" "test" {
 
 # Accepter
 resource "aws_dx_gateway_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   proposal_id                         = "${aws_dx_gateway_association_proposal.test.id}"
   dx_gateway_id                       = "${aws_dx_gateway.test.id}"
@@ -662,7 +662,7 @@ data "aws_caller_identity" "creator" {}
 
 # Accepter
 resource "aws_dx_gateway" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   amazon_side_asn = %[2]d
   name            = %[1]q
@@ -688,7 +688,7 @@ resource "aws_dx_gateway_association_proposal" "test" {
 
 # Accepter
 resource "aws_dx_gateway_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   proposal_id                         = "${aws_dx_gateway_association_proposal.test.id}"
   dx_gateway_id                       = "${aws_dx_gateway.test.id}"
@@ -797,7 +797,7 @@ resource "aws_dx_gateway_association_proposal" "test" {
 
 # Accepter
 resource "aws_dx_gateway_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   proposal_id                         = "${aws_dx_gateway_association_proposal.test.id}"
   dx_gateway_id                       = "${aws_dx_gateway.test.id}"
@@ -821,7 +821,7 @@ resource "aws_dx_gateway_association_proposal" "test" {
 
 # Accepter
 resource "aws_dx_gateway_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   proposal_id                         = "${aws_dx_gateway_association_proposal.test.id}"
   dx_gateway_id                       = "${aws_dx_gateway.test.id}"

--- a/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
@@ -179,11 +179,11 @@ resource "aws_dx_hosted_private_virtual_interface" "test" {
 
 # Accepter
 data "aws_caller_identity" "accepter" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 resource "aws_vpn_gateway" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   tags = {
     Name = %[2]q
@@ -195,7 +195,7 @@ resource "aws_vpn_gateway" "test" {
 func testAccDxHostedPrivateVirtualInterfaceConfig_basic(cid, rName string, bgpAsn, vlan int) string {
 	return testAccDxHostedPrivateVirtualInterfaceConfig_base(cid, rName, bgpAsn, vlan) + `
 resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   virtual_interface_id = "${aws_dx_hosted_private_virtual_interface.test.id}"
   vpn_gateway_id       = "${aws_vpn_gateway.test.id}"
@@ -206,7 +206,7 @@ resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
 func testAccDxHostedPrivateVirtualInterfaceConfig_accepterTags(cid, rName string, bgpAsn, vlan int) string {
 	return testAccDxHostedPrivateVirtualInterfaceConfig_base(cid, rName, bgpAsn, vlan) + fmt.Sprintf(`
 resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   virtual_interface_id = "${aws_dx_hosted_private_virtual_interface.test.id}"
   vpn_gateway_id       = "${aws_vpn_gateway.test.id}"
@@ -223,7 +223,7 @@ resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
 func testAccDxHostedPrivateVirtualInterfaceConfig_accepterTagsUpdated(cid, rName string, bgpAsn, vlan int) string {
 	return testAccDxHostedPrivateVirtualInterfaceConfig_base(cid, rName, bgpAsn, vlan) + fmt.Sprintf(`
 resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   virtual_interface_id = "${aws_dx_hosted_private_virtual_interface.test.id}"
   vpn_gateway_id       = "${aws_vpn_gateway.test.id}"

--- a/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
@@ -188,7 +188,7 @@ resource "aws_dx_hosted_public_virtual_interface" "test" {
 
 # Accepter
 data "aws_caller_identity" "accepter" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 `, cid, rName, amzAddr, custAddr, bgpAsn, vlan)
 }
@@ -196,7 +196,7 @@ data "aws_caller_identity" "accepter" {
 func testAccDxHostedPublicVirtualInterfaceConfig_basic(cid, rName, amzAddr, custAddr string, bgpAsn, vlan int) string {
 	return testAccDxHostedPublicVirtualInterfaceConfig_base(cid, rName, amzAddr, custAddr, bgpAsn, vlan) + `
 resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   virtual_interface_id = "${aws_dx_hosted_public_virtual_interface.test.id}"
 }
@@ -206,7 +206,7 @@ resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
 func testAccDxHostedPublicVirtualInterfaceConfig_accepterTags(cid, rName, amzAddr, custAddr string, bgpAsn, vlan int) string {
 	return testAccDxHostedPublicVirtualInterfaceConfig_base(cid, rName, amzAddr, custAddr, bgpAsn, vlan) + fmt.Sprintf(`
 resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   virtual_interface_id = "${aws_dx_hosted_public_virtual_interface.test.id}"
 
@@ -222,7 +222,7 @@ resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
 func testAccDxHostedPublicVirtualInterfaceConfig_accepterTagsUpdated(cid, rName, amzAddr, custAddr string, bgpAsn, vlan int) string {
 	return testAccDxHostedPublicVirtualInterfaceConfig_base(cid, rName, amzAddr, custAddr, bgpAsn, vlan) + fmt.Sprintf(`
 resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   virtual_interface_id = "${aws_dx_hosted_public_virtual_interface.test.id}"
 

--- a/aws/resource_aws_dx_hosted_transit_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_transit_virtual_interface_test.go
@@ -195,11 +195,11 @@ resource "aws_dx_hosted_transit_virtual_interface" "test" {
 
 # Accepter
 data "aws_caller_identity" "accepter" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 resource "aws_dx_gateway" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   amazon_side_asn = %[3]d
   name            = %[2]q
@@ -210,7 +210,7 @@ resource "aws_dx_gateway" "test" {
 func testAccDxHostedTransitVirtualInterfaceConfig_basic(cid, rName string, amzAsn, bgpAsn, vlan int) string {
 	return testAccDxHostedTransitVirtualInterfaceConfig_base(cid, rName, amzAsn, bgpAsn, vlan) + `
 resource "aws_dx_hosted_transit_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   dx_gateway_id        = "${aws_dx_gateway.test.id}"
   virtual_interface_id = "${aws_dx_hosted_transit_virtual_interface.test.id}"
@@ -221,7 +221,7 @@ resource "aws_dx_hosted_transit_virtual_interface_accepter" "test" {
 func testAccDxHostedTransitVirtualInterfaceConfig_accepterTags(cid, rName string, amzAsn, bgpAsn, vlan int) string {
 	return testAccDxHostedTransitVirtualInterfaceConfig_base(cid, rName, amzAsn, bgpAsn, vlan) + fmt.Sprintf(`
 resource "aws_dx_hosted_transit_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   dx_gateway_id        = "${aws_dx_gateway.test.id}"
   virtual_interface_id = "${aws_dx_hosted_transit_virtual_interface.test.id}"
@@ -238,7 +238,7 @@ resource "aws_dx_hosted_transit_virtual_interface_accepter" "test" {
 func testAccDxHostedTransitVirtualInterfaceConfig_accepterTagsUpdated(cid, rName string, amzAsn, bgpAsn, vlan int) string {
 	return testAccDxHostedTransitVirtualInterfaceConfig_base(cid, rName, amzAsn, bgpAsn, vlan) + fmt.Sprintf(`
 resource "aws_dx_hosted_transit_virtual_interface_accepter" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   dx_gateway_id        = "${aws_dx_gateway.test.id}"
   virtual_interface_id = "${aws_dx_hosted_transit_virtual_interface.test.id}"

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -186,7 +186,7 @@ resource "aws_dynamodb_global_table" "test" {
 func testAccDynamoDbGlobalTableConfig_multipleRegions_dynamodb_tables(tableName string) string {
 	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
 data "aws_region" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 data "aws_region" "current" {}
@@ -206,7 +206,7 @@ resource "aws_dynamodb_table" "test" {
 }
 
 resource "aws_dynamodb_table" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   hash_key         = "myAttribute"
   name             = %[1]q

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -2243,7 +2243,7 @@ func testAccAWSDynamoDbTableConfigReplica1(rName string) string {
 		testAccMultipleRegionProviderConfig(3), // Prevent "Provider configuration not present" errors
 		fmt.Sprintf(`
 data "aws_region" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -2270,11 +2270,11 @@ func testAccAWSDynamoDbTableConfigReplica2(rName string) string {
 		testAccMultipleRegionProviderConfig(3),
 		fmt.Sprintf(`
 data "aws_region" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 data "aws_region" "third" {
-  provider = "aws.third"
+  provider = "awsthird"
 }
 
 resource "aws_dynamodb_table" "test" {

--- a/aws/resource_aws_ebs_snapshot_copy_test.go
+++ b/aws/resource_aws_ebs_snapshot_copy_test.go
@@ -372,7 +372,7 @@ resource "aws_ebs_snapshot_copy" "test" {
 
 var testAccAwsEbsSnapshotCopyConfigWithRegions = testAccAlternateRegionProviderConfig() + `
 data "aws_availability_zones" "alternate_available" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
   state    = "available"
 
   filter {
@@ -382,11 +382,11 @@ data "aws_availability_zones" "alternate_available" {
 }
 
 data "aws_region" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 resource "aws_ebs_volume" "test" {
-  provider          = "aws.alternate"
+  provider          = "awsalternate"
   availability_zone = "${data.aws_availability_zones.alternate_available.names[0]}"
   size              = 1
 
@@ -396,7 +396,7 @@ resource "aws_ebs_volume" "test" {
 }
 
 resource "aws_ebs_snapshot" "test" {
-  provider  = "aws.alternate"
+  provider  = "awsalternate"
   volume_id = "${aws_ebs_volume.test.id}"
 
   tags = {

--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment_accepter_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment_accepter_test.go
@@ -150,14 +150,14 @@ resource "aws_ec2_transit_gateway" "test" {
 }
 
 resource "aws_ec2_transit_gateway" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   tags = {
     Name = %[1]q
   }
 }
 resource "aws_ec2_transit_gateway_peering_attachment" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   peer_account_id         = aws_ec2_transit_gateway.test.owner_id
   peer_region             = data.aws_region.current.name

--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
@@ -331,7 +331,7 @@ resource "aws_ec2_transit_gateway" "test" {
 }
 
 resource "aws_ec2_transit_gateway" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
@@ -228,11 +228,11 @@ resource "aws_ram_principal_association" "test" {
 
 # VPC attachment creator.
 data "aws_caller_identity" "creator" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 resource "aws_vpc" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.0.0.0/16"
 
@@ -242,7 +242,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "10.0.0.0/24"
@@ -254,7 +254,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   depends_on = ["aws_ram_principal_association.test", "aws_ram_resource_association.test"]
 

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -684,24 +684,24 @@ data "aws_availability_zones" "available" {
 data "aws_organizations_organization" "test" {}
 
 resource "aws_ec2_transit_gateway" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 resource "aws_ram_resource_share" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   name = %[1]q
 }
 
 resource "aws_ram_resource_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   resource_arn       = "${aws_ec2_transit_gateway.test.arn}"
   resource_share_arn = "${aws_ram_resource_share.test.id}"
 }
 
 resource "aws_ram_principal_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   principal          = "${data.aws_organizations_organization.test.arn}"
   resource_share_arn = "${aws_ram_resource_share.test.id}"

--- a/aws/resource_aws_guardduty_invite_accepter_test.go
+++ b/aws/resource_aws_guardduty_invite_accepter_test.go
@@ -110,13 +110,13 @@ func testAccCheckAwsGuardDutyInviteAccepterExists(resourceName string) resource.
 func testAccAwsGuardDutyInviteAccepterConfig_basic(email string) string {
 	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
 resource "aws_guardduty_detector" "master" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 resource "aws_guardduty_detector" "member" {}
 
 resource "aws_guardduty_member" "member" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   account_id                 = "${aws_guardduty_detector.member.account_id}"
   detector_id                = "${aws_guardduty_detector.master.id}"

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -3813,25 +3813,23 @@ resource "aws_instance" "test" {
 }
 
 const testAccInstanceConfigMultipleRegions = `
-provider "aws" {
-	alias = "west"
+provider "awswest" {
 	region = "us-west-2"
 }
 
-provider "aws" {
-	alias = "east"
+provider "awseast" {
 	region = "us-east-1"
 }
 resource "aws_instance" "test" {
 	# us-west-2
-	provider = "aws.west"
+	provider = "awswest"
 	ami = "ami-4fccb37f"
 	instance_type = "m1.small"
 }
 
 resource "aws_instance" "test2" {
 	# us-east-1
-	provider = "aws.east"
+	provider = "awseast"
 	ami = "ami-8c6ea9e4"
 	instance_type = "m1.small"
 }

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -113,7 +113,7 @@ resource "aws_ram_resource_share_accepter" "test" {
 }
 
 resource "aws_ram_resource_share" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   name                      = %[1]q
   allow_external_principals = true
@@ -124,7 +124,7 @@ resource "aws_ram_resource_share" "test" {
 }
 
 resource "aws_ram_principal_association" "test" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   principal          = "${data.aws_caller_identity.receiver.account_id}"
   resource_share_arn = "${aws_ram_resource_share.test.arn}"

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -2885,7 +2885,7 @@ resource "aws_rds_cluster" "test" {
 func testAccAWSClusterConfigEncryptedCrossRegionReplica(n int) string {
 	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   state = "available"
 
@@ -2928,7 +2928,7 @@ resource "aws_rds_cluster_instance" "test" {
 }
 
 resource "aws_kms_key" "alternate" {
-  provider    = "aws.alternate"
+  provider    = "awsalternate"
   description = "Terraform acc test %[1]d"
 
   policy = <<POLICY
@@ -2951,7 +2951,7 @@ resource "aws_kms_key" "alternate" {
 }
 
 resource "aws_vpc" "alternate" {
-  provider   = "aws.alternate"
+  provider   = "awsalternate"
   cidr_block = "10.0.0.0/16"
 
   tags = {
@@ -2960,7 +2960,7 @@ resource "aws_vpc" "alternate" {
 }
 
 resource "aws_subnet" "alternate" {
-  provider          = "aws.alternate"
+  provider          = "awsalternate"
   count             = 3
   vpc_id            = aws_vpc.alternate.id
   availability_zone = data.aws_availability_zones.alternate.names[count.index]
@@ -2972,13 +2972,13 @@ resource "aws_subnet" "alternate" {
 }
 
 resource "aws_db_subnet_group" "alternate" {
-  provider   = "aws.alternate"
+  provider   = "awsalternate"
   name       = "test_replica-subnet-%[1]d"
   subnet_ids = aws_subnet.alternate[*].id
 }
 
 resource "aws_rds_cluster" "alternate" {
-  provider                      = "aws.alternate"
+  provider                      = "awsalternate"
   cluster_identifier            = "tf-test-replica-%[1]d"
   db_subnet_group_name          = aws_db_subnet_group.alternate.name
   database_name                 = "mydb"

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -261,7 +261,7 @@ resource "aws_route53_zone_association" "foobar" {
 func testAccRoute53ZoneAssociationRegionConfig() string {
 	return testAccAlternateRegionProviderConfig() + `
 data "aws_region" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 data "aws_region" "current" {}
@@ -277,7 +277,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_vpc" "alternate" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block           = "10.7.0.0/16"
   enable_dns_hostnames = true

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -3653,7 +3653,7 @@ POLICY
 }
 
 resource "aws_s3_bucket" "destination" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
   bucket   = "tf-test-bucket-destination-%[1]d"
 
   versioning {
@@ -3706,7 +3706,7 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationWithSseKmsEncryptedObjects(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_kms_key" "replica" {
-  provider                = "aws.alternate"
+  provider                = "awsalternate"
   description             = "TF Acceptance Test S3 repl KMS key"
   deletion_window_in_days = 7
 }
@@ -3813,7 +3813,7 @@ func testAccAWSS3BucketConfigReplicationWithSseKmsEncryptedObjectsAndAccessContr
 data "aws_caller_identity" "current" {}
 
 resource "aws_kms_key" "replica" {
-  provider                = "aws.alternate"
+  provider                = "awsalternate"
   description             = "TF Acceptance Test S3 repl KMS key"
   deletion_window_in_days = 7
 }

--- a/aws/resource_aws_vpc_peering_connection_accepter_test.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter_test.go
@@ -240,7 +240,7 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_vpc" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.1.0.0/16"
 
@@ -263,7 +263,7 @@ resource "aws_vpc_peering_connection" "main" {
 
 // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection.main.id}"
   auto_accept               = true
@@ -286,7 +286,7 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_vpc" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.1.0.0/16"
 
@@ -296,7 +296,7 @@ resource "aws_vpc" "peer" {
 }
 
 data "aws_caller_identity" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 // Requester's side of the connection.
@@ -314,7 +314,7 @@ resource "aws_vpc_peering_connection" "main" {
 
  // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection.main.id}"
   auto_accept               = true
@@ -337,7 +337,7 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_vpc" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.1.0.0/16"
 
@@ -347,7 +347,7 @@ resource "aws_vpc" "peer" {
 }
 
 data "aws_caller_identity" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 // Requester's side of the connection.
@@ -365,7 +365,7 @@ resource "aws_vpc_peering_connection" "main" {
 
  // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection.main.id}"
   auto_accept               = true

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -286,7 +286,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_vpc" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -308,7 +308,7 @@ resource "aws_vpc_peering_connection" "test" {
 
 // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection.test.id}"
   auto_accept = true
@@ -330,7 +330,7 @@ resource "aws_vpc_peering_connection_options" "test" {
 
 // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_options" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
 
@@ -352,7 +352,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_vpc" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -362,7 +362,7 @@ resource "aws_vpc" "peer" {
 }
 
 data "aws_caller_identity" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 }
 
 // Requester's side of the connection.
@@ -378,7 +378,7 @@ resource "aws_vpc_peering_connection" "test" {
 
  // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection.test.id}"
   auto_accept = true
@@ -400,7 +400,7 @@ resource "aws_vpc_peering_connection_options" "test" {
 
 // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_options" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
 

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -780,7 +780,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_vpc" "peer" {
-  provider = "aws.alternate"
+  provider = "awsalternate"
 
   cidr_block = "10.1.0.0/16"
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
