### PR TITLE
r/secretsmanager_secret - policy wait for IAM eventual consistency

### DIFF
--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/secretsmanager/waiter"
 )
 

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -64,17 +64,10 @@ func resourceAwsSecretsManagerSecret() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  30,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
-					if value == 0 {
-						return
-					}
-					if value >= 7 && value <= 30 {
-						return
-					}
-					errors = append(errors, fmt.Errorf("%q must be 0 or between 7 and 30", k))
-					return
-				},
+				ValidateFunc: validation.Any(
+					validation.IntBetween(7, 30),
+					validation.IntInSlice([]int{0}),
+				),
 			},
 			"rotation_enabled": {
 				Deprecated: "Use the aws_secretsmanager_secret_rotation resource instead",
@@ -154,7 +147,7 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 		output, err = conn.CreateSecret(input)
 	}
 	if err != nil {
-		return fmt.Errorf("error creating Secrets Manager Secret: %s", err)
+		return fmt.Errorf("error creating Secrets Manager Secret: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.ARN))
@@ -165,10 +158,23 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 			SecretId:       aws.String(d.Id()),
 		}
 
-		log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %s", input)
-		_, err := conn.PutResourcePolicy(input)
+		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+			var err error
+			_, err = conn.PutResourcePolicy(input)
+			if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,
+				"This resource policy contains an unsupported principal") {
+				return resource.RetryableError(err)
+			}
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.PutResourcePolicy(input)
+		}
 		if err != nil {
-			return fmt.Errorf("error setting Secrets Manager Secret %q policy: %s", d.Id(), err)
+			return fmt.Errorf("error setting Secrets Manager Secret %q policy: %w", d.Id(), err)
 		}
 	}
 
@@ -195,7 +201,7 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 			_, err = conn.RotateSecret(input)
 		}
 		if err != nil {
-			return fmt.Errorf("error enabling Secrets Manager Secret %q rotation: %s", d.Id(), err)
+			return fmt.Errorf("error enabling Secrets Manager Secret %q rotation: %w", d.Id(), err)
 		}
 	}
 
@@ -218,7 +224,7 @@ func resourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interface{
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading Secrets Manager Secret: %s", err)
+		return fmt.Errorf("error reading Secrets Manager Secret: %w", err)
 	}
 
 	d.Set("arn", output.ARN)
@@ -232,13 +238,13 @@ func resourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] Reading Secrets Manager Secret policy: %s", pIn)
 	pOut, err := conn.GetResourcePolicy(pIn)
 	if err != nil {
-		return fmt.Errorf("error reading Secrets Manager Secret policy: %s", err)
+		return fmt.Errorf("error reading Secrets Manager Secret policy: %w", err)
 	}
 
 	if pOut.ResourcePolicy != nil {
 		policy, err := structure.NormalizeJsonString(aws.StringValue(pOut.ResourcePolicy))
 		if err != nil {
-			return fmt.Errorf("policy contains an invalid JSON: %s", err)
+			return fmt.Errorf("policy contains an invalid JSON: %w", err)
 		}
 		d.Set("policy", policy)
 	}
@@ -248,7 +254,7 @@ func resourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interface{
 	if aws.BoolValue(output.RotationEnabled) {
 		d.Set("rotation_lambda_arn", output.RotationLambdaARN)
 		if err := d.Set("rotation_rules", flattenSecretsManagerRotationRules(output.RotationRules)); err != nil {
-			return fmt.Errorf("error setting rotation_rules: %s", err)
+			return fmt.Errorf("error setting rotation_rules: %w", err)
 		}
 	} else {
 		d.Set("rotation_lambda_arn", "")
@@ -256,7 +262,7 @@ func resourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interface{
 	}
 
 	if err := d.Set("tags", keyvaluetags.SecretsmanagerKeyValueTags(output.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil
@@ -278,7 +284,7 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 		log.Printf("[DEBUG] Updating Secrets Manager Secret: %s", input)
 		_, err := conn.UpdateSecret(input)
 		if err != nil {
-			return fmt.Errorf("error updating Secrets Manager Secret: %s", err)
+			return fmt.Errorf("error updating Secrets Manager Secret: %w", err)
 		}
 	}
 
@@ -286,27 +292,41 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 		if v, ok := d.GetOk("policy"); ok && v.(string) != "" {
 			policy, err := structure.NormalizeJsonString(v.(string))
 			if err != nil {
-				return fmt.Errorf("policy contains an invalid JSON: %s", err)
+				return fmt.Errorf("policy contains an invalid JSON: %w", err)
 			}
 			input := &secretsmanager.PutResourcePolicyInput{
 				ResourcePolicy: aws.String(policy),
 				SecretId:       aws.String(d.Id()),
 			}
 
-			log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %s", input)
-			_, err = conn.PutResourcePolicy(input)
+			log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
+			err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+				var err error
+				_, err = conn.PutResourcePolicy(input)
+				if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,
+					"This resource policy contains an unsupported principal") {
+					return resource.RetryableError(err)
+				}
+				if err != nil {
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			if isResourceTimeoutError(err) {
+				_, err = conn.PutResourcePolicy(input)
+			}
 			if err != nil {
-				return fmt.Errorf("error setting Secrets Manager Secret %q policy: %s", d.Id(), err)
+				return fmt.Errorf("error setting Secrets Manager Secret %q policy: %w", d.Id(), err)
 			}
 		} else {
 			input := &secretsmanager.DeleteResourcePolicyInput{
 				SecretId: aws.String(d.Id()),
 			}
 
-			log.Printf("[DEBUG] Removing Secrets Manager Secret policy: %s", input)
+			log.Printf("[DEBUG] Removing Secrets Manager Secret policy: %#v", input)
 			_, err := conn.DeleteResourcePolicy(input)
 			if err != nil {
-				return fmt.Errorf("error removing Secrets Manager Secret %q policy: %s", d.Id(), err)
+				return fmt.Errorf("error removing Secrets Manager Secret %q policy: %w", d.Id(), err)
 			}
 		}
 	}
@@ -335,7 +355,7 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 				_, err = conn.RotateSecret(input)
 			}
 			if err != nil {
-				return fmt.Errorf("error updating Secrets Manager Secret %q rotation: %s", d.Id(), err)
+				return fmt.Errorf("error updating Secrets Manager Secret %q rotation: %w", d.Id(), err)
 			}
 		} else {
 			input := &secretsmanager.CancelRotateSecretInput{
@@ -345,7 +365,7 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 			log.Printf("[DEBUG] Cancelling Secrets Manager Secret rotation: %s", input)
 			_, err := conn.CancelRotateSecret(input)
 			if err != nil {
-				return fmt.Errorf("error cancelling Secret Manager Secret %q rotation: %s", d.Id(), err)
+				return fmt.Errorf("error cancelling Secret Manager Secret %q rotation: %w", d.Id(), err)
 			}
 		}
 	}
@@ -353,7 +373,7 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.SecretsmanagerUpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}
 
@@ -380,7 +400,7 @@ func resourceAwsSecretsManagerSecretDelete(d *schema.ResourceData, meta interfac
 		if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
 			return nil
 		}
-		return fmt.Errorf("error deleting Secrets Manager Secret: %s", err)
+		return fmt.Errorf("error deleting Secrets Manager Secret: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -300,7 +300,7 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 			}
 
 			log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy; %#v", input)
-			err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+			err = resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 				var err error
 				_, err = conn.PutResourcePolicy(input)
 				if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -158,7 +158,7 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 			SecretId:       aws.String(d.Id()),
 		}
 
-		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 			var err error
 			_, err = conn.PutResourcePolicy(input)
 			if isAWSErr(err, secretsmanager.ErrCodeMalformedPolicyDocumentException,


### PR DESCRIPTION
use %w for errors
wait for policy that relies on iam role (eventual consistency)

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14449

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resouce_aws_secretsmanager_secret - policy wait for IAM eventual consistency
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsSecretsManagerSecret_policy'
--- PASS: TestAccAwsSecretsManagerSecret_policy (127.27s)
```
