### PR TITLE
Update examples formatting to Terraform 0.12 syntax

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,24 @@
+# GitHub Workflows
+
+## Using the `setup-terraform` action
+
+By default, the [`setup-terraform` action](https://github.com/hashicorp/setup-terraform) adds a wrapper for the `terraform` command that allows passing results to subsequent steps. This will prevent using the output of a `terraform` command as the input to another command in the same step.
+
+The wrapper can be turned off by using
+
+```yaml
+steps:
+- uses: hashicorp/setup-terraform@v1
+  with:
+    terraform_wrapper: false
+```
+
+## Testing workflows locally
+
+The tool [`act`](https://github.com/nektos/act) can be used to test GitHub workflows locally. The default container [intentionally does not have feature parity](https://github.com/nektos/act#default-runners-are-intentionally-incomplete) with the containers used in GitHub due to the size of a full container.
+
+A fully-featured container can be used by specifying a different container.
+
+```console
+act -P ubuntu-latest=nektos/act-environments-ubuntu:18.04
+```

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -60,7 +60,9 @@ jobs:
           #   exit 1
           # fi
           JSON=$(terraform validate -json)
+          echo; echo -e "\e[1;35m===>\e[0m"
           echo "JSON = \"$JSON\""
+          echo -e "\e[1;35m===>\e[0m"; echo
           # echo "$JSON" | jq -r '.warning_count'
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -59,7 +59,8 @@ jobs:
           #   echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
           #   exit 1
           # fi
-          WARN=$(terraform validate -json | jq -r '.warning_count')
-          echo $WARN
+          JSON=$(terraform validate -json)
+          echo $JSON
+          echo "$JSON" | jq -r '.warning_count'
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -54,15 +54,5 @@ jobs:
           echo; echo -e "\e[1;35m===> Validating Example: $DIR <===\e[0m"; echo
           # Catch errors
           terraform validate
-          # # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
-          # if [ "$(terraform validate -json | jq -r '.warning_count')" != '0' ]; then
-          #   echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
-          #   exit 1
-          # fi
-          JSON=$(terraform validate -json)
-          echo; echo -e "\e[1;35m===>\e[0m"
-          echo "==========>JSON = \"$JSON\""
-          echo -e "\e[1;35m===>\e[0m"; echo
-          # echo "$JSON" | jq -r '.warning_count'
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -59,6 +59,6 @@ jobs:
           #   echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
           #   exit 1
           # fi
-          terraform validate -json
+          terraform validate -json | jq -r '.warning_count'
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         go_version: ["1.14"]
-        terraform_version: ["0.11.14", "0.12.24"]
+        terraform_version: ["0.12.29"]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -43,34 +43,19 @@ jobs:
     - name: terraform
       run: |
         for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u); do
-          if [ ${{ matrix.terraform_version }} = 0.11.14 ]; then
-            if [ $DIR = ./examples/count ]; then
-              # Skip example already converted to Terraform 0.12 and later syntax
-              continue
-            elif [ $DIR = ./examples/eks-getting-started ]; then
-              # Skip example already converted to Terraform 0.12 and later syntax
-              continue
-            elif [ $DIR = ./examples/sagemaker ]; then
-              # Skip example already converted to Terraform 0.12 and later syntax
-              continue
-            elif [ $DIR = ./examples/two-tier ]; then
-              # 0.11 validation requires file path to exist
-              mkdir -p ~/.ssh
-              touch ~/.ssh/terraform-provider-aws-example.pub
-            fi
-          fi
           pushd $DIR
           if [ -f terraform.template.tfvars ]; then
             cp terraform.template.tfvars terraform.tfvars
           fi
           echo; echo -e "\e[1;35m===> Initializing Example: $DIR <===\e[0m"; echo
           terraform init
-          # Prefer Terraform 0.12 and later format checking to prevent conflicts
-          if [ ${{ matrix.terraform_version }} != 0.11.14 ]; then
-            echo; echo -e "\e[1;35m===> Format Checking Example: $DIR <===\e[0m"; echo
-            terraform fmt -check
-          fi
+          echo; echo -e "\e[1;35m===> Format Checking Example: $DIR <===\e[0m"; echo
+          terraform fmt -check
           echo; echo -e "\e[1;35m===> Validating Example: $DIR <===\e[0m"; echo
-          terraform validate
+          JSON=$(terraform validate -json)
+          if [ $(echo $JSON | jq -r '.warning_count') = '1' ]
+            then
+              exit 1
+          fi
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -43,7 +43,7 @@ jobs:
     - name: terraform
       run: |
         for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u); do
-          pushd $DIR
+          pushd "$DIR"
           if [ -f terraform.template.tfvars ]; then
             cp terraform.template.tfvars terraform.tfvars
           fi
@@ -55,7 +55,10 @@ jobs:
           # Catch errors
           terraform validate
           # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
-          if [ $? -eq 0 ] && [ "$(terraform validate -json | jq -r '.warning_count')" -ne '0' ]; then
+          # The call to `terraform validate` is not inlined to allow the failure to terminate execution
+          # shellcheck disable=SC2181
+          if [ $? -eq 0 ] && [ "$(terraform validate -json | jq -r '.warning_count')" -ne 0 ]; then
+            echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
             exit 1
           fi
           popd

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -54,10 +54,10 @@ jobs:
           echo; echo -e "\e[1;35m===> Validating Example: $DIR <===\e[0m"; echo
           # Catch errors
           terraform validate
-          # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
-          if [ "$(terraform validate -json | jq -r '.warning_count')" != '0' ]; then
-            echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
-            exit 1
-          fi
+          # # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
+          # if [ "$(terraform validate -json | jq -r '.warning_count')" != '0' ]; then
+          #   echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
+          #   exit 1
+          # fi
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,7 +55,7 @@ jobs:
           # Catch errors
           terraform validate
           # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
-          if [ $? -eq '0' && $(terraform validate -json | jq -r '.warning_count') -ne '0' ]; then
+          if [ $? -eq '0' ] && [ $(terraform validate -json | jq -r '.warning_count') -ne '0' ]; then
             exit 1
           fi
           popd

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,9 +55,7 @@ jobs:
           # Catch errors
           terraform validate
           # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
-          # The call to `terraform validate` is not inlined to allow the failure to terminate execution
-          # shellcheck disable=SC2181
-          if [ $? -eq 0 ] && [ "$(terraform validate -json | jq -r '.warning_count')" != '0' ]; then
+          if [ "$(terraform validate -json | jq -r '.warning_count')" != '0' ]; then
             echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
             exit 1
           fi

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -61,6 +61,6 @@ jobs:
           # fi
           JSON=$(terraform validate -json)
           echo "JSON = \"$JSON\""
-          echo "$JSON" | jq -r '.warning_count'
+          # echo "$JSON" | jq -r '.warning_count'
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -52,10 +52,11 @@ jobs:
           echo; echo -e "\e[1;35m===> Format Checking Example: $DIR <===\e[0m"; echo
           terraform fmt -check
           echo; echo -e "\e[1;35m===> Validating Example: $DIR <===\e[0m"; echo
-          JSON=$(terraform validate -json)
-          if [ $(echo $JSON | jq -r '.warning_count') = '1' ]
-            then
-              exit 1
+          # Catch errors
+          terraform validate
+          # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
+          if [ $(terraform validate -json | jq -r '.warning_count') -ne '0' ]; then
+            exit 1
           fi
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -57,7 +57,7 @@ jobs:
           # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
           # The call to `terraform validate` is not inlined to allow the failure to terminate execution
           # shellcheck disable=SC2181
-          if [ $? -eq 0 ] && [ "$(terraform validate -json | jq -r '.warning_count')" -ne 0 ]; then
+          if [ $? -eq 0 ] && [ "$(terraform validate -json | jq -r '.warning_count')" != '0' ]; then
             echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
             exit 1
           fi

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -40,6 +40,8 @@ jobs:
     - uses: hashicorp/setup-terraform@v1
       with:
         terraform_version: ${{ matrix.terraform_version }}
+        # Needed to use the output of `terraform validate -json`
+        terraform_wrapper: false
     - name: terraform
       run: |
         for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u); do
@@ -54,5 +56,10 @@ jobs:
           echo; echo -e "\e[1;35m===> Validating Example: $DIR <===\e[0m"; echo
           # Catch errors
           terraform validate
+          # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
+          if [ "$(terraform validate -json | jq -r '.warning_count')" != '0' ]; then
+            echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
+            exit 1
+          fi
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -59,5 +59,6 @@ jobs:
           #   echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
           #   exit 1
           # fi
+          terraform validate -json
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -59,6 +59,7 @@ jobs:
           #   echo -e "\e[1;31mError:\e[0m Configuration contains warnings."
           #   exit 1
           # fi
-          terraform validate -json | jq -r '.warning_count'
+          WARN=$(terraform validate -json | jq -r '.warning_count')
+          echo $WARN
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -60,7 +60,7 @@ jobs:
           #   exit 1
           # fi
           JSON=$(terraform validate -json)
-          echo $JSON
+          echo "JSON = \"$JSON\""
           echo "$JSON" | jq -r '.warning_count'
           popd
         done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,7 +55,7 @@ jobs:
           # Catch errors
           terraform validate
           # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
-          if [ $(terraform validate -json | jq -r '.warning_count') -ne '0' ]; then
+          if [ $? -eq '0' && $(terraform validate -json | jq -r '.warning_count') -ne '0' ]; then
             exit 1
           fi
           popd

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -61,7 +61,7 @@ jobs:
           # fi
           JSON=$(terraform validate -json)
           echo; echo -e "\e[1;35m===>\e[0m"
-          echo "JSON = \"$JSON\""
+          echo "==========>JSON = \"$JSON\""
           echo -e "\e[1;35m===>\e[0m"; echo
           # echo "$JSON" | jq -r '.warning_count'
           popd

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,7 +55,7 @@ jobs:
           # Catch errors
           terraform validate
           # Check for warnings. For simplicity, assume warnings are related to pre-0.12 syntax
-          if [ $? -eq '0' ] && [ $(terraform validate -json | jq -r '.warning_count') -ne '0' ]; then
+          if [ $? -eq 0 ] && [ "$(terraform validate -json | jq -r '.warning_count')" -ne '0' ]; then
             exit 1
           fi
           popd

--- a/examples/alexa/main.tf
+++ b/examples/alexa/main.tf
@@ -1,21 +1,25 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 # Specify the provider and access details
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 # This resource is the core take away of this example.
 resource "aws_lambda_permission" "default" {
   statement_id  = "AllowExecutionFromAlexa"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.default.function_name}"
+  function_name = aws_lambda_function.default.function_name
   principal     = "alexa-appkit.amazon.com"
 }
 
 resource "aws_lambda_function" "default" {
   filename         = "lambda_function.zip"
-  source_code_hash = "${filebase64sha256("lambda_function.zip")}"
+  source_code_hash = filebase64sha256("lambda_function.zip")
   function_name    = "terraform_lambda_alexa_example"
-  role             = "${aws_iam_role.default.arn}"
+  role             = aws_iam_role.default.arn
   handler          = "lambda_function.lambda_handler"
   runtime          = "python2.7"
 }
@@ -47,7 +51,7 @@ EOF
 # so it was avoided for the purporse of this example.
 resource "aws_iam_role_policy" "default" {
   name = "terraform_lambda_alexa_example"
-  role = "${aws_iam_role.default.id}"
+  role = aws_iam_role.default.id
 
   policy = <<EOF
 {

--- a/examples/alexa/outputs.tf
+++ b/examples/alexa/outputs.tf
@@ -1,3 +1,3 @@
 output "aws_lambda_function_arn" {
-  value = "${aws_lambda_function.default.arn}"
+  value = aws_lambda_function.default.arn
 }

--- a/examples/api-gateway-websocket-chat-app/main.tf
+++ b/examples/api-gateway-websocket-chat-app/main.tf
@@ -3,12 +3,16 @@
 # Lambda functions needed to demonstrate the Websocket protocol on API Gateway.
 #
 
+terraform {
+  required_version = ">= 0.12"
+}
+
 #
 # Providers.
 #
 
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 provider "archive" {}
@@ -83,35 +87,35 @@ resource "aws_apigatewayv2_api" "SimpleChatWebSocket" {
 }
 
 resource "aws_apigatewayv2_deployment" "Deployment" {
-  api_id = "${aws_apigatewayv2_api.SimpleChatWebSocket.id}"
+  api_id = aws_apigatewayv2_api.SimpleChatWebSocket.id
 
   depends_on = [
-    "aws_apigatewayv2_route.ConnectRoute",
-    "aws_apigatewayv2_route.DisconnectRoute",
-    "aws_apigatewayv2_route.SendRoute",
+    aws_apigatewayv2_route.ConnectRoute,
+    aws_apigatewayv2_route.DisconnectRoute,
+    aws_apigatewayv2_route.SendRoute,
   ]
 }
 
 resource "aws_apigatewayv2_stage" "Stage" {
-  api_id        = "${aws_apigatewayv2_api.SimpleChatWebSocket.id}"
+  api_id        = aws_apigatewayv2_api.SimpleChatWebSocket.id
   name          = "Prod"
   description   = "Prod Stage"
-  deployment_id = "${aws_apigatewayv2_deployment.Deployment.id}"
+  deployment_id = aws_apigatewayv2_deployment.Deployment.id
 }
 
 ###########
 # OnConnect
 ###########
 resource "aws_apigatewayv2_integration" "ConnectIntegrat" {
-  api_id             = "${aws_apigatewayv2_api.SimpleChatWebSocket.id}"
+  api_id             = aws_apigatewayv2_api.SimpleChatWebSocket.id
   integration_type   = "AWS_PROXY"
   description        = "Connect Integration"
-  integration_uri    = "${aws_lambda_function.OnConnectFunction.invoke_arn}"
+  integration_uri    = aws_lambda_function.OnConnectFunction.invoke_arn
   integration_method = "POST"
 }
 
 resource "aws_apigatewayv2_route" "ConnectRoute" {
-  api_id         = "${aws_apigatewayv2_api.SimpleChatWebSocket.id}"
+  api_id         = aws_apigatewayv2_api.SimpleChatWebSocket.id
   route_key      = "$connect"
   operation_name = "ConnectRoute"
   target         = "integrations/${aws_apigatewayv2_integration.ConnectIntegrat.id}"
@@ -121,15 +125,15 @@ resource "aws_apigatewayv2_route" "ConnectRoute" {
 # OnDisconnect
 ##############
 resource "aws_apigatewayv2_integration" "DisconnectInteg" {
-  api_id             = "${aws_apigatewayv2_api.SimpleChatWebSocket.id}"
+  api_id             = aws_apigatewayv2_api.SimpleChatWebSocket.id
   integration_type   = "AWS_PROXY"
   description        = "Disconnect Integration"
-  integration_uri    = "${aws_lambda_function.OnDisconnectFunction.invoke_arn}"
+  integration_uri    = aws_lambda_function.OnDisconnectFunction.invoke_arn
   integration_method = "POST"
 }
 
 resource "aws_apigatewayv2_route" "DisconnectRoute" {
-  api_id         = "${aws_apigatewayv2_api.SimpleChatWebSocket.id}"
+  api_id         = aws_apigatewayv2_api.SimpleChatWebSocket.id
   route_key      = "$disconnect"
   operation_name = "DisconnectRoute"
   target         = "integrations/${aws_apigatewayv2_integration.DisconnectInteg.id}"
@@ -139,15 +143,15 @@ resource "aws_apigatewayv2_route" "DisconnectRoute" {
 # SendMessage
 #############
 resource "aws_apigatewayv2_integration" "SendInteg" {
-  api_id             = "${aws_apigatewayv2_api.SimpleChatWebSocket.id}"
+  api_id             = aws_apigatewayv2_api.SimpleChatWebSocket.id
   integration_type   = "AWS_PROXY"
   description        = "Send Integration"
-  integration_uri    = "${aws_lambda_function.SendMessageFunction.invoke_arn}"
+  integration_uri    = aws_lambda_function.SendMessageFunction.invoke_arn
   integration_method = "POST"
 }
 
 resource "aws_apigatewayv2_route" "SendRoute" {
-  api_id         = "${aws_apigatewayv2_api.SimpleChatWebSocket.id}"
+  api_id         = aws_apigatewayv2_api.SimpleChatWebSocket.id
   route_key      = "sendmessage"
   operation_name = "SendRoute"
   target         = "integrations/${aws_apigatewayv2_integration.SendInteg.id}"
@@ -167,23 +171,23 @@ data "archive_file" "OnConnectZip" {
 }
 
 resource "aws_lambda_function" "OnConnectFunction" {
-  filename      = "${data.archive_file.OnConnectZip.output_path}"
+  filename      = data.archive_file.OnConnectZip.output_path
   function_name = "OnConnectFunction"
-  role          = "${aws_iam_role.OnConnectRole.arn}"
+  role          = aws_iam_role.OnConnectRole.arn
   handler       = "app.handler"
   runtime       = "nodejs12.x"
   memory_size   = 256
 
   environment {
     variables = {
-      TABLE_NAME = "${aws_dynamodb_table.ConnectionsTable.name}"
+      TABLE_NAME = aws_dynamodb_table.ConnectionsTable.name
     }
   }
 }
 
 resource "aws_lambda_permission" "OnConnectPermission" {
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.OnConnectFunction.function_name}"
+  function_name = aws_lambda_function.OnConnectFunction.function_name
   principal     = "apigateway.amazonaws.com"
 }
 
@@ -202,11 +206,12 @@ resource "aws_iam_role" "OnConnectRole" {
   }]
 }
 EOT
+
 }
 
 resource "aws_iam_role_policy_attachment" "OnConnectRoleDynamoDBCrudPolicyAttachment" {
-  role       = "${aws_iam_role.OnConnectRole.name}"
-  policy_arn = "${aws_iam_policy.DynamoDBCrudPolicy.arn}"
+  role       = aws_iam_role.OnConnectRole.name
+  policy_arn = aws_iam_policy.DynamoDBCrudPolicy.arn
 }
 
 resource "aws_iam_policy" "OnConnectCloudWatchLogsPolicy" {
@@ -237,8 +242,8 @@ EOT
 }
 
 resource "aws_iam_role_policy_attachment" "OnConnectRoleOnConnectCloudWatchLogsPolicyAttachment" {
-  role       = "${aws_iam_role.OnConnectRole.name}"
-  policy_arn = "${aws_iam_policy.OnConnectCloudWatchLogsPolicy.arn}"
+  role       = aws_iam_role.OnConnectRole.name
+  policy_arn = aws_iam_policy.OnConnectCloudWatchLogsPolicy.arn
 }
 
 ##############
@@ -251,23 +256,23 @@ data "archive_file" "OnDisconnectZip" {
 }
 
 resource "aws_lambda_function" "OnDisconnectFunction" {
-  filename      = "${data.archive_file.OnDisconnectZip.output_path}"
+  filename      = data.archive_file.OnDisconnectZip.output_path
   function_name = "OnDisconnectFunction"
-  role          = "${aws_iam_role.OnDisconnectRole.arn}"
+  role          = aws_iam_role.OnDisconnectRole.arn
   handler       = "app.handler"
   runtime       = "nodejs12.x"
   memory_size   = 256
 
   environment {
     variables = {
-      TABLE_NAME = "${aws_dynamodb_table.ConnectionsTable.name}"
+      TABLE_NAME = aws_dynamodb_table.ConnectionsTable.name
     }
   }
 }
 
 resource "aws_lambda_permission" "OnDisconnectPermission" {
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.OnDisconnectFunction.function_name}"
+  function_name = aws_lambda_function.OnDisconnectFunction.function_name
   principal     = "apigateway.amazonaws.com"
 }
 
@@ -289,8 +294,8 @@ EOT
 }
 
 resource "aws_iam_role_policy_attachment" "OnDisconnectRoleDynamoDBCrudPolicyAttachment" {
-  role       = "${aws_iam_role.OnDisconnectRole.name}"
-  policy_arn = "${aws_iam_policy.DynamoDBCrudPolicy.arn}"
+  role       = aws_iam_role.OnDisconnectRole.name
+  policy_arn = aws_iam_policy.DynamoDBCrudPolicy.arn
 }
 
 resource "aws_iam_policy" "OnDisconnectCloudWatchLogsPolicy" {
@@ -321,8 +326,8 @@ EOT
 }
 
 resource "aws_iam_role_policy_attachment" "OnDisconnectRoleOnDisconnectCloudWatchLogsPolicyAttachment" {
-  role       = "${aws_iam_role.OnDisconnectRole.name}"
-  policy_arn = "${aws_iam_policy.OnDisconnectCloudWatchLogsPolicy.arn}"
+  role       = aws_iam_role.OnDisconnectRole.name
+  policy_arn = aws_iam_policy.OnDisconnectCloudWatchLogsPolicy.arn
 }
 
 #############
@@ -335,23 +340,23 @@ data "archive_file" "SendMessageZip" {
 }
 
 resource "aws_lambda_function" "SendMessageFunction" {
-  filename      = "${data.archive_file.SendMessageZip.output_path}"
+  filename      = data.archive_file.SendMessageZip.output_path
   function_name = "SendMessageFunction"
-  role          = "${aws_iam_role.SendMessageRole.arn}"
+  role          = aws_iam_role.SendMessageRole.arn
   handler       = "app.handler"
   runtime       = "nodejs12.x"
   memory_size   = 256
 
   environment {
     variables = {
-      TABLE_NAME = "${aws_dynamodb_table.ConnectionsTable.name}"
+      TABLE_NAME = aws_dynamodb_table.ConnectionsTable.name
     }
   }
 }
 
 resource "aws_lambda_permission" "SendMessagePermission" {
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.SendMessageFunction.function_name}"
+  function_name = aws_lambda_function.SendMessageFunction.function_name
   principal     = "apigateway.amazonaws.com"
 }
 
@@ -373,8 +378,8 @@ EOT
 }
 
 resource "aws_iam_role_policy_attachment" "SendMessageRoleDynamoDBCrudPolicyAttachment" {
-  role       = "${aws_iam_role.SendMessageRole.name}"
-  policy_arn = "${aws_iam_policy.DynamoDBCrudPolicy.arn}"
+  role       = aws_iam_role.SendMessageRole.name
+  policy_arn = aws_iam_policy.DynamoDBCrudPolicy.arn
 }
 
 resource "aws_iam_policy" "SendMessageCloudWatchLogsPolicy" {
@@ -405,8 +410,8 @@ EOT
 }
 
 resource "aws_iam_role_policy_attachment" "SendMessageRoleSendMessageCloudWatchLogsPolicyAttachment" {
-  role       = "${aws_iam_role.SendMessageRole.name}"
-  policy_arn = "${aws_iam_policy.SendMessageCloudWatchLogsPolicy.arn}"
+  role       = aws_iam_role.SendMessageRole.name
+  policy_arn = aws_iam_policy.SendMessageCloudWatchLogsPolicy.arn
 }
 
 resource "aws_iam_policy" "SendMessageManageConnectionsPolicy" {
@@ -425,8 +430,8 @@ EOT
 }
 
 resource "aws_iam_role_policy_attachment" "SendMessageRoleSendMessageManageConnectionsPolicyAttachment" {
-  role       = "${aws_iam_role.SendMessageRole.name}"
-  policy_arn = "${aws_iam_policy.SendMessageManageConnectionsPolicy.arn}"
+  role       = aws_iam_role.SendMessageRole.name
+  policy_arn = aws_iam_policy.SendMessageManageConnectionsPolicy.arn
 }
 
 #
@@ -434,21 +439,21 @@ resource "aws_iam_role_policy_attachment" "SendMessageRoleSendMessageManageConne
 #
 
 output "ConnectionsTableArn" {
-  value = "${aws_dynamodb_table.ConnectionsTable.arn}"
+  value = aws_dynamodb_table.ConnectionsTable.arn
 }
 
 output "OnConnectFunctionArn" {
-  value = "${aws_lambda_function.OnConnectFunction.arn}"
+  value = aws_lambda_function.OnConnectFunction.arn
 }
 
 output "OnDisconnectFunctionArn" {
-  value = "${aws_lambda_function.OnDisconnectFunction.arn}"
+  value = aws_lambda_function.OnDisconnectFunction.arn
 }
 
 output "SendMessageFunctionArn" {
-  value = "${aws_lambda_function.SendMessageFunction.arn}"
+  value = aws_lambda_function.SendMessageFunction.arn
 }
 
 output "WebSocketURI" {
-  value = "${aws_apigatewayv2_stage.Stage.invoke_url}"
+  value = aws_apigatewayv2_stage.Stage.invoke_url
 }

--- a/examples/api-gateway-websocket-chat-app/main.tf
+++ b/examples/api-gateway-websocket-chat-app/main.tf
@@ -12,7 +12,7 @@ terraform {
 #
 
 provider "aws" {
-  region = var.aws_region
+  region = var.aws_regionXX
 }
 
 provider "archive" {}

--- a/examples/api-gateway-websocket-chat-app/main.tf
+++ b/examples/api-gateway-websocket-chat-app/main.tf
@@ -12,7 +12,7 @@ terraform {
 #
 
 provider "aws" {
-  region = var.aws_regionXX
+  region = var.aws_region
 }
 
 provider "archive" {}

--- a/examples/asg/main.tf
+++ b/examples/asg/main.tf
@@ -1,17 +1,20 @@
-# Specify the provider and access details
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 locals {
-  availability_zones = "${split(",", var.availability_zones)}"
+  availability_zones = split(",", var.availability_zones)
 }
 
 resource "aws_elb" "web-elb" {
   name = "terraform-example-elb"
 
   # The same availability zone as our instances
-  availability_zones = "${local.availability_zones}"
+  availability_zones = local.availability_zones
 
   listener {
     instance_port     = 80
@@ -30,14 +33,14 @@ resource "aws_elb" "web-elb" {
 }
 
 resource "aws_autoscaling_group" "web-asg" {
-  availability_zones   = "${local.availability_zones}"
+  availability_zones   = local.availability_zones
   name                 = "terraform-example-asg"
-  max_size             = "${var.asg_max}"
-  min_size             = "${var.asg_min}"
-  desired_capacity     = "${var.asg_desired}"
+  max_size             = var.asg_max
+  min_size             = var.asg_min
+  desired_capacity     = var.asg_desired
   force_delete         = true
-  launch_configuration = "${aws_launch_configuration.web-lc.name}"
-  load_balancers       = ["${aws_elb.web-elb.name}"]
+  launch_configuration = aws_launch_configuration.web-lc.name
+  load_balancers       = [aws_elb.web-elb.name]
 
   #vpc_zone_identifier = ["${split(",", var.availability_zones)}"]
   tag {
@@ -49,13 +52,13 @@ resource "aws_autoscaling_group" "web-asg" {
 
 resource "aws_launch_configuration" "web-lc" {
   name          = "terraform-example-lc"
-  image_id      = "${lookup(var.aws_amis, var.aws_region)}"
-  instance_type = "${var.instance_type}"
+  image_id      = var.aws_amis[var.aws_region]
+  instance_type = var.instance_type
 
   # Security group
-  security_groups = ["${aws_security_group.default.id}"]
-  user_data       = "${file("userdata.sh")}"
-  key_name        = "${var.key_name}"
+  security_groups = [aws_security_group.default.id]
+  user_data       = file("userdata.sh")
+  key_name        = var.key_name
 }
 
 # Our default security group to access

--- a/examples/asg/outputs.tf
+++ b/examples/asg/outputs.tf
@@ -1,15 +1,15 @@
 output "security_group" {
-  value = "${aws_security_group.default.id}"
+  value = aws_security_group.default.id
 }
 
 output "launch_configuration" {
-  value = "${aws_launch_configuration.web-lc.id}"
+  value = aws_launch_configuration.web-lc.id
 }
 
 output "asg_name" {
-  value = "${aws_autoscaling_group.web-asg.id}"
+  value = aws_autoscaling_group.web-asg.id
 }
 
 output "elb_name" {
-  value = "${aws_elb.web-elb.dns_name}"
+  value = aws_elb.web-elb.dns_name
 }

--- a/examples/cloudhsm/main.tf
+++ b/examples/cloudhsm/main.tf
@@ -1,5 +1,9 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 data "aws_availability_zones" "available" {}
@@ -14,10 +18,10 @@ resource "aws_vpc" "cloudhsm_v2_vpc" {
 
 resource "aws_subnet" "cloudhsm_v2_subnets" {
   count                   = 2
-  vpc_id                  = "${aws_vpc.cloudhsm_v2_vpc.id}"
-  cidr_block              = "${element(var.subnets, count.index)}"
+  vpc_id                  = aws_vpc.cloudhsm_v2_vpc.id
+  cidr_block              = element(var.subnets, count.index)
   map_public_ip_on_launch = false
-  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
 
   tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
@@ -26,7 +30,7 @@ resource "aws_subnet" "cloudhsm_v2_subnets" {
 
 resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = ["${aws_subnet.cloudhsm_v2_subnets.*.id}"]
+  subnet_ids = aws_subnet.cloudhsm_v2_subnets.*.id
 
   tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
@@ -34,11 +38,11 @@ resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
 }
 
 resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
-  subnet_id  = "${aws_subnet.cloudhsm_v2_subnets.0.id}"
-  cluster_id = "${aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.cluster_id}"
+  subnet_id  = aws_subnet.cloudhsm_v2_subnets[0].id
+  cluster_id = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.cluster_id
 }
 
 data "aws_cloudhsm_v2_cluster" "cluster" {
-  cluster_id = "${aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.cluster_id}"
-  depends_on = ["aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm"]
+  cluster_id = aws_cloudhsm_v2_cluster.cloudhsm_v2_cluster.cluster_id
+  depends_on = [aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm]
 }

--- a/examples/cloudhsm/outputs.tf
+++ b/examples/cloudhsm/outputs.tf
@@ -1,7 +1,7 @@
 output "hsm_ip_address" {
-  value = "${aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm.ip_address}"
+  value = aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm.ip_address
 }
 
 output "cluster_data_certificate" {
-  value = "${data.aws_cloudhsm_v2_cluster.cluster.cluster_certificates.0.cluster_csr}"
+  value = data.aws_cloudhsm_v2_cluster.cluster.cluster_certificates[0].cluster_csr
 }

--- a/examples/cloudhsm/variables.tf
+++ b/examples/cloudhsm/variables.tf
@@ -5,5 +5,5 @@ variable "aws_region" {
 
 variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = "list"
+  type    = list(string)
 }

--- a/examples/cloudwatch-events/kinesis/README.md
+++ b/examples/cloudwatch-events/kinesis/README.md
@@ -9,6 +9,5 @@ in the official AWS docs.
 ## How to run the example
 
 ```
-terraform apply \
-	-var=aws_region=us-west-2
+terraform apply -var=aws_region=us-west-2
 ```

--- a/examples/cloudwatch-events/kinesis/main.tf
+++ b/examples/cloudwatch-events/kinesis/main.tf
@@ -1,9 +1,13 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 resource "aws_cloudwatch_event_rule" "foo" {
-  name = "${var.rule_name}"
+  name = var.rule_name
 
   event_pattern = <<PATTERN
 {
@@ -18,11 +22,11 @@ resource "aws_cloudwatch_event_rule" "foo" {
 }
 PATTERN
 
-  role_arn = "${aws_iam_role.role.arn}"
+  role_arn = aws_iam_role.role.arn
 }
 
 resource "aws_iam_role" "role" {
-  name = "${var.iam_role_name}"
+  name = var.iam_role_name
 
   assume_role_policy = <<POLICY
 {
@@ -43,7 +47,7 @@ POLICY
 
 resource "aws_iam_role_policy" "policy" {
   name = "tf-example-policy"
-  role = "${aws_iam_role.role.id}"
+  role = aws_iam_role.role.id
 
   policy = <<POLICY
 {
@@ -65,12 +69,12 @@ POLICY
 }
 
 resource "aws_cloudwatch_event_target" "foobar" {
-  rule      = "${aws_cloudwatch_event_rule.foo.name}"
-  target_id = "${var.target_name}"
-  arn       = "${aws_kinesis_stream.foo.arn}"
+  rule      = aws_cloudwatch_event_rule.foo.name
+  target_id = var.target_name
+  arn       = aws_kinesis_stream.foo.arn
 }
 
 resource "aws_kinesis_stream" "foo" {
-  name        = "${var.stream_name}"
+  name        = var.stream_name
   shard_count = 1
 }

--- a/examples/cloudwatch-events/kinesis/outputs.tf
+++ b/examples/cloudwatch-events/kinesis/outputs.tf
@@ -1,7 +1,7 @@
 output "rule_arn" {
-  value = "${aws_cloudwatch_event_rule.foo.arn}"
+  value = aws_cloudwatch_event_rule.foo.arn
 }
 
 output "kinesis_stream_arn" {
-  value = "${aws_kinesis_stream.foo.arn}"
+  value = aws_kinesis_stream.foo.arn
 }

--- a/examples/cloudwatch-events/sns/README.md
+++ b/examples/cloudwatch-events/sns/README.md
@@ -10,6 +10,5 @@ in the official AWS docs.
 ## How to run the example
 
 ```
-terraform apply \
-	-var=aws_region=us-west-2
+terraform apply -var=aws_region=us-west-2
 ```

--- a/examples/cloudwatch-events/sns/main.tf
+++ b/examples/cloudwatch-events/sns/main.tf
@@ -1,9 +1,13 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 resource "aws_cloudwatch_event_rule" "foo" {
-  name = "${var.rule_name}"
+  name = var.rule_name
 
   event_pattern = <<PATTERN
 {
@@ -20,11 +24,11 @@ PATTERN
 }
 
 resource "aws_cloudwatch_event_target" "bar" {
-  rule      = "${aws_cloudwatch_event_rule.foo.name}"
-  target_id = "${var.target_name}"
-  arn       = "${aws_sns_topic.foo.arn}"
+  rule      = aws_cloudwatch_event_rule.foo.name
+  target_id = var.target_name
+  arn       = aws_sns_topic.foo.arn
 }
 
 resource "aws_sns_topic" "foo" {
-  name = "${var.sns_topic_name}"
+  name = var.sns_topic_name
 }

--- a/examples/cloudwatch-events/sns/outputs.tf
+++ b/examples/cloudwatch-events/sns/outputs.tf
@@ -1,7 +1,7 @@
 output "rule_arn" {
-  value = "${aws_cloudwatch_event_rule.foo.arn}"
+  value = aws_cloudwatch_event_rule.foo.arn
 }
 
 output "sns_topic_arn" {
-  value = "${aws_sns_topic.foo.arn}"
+  value = aws_sns_topic.foo.arn
 }

--- a/examples/cognito-user-pool/main.tf
+++ b/examples/cognito-user-pool/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
 resource "aws_iam_role" "main" {
   name = "terraform-example-lambda"
 
@@ -21,7 +29,7 @@ EOF
 resource "aws_lambda_function" "main" {
   filename      = "lambda.zip"
   function_name = "terraform-example"
-  role          = "${aws_iam_role.main.arn}"
+  role          = aws_iam_role.main.arn
   handler       = "exports.example"
   runtime       = "nodejs4.3"
 }
@@ -54,7 +62,7 @@ POLICY
 
 resource "aws_iam_role_policy" "main" {
   name = "terraform-example-cognito-idp"
-  role = "${aws_iam_role.cidp.id}"
+  role = aws_iam_role.cidp.id
 
   policy = <<EOF
 {
@@ -99,16 +107,16 @@ resource "aws_cognito_user_pool" "pool" {
   }
 
   lambda_config {
-    create_auth_challenge          = "${aws_lambda_function.main.arn}"
-    custom_message                 = "${aws_lambda_function.main.arn}"
-    define_auth_challenge          = "${aws_lambda_function.main.arn}"
-    post_authentication            = "${aws_lambda_function.main.arn}"
-    post_confirmation              = "${aws_lambda_function.main.arn}"
-    pre_authentication             = "${aws_lambda_function.main.arn}"
-    pre_sign_up                    = "${aws_lambda_function.main.arn}"
-    pre_token_generation           = "${aws_lambda_function.main.arn}"
-    user_migration                 = "${aws_lambda_function.main.arn}"
-    verify_auth_challenge_response = "${aws_lambda_function.main.arn}"
+    create_auth_challenge          = aws_lambda_function.main.arn
+    custom_message                 = aws_lambda_function.main.arn
+    define_auth_challenge          = aws_lambda_function.main.arn
+    post_authentication            = aws_lambda_function.main.arn
+    post_confirmation              = aws_lambda_function.main.arn
+    pre_authentication             = aws_lambda_function.main.arn
+    pre_sign_up                    = aws_lambda_function.main.arn
+    pre_token_generation           = aws_lambda_function.main.arn
+    user_migration                 = aws_lambda_function.main.arn
+    verify_auth_challenge_response = aws_lambda_function.main.arn
   }
 
   schema {
@@ -139,7 +147,7 @@ resource "aws_cognito_user_pool" "pool" {
 
   sms_configuration {
     external_id    = "12345"
-    sns_caller_arn = "${aws_iam_role.cidp.arn}"
+    sns_caller_arn = aws_iam_role.cidp.arn
   }
 
   tags = {

--- a/examples/cognito-user-pool/variables.tf
+++ b/examples/cognito-user-pool/variables.tf
@@ -1,0 +1,4 @@
+variable "aws_region" {
+  default = "us-west-2"
+}
+

--- a/examples/count/main.tf
+++ b/examples/count/main.tf
@@ -1,4 +1,7 @@
-# Specify the provider and access details
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
   region = var.aws_region
 }

--- a/examples/count/versions.tf
+++ b/examples/count/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/examples/dx-gateway-cross-account-vgw-association/main.tf
+++ b/examples/dx-gateway-cross-account-vgw-association/main.tf
@@ -1,25 +1,31 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 // First account owns the VGW.
 provider "aws" {
   alias = "first"
 
-  region     = "${var.aws_region}"
-  access_key = "${var.aws_first_access_key}"
-  secret_key = "${var.aws_first_secret_key}"
+  region     = var.aws_region
+  access_key = var.aws_first_access_key
+  secret_key = var.aws_first_secret_key
 }
 
 // Second account owns the DXGW.
 provider "aws" {
   alias = "second"
 
-  region     = "${var.aws_region}"
-  access_key = "${var.aws_second_access_key}"
-  secret_key = "${var.aws_second_secret_key}"
+  region     = var.aws_region
+  access_key = var.aws_second_access_key
+  secret_key = var.aws_second_secret_key
 }
 
-data "aws_caller_identity" "first" {}
+data "aws_caller_identity" "first" {
+  provider = aws.first
+}
 
 resource "aws_vpc" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
   cidr_block = "10.255.255.0/28"
 
@@ -29,9 +35,9 @@ resource "aws_vpc" "example" {
 }
 
 resource "aws_vpn_gateway" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
-  vpc_id = "${aws_vpc.example.id}"
+  vpc_id = aws_vpc.example.id
 
   tags = {
     Name = "terraform-example"
@@ -40,24 +46,24 @@ resource "aws_vpn_gateway" "example" {
 
 // Create the association proposal in the first account...
 resource "aws_dx_gateway_association_proposal" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
-  dx_gateway_id               = "${aws_dx_gateway.example.id}"
-  dx_gateway_owner_account_id = "${aws_dx_gateway.example.owner_account_id}"
-  associated_gateway_id       = "${aws_vpn_gateway.example.id}"
+  dx_gateway_id               = aws_dx_gateway.example.id
+  dx_gateway_owner_account_id = aws_dx_gateway.example.owner_account_id
+  associated_gateway_id       = aws_vpn_gateway.example.id
 }
 
 // ...and accept it in the second account, creating the association.
 resource "aws_dx_gateway_association" "example" {
-  provider = "aws.second"
+  provider = aws.second
 
-  proposal_id                         = "${aws_dx_gateway_association_proposal.example.id}"
-  dx_gateway_id                       = "${aws_dx_gateway.example.id}"
-  associated_gateway_owner_account_id = "${data.aws_caller_identity.first.account_id}"
+  proposal_id                         = aws_dx_gateway_association_proposal.example.id
+  dx_gateway_id                       = aws_dx_gateway.example.id
+  associated_gateway_owner_account_id = data.aws_caller_identity.first.account_id
 }
 
 resource "aws_dx_gateway" "example" {
-  provider = "aws.second"
+  provider = aws.second
 
   name            = "terraform-example"
   amazon_side_asn = "64512"

--- a/examples/dx-gateway-cross-account-vgw-association/terraform.template.tfvars
+++ b/examples/dx-gateway-cross-account-vgw-association/terraform.template.tfvars
@@ -6,4 +6,4 @@ aws_first_secret_key = "SuperSecretKeyForAccount1"
 aws_second_access_key = "BBBBBBBBBBBBBBBBBBB"
 aws_second_secret_key = "SuperSecretKeyForAccount2"
 
-aws_region = "us-east-1"
+aws_region = "us-west-2"

--- a/examples/dx-gateway-cross-account-vgw-association/variables.tf
+++ b/examples/dx-gateway-cross-account-vgw-association/variables.tf
@@ -6,4 +6,6 @@ variable "aws_second_access_key" {}
 
 variable "aws_second_secret_key" {}
 
-variable "aws_region" {}
+variable "aws_region" {
+  default = "us-west-2"
+}

--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -1,6 +1,9 @@
-# Specify the provider and access details
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 ## EC2
@@ -14,51 +17,51 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "main" {
-  count             = "${var.az_count}"
-  cidr_block        = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
-  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
-  vpc_id            = "${aws_vpc.main.id}"
+  count             = var.az_count
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.main.id
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_route_table" "r" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gw.id}"
+    gateway_id = aws_internet_gateway.gw.id
   }
 }
 
 resource "aws_route_table_association" "a" {
-  count          = "${var.az_count}"
-  subnet_id      = "${element(aws_subnet.main.*.id, count.index)}"
-  route_table_id = "${aws_route_table.r.id}"
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.main.*.id, count.index)
+  route_table_id = aws_route_table.r.id
 }
 
 ### Compute
 
 resource "aws_autoscaling_group" "app" {
   name                 = "tf-test-asg"
-  vpc_zone_identifier  = ["${aws_subnet.main.*.id}"]
-  min_size             = "${var.asg_min}"
-  max_size             = "${var.asg_max}"
-  desired_capacity     = "${var.asg_desired}"
-  launch_configuration = "${aws_launch_configuration.app.name}"
+  vpc_zone_identifier  = aws_subnet.main.*.id
+  min_size             = var.asg_min
+  max_size             = var.asg_max
+  desired_capacity     = var.asg_desired
+  launch_configuration = aws_launch_configuration.app.name
 }
 
 data "template_file" "cloud_config" {
-  template = "${file("${path.module}/cloud-config.yml")}"
+  template = file("${path.module}/cloud-config.yml")
 
   vars = {
-    aws_region         = "${var.aws_region}"
-    ecs_cluster_name   = "${aws_ecs_cluster.main.name}"
+    aws_region         = var.aws_region
+    ecs_cluster_name   = aws_ecs_cluster.main.name
     ecs_log_level      = "info"
     ecs_agent_version  = "latest"
-    ecs_log_group_name = "${aws_cloudwatch_log_group.ecs.name}"
+    ecs_log_group_name = aws_cloudwatch_log_group.ecs.name
   }
 }
 
@@ -85,14 +88,14 @@ data "aws_ami" "stable_coreos" {
 
 resource "aws_launch_configuration" "app" {
   security_groups = [
-    "${aws_security_group.instance_sg.id}",
+    aws_security_group.instance_sg.id,
   ]
 
-  key_name                    = "${var.key_name}"
-  image_id                    = "${data.aws_ami.stable_coreos.id}"
-  instance_type               = "${var.instance_type}"
-  iam_instance_profile        = "${aws_iam_instance_profile.app.name}"
-  user_data                   = "${data.template_file.cloud_config.rendered}"
+  key_name                    = var.key_name
+  image_id                    = data.aws_ami.stable_coreos.id
+  instance_type               = var.instance_type
+  iam_instance_profile        = aws_iam_instance_profile.app.name
+  user_data                   = data.template_file.cloud_config.rendered
   associate_public_ip_address = true
 
   lifecycle {
@@ -105,7 +108,7 @@ resource "aws_launch_configuration" "app" {
 resource "aws_security_group" "lb_sg" {
   description = "controls access to the application ELB"
 
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
   name   = "tf-ecs-lbsg"
 
   ingress {
@@ -128,7 +131,7 @@ resource "aws_security_group" "lb_sg" {
 
 resource "aws_security_group" "instance_sg" {
   description = "controls direct access to application instances"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
   name        = "tf-ecs-instsg"
 
   ingress {
@@ -137,7 +140,7 @@ resource "aws_security_group" "instance_sg" {
     to_port   = 22
 
     cidr_blocks = [
-      "${var.admin_cidr_ingress}",
+      var.admin_cidr_ingress,
     ]
   }
 
@@ -147,7 +150,7 @@ resource "aws_security_group" "instance_sg" {
     to_port   = 61000
 
     security_groups = [
-      "${aws_security_group.lb_sg.id}",
+      aws_security_group.lb_sg.id,
     ]
   }
 
@@ -166,37 +169,37 @@ resource "aws_ecs_cluster" "main" {
 }
 
 data "template_file" "task_definition" {
-  template = "${file("${path.module}/task-definition.json")}"
+  template = file("${path.module}/task-definition.json")
 
   vars = {
     image_url        = "ghost:latest"
     container_name   = "ghost"
-    log_group_region = "${var.aws_region}"
-    log_group_name   = "${aws_cloudwatch_log_group.app.name}"
+    log_group_region = var.aws_region
+    log_group_name   = aws_cloudwatch_log_group.app.name
   }
 }
 
 resource "aws_ecs_task_definition" "ghost" {
   family                = "tf_example_ghost_td"
-  container_definitions = "${data.template_file.task_definition.rendered}"
+  container_definitions = data.template_file.task_definition.rendered
 }
 
 resource "aws_ecs_service" "test" {
   name            = "tf-example-ecs-ghost"
-  cluster         = "${aws_ecs_cluster.main.id}"
-  task_definition = "${aws_ecs_task_definition.ghost.arn}"
-  desired_count   = "${var.service_desired}"
-  iam_role        = "${aws_iam_role.ecs_service.name}"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.ghost.arn
+  desired_count   = var.service_desired
+  iam_role        = aws_iam_role.ecs_service.name
 
   load_balancer {
-    target_group_arn = "${aws_alb_target_group.test.id}"
+    target_group_arn = aws_alb_target_group.test.id
     container_name   = "ghost"
     container_port   = "2368"
   }
 
   depends_on = [
-    "aws_iam_role_policy.ecs_service",
-    "aws_alb_listener.front_end",
+    aws_iam_role_policy.ecs_service,
+    aws_alb_listener.front_end,
   ]
 }
 
@@ -224,7 +227,7 @@ EOF
 
 resource "aws_iam_role_policy" "ecs_service" {
   name = "tf_example_ecs_policy"
-  role = "${aws_iam_role.ecs_service.name}"
+  role = aws_iam_role.ecs_service.name
 
   policy = <<EOF
 {
@@ -249,7 +252,7 @@ EOF
 
 resource "aws_iam_instance_profile" "app" {
   name = "tf-ecs-instprofile"
-  role = "${aws_iam_role.app_instance.name}"
+  role = aws_iam_role.app_instance.name
 }
 
 resource "aws_iam_role" "app_instance" {
@@ -273,18 +276,18 @@ EOF
 }
 
 data "template_file" "instance_profile" {
-  template = "${file("${path.module}/instance-profile-policy.json")}"
+  template = file("${path.module}/instance-profile-policy.json")
 
   vars = {
-    app_log_group_arn = "${aws_cloudwatch_log_group.app.arn}"
-    ecs_log_group_arn = "${aws_cloudwatch_log_group.ecs.arn}"
+    app_log_group_arn = aws_cloudwatch_log_group.app.arn
+    ecs_log_group_arn = aws_cloudwatch_log_group.ecs.arn
   }
 }
 
 resource "aws_iam_role_policy" "instance" {
   name   = "TfEcsExampleInstanceRole"
-  role   = "${aws_iam_role.app_instance.name}"
-  policy = "${data.template_file.instance_profile.rendered}"
+  role   = aws_iam_role.app_instance.name
+  policy = data.template_file.instance_profile.rendered
 }
 
 ## ALB
@@ -293,22 +296,22 @@ resource "aws_alb_target_group" "test" {
   name     = "tf-example-ecs-ghost"
   port     = 8080
   protocol = "HTTP"
-  vpc_id   = "${aws_vpc.main.id}"
+  vpc_id   = aws_vpc.main.id
 }
 
 resource "aws_alb" "main" {
   name            = "tf-example-alb-ecs"
-  subnets         = ["${aws_subnet.main.*.id}"]
-  security_groups = ["${aws_security_group.lb_sg.id}"]
+  subnets         = aws_subnet.main.*.id
+  security_groups = [aws_security_group.lb_sg.id]
 }
 
 resource "aws_alb_listener" "front_end" {
-  load_balancer_arn = "${aws_alb.main.id}"
+  load_balancer_arn = aws_alb.main.id
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_alb_target_group.test.id}"
+    target_group_arn = aws_alb_target_group.test.id
     type             = "forward"
   }
 }

--- a/examples/ecs-alb/outputs.tf
+++ b/examples/ecs-alb/outputs.tf
@@ -1,15 +1,15 @@
 output "instance_security_group" {
-  value = "${aws_security_group.instance_sg.id}"
+  value = aws_security_group.instance_sg.id
 }
 
 output "launch_configuration" {
-  value = "${aws_launch_configuration.app.id}"
+  value = aws_launch_configuration.app.id
 }
 
 output "asg_name" {
-  value = "${aws_autoscaling_group.app.id}"
+  value = aws_autoscaling_group.app.id
 }
 
 output "elb_hostname" {
-  value = "${aws_alb.main.dns_name}"
+  value = aws_alb.main.dns_name
 }

--- a/examples/eip/main.tf
+++ b/examples/eip/main.tf
@@ -1,10 +1,13 @@
-# Specify the provider and access details
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 resource "aws_eip" "default" {
-  instance = "${aws_instance.web.id}"
+  instance = aws_instance.web.id
   vpc      = true
 }
 
@@ -44,22 +47,22 @@ resource "aws_instance" "web" {
 
   # Lookup the correct AMI based on the region
   # we specified
-  ami = "${lookup(var.aws_amis, var.aws_region)}"
+  ami = var.aws_amis[var.aws_region]
 
   # The name of our SSH keypair you've created and downloaded
   # from the AWS console.
   #
   # https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#KeyPairs:
   #
-  key_name = "${var.key_name}"
+  key_name = var.key_name
 
   # Our Security group to allow HTTP and SSH access
-  security_groups = ["${aws_security_group.default.name}"]
+  security_groups = [aws_security_group.default.name]
 
   # We run a remote provisioner on the instance after creating it.
   # In this case, we just install nginx and start it. By default,
   # this should be on port 80
-  user_data = "${file("userdata.sh")}"
+  user_data = file("userdata.sh")
 
   #Instance tags
   tags = {

--- a/examples/eip/outputs.tf
+++ b/examples/eip/outputs.tf
@@ -1,7 +1,7 @@
 output "address" {
-  value = "${aws_instance.web.private_ip}"
+  value = aws_instance.web.private_ip
 }
 
 output "elastic_ip" {
-  value = "${aws_eip.default.public_ip}"
+  value = aws_eip.default.public_ip
 }

--- a/examples/eks-getting-started/providers.tf
+++ b/examples/eks-getting-started/providers.tf
@@ -1,10 +1,9 @@
-#
-# Provider Configuration
-#
+terraform {
+  required_version = ">= 0.12"
+}
 
 provider "aws" {
-  region  = "us-west-2"
-  version = ">= 2.38.0"
+  region = var.aws_region
 }
 
 # Using these data sources allows the configuration to be

--- a/examples/eks-getting-started/variables.tf
+++ b/examples/eks-getting-started/variables.tf
@@ -1,6 +1,6 @@
-#
-# Variables Configuration
-#
+variable "aws_region" {
+  default = "us-west-2"
+}
 
 variable "cluster-name" {
   default = "terraform-eks-demo"

--- a/examples/elasticsearch-domain/main.tf
+++ b/examples/elasticsearch-domain/main.tf
@@ -1,9 +1,17 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name           = "${var.domain}"
+  domain_name           = var.domain
   elasticsearch_version = "7.1"
   cluster_config {
     instance_type = "r5.large.elasticsearch"

--- a/examples/elasticsearch-domain/variables.tf
+++ b/examples/elasticsearch-domain/variables.tf
@@ -1,3 +1,7 @@
+variable "aws_region" {
+  default = "us-west-2"
+}
+
 variable "domain" {
   description = "The name of the Elasticsearch Domain"
   default     = "elasticsearch-domain-test"

--- a/examples/elb/outputs.tf
+++ b/examples/elb/outputs.tf
@@ -1,3 +1,3 @@
 output "address" {
-  value = "${aws_elb.web.dns_name}"
+  value = aws_elb.web.dns_name
 }

--- a/examples/lambda-file-systems/outputs.tf
+++ b/examples/lambda-file-systems/outputs.tf
@@ -1,3 +1,3 @@
 output "lambda" {
-  value = "${aws_lambda_function.example_lambda.qualified_arn}"
+  value = aws_lambda_function.example_lambda.qualified_arn
 }

--- a/examples/lambda/main.tf
+++ b/examples/lambda/main.tf
@@ -1,6 +1,9 @@
-# Specify the provider and access details
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 provider "archive" {}
@@ -27,16 +30,16 @@ data "aws_iam_policy_document" "policy" {
 
 resource "aws_iam_role" "iam_for_lambda" {
   name               = "iam_for_lambda"
-  assume_role_policy = "${data.aws_iam_policy_document.policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.policy.json
 }
 
 resource "aws_lambda_function" "lambda" {
   function_name = "hello_lambda"
 
-  filename         = "${data.archive_file.zip.output_path}"
-  source_code_hash = "${data.archive_file.zip.output_base64sha256}"
+  filename         = data.archive_file.zip.output_path
+  source_code_hash = data.archive_file.zip.output_base64sha256
 
-  role    = "${aws_iam_role.iam_for_lambda.arn}"
+  role    = aws_iam_role.iam_for_lambda.arn
   handler = "hello_lambda.lambda_handler"
   runtime = "python3.6"
 

--- a/examples/lambda/outputs.tf
+++ b/examples/lambda/outputs.tf
@@ -1,3 +1,3 @@
 output "lambda" {
-  value = "${aws_lambda_function.lambda.qualified_arn}"
+  value = aws_lambda_function.lambda.qualified_arn
 }

--- a/examples/networking/region/outputs.tf
+++ b/examples/networking/region/outputs.tf
@@ -1,11 +1,11 @@
 output "vpc_id" {
-  value = "${aws_vpc.main.id}"
+  value = aws_vpc.main.id
 }
 
 output "primary_subnet_id" {
-  value = "${module.primary_subnet.subnet_id}"
+  value = module.primary_subnet.subnet_id
 }
 
 output "secondary_subnet_id" {
-  value = "${module.secondary_subnet.subnet_id}"
+  value = module.secondary_subnet.subnet_id
 }

--- a/examples/networking/region/security_group.tf
+++ b/examples/networking/region/security_group.tf
@@ -1,25 +1,25 @@
 resource "aws_security_group" "region" {
   name        = "region"
   description = "Open access within this region"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = -1
-    cidr_blocks = ["${aws_vpc.main.cidr_block}"]
+    cidr_blocks = [aws_vpc.main.cidr_block]
   }
 }
 
 resource "aws_security_group" "internal-all" {
   name        = "internal-all"
   description = "Open access within the full internal network"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = -1
-    cidr_blocks = ["${var.base_cidr_block}"]
+    cidr_blocks = [var.base_cidr_block]
   }
 }

--- a/examples/networking/region/subnets.tf
+++ b/examples/networking/region/subnets.tf
@@ -2,12 +2,12 @@ data "aws_availability_zones" "all" {}
 
 module "primary_subnet" {
   source            = "../subnet"
-  vpc_id            = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.all.names[0]}"
+  vpc_id            = aws_vpc.main.id
+  availability_zone = data.aws_availability_zones.all.names[0]
 }
 
 module "secondary_subnet" {
   source            = "../subnet"
-  vpc_id            = "${aws_vpc.main.id}"
-  availability_zone = "${data.aws_availability_zones.all.names[1]}"
+  vpc_id            = aws_vpc.main.id
+  availability_zone = data.aws_availability_zones.all.names[1]
 }

--- a/examples/networking/region/variables.tf
+++ b/examples/networking/region/variables.tf
@@ -5,7 +5,7 @@ variable "region" {
 variable "base_cidr_block" {}
 
 provider "aws" {
-  region = "${var.region}"
+  region = var.region
 }
 
 variable "region_numbers" {

--- a/examples/networking/region/versions.tf
+++ b/examples/networking/region/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/networking/region/vpc.tf
+++ b/examples/networking/region/vpc.tf
@@ -1,7 +1,7 @@
 resource "aws_vpc" "main" {
-  cidr_block = "${cidrsubnet(var.base_cidr_block, 4, lookup(var.region_numbers, var.region))}"
+  cidr_block = cidrsubnet(var.base_cidr_block, 4, var.region_numbers[var.region])
 }
 
 resource "aws_internet_gateway" "main" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }

--- a/examples/networking/regions.tf
+++ b/examples/networking/regions.tf
@@ -1,11 +1,11 @@
 module "us-east-1" {
   source          = "./region"
   region          = "us-east-1"
-  base_cidr_block = "${var.base_cidr_block}"
+  base_cidr_block = var.base_cidr_block
 }
 
 module "us-west-2" {
   source          = "./region"
   region          = "us-west-2"
-  base_cidr_block = "${var.base_cidr_block}"
+  base_cidr_block = var.base_cidr_block
 }

--- a/examples/networking/subnet/outputs.tf
+++ b/examples/networking/subnet/outputs.tf
@@ -1,3 +1,3 @@
 output "subnet_id" {
-  value = "${aws_subnet.main.id}"
+  value = aws_subnet.main.id
 }

--- a/examples/networking/subnet/security_group.tf
+++ b/examples/networking/subnet/security_group.tf
@@ -1,12 +1,12 @@
 resource "aws_security_group" "az" {
   name        = "az-${data.aws_availability_zone.target.name}"
   description = "Open access within the AZ ${data.aws_availability_zone.target.name}"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = -1
-    cidr_blocks = ["${aws_subnet.main.cidr_block}"]
+    cidr_blocks = [aws_subnet.main.cidr_block]
   }
 }

--- a/examples/networking/subnet/subnet.tf
+++ b/examples/networking/subnet/subnet.tf
@@ -1,14 +1,14 @@
 resource "aws_subnet" "main" {
-  cidr_block        = "${cidrsubnet(data.aws_vpc.target.cidr_block, 2, lookup(var.az_numbers, data.aws_availability_zone.target.name_suffix))}"
-  vpc_id            = "${var.vpc_id}"
-  availability_zone = "${var.availability_zone}"
+  cidr_block        = cidrsubnet(data.aws_vpc.target.cidr_block, 2, var.az_numbers[data.aws_availability_zone.target.name_suffix])
+  vpc_id            = var.vpc_id
+  availability_zone = var.availability_zone
 }
 
 resource "aws_route_table" "main" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 }
 
 resource "aws_route_table_association" "main" {
-  subnet_id      = "${aws_subnet.main.id}"
-  route_table_id = "${aws_route_table.main.id}"
+  subnet_id      = aws_subnet.main.id
+  route_table_id = aws_route_table.main.id
 }

--- a/examples/networking/subnet/variables.tf
+++ b/examples/networking/subnet/variables.tf
@@ -1,13 +1,15 @@
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
-variable "availability_zone" {}
+variable "availability_zone" {
+}
 
 data "aws_availability_zone" "target" {
-  name = "${var.availability_zone}"
+  name = var.availability_zone
 }
 
 data "aws_vpc" "target" {
-  id = "${var.vpc_id}"
+  id = var.vpc_id
 }
 
 variable "az_numbers" {

--- a/examples/networking/subnet/versions.tf
+++ b/examples/networking/subnet/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/networking/versions.tf
+++ b/examples/networking/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/rds/main.tf
+++ b/examples/rds/main.tf
@@ -1,19 +1,27 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
 resource "aws_db_instance" "default" {
-  depends_on             = ["aws_security_group.default"]
-  identifier             = "${var.identifier}"
-  allocated_storage      = "${var.storage}"
-  engine                 = "${var.engine}"
-  engine_version         = "${lookup(var.engine_version, var.engine)}"
-  instance_class         = "${var.instance_class}"
-  name                   = "${var.db_name}"
-  username               = "${var.username}"
-  password               = "${var.password}"
-  vpc_security_group_ids = ["${aws_security_group.default.id}"]
-  db_subnet_group_name   = "${aws_db_subnet_group.default.id}"
+  depends_on             = [aws_security_group.default]
+  identifier             = var.identifier
+  allocated_storage      = var.storage
+  engine                 = var.engine
+  engine_version         = var.engine_version[var.engine]
+  instance_class         = var.instance_class
+  name                   = var.db_name
+  username               = var.username
+  password               = var.password
+  vpc_security_group_ids = [aws_security_group.default.id]
+  db_subnet_group_name   = aws_db_subnet_group.default.id
 }
 
 resource "aws_db_subnet_group" "default" {
   name        = "main_subnet_group"
   description = "Our main group of subnets"
-  subnet_ids  = ["${aws_subnet.subnet_1.id}", "${aws_subnet.subnet_2.id}"]
+  subnet_ids  = [aws_subnet.subnet_1.id, aws_subnet.subnet_2.id]
 }

--- a/examples/rds/outputs.tf
+++ b/examples/rds/outputs.tf
@@ -1,11 +1,11 @@
 output "subnet_group" {
-  value = "${aws_db_subnet_group.default.name}"
+  value = aws_db_subnet_group.default.name
 }
 
 output "db_instance_id" {
-  value = "${aws_db_instance.default.id}"
+  value = aws_db_instance.default.id
 }
 
 output "db_instance_address" {
-  value = "${aws_db_instance.default.address}"
+  value = aws_db_instance.default.address
 }

--- a/examples/rds/sg.tf
+++ b/examples/rds/sg.tf
@@ -1,13 +1,13 @@
 resource "aws_security_group" "default" {
   name        = "main_rds_sg"
   description = "Allow all inbound traffic"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
     from_port   = 0
     to_port     = 65535
     protocol    = "TCP"
-    cidr_blocks = ["${var.cidr_blocks}"]
+    cidr_blocks = [var.cidr_blocks]
   }
 
   egress {
@@ -18,6 +18,6 @@ resource "aws_security_group" "default" {
   }
 
   tags = {
-    Name = "${var.sg_name}"
+    Name = var.sg_name
   }
 }

--- a/examples/rds/subnets.tf
+++ b/examples/rds/subnets.tf
@@ -1,7 +1,7 @@
 resource "aws_subnet" "subnet_1" {
-  vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${var.subnet_1_cidr}"
-  availability_zone = "${var.az_1}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.subnet_1_cidr
+  availability_zone = var.az_1
 
   tags = {
     Name = "main_subnet1"
@@ -9,9 +9,9 @@ resource "aws_subnet" "subnet_1" {
 }
 
 resource "aws_subnet" "subnet_2" {
-  vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${var.subnet_2_cidr}"
-  availability_zone = "${var.az_2}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.subnet_2_cidr
+  availability_zone = var.az_2
 
   tags = {
     Name = "main_subnet2"

--- a/examples/rds/variables.tf
+++ b/examples/rds/variables.tf
@@ -1,3 +1,7 @@
+variable "aws_region" {
+  default = "us-west-2"
+}
+
 variable "identifier" {
   default     = "mydb-rds"
   description = "Identifier for your DB"

--- a/examples/s3-api-gateway-integration/README.md
+++ b/examples/s3-api-gateway-integration/README.md
@@ -8,9 +8,6 @@ This example demonstrates how to create an S3 Proxy using AWS API Gateway. It ta
 
 Only three variables are required to run this example. They can be provided by ```cp terraform.template.tfvars terraform.tfvars```, modifying ```terraform.tfvars``` with your variables, and running ```terraform apply```. Alternatively, the variables can be provided as flags by running:
 ```
-terraform apply \
-    -var="aws_access_key=yourawsaccesskey" \
-    -var="aws_secret_key=yourawssecretkey" \
-    -var="aws_region=us-east-1"
+terraform apply -var="aws_region=us-west-2"
 ```
 

--- a/examples/s3-api-gateway-integration/main.tf
+++ b/examples/s3-api-gateway-integration/main.tf
@@ -1,8 +1,9 @@
-# Provide AWS Credentials
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region     = "${var.aws_region}"
+  region = var.aws_region
 }
 
 # Create S3 Full Access Policy
@@ -42,14 +43,14 @@ resource "aws_iam_role" "s3_api_gateyway_role" {
       "Action": "sts:AssumeRole"
     }
   ]
-} 
-  EOF
+}
+EOF
 }
 
 # Attach S3 Access Policy to the API Gateway Role
 resource "aws_iam_role_policy_attachment" "s3_policy_attach" {
-  role       = "${aws_iam_role.s3_api_gateyway_role.name}"
-  policy_arn = "${aws_iam_policy.s3_policy.arn}"
+  role       = aws_iam_role.s3_api_gateyway_role.name
+  policy_arn = aws_iam_policy.s3_policy.arn
 }
 
 resource "aws_api_gateway_rest_api" "MyS3" {
@@ -58,28 +59,28 @@ resource "aws_api_gateway_rest_api" "MyS3" {
 }
 
 resource "aws_api_gateway_resource" "Folder" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  parent_id   = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  parent_id   = aws_api_gateway_rest_api.MyS3.root_resource_id
   path_part   = "{folder}"
 }
 
 resource "aws_api_gateway_resource" "Item" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  parent_id   = "${aws_api_gateway_resource.Folder.id}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  parent_id   = aws_api_gateway_resource.Folder.id
   path_part   = "{item}"
 }
 
 resource "aws_api_gateway_method" "GetBuckets" {
-  rest_api_id   = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id   = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  rest_api_id   = aws_api_gateway_rest_api.MyS3.id
+  resource_id   = aws_api_gateway_rest_api.MyS3.root_resource_id
   http_method   = "GET"
   authorization = "AWS_IAM"
 }
 
 resource "aws_api_gateway_integration" "S3Integration" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
 
   # Included because of this issue: https://github.com/hashicorp/terraform/issues/10501
   integration_http_method = "GET"
@@ -88,13 +89,13 @@ resource "aws_api_gateway_integration" "S3Integration" {
 
   # See uri description: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
   uri         = "arn:aws:apigateway:${var.aws_region}:s3:path//"
-  credentials = "${aws_iam_role.s3_api_gateyway_role.arn}"
+  credentials = aws_iam_role.s3_api_gateyway_role.arn
 }
 
 resource "aws_api_gateway_method_response" "Status200" {
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
   status_code = "200"
 
   response_parameters = {
@@ -109,30 +110,30 @@ resource "aws_api_gateway_method_response" "Status200" {
 }
 
 resource "aws_api_gateway_method_response" "Status400" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
   status_code = "400"
 }
 
 resource "aws_api_gateway_method_response" "Status500" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
   status_code = "500"
 }
 
 resource "aws_api_gateway_integration_response" "IntegrationResponse200" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
-  status_code = "${aws_api_gateway_method_response.Status200.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
+  status_code = aws_api_gateway_method_response.Status200.status_code
 
   response_parameters = {
     "method.response.header.Timestamp"      = "integration.response.header.Date"
@@ -142,29 +143,29 @@ resource "aws_api_gateway_integration_response" "IntegrationResponse200" {
 }
 
 resource "aws_api_gateway_integration_response" "IntegrationResponse400" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
-  status_code = "${aws_api_gateway_method_response.Status400.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
+  status_code = aws_api_gateway_method_response.Status400.status_code
 
   selection_pattern = "4\\d{2}"
 }
 
 resource "aws_api_gateway_integration_response" "IntegrationResponse500" {
-  depends_on = ["aws_api_gateway_integration.S3Integration"]
+  depends_on = [aws_api_gateway_integration.S3Integration]
 
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
-  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
-  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
-  status_code = "${aws_api_gateway_method_response.Status500.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
+  resource_id = aws_api_gateway_rest_api.MyS3.root_resource_id
+  http_method = aws_api_gateway_method.GetBuckets.http_method
+  status_code = aws_api_gateway_method_response.Status500.status_code
 
   selection_pattern = "5\\d{2}"
 }
 
 resource "aws_api_gateway_deployment" "S3APIDeployment" {
-  depends_on  = ["aws_api_gateway_integration.S3Integration"]
-  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  depends_on  = [aws_api_gateway_integration.S3Integration]
+  rest_api_id = aws_api_gateway_rest_api.MyS3.id
   stage_name  = "MyS3"
 }

--- a/examples/s3-api-gateway-integration/terraform.template.tfvars
+++ b/examples/s3-api-gateway-integration/terraform.template.tfvars
@@ -1,5 +1,1 @@
-aws_access_key = "yourawsaccesskey"
-
-aws_secret_key = "yourawssecretkey"
-
-aws_region = "us-east-1"
+aws_region = "us-west-2"

--- a/examples/s3-api-gateway-integration/variables.tf
+++ b/examples/s3-api-gateway-integration/variables.tf
@@ -1,11 +1,3 @@
-variable "aws_access_key" {
-  description = ""
-}
-
-variable "aws_secret_key" {
-  description = ""
-}
-
 variable "aws_region" {
-  description = ""
+  default = "us-west-2"
 }

--- a/examples/s3-cross-account-access/main.tf
+++ b/examples/s3-cross-account-access/main.tf
@@ -1,15 +1,19 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
   alias = "prod"
 
   region     = "us-east-1"
-  access_key = "${var.prod_access_key}"
-  secret_key = "${var.prod_secret_key}"
+  access_key = var.prod_access_key
+  secret_key = var.prod_secret_key
 }
 
 resource "aws_s3_bucket" "prod" {
-  provider = "aws.prod"
+  provider = aws.prod
 
-  bucket = "${var.bucket_name}"
+  bucket = var.bucket_name
   acl    = "private"
 
   policy = <<POLICY
@@ -31,9 +35,9 @@ POLICY
 }
 
 resource "aws_s3_bucket_object" "prod" {
-  provider = "aws.prod"
+  provider = aws.prod
 
-  bucket = "${aws_s3_bucket.prod.id}"
+  bucket = aws_s3_bucket.prod.id
   key    = "object-uploaded-via-prod-creds"
   source = "${path.module}/prod.txt"
 }
@@ -42,14 +46,14 @@ provider "aws" {
   alias = "test"
 
   region     = "us-east-1"
-  access_key = "${var.test_access_key}"
-  secret_key = "${var.test_secret_key}"
+  access_key = var.test_access_key
+  secret_key = var.test_secret_key
 }
 
 resource "aws_s3_bucket_object" "test" {
-  provider = "aws.test"
+  provider = aws.test
 
-  bucket = "${aws_s3_bucket.prod.id}"
+  bucket = aws_s3_bucket.prod.id
   key    = "object-uploaded-via-test-creds"
   source = "${path.module}/test.txt"
 }

--- a/examples/sagemaker/main.tf
+++ b/examples/sagemaker/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
   region = "us-west-2"
 }

--- a/examples/transit-gateway-cross-account-peering-attachment/main.tf
+++ b/examples/transit-gateway-cross-account-peering-attachment/main.tf
@@ -1,31 +1,35 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 // First accepts the Peering attachment.
 provider "aws" {
   alias = "first"
 
-  region     = "${var.aws_first_region}"
-  access_key = "${var.aws_first_access_key}"
-  secret_key = "${var.aws_first_secret_key}"
+  region     = var.aws_first_region
+  access_key = var.aws_first_access_key
+  secret_key = var.aws_first_secret_key
 }
 
 // Second creates the Peering attachment.
 provider "aws" {
   alias = "second"
 
-  region     = "${var.aws_second_region}"
-  access_key = "${var.aws_second_access_key}"
-  secret_key = "${var.aws_second_secret_key}"
+  region     = var.aws_second_region
+  access_key = var.aws_second_access_key
+  secret_key = var.aws_second_secret_key
 }
 
 data "aws_caller_identity" "first" {
-  provider = "aws.first"
+  provider = aws.first
 }
 
 data "aws_caller_identity" "second" {
-  provider = "aws.second"
+  provider = aws.second
 }
 
 resource "aws_ec2_transit_gateway" "first" {
-  provider = "aws.first"
+  provider = aws.first
 
   tags = {
     Name = "terraform-example"
@@ -33,7 +37,7 @@ resource "aws_ec2_transit_gateway" "first" {
 }
 
 resource "aws_ram_resource_share" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
   name = "terraform-example"
 
@@ -44,22 +48,22 @@ resource "aws_ram_resource_share" "example" {
 
 // Share the transit gateway...
 resource "aws_ram_resource_association" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
-  resource_arn       = "${aws_ec2_transit_gateway.first.arn}"
-  resource_share_arn = "${aws_ram_resource_share.example.id}"
+  resource_arn       = aws_ec2_transit_gateway.first.arn
+  resource_share_arn = aws_ram_resource_share.example.id
 }
 
 // ...with the second account.
 resource "aws_ram_principal_association" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
-  principal          = "${data.aws_caller_identity.second.account_id}"
-  resource_share_arn = "${aws_ram_resource_share.example.id}"
+  principal          = data.aws_caller_identity.second.account_id
+  resource_share_arn = aws_ram_resource_share.example.id
 }
 
 resource "aws_ec2_transit_gateway" "second" {
-  provider = "aws.second"
+  provider = aws.second
 
   tags = {
     Name = "terraform-example"
@@ -68,20 +72,21 @@ resource "aws_ec2_transit_gateway" "second" {
 
 // Create the Peering attachment in the second account...
 resource "aws_ec2_transit_gateway_peering_attachment" "example" {
-  provider = "aws.second"
+  provider = aws.second
 
-  peer_account_id         = "${data.aws_caller_identity.first.account_id}"
-  peer_region             = "${var.aws_first_region}"
-  peer_transit_gateway_id = "${aws_ec2_transit_gateway.first.id}"
-  transit_gateway_id      = "${aws_ec2_transit_gateway.second.id}"
+  peer_account_id         = data.aws_caller_identity.first.account_id
+  peer_region             = var.aws_first_region
+  peer_transit_gateway_id = aws_ec2_transit_gateway.first.id
+  transit_gateway_id      = aws_ec2_transit_gateway.second.id
   tags = {
     Name = "terraform-example"
     Side = "Creator"
   }
-  depends_on = ["aws_ram_principal_association.example", "aws_ram_resource_association.example"]
-
+  depends_on = [
+    aws_ram_principal_association.example,
+    aws_ram_resource_association.example,
+  ]
 }
 
 // ...it then needs to accepted by the first account.
-
 // ...terraform currently doesnt have resource for Transit Gateway Peering Attachment Acceptance

--- a/examples/transit-gateway-cross-account-vpc-attachment/main.tf
+++ b/examples/transit-gateway-cross-account-vpc-attachment/main.tf
@@ -1,33 +1,37 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 // First account owns the transit gateway and accepts the VPC attachment.
 provider "aws" {
   alias = "first"
 
-  region     = "${var.aws_region}"
-  access_key = "${var.aws_first_access_key}"
-  secret_key = "${var.aws_first_secret_key}"
+  region     = var.aws_region
+  access_key = var.aws_first_access_key
+  secret_key = var.aws_first_secret_key
 }
 
 // Second account owns the VPC and creates the VPC attachment.
 provider "aws" {
   alias = "second"
 
-  region     = "${var.aws_region}"
-  access_key = "${var.aws_second_access_key}"
-  secret_key = "${var.aws_second_secret_key}"
+  region     = var.aws_region
+  access_key = var.aws_second_access_key
+  secret_key = var.aws_second_secret_key
 }
 
 data "aws_availability_zones" "available" {
-  provider = "aws.second"
+  provider = aws.second
 
   state = "available"
 }
 
 data "aws_caller_identity" "second" {
-  provider = "aws.second"
+  provider = aws.second
 }
 
 resource "aws_ec2_transit_gateway" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
   tags = {
     Name = "terraform-example"
@@ -35,7 +39,7 @@ resource "aws_ec2_transit_gateway" "example" {
 }
 
 resource "aws_ram_resource_share" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
   name = "terraform-example"
 
@@ -46,22 +50,22 @@ resource "aws_ram_resource_share" "example" {
 
 // Share the transit gateway...
 resource "aws_ram_resource_association" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
-  resource_arn       = "${aws_ec2_transit_gateway.example.arn}"
-  resource_share_arn = "${aws_ram_resource_share.example.id}"
+  resource_arn       = aws_ec2_transit_gateway.example.arn
+  resource_share_arn = aws_ram_resource_share.example.id
 }
 
 // ...with the second account.
 resource "aws_ram_principal_association" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
-  principal          = "${data.aws_caller_identity.second.account_id}"
-  resource_share_arn = "${aws_ram_resource_share.example.id}"
+  principal          = data.aws_caller_identity.second.account_id
+  resource_share_arn = aws_ram_resource_share.example.id
 }
 
 resource "aws_vpc" "example" {
-  provider = "aws.second"
+  provider = aws.second
 
   cidr_block = "10.0.0.0/16"
 
@@ -71,11 +75,11 @@ resource "aws_vpc" "example" {
 }
 
 resource "aws_subnet" "example" {
-  provider = "aws.second"
+  provider = aws.second
 
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.0.0.0/24"
-  vpc_id            = "${aws_vpc.example.id}"
+  vpc_id            = aws_vpc.example.id
 
   tags = {
     Name = "terraform-example"
@@ -84,13 +88,16 @@ resource "aws_subnet" "example" {
 
 // Create the VPC attachment in the second account...
 resource "aws_ec2_transit_gateway_vpc_attachment" "example" {
-  provider = "aws.second"
+  provider = aws.second
 
-  depends_on = ["aws_ram_principal_association.example", "aws_ram_resource_association.example"]
+  depends_on = [
+    aws_ram_principal_association.example,
+    aws_ram_resource_association.example,
+  ]
 
-  subnet_ids         = ["${aws_subnet.example.id}"]
-  transit_gateway_id = "${aws_ec2_transit_gateway.example.id}"
-  vpc_id             = "${aws_vpc.example.id}"
+  subnet_ids         = [aws_subnet.example.id]
+  transit_gateway_id = aws_ec2_transit_gateway.example.id
+  vpc_id             = aws_vpc.example.id
 
   tags = {
     Name = "terraform-example"
@@ -100,9 +107,9 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "example" {
 
 // ...and accept it in the first account.
 resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
-  provider = "aws.first"
+  provider = aws.first
 
-  transit_gateway_attachment_id = "${aws_ec2_transit_gateway_vpc_attachment.example.id}"
+  transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.example.id
 
   tags = {
     Name = "terraform-example"

--- a/examples/two-tier/main.tf
+++ b/examples/two-tier/main.tf
@@ -1,6 +1,9 @@
-# Specify the provider and access details
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 # Create a VPC to launch our instances into
@@ -10,19 +13,19 @@ resource "aws_vpc" "default" {
 
 # Create an internet gateway to give our subnet access to the outside world
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 }
 
 # Grant the VPC internet access on its main route table
 resource "aws_route" "internet_access" {
-  route_table_id         = "${aws_vpc.default.main_route_table_id}"
+  route_table_id         = aws_vpc.default.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.default.id}"
+  gateway_id             = aws_internet_gateway.default.id
 }
 
 # Create a subnet to launch our instances into
 resource "aws_subnet" "default" {
-  vpc_id                  = "${aws_vpc.default.id}"
+  vpc_id                  = aws_vpc.default.id
   cidr_block              = "10.0.1.0/24"
   map_public_ip_on_launch = true
 }
@@ -31,7 +34,7 @@ resource "aws_subnet" "default" {
 resource "aws_security_group" "elb" {
   name        = "terraform_example_elb"
   description = "Used in the terraform"
-  vpc_id      = "${aws_vpc.default.id}"
+  vpc_id      = aws_vpc.default.id
 
   # HTTP access from anywhere
   ingress {
@@ -55,7 +58,7 @@ resource "aws_security_group" "elb" {
 resource "aws_security_group" "default" {
   name        = "terraform_example"
   description = "Used in the terraform"
-  vpc_id      = "${aws_vpc.default.id}"
+  vpc_id      = aws_vpc.default.id
 
   # SSH access from anywhere
   ingress {
@@ -85,9 +88,9 @@ resource "aws_security_group" "default" {
 resource "aws_elb" "web" {
   name = "terraform-example-elb"
 
-  subnets         = ["${aws_subnet.default.id}"]
-  security_groups = ["${aws_security_group.elb.id}"]
-  instances       = ["${aws_instance.web.id}"]
+  subnets         = [aws_subnet.default.id]
+  security_groups = [aws_security_group.elb.id]
+  instances       = [aws_instance.web.id]
 
   listener {
     instance_port     = 80
@@ -98,17 +101,18 @@ resource "aws_elb" "web" {
 }
 
 resource "aws_key_pair" "auth" {
-  key_name   = "${var.key_name}"
-  public_key = "${file(var.public_key_path)}"
+  key_name   = var.key_name
+  public_key = file(var.public_key_path)
 }
 
 resource "aws_instance" "web" {
   # The connection block tells our provisioner how to
   # communicate with the resource (instance)
   connection {
+    type = "ssh"
     # The default username for our AMI
     user = "ubuntu"
-    host = "${self.public_ip}"
+    host = self.public_ip
     # The connection will use the local SSH agent for authentication.
   }
 
@@ -116,18 +120,18 @@ resource "aws_instance" "web" {
 
   # Lookup the correct AMI based on the region
   # we specified
-  ami = "${lookup(var.aws_amis, var.aws_region)}"
+  ami = var.aws_amis[var.aws_region]
 
   # The name of our SSH keypair we created above.
-  key_name = "${aws_key_pair.auth.id}"
+  key_name = aws_key_pair.auth.id
 
   # Our Security group to allow HTTP and SSH access
-  vpc_security_group_ids = ["${aws_security_group.default.id}"]
+  vpc_security_group_ids = [aws_security_group.default.id]
 
   # We're going to launch into the same subnet as our ELB. In a production
   # environment it's more common to have a separate private subnet for
   # backend instances.
-  subnet_id = "${aws_subnet.default.id}"
+  subnet_id = aws_subnet.default.id
 
   # We run a remote provisioner on the instance after creating it.
   # In this case, we just install nginx and start it. By default,

--- a/examples/two-tier/outputs.tf
+++ b/examples/two-tier/outputs.tf
@@ -1,3 +1,3 @@
 output "address" {
-  value = "${aws_elb.web.dns_name}"
+  value = aws_elb.web.dns_name
 }


### PR DESCRIPTION
Updates the formatting for all examples in the provider repo to use Terraform 0.12 syntax.

This was a basic update of the syntax, and does not fix existing errors in the examples.

The following commands were run against each example directory, using Terraform 0.12.29:
* `terraform init`
* `terraform validate`
* `terraform 0.12upgrade -yes`

Minor manual tweaks were applied where `terraform 0.12upgrade` adds or removes lines that `terraform fmt` does not change.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8950 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
