### PR TITLE
resource/aws_spot_fleet_request: Capture additional IAM eventual consistency error during RequestSpotFleet

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -959,6 +959,10 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 			return resource.RetryableError(err)
 		}
 
+		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "The provided SpotFleetRequestConfig.IamFleetRole does not have permission to call") {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/14265

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Caught before it was released via daily acceptance testing.

Previously (inconsistently!):

```
TestAccAWSSpotFleetRequest_iamInstanceProfileArn: testing.go:684: Step 0 error: errors during apply:
Error: Error requesting spot fleet: InvalidSpotFleetRequestConfig: The provided SpotFleetRequestConfig.IamFleetRole does not have permission to call DescribeSubnet.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (357.30s)
--- PASS: TestAccAWSSpotFleetRequest_basic (345.77s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (624.59s)
--- PASS: TestAccAWSSpotFleetRequest_disappears (282.46s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (862.86s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (347.01s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (345.46s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (292.74s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (140.49s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (142.89s)
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (552.78s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (212.21s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (203.07s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (624.12s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (273.68s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (253.37s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (347.63s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (253.01s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (548.08s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (253.77s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (262.55s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (535.56s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (60.24s)
--- PASS: TestAccAWSSpotFleetRequest_tags (282.26s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (624.59s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (970.38s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (230.13s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (284.19s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (525.74s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (270.52s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (432.60s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (252.23s)
```