### PR TITLE
tech-debt: remove iam_role_arn from aws_flow_log acctest

### DIFF
--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -599,11 +599,9 @@ resource "aws_s3_bucket" "test" {
 resource "aws_flow_log" "test" {
   log_destination      = "${aws_s3_bucket.test.arn}"
   log_destination_type = "s3"
-  iam_role_arn         = "${aws_iam_role.test.arn}"
-
-  traffic_type   = "ALL"
-  vpc_id         = "${aws_vpc.test.id}"
-  log_format     = "$${version} $${vpc-id} $${subnet-id}"
+  traffic_type         = "ALL"
+  vpc_id               = "${aws_vpc.test.id}"
+  log_format           = "$${version} $${vpc-id} $${subnet-id}"
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14397 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: remove iam_role_arn argument from aws_flow_log config with s3 log_destination_type
```

Output from acceptance testing before fix:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
    TestAccAWSFlowLog_LogFormat: testing.go:684: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_flow_log.test
          arn:                      "arn:aws:ec2:us-west-2:*******:vpc-flow-log/fl-0c12677fb5c2f9810" => "<computed>"
          iam_role_arn:             "" => "arn:aws:iam::*******:role/tf-acc-test-2836420413734541030" (forces new resource)

```

Output from acceptance testing after fix:
```
--- PASS: TestAccAWSFlowLog_LogFormat (44.83s)
```