### PR TITLE
tests/provider: Use SDK v2 compliant ExpectError conditions

### DIFF
--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -262,7 +262,7 @@ func TestAccAWSAcmCertificate_root_TrailingPeriod(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAcmCertificateConfig(domain, acm.ValidationMethodDns),
-				ExpectError: regexp.MustCompile(`config is invalid: invalid value for domain_name \(cannot end with a period\)`),
+				ExpectError: regexp.MustCompile(`invalid value for domain_name \(cannot end with a period\)`),
 			},
 		},
 	})

--- a/aws/resource_aws_s3_bucket_analytics_configuration_test.go
+++ b/aws/resource_aws_s3_bucket_analytics_configuration_test.go
@@ -134,7 +134,7 @@ func TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSS3BucketAnalyticsConfigurationWithEmptyFilter(rName, rName),
-				ExpectError: regexp.MustCompile(`config is invalid:`),
+				ExpectError: regexp.MustCompile(`one of .* must be specified`),
 			},
 		},
 	})
@@ -365,7 +365,7 @@ func TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty(t *
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSS3BucketAnalyticsConfigurationWithEmptyStorageClassAnalysis(rName, rName),
-				ExpectError: regexp.MustCompile(`config is invalid:`),
+				ExpectError: regexp.MustCompile(`required field is not set`),
 			},
 		},
 	})

--- a/aws/resource_aws_s3_bucket_metric_test.go
+++ b/aws/resource_aws_s3_bucket_metric_test.go
@@ -313,7 +313,7 @@ func TestAccAWSS3BucketMetric_WithEmptyFilter(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketMetricsConfigExists(resourceName, &conf),
 				),
-				ExpectError: regexp.MustCompile(`config is invalid`),
+				ExpectError: regexp.MustCompile(`one of .* must be specified`),
 			},
 		},
 	})

--- a/aws/resource_aws_ses_domain_identity_test.go
+++ b/aws/resource_aws_ses_domain_identity_test.go
@@ -124,7 +124,7 @@ func TestAccAWSSESDomainIdentity_trailingPeriod(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAwsSESDomainIdentityConfig(domain),
-				ExpectError: regexp.MustCompile(`config is invalid: invalid value for domain \(cannot end with a period\)`),
+				ExpectError: regexp.MustCompile(`invalid value for domain \(cannot end with a period\)`),
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12087

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The `config is invalid:` prefix is no longer present in Terraform Plugin SDK v2. e.g.

```
TestAccAWSAcmCertificate_root_TrailingPeriod: resource_aws_acm_certificate_test.go:258: Expected an error with pattern, no match on: terraform failed: exit status 1
stderr:
Error: invalid value for domain_name (cannot end with a period)
on config733606703/terraform_plugin_test.tf line 3, in resource "aws_acm_certificate" "cert":
3:   domain_name       = "--OMITTED--"
--- FAIL: TestAccAWSAcmCertificate_root_TrailingPeriod (4.02s)
```

Output from acceptance testing (V1):

```
--- PASS: TestAccAWSAcmCertificate_root_TrailingPeriod (0.85s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty (0.85s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty (0.94s)
--- PASS: TestAccAWSSESDomainIdentity_trailingPeriod (1.17s)
```
