### PR TITLE
Remove hardcoded AMIs and AZs from autoscaling schedule

### DIFF
--- a/aws/resource_aws_autoscaling_schedule_test.go
+++ b/aws/resource_aws_autoscaling_schedule_test.go
@@ -267,15 +267,24 @@ func testAccCheckScalingScheduleHasNoDesiredCapacity(
 }
 
 func testAccAWSAutoscalingScheduleConfig(r, start, end string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
-  image_id      = "ami-21f78e11"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_autoscaling_group" "foobar" {
-  availability_zones        = ["us-west-2a"]
+  availability_zones        = [data.aws_availability_zones.available.names[1]]
   name                      = "%s"
   max_size                  = 1
   min_size                  = 1
@@ -305,15 +314,24 @@ resource "aws_autoscaling_schedule" "foobar" {
 }
 
 func testAccAWSAutoscalingScheduleConfig_recurrence(r string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
-  image_id      = "ami-21f78e11"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_autoscaling_group" "foobar" {
-  availability_zones        = ["us-west-2a"]
+  availability_zones        = [data.aws_availability_zones.available.names[1]]
   name                      = "%s"
   max_size                  = 1
   min_size                  = 1
@@ -342,15 +360,24 @@ resource "aws_autoscaling_schedule" "foobar" {
 }
 
 func testAccAWSAutoscalingScheduleConfig_zeroValues(r, start, end string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
-  image_id      = "ami-21f78e11"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_autoscaling_group" "foobar" {
-  availability_zones        = ["us-west-2a"]
+  availability_zones        = [data.aws_availability_zones.available.names[1]]
   name                      = "%s"
   max_size                  = 1
   min_size                  = 1
@@ -380,15 +407,24 @@ resource "aws_autoscaling_schedule" "foobar" {
 }
 
 func testAccAWSAutoscalingScheduleConfig_negativeOne(r, start, end string) string {
-	return fmt.Sprintf(`
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_launch_configuration" "foobar" {
   name          = "%s"
-  image_id      = "ami-21f78e11"
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t1.micro"
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 resource "aws_autoscaling_group" "foobar" {
-  availability_zones        = ["us-west-2a"]
+  availability_zones        = [data.aws_availability_zones.available.names[1]]
   name                      = "%s"
   max_size                  = 1
   min_size                  = 1


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSAutoscalingSchedule_basic (131.55s)
--- PASS: TestAccAWSAutoscalingSchedule_negativeOne (140.23s)
--- PASS: TestAccAWSAutoscalingSchedule_zeroValues (140.44s)
--- PASS: TestAccAWSAutoscalingSchedule_recurrence (141.04s)
--- PASS: TestAccAWSAutoscalingSchedule_disappears (141.65s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSAutoscalingSchedule_negativeOne (136.59s)
--- PASS: TestAccAWSAutoscalingSchedule_basic (137.85s)
--- PASS: TestAccAWSAutoscalingSchedule_recurrence (146.76s)
--- PASS: TestAccAWSAutoscalingSchedule_zeroValues (147.04s)
--- PASS: TestAccAWSAutoscalingSchedule_disappears (147.44s)
```
