### PR TITLE
Fix writing of aws_security_group name_prefix to statefile.

### DIFF
--- a/aws/internal/naming/naming.go
+++ b/aws/internal/naming/naming.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var resourceUniqueIDSuffixRegexpPattern = fmt.Sprintf("\\d{%d}$", resource.UniqueIDSuffixLength)
+var resourceUniqueIDSuffixRegexpPattern = fmt.Sprintf("[[:xdigit:]]{%d}$", resource.UniqueIDSuffixLength)
 var resourceUniqueIDSuffixRegexp = regexp.MustCompile(resourceUniqueIDSuffixRegexpPattern)
 
 var resourceUniqueIDRegexpPattern = resourcePrefixedUniqueIDRegexpPattern(resource.UniqueIdPrefix)

--- a/aws/internal/naming/naming_test.go
+++ b/aws/internal/naming/naming_test.go
@@ -109,8 +109,18 @@ func TestHasResourceUniqueIdSuffix(t *testing.T) {
 			Expected: true,
 		},
 		{
+			TestName: "correct suffix with hex, incorrect prefix",
+			Input:    "test-200601021504050000000000a1",
+			Expected: true,
+		},
+		{
 			TestName: "correct suffix, correct prefix",
 			Input:    "terraform-20060102150405000000000001",
+			Expected: true,
+		},
+		{
+			TestName: "correct suffix with hex, correct prefix",
+			Input:    "terraform-2006010215040500000000000a",
 			Expected: true,
 		},
 	}
@@ -153,6 +163,11 @@ func TestNamePrefixFromName(t *testing.T) {
 			Expected: strPtr("test-"),
 		},
 		{
+			TestName: "correct prefix with hyphen, correct suffix with hex",
+			Input:    "test-200601021504050000000000f1",
+			Expected: strPtr("test-"),
+		},
+		{
 			TestName: "incorrect prefix, correct suffix",
 			Input:    "terraform-20060102150405000000000001",
 			Expected: nil,
@@ -177,4 +192,20 @@ func TestNamePrefixFromName(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("extracting prefix from generated name", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			prefix := "test-"
+			input := Generate("", prefix)
+			got := NamePrefixFromName(input)
+
+			if got == nil {
+				t.Errorf("run%d: got nil, expected %s for input %s", i, prefix, input)
+			}
+
+			if got != nil && prefix != *got {
+				t.Errorf("run%d: got %s, expected %s for input %s", i, *got, prefix, input)
+			}
+		}
+	})
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14474 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
resource/aws_security_group: Properly store name_prefix in state file to prevent spurious re-creation.
```

### Details

As reported in #14474, I've been seeing some of our security groups being recreated unnecessarily due to their name_prefix property not being written to the statefile.

[`resource.PrefixedUniqueId`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk@v1.14.0/helper/resource?tab=doc#PrefixedUniqueId) generates names with a suffix containing hex digits, whereas the naming package was assuming these were purely decimal. This meant that NamePrefixFromName was returning `nil` when the generated name included hex digits a-f, which in turn caused the name_prefix property not to be set in the statefile.