### PR TITLE
d/ecr_repository- make `registry_id` optional to allow to filter by account + add missing attributes

### DIFF
--- a/aws/data_source_aws_ecr_repository.go
+++ b/aws/data_source_aws_ecr_repository.go
@@ -26,6 +26,7 @@ func dataSourceAwsEcrRepository() *schema.Resource {
 			"registry_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"repository_url": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_ecr_repository_test.go
+++ b/aws/data_source_aws_ecr_repository_test.go
@@ -25,6 +25,8 @@ func TestAccAWSEcrDataSource_ecrRepository(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "registry_id", dataSourceName, "registry_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "repository_url", dataSourceName, "repository_url"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_scanning_configuration", dataSourceName, "image_scanning_configuration"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_tag_mutability", dataSourceName, "image_tag_mutability"),
 				),
 			},
 		},

--- a/aws/data_source_aws_ecr_repository_test.go
+++ b/aws/data_source_aws_ecr_repository_test.go
@@ -25,7 +25,7 @@ func TestAccAWSEcrDataSource_ecrRepository(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "registry_id", dataSourceName, "registry_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "repository_url", dataSourceName, "repository_url"),
 					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
-					resource.TestCheckResourceAttrPair(resourceName, "image_scanning_configuration", dataSourceName, "image_scanning_configuration"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_scanning_configuration.#", dataSourceName, "image_scanning_configuration.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "image_tag_mutability", dataSourceName, "image_tag_mutability"),
 				),
 			},

--- a/aws/data_source_aws_ecr_repository_test.go
+++ b/aws/data_source_aws_ecr_repository_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAWSEcrDataSource_ecrRepository(t *testing.T) {
+func TestAccAWSEcrRepositoryDataSource_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ecr_repository.test"
 	dataSourceName := "data.aws_ecr_repository.test"
@@ -33,7 +33,7 @@ func TestAccAWSEcrDataSource_ecrRepository(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcrDataSource_nonExistent(t *testing.T) {
+func TestAccAWSEcrRepositoryDataSource_nonExistent(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/website/docs/d/ecr_repository.html.markdown
+++ b/website/docs/d/ecr_repository.html.markdown
@@ -23,12 +23,19 @@ data "aws_ecr_repository" "service" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the ECR Repository.
+* `registry_id` - (Optional) The registry ID where the repository was created.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Full ARN of the repository.
-* `registry_id` - The registry ID where the repository was created.
 * `repository_url` - The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`).
+* `image_tag_mutability` - The tag mutability setting for the repository.
+* `image_scanning_configuration` - Configuration block that defines image scanning configuration for the repository. see [Image Scanning Configuration](#image-scanning-configuration)
 * `tags` - A map of tags assigned to the resource.
+
+### Image Scanning Configuration
+
+* `scan_on_push` - Indicates whether images are scanned after being pushed to the repository.
+


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14327

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_ecr_repository - make `registry_id` optional to allow to filter by account
data_source_aws_ecr_repository - add `image_scanning_configuration`, `image_tag_mutability` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcrDataSource_'
--- PASS: TestAccAWSEcrDataSource_ecrImage (42.83s)
--- PASS: TestAccAWSEcrDataSource_ecrRepository (53.71s)
--- PASS: TestAccAWSEcrDataSource_nonExistent (7.93s)
```
