### PR TITLE
Add mount_name to aws_fsx_lustre_file_system

### DIFF
--- a/aws/resource_aws_fsx_lustre_file_system.go
+++ b/aws/resource_aws_fsx_lustre_file_system.go
@@ -64,6 +64,10 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(1, 512000),
 			},
+			"mount_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"network_interface_ids": {
 				// As explained in https://docs.aws.amazon.com/fsx/latest/LustreGuide/mounting-on-premises.html, the first
 				// network_interface_id is the primary one, so ordering matters. Use TypeList instead of TypeSet to preserve it.
@@ -304,6 +308,7 @@ func resourceAwsFsxLustreFileSystemRead(d *schema.ResourceData, meta interface{}
 	if lustreConfig.PerUnitStorageThroughput != nil {
 		d.Set("per_unit_storage_throughput", lustreConfig.PerUnitStorageThroughput)
 	}
+	d.Set("mount_name", filesystem.LustreConfiguration.MountName)
 
 	if filesystem.KmsKeyId != nil {
 		d.Set("kms_key_id", filesystem.KmsKeyId)

--- a/aws/resource_aws_fsx_lustre_file_system_test.go
+++ b/aws/resource_aws_fsx_lustre_file_system_test.go
@@ -86,6 +86,7 @@ func TestAccAWSFsxLustreFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "export_path", ""),
 					resource.TestCheckResourceAttr(resourceName, "import_path", ""),
 					resource.TestCheckResourceAttr(resourceName, "imported_file_chunk_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mount_name", "fsx"),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_ids.#", "2"),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "1200"),
@@ -447,6 +448,8 @@ func TestAccAWSFsxLustreFileSystem_DeploymentTypePersistent1(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deployment_type", fsx.LustreDeploymentTypePersistent1),
 					resource.TestCheckResourceAttr(resourceName, "automatic_backup_retention_days", "0"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "kms_key_id", "kms", regexp.MustCompile(`key/.+`)),
+					// We don't know the randomly generated mount_name ahead of time like for SCRATCH_1 deployment types.
+					resource.TestCheckResourceAttrSet(resourceName, "mount_name"),
 				),
 			},
 			{
@@ -511,6 +514,8 @@ func TestAccAWSFsxLustreFileSystem_DeploymentTypeScratch2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFsxLustreFileSystemExists(resourceName, &filesystem),
 					resource.TestCheckResourceAttr(resourceName, "deployment_type", fsx.LustreDeploymentTypeScratch2),
+					// We don't know the randomly generated mount_name ahead of time like for SCRATCH_1 deployment types.
+					resource.TestCheckResourceAttrSet(resourceName, "mount_name"),
 				),
 			},
 			{

--- a/website/docs/r/fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/fsx_lustre_file_system.html.markdown
@@ -45,6 +45,7 @@ In addition to all arguments above, the following attributes are exported:
 * `dns_name` - DNS name for the file system, e.g. `fs-12345678.fsx.us-west-2.amazonaws.com`
 * `id` - Identifier of the file system, e.g. `fs-12345678`
 * `network_interface_ids` - Set of Elastic Network Interface identifiers from which the file system is accessible. As explained in the [documentation](https://docs.aws.amazon.com/fsx/latest/LustreGuide/mounting-on-premises.html), the first network interface returned is the primary network interface.
+* `mount_name` - The value to be used when mounting the filesystem.
 * `owner_id` - AWS account identifier that created the file system.
 * `vpc_id` - Identifier of the Virtual Private Cloud for the file system.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12181

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_fsx_lustre_file_system: Add `mount_name`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSFsxLustreFileSystem_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSFsxLustreFileSystem_basic -timeout 120m
=== RUN   TestAccAWSFsxLustreFileSystem_basic
=== PAUSE TestAccAWSFsxLustreFileSystem_basic
=== CONT  TestAccAWSFsxLustreFileSystem_basic
--- PASS: TestAccAWSFsxLustreFileSystem_basic (500.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	500.359s
```
