### PR TITLE
data-source/aws_availability_zones: Fix group_names attribute to be Computed instead of Optional

### DIFF
--- a/aws/data_source_aws_availability_zones.go
+++ b/aws/data_source_aws_availability_zones.go
@@ -34,7 +34,7 @@ func dataSourceAwsAvailabilityZones() *schema.Resource {
 			"filter": ec2CustomFiltersSchema(),
 			"group_names": {
 				Type:     schema.TypeSet,
-				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"names": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14405

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_availability_zones: Prevent unexpected plan output every apply with `group_names` attribute
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAvailabilityZones_Filter (7.67s)
--- PASS: TestAccAWSAvailabilityZones_basic (7.83s)
--- PASS: TestAccAWSAvailabilityZones_AllAvailabilityZones (7.88s)
--- PASS: TestAccAWSAvailabilityZones_stateFilter (7.88s)
--- PASS: TestAccAWSAvailabilityZones_ExcludeNames (9.35s)
--- PASS: TestAccAWSAvailabilityZones_ExcludeZoneIds (9.41s)
```

