### PR TITLE
Preserve ordering in aws_fsx_lustre_file_system's network_interface_ids

### DIFF
--- a/aws/resource_aws_fsx_lustre_file_system.go
+++ b/aws/resource_aws_fsx_lustre_file_system.go
@@ -65,7 +65,9 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 512000),
 			},
 			"network_interface_ids": {
-				Type:     schema.TypeSet,
+				// As explained in https://docs.aws.amazon.com/fsx/latest/LustreGuide/mounting-on-premises.html, the first
+				// network_interface_id is the primary one, so ordering matters. Use TypeList instead of TypeSet to preserve it.
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/website/docs/r/fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/fsx_lustre_file_system.html.markdown
@@ -40,7 +40,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Amazon Resource Name of the file system.
 * `dns_name` - DNS name for the file system, e.g. `fs-12345678.fsx.us-west-2.amazonaws.com`
 * `id` - Identifier of the file system, e.g. `fs-12345678`
-* `network_interface_ids` - Set of Elastic Network Interface identifiers from which the file system is accessible.
+* `network_interface_ids` - Set of Elastic Network Interface identifiers from which the file system is accessible. As explained in the [documentation](https://docs.aws.amazon.com/fsx/latest/LustreGuide/mounting-on-premises.html), the first network interface returned is the primary network interface.
 * `owner_id` - AWS account identifier that created the file system.
 * `vpc_id` - Identifier of the Virtual Private Cloud for the file system.
 


### PR DESCRIPTION
As explained in FSX lustre's [documentation](https://docs.aws.amazon.com/fsx/latest/LustreGuide/mounting-on-premises.html), the first `network_interface_id` is important and the primary one. So use a `schema.TypeList` instead of `schema.TypeSet` to preserve the ordering of this resource.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12181

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Change `aws_fsx_lustre_file_system's`'s `network_interface_ids` to `TypeList` to preserve ordering.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSFsxLustreFileSystem_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSFsxLustreFileSystem_basic -timeout 120m
=== RUN   TestAccAWSFsxLustreFileSystem_basic
=== PAUSE TestAccAWSFsxLustreFileSystem_basic
=== CONT  TestAccAWSFsxLustreFileSystem_basic
--- PASS: TestAccAWSFsxLustreFileSystem_basic (496.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	496.407s
```
