### PR TITLE
Remove hardcoded AMI and AZ from autoscaling lifecycle hook tests

### DIFF
--- a/aws/resource_aws_autoscaling_lifecycle_hook_test.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook_test.go
@@ -125,10 +125,10 @@ func testAccAWSAutoscalingLifecycleHookImportStateIdFunc(resourceName string) re
 }
 
 func testAccAWSAutoscalingLifecycleHookConfig(name string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
-  image_id      = "ami-21f78e11"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
@@ -177,8 +177,17 @@ resource "aws_iam_role_policy" "foobar" {
 EOF
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_autoscaling_group" "foobar" {
-  availability_zones        = ["us-west-2a"]
+  availability_zones        = [data.aws_availability_zones.available.names[1]]
   name                      = "%s"
   max_size                  = 5
   min_size                  = 2
@@ -215,10 +224,10 @@ EOF
 }
 
 func testAccAWSAutoscalingLifecycleHookConfig_omitDefaultResult(name string, rInt int) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
-  image_id      = "ami-21f78e11"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
@@ -267,8 +276,17 @@ resource "aws_iam_role_policy" "foobar" {
 EOF
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_autoscaling_group" "foobar" {
-  availability_zones        = ["us-west-2a"]
+  availability_zones        = [data.aws_availability_zones.available.names[1]]
   name                      = "%s"
   max_size                  = 5
   min_size                  = 2


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from GovCloud acceptance testing:

```
% testacc TestAccAWSAutoscalingLifecycleHook_
--- PASS: TestAccAWSAutoscalingLifecycleHook_basic (167.05s)
--- PASS: TestAccAWSAutoscalingLifecycleHook_omitDefaultResult (179.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	179.312s
```

The output from standard partition acceptance testing:

```
% testacc TestAccAWSAutoscalingLifecycleHook_
--- PASS: TestAccAWSAutoscalingLifecycleHook_omitDefaultResult (132.17s)
--- PASS: TestAccAWSAutoscalingLifecycleHook_basic (140.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	140.642s
```