### PR TITLE
r/api_gateway_usage_plan - change `api_stages` to set to fix ordering change

### DIFF
--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -71,13 +71,9 @@ func resourceAwsApiGatewayUsagePlan() *schema.Resource {
 						},
 
 						"period": {
-							Type:     schema.TypeString,
-							Required: true, // Required as not removable
-							ValidateFunc: validation.StringInSlice([]string{
-								apigateway.QuotaPeriodTypeDay,
-								apigateway.QuotaPeriodTypeWeek,
-								apigateway.QuotaPeriodTypeMonth,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true, // Required as not removable
+							ValidateFunc: validation.StringInSlice(apigateway.QuotaPeriodType_Values(), false),
 						},
 					},
 				},

--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -36,7 +36,7 @@ func resourceAwsApiGatewayUsagePlan() *schema.Resource {
 			},
 
 			"api_stages": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -90,15 +90,17 @@ func resourceAwsApiGatewayUsagePlan() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"burst_limit": {
-							Type:     schema.TypeInt,
-							Default:  0,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Default:      0,
+							Optional:     true,
+							AtLeastOneOf: []string{"throttle_settings.0.burst_limit", "throttle_settings.0.rate_limit"},
 						},
 
 						"rate_limit": {
-							Type:     schema.TypeFloat,
-							Default:  0,
-							Optional: true,
+							Type:         schema.TypeFloat,
+							Default:      0,
+							Optional:     true,
+							AtLeastOneOf: []string{"throttle_settings.0.burst_limit", "throttle_settings.0.rate_limit"},
 						},
 					},
 				},
@@ -129,78 +131,27 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 		params.Description = aws.String(v.(string))
 	}
 
-	if s, ok := d.GetOk("api_stages"); ok {
-		stages := s.([]interface{})
-		as := make([]*apigateway.ApiStage, 0)
-
-		for _, v := range stages {
-			sv := v.(map[string]interface{})
-			stage := &apigateway.ApiStage{}
-
-			if v, ok := sv["api_id"].(string); ok && v != "" {
-				stage.ApiId = aws.String(v)
-			}
-
-			if v, ok := sv["stage"].(string); ok && v != "" {
-				stage.Stage = aws.String(v)
-			}
-
-			as = append(as, stage)
-		}
-
-		if len(as) > 0 {
-			params.ApiStages = as
-		}
+	if v, ok := d.GetOk("api_stages"); ok && v.(*schema.Set).Len() > 0 {
+		params.ApiStages = expandApiGatewayUsageApiStages(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("quota_settings"); ok {
 		settings := v.([]interface{})
 		q, ok := settings[0].(map[string]interface{})
 
-		if errors := validateApiGatewayUsagePlanQuotaSettings(q); len(errors) > 0 {
-			return fmt.Errorf("Error validating the quota settings: %v", errors)
+		if err := validateApiGatewayUsagePlanQuotaSettings(q); len(err) > 0 {
+			return fmt.Errorf("error validating the quota settings: %v", err)
 		}
 
 		if !ok {
 			return errors.New("At least one field is expected inside quota_settings")
 		}
 
-		qs := &apigateway.QuotaSettings{}
-
-		if sv, ok := q["limit"].(int); ok {
-			qs.Limit = aws.Int64(int64(sv))
-		}
-
-		if sv, ok := q["offset"].(int); ok {
-			qs.Offset = aws.Int64(int64(sv))
-		}
-
-		if sv, ok := q["period"].(string); ok && sv != "" {
-			qs.Period = aws.String(sv)
-		}
-
-		params.Quota = qs
+		params.Quota = expandApiGatewayUsageQuotaSettings(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("throttle_settings"); ok {
-		settings := v.([]interface{})
-		q, ok := settings[0].(map[string]interface{})
-
-		if !ok {
-			return errors.New("At least one field is expected inside throttle_settings")
-		}
-
-		ts := &apigateway.ThrottleSettings{}
-
-		if sv, ok := q["burst_limit"].(int); ok {
-			ts.BurstLimit = aws.Int64(int64(sv))
-		}
-
-		if sv, ok := q["rate_limit"].(float64); ok {
-			ts.RateLimit = aws.Float64(sv)
-		}
-
-		params.Throttle = ts
+		params.Throttle = expandApiGatewayUsageThrottleSettings(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
@@ -209,10 +160,10 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 
 	up, err := conn.CreateUsagePlan(params)
 	if err != nil {
-		return fmt.Errorf("Error creating API Gateway Usage Plan: %s", err)
+		return fmt.Errorf("error creating API Gateway Usage Plan: %w", err)
 	}
 
-	d.SetId(*up.Id)
+	d.SetId(aws.StringValue(up.Id))
 
 	// Handle case of adding the product code since not addable when
 	// creating the Usage Plan initially.
@@ -230,7 +181,7 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 
 		_, err = conn.UpdateUsagePlan(updateParameters)
 		if err != nil {
-			return fmt.Errorf("Error creating the API Gateway Usage Plan product code: %s", err)
+			return fmt.Errorf("error creating the API Gateway Usage Plan product code: %w", err)
 		}
 	}
 
@@ -256,7 +207,7 @@ func resourceAwsApiGatewayUsagePlanRead(d *schema.ResourceData, meta interface{}
 	}
 
 	if err := d.Set("tags", keyvaluetags.ApigatewayKeyValueTags(up.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	arn := arn.ARN{
@@ -273,19 +224,19 @@ func resourceAwsApiGatewayUsagePlanRead(d *schema.ResourceData, meta interface{}
 
 	if up.ApiStages != nil {
 		if err := d.Set("api_stages", flattenApiGatewayUsageApiStages(up.ApiStages)); err != nil {
-			return fmt.Errorf("Error setting api_stages error: %#v", err)
+			return fmt.Errorf("error setting api_stages error: %w", err)
 		}
 	}
 
 	if up.Throttle != nil {
 		if err := d.Set("throttle_settings", flattenApiGatewayUsagePlanThrottling(up.Throttle)); err != nil {
-			return fmt.Errorf("Error setting throttle_settings error: %#v", err)
+			return fmt.Errorf("error setting throttle_settings error: %w", err)
 		}
 	}
 
 	if up.Quota != nil {
 		if err := d.Set("quota_settings", flattenApiGatewayUsagePlanQuota(up.Quota)); err != nil {
-			return fmt.Errorf("Error setting quota_settings error: %#v", err)
+			return fmt.Errorf("error setting quota_settings error: %w", err)
 		}
 	}
 
@@ -333,12 +284,12 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChange("api_stages") {
 		o, n := d.GetChange("api_stages")
-		old := o.([]interface{})
-		new := n.([]interface{})
+		os := o.(*schema.Set).List()
+		ns := n.(*schema.Set).List()
 
-		// Remove every stages associated. Simpler to remove and add new ones,
+		// Remove every stages associated. Simpler to remove and add ns ones,
 		// since there are no replacings.
-		for _, v := range old {
+		for _, v := range os {
 			m := v.(map[string]interface{})
 			operations = append(operations, &apigateway.PatchOperation{
 				Op:    aws.String(apigateway.OpRemove),
@@ -348,8 +299,8 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 		}
 
 		// Handle additions
-		if len(new) > 0 {
-			for _, v := range new {
+		if len(ns) > 0 {
+			for _, v := range ns {
 				m := v.(map[string]interface{})
 				operations = append(operations, &apigateway.PatchOperation{
 					Op:    aws.String(apigateway.OpAdd),
@@ -467,7 +418,7 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.ApigatewayUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}
 
@@ -478,7 +429,7 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 
 	_, err := conn.UpdateUsagePlan(params)
 	if err != nil {
-		return fmt.Errorf("Error updating API Gateway Usage Plan: %s", err)
+		return fmt.Errorf("error updating API Gateway Usage Plan: %w", err)
 	}
 
 	return resourceAwsApiGatewayUsagePlanRead(d, meta)
@@ -490,10 +441,10 @@ func resourceAwsApiGatewayUsagePlanDelete(d *schema.ResourceData, meta interface
 	// Removing existing api stages associated
 	if apistages, ok := d.GetOk("api_stages"); ok {
 		log.Printf("[DEBUG] Deleting API Stages associated with Usage Plan: %s", d.Id())
-		stages := apistages.([]interface{})
+		stages := apistages.(*schema.Set)
 		operations := []*apigateway.PatchOperation{}
 
-		for _, v := range stages {
+		for _, v := range stages.List() {
 			sv := v.(map[string]interface{})
 
 			operations = append(operations, &apigateway.PatchOperation{
@@ -508,7 +459,7 @@ func resourceAwsApiGatewayUsagePlanDelete(d *schema.ResourceData, meta interface
 			PatchOperations: operations,
 		})
 		if err != nil {
-			return fmt.Errorf("Error removing API Stages associated with Usage Plan: %s", err)
+			return fmt.Errorf("error removing API Stages associated with Usage Plan: %w", err)
 		}
 	}
 
@@ -519,9 +470,134 @@ func resourceAwsApiGatewayUsagePlanDelete(d *schema.ResourceData, meta interface
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error deleting API gateway usage plan: %s", err)
+		return fmt.Errorf("error deleting API gateway usage plan: %w", err)
 	}
 
 	return nil
 
+}
+
+func expandApiGatewayUsageApiStages(s *schema.Set) []*apigateway.ApiStage {
+	stages := []*apigateway.ApiStage{}
+
+	for _, stageRaw := range s.List() {
+		stage := &apigateway.ApiStage{}
+		mStage := stageRaw.(map[string]interface{})
+
+		if v, ok := mStage["api_id"].(string); ok && v != "" {
+			stage.ApiId = aws.String(v)
+		}
+
+		if v, ok := mStage["stage"].(string); ok && v != "" {
+			stage.Stage = aws.String(v)
+		}
+
+		stages = append(stages, stage)
+	}
+
+	return stages
+}
+
+func expandApiGatewayUsageQuotaSettings(l []interface{}) *apigateway.QuotaSettings {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	qs := &apigateway.QuotaSettings{}
+
+	if v, ok := m["limit"].(int); ok {
+		qs.Limit = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["offset"].(int); ok {
+		qs.Offset = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["period"].(string); ok && v != "" {
+		qs.Period = aws.String(v)
+	}
+
+	return qs
+}
+
+func expandApiGatewayUsageThrottleSettings(l []interface{}) *apigateway.ThrottleSettings {
+	if len(l) == 0 {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	ts := &apigateway.ThrottleSettings{}
+
+	if sv, ok := m["burst_limit"].(int); ok {
+		ts.BurstLimit = aws.Int64(int64(sv))
+	}
+
+	if sv, ok := m["rate_limit"].(float64); ok {
+		ts.RateLimit = aws.Float64(sv)
+	}
+
+	return ts
+}
+
+func flattenApiGatewayUsageApiStages(s []*apigateway.ApiStage) []map[string]interface{} {
+	stages := make([]map[string]interface{}, 0)
+
+	for _, bd := range s {
+		if bd.ApiId != nil && bd.Stage != nil {
+			stage := make(map[string]interface{})
+			stage["api_id"] = aws.StringValue(bd.ApiId)
+			stage["stage"] = aws.StringValue(bd.Stage)
+
+			stages = append(stages, stage)
+		}
+	}
+
+	if len(stages) > 0 {
+		return stages
+	}
+
+	return nil
+}
+
+func flattenApiGatewayUsagePlanThrottling(s *apigateway.ThrottleSettings) []map[string]interface{} {
+	settings := make(map[string]interface{})
+
+	if s == nil {
+		return nil
+	}
+
+	if s.BurstLimit != nil {
+		settings["burst_limit"] = aws.Int64Value(s.BurstLimit)
+	}
+
+	if s.RateLimit != nil {
+		settings["rate_limit"] = aws.Float64Value(s.RateLimit)
+	}
+
+	return []map[string]interface{}{settings}
+}
+
+func flattenApiGatewayUsagePlanQuota(s *apigateway.QuotaSettings) []map[string]interface{} {
+	settings := make(map[string]interface{})
+
+	if s == nil {
+		return nil
+	}
+
+	if s.Limit != nil {
+		settings["limit"] = aws.Int64Value(s.Limit)
+	}
+
+	if s.Offset != nil {
+		settings["offset"] = aws.Int64Value(s.Offset)
+	}
+
+	if s.Period != nil {
+		settings["period"] = aws.StringValue(s.Period)
+	}
+
+	return []map[string]interface{}{settings}
 }

--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -135,8 +135,8 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 		settings := v.([]interface{})
 		q, ok := settings[0].(map[string]interface{})
 
-		if err := validateApiGatewayUsagePlanQuotaSettings(q); len(err) > 0 {
-			return fmt.Errorf("error validating the quota settings: %w", err)
+		if errs := validateApiGatewayUsagePlanQuotaSettings(q); len(errs) > 0 {
+			return fmt.Errorf("error validating the quota settings: %v", errs)
 		}
 
 		if !ok {

--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -136,7 +136,7 @@ func resourceAwsApiGatewayUsagePlanCreate(d *schema.ResourceData, meta interface
 		q, ok := settings[0].(map[string]interface{})
 
 		if err := validateApiGatewayUsagePlanQuotaSettings(q); len(err) > 0 {
-			return fmt.Errorf("error validating the quota settings: %v", err)
+			return fmt.Errorf("error validating the quota settings: %w", err)
 		}
 
 		if !ok {
@@ -283,7 +283,7 @@ func resourceAwsApiGatewayUsagePlanUpdate(d *schema.ResourceData, meta interface
 		os := o.(*schema.Set).List()
 		ns := n.(*schema.Set).List()
 
-		// Remove every stages associated. Simpler to remove and add ns ones,
+		// Remove every stages associated. Simpler to remove and add new ones,
 		// since there are no replacings.
 		for _, v := range os {
 			m := v.(map[string]interface{})

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -720,7 +720,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 func testAccAWSApiGatewayUsagePlanApiStagesModifiedConfig(rName string) string {
 	return testAccAWSAPIGatewayUsagePlanConfig(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_usage_plan" "test" {
-  name        = "%s"
+  name = "%s"
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,7 +29,12 @@ func TestAccAWSAPIGatewayUsagePlan_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayUsagePlanExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/usageplans/+.`)),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "api_stages.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "quota_settings.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "throttle_settings.%", "0"),
 				),
 			},
 			{

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -723,8 +723,8 @@ resource "aws_api_gateway_usage_plan" "test" {
   name        = "%s"
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.test.id}"
-    stage  = "${aws_api_gateway_deployment.foo.stage_name}"
+    api_id = aws_api_gateway_rest_api.test.id
+    stage  = aws_api_gateway_deployment.foo.stage_name
   }
 }
 `, rName)
@@ -741,8 +741,8 @@ resource "aws_api_gateway_usage_plan" "test" {
   }
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.test.id}"
-    stage  = "${aws_api_gateway_deployment.test.stage_name}"
+    api_id = aws_api_gateway_rest_api.test.id
+    stage  = aws_api_gateway_deployment.test.stage_name
   }
 }
 `, rName)

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -16,7 +16,7 @@ import (
 func TestAccAWSAPIGatewayUsagePlan_basic(t *testing.T) {
 	var conf apigateway.UsagePlan
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	updatedName := acctest.RandomWithPrefix("tf-acc-test")
+	updatedName := acctest.RandomWithPrefix("tf-acc-test-2")
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -511,7 +511,7 @@ func testAccCheckAWSAPIGatewayUsagePlanDestroy(s *terraform.State) error {
 		}
 
 		req := &apigateway.GetUsagePlanInput{
-			UsagePlanId: aws.String(s.RootModule().Resources["aws_api_gateway_rest_api.test"].Primary.ID),
+			UsagePlanId: aws.String(rs.Primary.ID),
 		}
 		describe, err := conn.GetUsagePlan(req)
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2275,66 +2275,6 @@ func normalizeJsonOrYamlString(templateString interface{}) (string, error) {
 	return checkYamlString(templateString)
 }
 
-func flattenApiGatewayUsageApiStages(s []*apigateway.ApiStage) []map[string]interface{} {
-	stages := make([]map[string]interface{}, 0)
-
-	for _, bd := range s {
-		if bd.ApiId != nil && bd.Stage != nil {
-			stage := make(map[string]interface{})
-			stage["api_id"] = *bd.ApiId
-			stage["stage"] = *bd.Stage
-
-			stages = append(stages, stage)
-		}
-	}
-
-	if len(stages) > 0 {
-		return stages
-	}
-
-	return nil
-}
-
-func flattenApiGatewayUsagePlanThrottling(s *apigateway.ThrottleSettings) []map[string]interface{} {
-	settings := make(map[string]interface{})
-
-	if s == nil {
-		return nil
-	}
-
-	if s.BurstLimit != nil {
-		settings["burst_limit"] = *s.BurstLimit
-	}
-
-	if s.RateLimit != nil {
-		settings["rate_limit"] = *s.RateLimit
-	}
-
-	return []map[string]interface{}{settings}
-}
-
-func flattenApiGatewayUsagePlanQuota(s *apigateway.QuotaSettings) []map[string]interface{} {
-	settings := make(map[string]interface{})
-
-	if s == nil {
-		return nil
-	}
-
-	if s.Limit != nil {
-		settings["limit"] = *s.Limit
-	}
-
-	if s.Offset != nil {
-		settings["offset"] = *s.Offset
-	}
-
-	if s.Period != nil {
-		settings["period"] = *s.Period
-	}
-
-	return []map[string]interface{}{settings}
-}
-
 func buildApiGatewayInvokeURL(client *AWSClient, restApiId, stageName string) string {
 	hostname := client.RegionalHostname(fmt.Sprintf("%s.execute-api", restApiId))
 	return fmt.Sprintf("https://%s/%s", hostname, stageName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1675

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_api_gateway_usage_plan - change `api_stages` to type set
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAPIGatewayUsagePlan_'
--- PASS: TestAccAWSAPIGatewayUsagePlan_tags (129.57s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (195.11s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (185.23s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (192.53s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (94.42s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (174.57s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (231.82s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages_multiple (77.07s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_disappears (63.35s)
```
