### PR TITLE
tests/resource/aws_autoscaling_group: Use Amazon Linux for web server testing

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -2315,8 +2315,10 @@ resource "aws_autoscaling_group" "bar" {
 }
 
 func testAccAWSAutoScalingGroupConfigWithLoadBalancer() string {
-	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
-		fmt.Sprintf(`
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags = {
@@ -2377,22 +2379,17 @@ resource "aws_elb" "bar" {
   depends_on = ["aws_internet_gateway.gw"]
 }
 
-// need an AMI that listens on :80 at boot, this is:
-data "aws_ami" "test_ami" {
-  most_recent = true
-
-  owners = ["979382823631"]
-
-  filter {
-    name   = "name"
-    values = ["bitnami-nginxstack-*-linux-debian-9-x86_64-hvm-ebs"]
-  }
-}
-
 resource "aws_launch_configuration" "foobar" {
-  image_id        = data.aws_ami.test_ami.id
+  image_id        = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type   = "t2.micro"
   security_groups = [aws_security_group.foo.id]
+
+  # Need the instance to listen on port 80 at boot
+  user_data = <<EOF
+#!/bin/bash
+echo "Terraform aws_autoscaling_group Testing" > index.html
+nohup python -m SimpleHTTPServer 80 &
+EOF
 }
 
 resource "aws_autoscaling_group" "bar" {
@@ -2411,8 +2408,10 @@ resource "aws_autoscaling_group" "bar" {
 }
 
 func testAccAWSAutoScalingGroupConfigWithTargetGroup() string {
-	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
-		fmt.Sprintf(`
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags = {
@@ -2479,22 +2478,17 @@ resource "aws_elb" "bar" {
   depends_on = ["aws_internet_gateway.gw"]
 }
 
-// need an AMI that listens on :80 at boot, this is:
-data "aws_ami" "test_ami" {
-  most_recent = true
-
-  owners = ["979382823631"]
-
-  filter {
-    name   = "name"
-    values = ["bitnami-nginxstack-*-linux-debian-9-x86_64-hvm-ebs"]
-  }
-}
-
 resource "aws_launch_configuration" "foobar" {
-  image_id        = data.aws_ami.test_ami.id
+  image_id        = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type   = "t2.micro"
   security_groups = [aws_security_group.foo.id]
+
+  # Need the instance to listen on port 80 at boot
+  user_data = <<EOF
+#!/bin/bash
+echo "Terraform aws_autoscaling_group Testing" > index.html
+nohup python -m SimpleHTTPServer 80 &
+EOF
 }
 
 resource "aws_autoscaling_group" "bar" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14392

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Amazon Linux is pretty much guaranteed to be available in all AWS Regions and Python is already installed to spin up a quick little web server to satisfy the ELB health checks.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (234.35s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (375.93s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (210.52s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (351.67s)
```
