### PR TITLE
r/vpc_dhcp_options_association - add disappears tests + prevent error when vpc is deleted out of terraform

### DIFF
--- a/aws/resource_aws_vpc_dhcp_options_association.go
+++ b/aws/resource_aws_vpc_dhcp_options_association.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,33 +50,31 @@ func resourceAwsVpcDhcpOptionsAssociationImport(d *schema.ResourceData, meta int
 	if err = d.Set("dhcp_options_id", vpc.DhcpOptionsId); err != nil {
 		return nil, err
 	}
-	d.SetId(*vpc.DhcpOptionsId + "-" + *vpc.VpcId)
+	d.SetId(fmt.Sprintf("%s-%s", aws.StringValue(vpc.DhcpOptionsId), aws.StringValue(vpc.VpcId)))
 	return []*schema.ResourceData{d}, nil
 }
 
 func resourceAwsVpcDhcpOptionsAssociationCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	log.Printf(
-		"[INFO] Creating DHCP Options association: %s => %s",
-		d.Get("vpc_id").(string),
-		d.Get("dhcp_options_id").(string))
+	vpcId := d.Get("vpc_id").(string)
+	optsID := d.Get("dhcp_options_id").(string)
 
-	optsID := aws.String(d.Get("dhcp_options_id").(string))
-	vpcID := aws.String(d.Get("vpc_id").(string))
+	log.Printf("[INFO] Creating DHCP Options association: %s => %s", vpcId, optsID)
 
 	if _, err := conn.AssociateDhcpOptions(&ec2.AssociateDhcpOptionsInput{
-		DhcpOptionsId: optsID,
-		VpcId:         vpcID,
+		DhcpOptionsId: aws.String(optsID),
+		VpcId:         aws.String(vpcId),
 	}); err != nil {
 		return err
 	}
 
 	// Set the ID and return
-	d.SetId(*optsID + "-" + *vpcID)
-	log.Printf("[INFO] Association ID: %s", d.Id())
+	d.SetId(fmt.Sprintf("%s-%s", optsID, vpcId))
 
-	return nil
+	log.Printf("[INFO] VPC DHCP Association ID: %s", d.Id())
+
+	return resourceAwsVpcDhcpOptionsAssociationRead(d, meta)
 }
 
 func resourceAwsVpcDhcpOptionsAssociationRead(d *schema.ResourceData, meta interface{}) error {
@@ -92,10 +91,14 @@ func resourceAwsVpcDhcpOptionsAssociationRead(d *schema.ResourceData, meta inter
 	}
 
 	vpc := vpcRaw.(*ec2.Vpc)
-	if *vpc.VpcId != d.Get("vpc_id") || *vpc.DhcpOptionsId != d.Get("dhcp_options_id") {
+	if aws.StringValue(vpc.VpcId) != d.Get("vpc_id") ||
+		aws.StringValue(vpc.DhcpOptionsId) != d.Get("dhcp_options_id") {
 		log.Printf("[INFO] It seems the DHCP Options association is gone. Deleting reference from Graph...")
 		d.SetId("")
 	}
+
+	d.Set("vpc_id", vpc.VpcId)
+	d.Set("dhcp_options_id", vpc.DhcpOptionsId)
 
 	return nil
 }
@@ -115,6 +118,10 @@ func resourceAwsVpcDhcpOptionsAssociationDelete(d *schema.ResourceData, meta int
 		DhcpOptionsId: aws.String("default"),
 		VpcId:         aws.String(d.Get("vpc_id").(string)),
 	})
+
+	if isAWSErr(err, "InvalidVpcID.NotFound", "") {
+		return nil
+	}
 
 	return err
 }

--- a/aws/resource_aws_vpc_dhcp_options_association_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_association_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -12,7 +13,7 @@ import (
 func TestAccAWSDHCPOptionsAssociation_basic(t *testing.T) {
 	var v ec2.Vpc
 	var d ec2.DhcpOptions
-	resourceName := "aws_vpc_dhcp_options_association.foo"
+	resourceName := "aws_vpc_dhcp_options_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,9 +23,9 @@ func TestAccAWSDHCPOptionsAssociation_basic(t *testing.T) {
 			{
 				Config: testAccDHCPOptionsAssociationConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDHCPOptionsExists("aws_vpc_dhcp_options.foo", &d),
-					testAccCheckVpcExists("aws_vpc.foo", &v),
-					testAccCheckDHCPOptionsAssociationExist("aws_vpc_dhcp_options_association.foo", &v),
+					testAccCheckDHCPOptionsExists("aws_vpc_dhcp_options.test", &d),
+					testAccCheckVpcExists("aws_vpc.test", &v),
+					testAccCheckDHCPOptionsAssociationExist(resourceName, &v),
 				),
 			},
 			{
@@ -32,6 +33,54 @@ func TestAccAWSDHCPOptionsAssociation_basic(t *testing.T) {
 				ImportStateIdFunc: testAccDHCPOptionsAssociationVPCImportIdFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDHCPOptionsAssociation_disappears_vpc(t *testing.T) {
+	var v ec2.Vpc
+	var d ec2.DhcpOptions
+	resourceName := "aws_vpc_dhcp_options_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDHCPOptionsAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDHCPOptionsAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDHCPOptionsExists("aws_vpc_dhcp_options.test", &d),
+					testAccCheckVpcExists("aws_vpc.test", &v),
+					testAccCheckDHCPOptionsAssociationExist(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsVpc(), "aws_vpc.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDHCPOptionsAssociation_disappears_dhcp(t *testing.T) {
+	var v ec2.Vpc
+	var d ec2.DhcpOptions
+	resourceName := "aws_vpc_dhcp_options_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDHCPOptionsAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDHCPOptionsAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDHCPOptionsExists("aws_vpc_dhcp_options.test", &d),
+					testAccCheckVpcExists("aws_vpc.test", &v),
+					testAccCheckDHCPOptionsAssociationExist(resourceName, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsVpcDhcpOptions(), "aws_vpc_dhcp_options.test"),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -81,12 +130,14 @@ func testAccCheckDHCPOptionsAssociationExist(n string, vpc *ec2.Vpc) resource.Te
 			return fmt.Errorf("No DHCP Options Set association ID is set")
 		}
 
-		if *vpc.DhcpOptionsId != rs.Primary.Attributes["dhcp_options_id"] {
-			return fmt.Errorf("VPC %s does not have DHCP Options Set %s associated", *vpc.VpcId, rs.Primary.Attributes["dhcp_options_id"])
+		if aws.StringValue(vpc.DhcpOptionsId) != rs.Primary.Attributes["dhcp_options_id"] {
+			return fmt.Errorf("VPC %s does not have DHCP Options Set %s associated",
+				aws.StringValue(vpc.VpcId), rs.Primary.Attributes["dhcp_options_id"])
 		}
 
-		if *vpc.VpcId != rs.Primary.Attributes["vpc_id"] {
-			return fmt.Errorf("DHCP Options Set %s is not associated with VPC %s", rs.Primary.Attributes["dhcp_options_id"], *vpc.VpcId)
+		if aws.StringValue(vpc.VpcId) != rs.Primary.Attributes["vpc_id"] {
+			return fmt.Errorf("DHCP Options Set %s is not associated with VPC %s",
+				rs.Primary.Attributes["dhcp_options_id"], aws.StringValue(vpc.VpcId))
 		}
 
 		return nil
@@ -94,27 +145,28 @@ func testAccCheckDHCPOptionsAssociationExist(n string, vpc *ec2.Vpc) resource.Te
 }
 
 const testAccDHCPOptionsAssociationConfig = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-vpc-dhcp-options-association"
-	}
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-vpc-dhcp-options-association"
+  }
 }
 
-resource "aws_vpc_dhcp_options" "foo" {
-	domain_name = "service.consul"
-	domain_name_servers = ["127.0.0.1", "10.0.0.2"]
-	ntp_servers = ["127.0.0.1"]
-	netbios_name_servers = ["127.0.0.1"]
-	netbios_node_type = 2
+resource "aws_vpc_dhcp_options" "test" {
+  domain_name          = "service.consul"
+  domain_name_servers  = ["127.0.0.1", "10.0.0.2"]
+  ntp_servers          = ["127.0.0.1"]
+  netbios_name_servers = ["127.0.0.1"]
+  netbios_node_type    = 2
 
-	tags = {
-		Name = "foo"
-	}
+  tags = {
+    Name = "terraform-testacc-vpc-dhcp-options-association"
+  }
 }
 
-resource "aws_vpc_dhcp_options_association" "foo" {
-	vpc_id = "${aws_vpc.foo.id}"
-	dhcp_options_id = "${aws_vpc_dhcp_options.foo.id}"
+resource "aws_vpc_dhcp_options_association" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  dhcp_options_id = "${aws_vpc_dhcp_options.test.id}"
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14359

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_vpc_dhcp_options_association - fix error when vpc is deleted outside of terraform
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDHCPOptionsAssociation_'
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (83.81s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_vpc (55.53s)
--- PASS: TestAccAWSDHCPOptionsAssociation_disappears_dhcp (72.12s)
```
