### PR TITLE
Remove hardcoded AMIs and AZs in network interface test

### DIFF
--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -77,10 +78,11 @@ func TestAccAWSENI_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSENIConfig,
+				Config: testAccAWSENIConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
 					testAccCheckAWSENIAttributes(&conf),
+					testAccCheckAWSENIAvailabilityZone("data.aws_availability_zones.available", "names.0", &conf),
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "private_ips.#", "1"),
 					resource.TestCheckResourceAttrSet(
@@ -114,7 +116,7 @@ func TestAccAWSENI_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSENIConfig,
+				Config: testAccAWSENIConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists(resourceName, &networkInterface),
 					testAccCheckAWSENIDisappears(&networkInterface),
@@ -135,7 +137,7 @@ func TestAccAWSENI_updatedDescription(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSENIConfig,
+				Config: testAccAWSENIConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
 					resource.TestCheckResourceAttr(
@@ -148,7 +150,7 @@ func TestAccAWSENI_updatedDescription(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSENIConfigUpdatedDescription,
+				Config: testAccAWSENIConfigUpdatedDescription(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
 					resource.TestCheckResourceAttr(
@@ -169,10 +171,11 @@ func TestAccAWSENI_attached(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSENIConfigWithAttachment,
+				Config: testAccAWSENIConfigWithAttachment(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
 					testAccCheckAWSENIAttributesWithAttachment(&conf),
+					testAccCheckAWSENIAvailabilityZone("data.aws_availability_zones.available", "names.0", &conf),
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "private_ips.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -198,10 +201,11 @@ func TestAccAWSENI_ignoreExternalAttachment(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSENIConfigExternalAttachment,
+				Config: testAccAWSENIConfigExternalAttachment(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
 					testAccCheckAWSENIAttributes(&conf),
+					testAccCheckAWSENIAvailabilityZone("data.aws_availability_zones.available", "names.0", &conf),
 					testAccCheckAWSENIMakeExternalAttachment("aws_instance.foo", &conf),
 				),
 			},
@@ -224,7 +228,7 @@ func TestAccAWSENI_sourceDestCheck(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSENIConfigWithSourceDestCheck,
+				Config: testAccAWSENIConfigWithSourceDestCheck(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
 					resource.TestCheckResourceAttr(
@@ -250,7 +254,7 @@ func TestAccAWSENI_computedIPs(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSENIDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSENIConfigWithNoPrivateIPs,
+				Config: testAccAWSENIConfigWithNoPrivateIPs(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSENIExists("aws_network_interface.bar", &conf),
 					resource.TestCheckResourceAttr(
@@ -366,10 +370,6 @@ func testAccCheckAWSENIAttributes(conf *ec2.NetworkInterface) resource.TestCheck
 			return fmt.Errorf("expected attachment to be nil")
 		}
 
-		if *conf.AvailabilityZone != "us-west-2a" {
-			return fmt.Errorf("expected availability_zone to be us-west-2a, but was %s", *conf.AvailabilityZone)
-		}
-
 		if len(conf.Groups) != 1 && *conf.Groups[0].GroupName != "foo" {
 			return fmt.Errorf("expected security group to be foo, but was %#v", conf.Groups)
 		}
@@ -378,8 +378,8 @@ func testAccCheckAWSENIAttributes(conf *ec2.NetworkInterface) resource.TestCheck
 			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIpAddress)
 		}
 
-		if *conf.PrivateDnsName != "ip-172-16-10-100.us-west-2.compute.internal" {
-			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.us-west-2.compute.internal, but was %s", *conf.PrivateDnsName)
+		if !strings.HasPrefix(*conf.PrivateDnsName, "ip-172-16-10-100.") || !strings.HasSuffix(*conf.PrivateDnsName, ".compute.internal") {
+			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.<region>.compute.internal, but was %s", *conf.PrivateDnsName)
 		}
 
 		if len(*conf.MacAddress) == 0 {
@@ -398,6 +398,21 @@ func testAccCheckAWSENIAttributes(conf *ec2.NetworkInterface) resource.TestCheck
 	}
 }
 
+func testAccCheckAWSENIAvailabilityZone(name, attr string, conf *ec2.NetworkInterface) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok || rs.Primary.ID == "" {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.Attributes[attr] != *conf.AvailabilityZone {
+			return fmt.Errorf("%s", fmt.Sprintf("expected %s, found %s", rs.Primary.Attributes[attr], *conf.AvailabilityZone))
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckAWSENIAttributesWithAttachment(conf *ec2.NetworkInterface) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -409,10 +424,6 @@ func testAccCheckAWSENIAttributesWithAttachment(conf *ec2.NetworkInterface) reso
 			return fmt.Errorf("expected attachment device index to be 1, but was %d", *conf.Attachment.DeviceIndex)
 		}
 
-		if *conf.AvailabilityZone != "us-west-2a" {
-			return fmt.Errorf("expected availability_zone to be us-west-2a, but was %s", *conf.AvailabilityZone)
-		}
-
 		if len(conf.Groups) != 1 && *conf.Groups[0].GroupName != "foo" {
 			return fmt.Errorf("expected security group to be foo, but was %#v", conf.Groups)
 		}
@@ -421,8 +432,8 @@ func testAccCheckAWSENIAttributesWithAttachment(conf *ec2.NetworkInterface) reso
 			return fmt.Errorf("expected private ip to be 172.16.10.100, but was %s", *conf.PrivateIpAddress)
 		}
 
-		if *conf.PrivateDnsName != "ip-172-16-10-100.us-west-2.compute.internal" {
-			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.us-west-2.compute.internal, but was %s", *conf.PrivateDnsName)
+		if !strings.HasPrefix(*conf.PrivateDnsName, "ip-172-16-10-100.") || !strings.HasSuffix(*conf.PrivateDnsName, ".compute.internal") {
+			return fmt.Errorf("expected private dns name to be ip-172-16-10-100.<region>.compute.internal, but was %s", *conf.PrivateDnsName)
 		}
 
 		return nil
@@ -486,250 +497,315 @@ func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterfa
 	}
 }
 
-const testAccAWSENIConfig = `
+func testAccAWSENIConfig() string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-	cidr_block = "172.16.0.0/16"
-	enable_dns_hostnames = true
-	tags = {
-		Name = "terraform-testacc-network-interface"
-	}
+  cidr_block           = "172.16.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = "terraform-testacc-network-interface"
+  }
 }
 
+data "aws_availability_zones" "available" {
+   state = "available"
+
+   filter {
+     name   = "opt-in-status"
+     values = ["opt-in-not-required"]
+   }
+ }
+
 resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "172.16.10.0/24"
-    availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "172.16.10.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-        Name = "tf-acc-network-interface"
-    }
+    Name = "tf-acc-network-interface"
+  }
 }
 
 resource "aws_security_group" "foo" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = "${aws_vpc.foo.id}"
   description = "foo"
-  name = "foo"
+  name        = "foo"
 
-        egress {
-                from_port = 0
-                to_port = 0
-                protocol = "tcp"
-                cidr_blocks = ["10.0.0.0/16"]
-        }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
 }
 
 resource "aws_network_interface" "bar" {
-    subnet_id = "${aws_subnet.foo.id}"
-    private_ips = ["172.16.10.100"]
-    security_groups = ["${aws_security_group.foo.id}"]
-    description = "Managed by Terraform"
+  subnet_id       = "${aws_subnet.foo.id}"
+  private_ips     = ["172.16.10.100"]
+  security_groups = ["${aws_security_group.foo.id}"]
+  description     = "Managed by Terraform"
   tags = {
-        Name = "bar_interface"
-    }
+    Name = "bar_interface"
+  }
 }
-`
+`)
+}
 
-const testAccAWSENIConfigUpdatedDescription = `
+func testAccAWSENIConfigUpdatedDescription() string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-	cidr_block = "172.16.0.0/16"
-	enable_dns_hostnames = true
-	tags = {
-		Name = "terraform-testacc-network-interface-update-desc"
-	}
+  cidr_block           = "172.16.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = "terraform-testacc-network-interface-update-desc"
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "172.16.10.0/24"
-    availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "172.16.10.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-        Name = "tf-acc-network-interface-update-desc"
-    }
+    Name = "tf-acc-network-interface-update-desc"
+  }
 }
 
 resource "aws_security_group" "foo" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = "${aws_vpc.foo.id}"
   description = "foo"
-  name = "foo"
+  name        = "foo"
 
-        egress {
-                from_port = 0
-                to_port = 0
-                protocol = "tcp"
-                cidr_blocks = ["10.0.0.0/16"]
-        }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
 }
 
 resource "aws_network_interface" "bar" {
-    subnet_id = "${aws_subnet.foo.id}"
-    private_ips = ["172.16.10.100"]
-    security_groups = ["${aws_security_group.foo.id}"]
-    description = "Updated ENI Description"
+  subnet_id       = "${aws_subnet.foo.id}"
+  private_ips     = ["172.16.10.100"]
+  security_groups = ["${aws_security_group.foo.id}"]
+  description     = "Updated ENI Description"
   tags = {
-        Name = "bar_interface"
-    }
+    Name = "bar_interface"
+  }
 }
-`
+`)
+}
 
-const testAccAWSENIConfigWithSourceDestCheck = `
+func testAccAWSENIConfigWithSourceDestCheck() string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-	cidr_block = "172.16.0.0/16"
-	enable_dns_hostnames = true
-	tags = {
-		Name = "terraform-testacc-network-interface-w-source-dest-check"
-	}
+  cidr_block           = "172.16.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = "terraform-testacc-network-interface-w-source-dest-check"
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "172.16.10.0/24"
-    availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "172.16.10.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-        Name = "tf-acc-network-interface-w-source-dest-check"
-    }
+    Name = "tf-acc-network-interface-w-source-dest-check"
+  }
 }
 
 resource "aws_network_interface" "bar" {
-    subnet_id = "${aws_subnet.foo.id}"
-        source_dest_check = false
-    private_ips = ["172.16.10.100"]
+  subnet_id         = "${aws_subnet.foo.id}"
+  source_dest_check = false
+  private_ips       = ["172.16.10.100"]
 }
-`
+`)
+}
 
-const testAccAWSENIConfigWithNoPrivateIPs = `
+func testAccAWSENIConfigWithNoPrivateIPs() string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-	cidr_block = "172.16.0.0/16"
-	enable_dns_hostnames = true
-	tags = {
-		Name = "terraform-testacc-network-interface-w-no-private-ips"
-	}
+  cidr_block           = "172.16.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = "terraform-testacc-network-interface-w-no-private-ips"
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "172.16.10.0/24"
-    availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "172.16.10.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-        Name = "tf-acc-network-interface-w-no-private-ips"
-    }
+    Name = "tf-acc-network-interface-w-no-private-ips"
+  }
 }
 
 resource "aws_network_interface" "bar" {
-    subnet_id = "${aws_subnet.foo.id}"
-        source_dest_check = false
+  subnet_id         = "${aws_subnet.foo.id}"
+  source_dest_check = false
 }
-`
+`)
+}
 
-const testAccAWSENIConfigWithAttachment = `
+func testAccAWSENIConfigWithAttachment() string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-	cidr_block = "172.16.0.0/16"
-	enable_dns_hostnames = true
+  cidr_block           = "172.16.0.0/16"
+  enable_dns_hostnames = true
   tags = {
-        Name = "terraform-testacc-network-interface-w-attachment"
-    }
+    Name = "terraform-testacc-network-interface-w-attachment"
+  }
 }
+
+data "aws_availability_zones" "available" {
+   state = "available"
+
+   filter {
+     name   = "opt-in-status"
+     values = ["opt-in-not-required"]
+   }
+ }
 
 resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "172.16.10.0/24"
-    availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "172.16.10.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-            Name = "tf-acc-network-interface-w-attachment-foo"
-        }
+    Name = "tf-acc-network-interface-w-attachment-foo"
+  }
 }
 
 resource "aws_subnet" "bar" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "172.16.11.0/24"
-    availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "172.16.11.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-            Name = "tf-acc-network-interface-w-attachment-bar"
-        }
+    Name = "tf-acc-network-interface-w-attachment-bar"
+  }
 }
 
 resource "aws_security_group" "foo" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = "${aws_vpc.foo.id}"
   description = "foo"
-  name = "foo"
+  name        = "foo"
 }
 
 resource "aws_instance" "foo" {
-    ami = "ami-c5eabbf5"
-    instance_type = "t2.micro"
-    subnet_id = "${aws_subnet.bar.id}"
-    associate_public_ip_address = false
-    private_ip = "172.16.11.50"
+  ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type               = "t2.micro"
+  subnet_id                   = "${aws_subnet.bar.id}"
+  associate_public_ip_address = false
+  private_ip                  = "172.16.11.50"
   tags = {
-        Name = "foo-tf-eni-test"
-    }
+    Name = "foo-tf-eni-test"
+  }
 }
 
 resource "aws_network_interface" "bar" {
-    subnet_id = "${aws_subnet.foo.id}"
-    private_ips = ["172.16.10.100"]
-    security_groups = ["${aws_security_group.foo.id}"]
-    attachment {
-        instance = "${aws_instance.foo.id}"
-        device_index = 1
-    }
+  subnet_id       = "${aws_subnet.foo.id}"
+  private_ips     = ["172.16.10.100"]
+  security_groups = ["${aws_security_group.foo.id}"]
+  attachment {
+    instance     = "${aws_instance.foo.id}"
+    device_index = 1
+  }
   tags = {
-        Name = "bar_interface"
-    }
+    Name = "bar_interface"
+  }
+}`)
 }
-`
 
-const testAccAWSENIConfigExternalAttachment = `
+func testAccAWSENIConfigExternalAttachment() string {
+	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + fmt.Sprintf(`
 resource "aws_vpc" "foo" {
-	cidr_block = "172.16.0.0/16"
-	enable_dns_hostnames = true
+  cidr_block           = "172.16.0.0/16"
+  enable_dns_hostnames = true
   tags = {
-        Name = "terraform-testacc-network-interface-external-attachment"
-    }
+    Name = "terraform-testacc-network-interface-external-attachment"
+  }
 }
+
+data "aws_availability_zones" "available" {
+   state = "available"
+
+   filter {
+     name   = "opt-in-status"
+     values = ["opt-in-not-required"]
+   }
+ }
 
 resource "aws_subnet" "foo" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "172.16.10.0/24"
-    availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "172.16.10.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-        Name = "tf-acc-network-interface-external-attachment-foo"
-    }
+    Name = "tf-acc-network-interface-external-attachment-foo"
+  }
 }
 
 resource "aws_subnet" "bar" {
-    vpc_id = "${aws_vpc.foo.id}"
-    cidr_block = "172.16.11.0/24"
-    availability_zone = "us-west-2a"
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "172.16.11.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
   tags = {
-        Name = "tf-acc-network-interface-external-attachment-bar"
-    }
+    Name = "tf-acc-network-interface-external-attachment-bar"
+  }
 }
 
 resource "aws_security_group" "foo" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = "${aws_vpc.foo.id}"
   description = "foo"
-  name = "foo"
+  name        = "foo"
 }
 
 resource "aws_instance" "foo" {
-    ami = "ami-c5eabbf5"
-    instance_type = "t2.micro"
-    subnet_id = "${aws_subnet.bar.id}"
-    associate_public_ip_address = false
-    private_ip = "172.16.11.50"
+  ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type               = "t2.micro"
+  subnet_id                   = "${aws_subnet.bar.id}"
+  associate_public_ip_address = false
+  private_ip                  = "172.16.11.50"
   tags = {
-        Name = "tf-eni-test"
-    }
+    Name = "tf-eni-test"
+  }
 }
 
 resource "aws_network_interface" "bar" {
-    subnet_id = "${aws_subnet.foo.id}"
-    private_ips = ["172.16.10.100"]
-    security_groups = ["${aws_security_group.foo.id}"]
+  subnet_id       = "${aws_subnet.foo.id}"
+  private_ips     = ["172.16.10.100"]
+  security_groups = ["${aws_security_group.foo.id}"]
   tags = {
-        Name = "bar_interface"
-    }
+    Name = "bar_interface"
+  }
 }
-`
+`)
+}
 
 func testAccAWSENIConfigPrivateIpsCount(privateIpsCount int) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSENI_computedIPs (32.93s)
--- PASS: TestAccAWSENI_sourceDestCheck (33.16s)
--- PASS: TestAccAWSENI_disappears (36.21s)
--- PASS: TestAccAWSENI_basic (37.60s)
--- PASS: TestAccAWSENI_updatedDescription (60.09s)
--- PASS: TestAccAWSENI_PrivateIpsCount (83.69s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (116.94s)
--- PASS: TestAccAWSENI_attached (122.62s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSENI_computedIPs (38.01s)
--- PASS: TestAccAWSENI_sourceDestCheck (38.79s)
--- PASS: TestAccAWSENI_disappears (40.66s)
--- PASS: TestAccAWSENI_basic (42.11s)
--- PASS: TestAccAWSENI_updatedDescription (68.26s)
--- PASS: TestAccAWSENI_PrivateIpsCount (100.21s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (111.35s)
--- PASS: TestAccAWSENI_attached (123.45s)
```