### PR TITLE
Fix data source config formatting, 0.12 up to regions

### DIFF
--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -453,6 +453,7 @@ resource "aws_efs_access_point" "access_point_1" {
 
   root_directory {
     path = "/lambda"
+
     creation_info {
       owner_gid   = 1000
       owner_uid   = 1000

--- a/aws/data_source_aws_launch_template_test.go
+++ b/aws/data_source_aws_launch_template_test.go
@@ -161,7 +161,6 @@ func TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress(t *testing.T) {
 }
 
 func TestAccAWSLaunchTemplateDataSource_NonExistent(t *testing.T) {
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/aws/data_source_aws_nat_gateway_test.go
+++ b/aws/data_source_aws_nat_gateway_test.go
@@ -52,7 +52,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.123.0/24"
   availability_zone = "us-west-2a"
 
@@ -68,7 +68,7 @@ resource "aws_eip" "test" {
 
 # IGWs are required for an NGW to spin up; manual dependency
 resource "aws_internet_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = "terraform-testacc-nat-gateway-data-source-%d"
@@ -76,8 +76,8 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_nat_gateway" "test" {
-  subnet_id     = "${aws_subnet.test.id}"
-  allocation_id = "${aws_eip.test.id}"
+  subnet_id     = aws_subnet.test.id
+  allocation_id = aws_eip.test.id
 
   tags = {
     Name     = "terraform-testacc-nat-gw-data-source-%d"
@@ -88,16 +88,16 @@ resource "aws_nat_gateway" "test" {
 }
 
 data "aws_nat_gateway" "test_by_id" {
-  id = "${aws_nat_gateway.test.id}"
+  id = aws_nat_gateway.test.id
 }
 
 data "aws_nat_gateway" "test_by_subnet_id" {
-  subnet_id = "${aws_nat_gateway.test.subnet_id}"
+  subnet_id = aws_nat_gateway.test.subnet_id
 }
 
 data "aws_nat_gateway" "test_by_tags" {
   tags = {
-    Name = "${aws_nat_gateway.test.tags["Name"]}"
+    Name = aws_nat_gateway.test.tags["Name"]
   }
 }
 `, rInt, rInt, rInt, rInt)

--- a/aws/data_source_aws_network_acls_test.go
+++ b/aws/data_source_aws_network_acls_test.go
@@ -96,7 +96,7 @@ resource "aws_vpc" "test" {
 resource "aws_network_acl" "acl" {
   count = 2
 
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = "testacc-acl-%s"
@@ -116,7 +116,7 @@ func testAccDataSourceAwsNetworkAclsConfig_Filter(rName string) string {
 data "aws_network_acls" "test" {
   filter {
     name   = "network-acl-id"
-    values = ["${aws_network_acl.acl.0.id}"]
+    values = [aws_network_acl.acl.0.id]
   }
 }
 `
@@ -126,7 +126,7 @@ func testAccDataSourceAwsNetworkAclsConfig_Tags(rName string) string {
 	return testAccDataSourceAwsNetworkAclsConfig_Base(rName) + `
 data "aws_network_acls" "test" {
   tags = {
-    Name = "${aws_network_acl.acl.0.tags.Name}"
+    Name = aws_network_acl.acl.0.tags.Name
   }
 }
 `
@@ -135,7 +135,7 @@ data "aws_network_acls" "test" {
 func testAccDataSourceAwsNetworkAclsConfig_VpcID(rName string) string {
 	return testAccDataSourceAwsNetworkAclsConfig_Base(rName) + `
 data "aws_network_acls" "test" {
-  vpc_id = "${aws_network_acl.acl.0.vpc_id}"
+  vpc_id = aws_network_acl.acl.0.vpc_id
 }
 `
 }

--- a/aws/data_source_aws_network_interface_test.go
+++ b/aws/data_source_aws_network_interface_test.go
@@ -54,8 +54,8 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   cidr_block        = "10.0.0.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-eni-data-source-basic"
@@ -64,17 +64,17 @@ resource "aws_subnet" "test" {
 
 resource "aws_security_group" "test" {
   name   = "tf-sg-%s"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_network_interface" "test" {
-  subnet_id       = "${aws_subnet.test.id}"
+  subnet_id       = aws_subnet.test.id
   private_ips     = ["10.0.0.50"]
-  security_groups = ["${aws_security_group.test.id}"]
+  security_groups = [aws_security_group.test.id]
 }
 
 data "aws_network_interface" "test" {
-  id = "${aws_network_interface.test.id}"
+  id = aws_network_interface.test.id
 }
 `, rName)
 }
@@ -117,8 +117,8 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   cidr_block        = "10.0.0.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  vpc_id            = "${aws_vpc.test.id}"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id            = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-eni-data-source-filters"
@@ -127,19 +127,19 @@ resource "aws_subnet" "test" {
 
 resource "aws_security_group" "test" {
   name   = "tf-sg-%s"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_network_interface" "test" {
-  subnet_id       = "${aws_subnet.test.id}"
+  subnet_id       = aws_subnet.test.id
   private_ips     = ["10.0.0.60"]
-  security_groups = ["${aws_security_group.test.id}"]
+  security_groups = [aws_security_group.test.id]
 }
 
 data "aws_network_interface" "test" {
   filter {
     name   = "network-interface-id"
-    values = ["${aws_network_interface.test.id}"]
+    values = [aws_network_interface.test.id]
   }
 }
 `, rName)

--- a/aws/data_source_aws_network_interfaces_test.go
+++ b/aws/data_source_aws_network_interfaces_test.go
@@ -54,7 +54,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  vpc_id     = aws_vpc.test.id
 
   tags = {
     Name = "terraform-testacc-eni-data-source-basic-%s"
@@ -62,14 +62,14 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_network_interface" "test" {
-  subnet_id = "${aws_subnet.test.id}"
+  subnet_id = aws_subnet.test.id
 }
 
 resource "aws_network_interface" "test1" {
-  subnet_id = "${aws_subnet.test.id}"
+  subnet_id = aws_subnet.test.id
 
   tags = {
-    Name = "${aws_vpc.test.tags.Name}"
+    Name = aws_vpc.test.tags.Name
   }
 }
 `, rName, rName)
@@ -80,7 +80,7 @@ func testAccDataSourceAwsNetworkInterfacesConfig_Filter(rName string) string {
 data "aws_network_interfaces" "test" {
   filter {
     name   = "subnet-id"
-    values = ["${aws_network_interface.test.subnet_id}", "${aws_network_interface.test1.subnet_id}"]
+    values = [aws_network_interface.test.subnet_id, aws_network_interface.test1.subnet_id]
   }
 }
 `
@@ -90,7 +90,7 @@ func testAccDataSourceAwsNetworkInterfacesConfig_Tags(rName string) string {
 	return testAccDataSourceAwsNetworkInterfacesConfig_Base(rName) + `
 data "aws_network_interfaces" "test" {
   tags = {
-    Name = "${aws_network_interface.test1.tags.Name}"
+    Name = aws_network_interface.test1.tags.Name
   }
 }
 `

--- a/aws/data_source_aws_organizations_organizational_units_test.go
+++ b/aws/data_source_aws_organizations_organizational_units_test.go
@@ -33,11 +33,11 @@ const testAccDataSourceAwsOrganizationsOrganizationalUnitsConfig = `
 resource "aws_organizations_organization" "test" {}
 
 resource "aws_organizations_organizational_unit" "test" {
-    name      = "test"
-    parent_id = aws_organizations_organization.test.roots[0].id
+  name      = "test"
+  parent_id = aws_organizations_organization.test.roots[0].id
 }
 
 data "aws_organizations_organizational_units" "test" {
-    parent_id = aws_organizations_organizational_unit.test.parent_id
+  parent_id = aws_organizations_organizational_unit.test.parent_id
 }
 `

--- a/aws/data_source_aws_partition_test.go
+++ b/aws/data_source_aws_partition_test.go
@@ -61,5 +61,5 @@ func testAccCheckAwsDnsSuffix(n string) resource.TestCheckFunc {
 }
 
 const testAccCheckAwsPartitionConfig_basic = `
-data "aws_partition" "current" { }
+data "aws_partition" "current" {}
 `

--- a/aws/data_source_aws_prefix_list_test.go
+++ b/aws/data_source_aws_prefix_list_test.go
@@ -79,7 +79,7 @@ data "aws_prefix_list" "s3_by_id" {
 }
 
 data "aws_prefix_list" "s3_by_name" {
- name = "com.amazonaws.us-west-2.s3"
+  name = "com.amazonaws.us-west-2.s3"
 }
 `
 

--- a/aws/data_source_aws_pricing_product_test.go
+++ b/aws/data_source_aws_pricing_product_test.go
@@ -49,60 +49,62 @@ func TestAccDataSourceAwsPricingProduct_redshift(t *testing.T) {
 }
 
 func testAccDataSourceAwsPricingProductConfigEc2(dataName string, instanceType string) string {
-	return fmt.Sprintf(`data "aws_pricing_product" "%s" {
-		service_code = "AmazonEC2"
-	  
-		filters {
-			field = "instanceType"
-			value = "%s"
-		}
+	return fmt.Sprintf(`
+data "aws_pricing_product" "%s" {
+  service_code = "AmazonEC2"
 
-		filters {
-			field = "operatingSystem"
-			value = "Linux"
-		}
+  filters {
+    field = "instanceType"
+    value = "%s"
+  }
 
-		filters {
-			field = "location"
-			value = "US East (N. Virginia)"
-		}
+  filters {
+    field = "operatingSystem"
+    value = "Linux"
+  }
 
-		filters {
-			field = "preInstalledSw"
-			value = "NA"
-		}
+  filters {
+    field = "location"
+    value = "US East (N. Virginia)"
+  }
 
-		filters {
-			field = "licenseModel"
-			value = "No License required"
-		}
+  filters {
+    field = "preInstalledSw"
+    value = "NA"
+  }
 
-		filters {
-			field = "tenancy"
-			value = "Shared"
-		}
+  filters {
+    field = "licenseModel"
+    value = "No License required"
+  }
 
-		filters {
-			field = "capacitystatus"
-			value = "Used"
-		}
+  filters {
+    field = "tenancy"
+    value = "Shared"
+  }
+
+  filters {
+    field = "capacitystatus"
+    value = "Used"
+  }
 }
 `, dataName, instanceType)
 }
 
 func testAccDataSourceAwsPricingProductConfigRedshift() string {
-	return `data "aws_pricing_product" "test" {
-		service_code = "AmazonRedshift"
-	  
-		filters {
-			field = "instanceType"
-			value = "ds1.xlarge"
-		}
+	return `
+data "aws_pricing_product" "test" {
+  service_code = "AmazonRedshift"
 
-		filters {
-			field = "location"
-			value = "US East (N. Virginia)"
-		}
+  filters {
+    field = "instanceType"
+    value = "ds1.xlarge"
+  }
+
+  filters {
+    field = "location"
+    value = "US East (N. Virginia)"
+  }
 }
 `
 }

--- a/aws/data_source_aws_qldb_ledger_test.go
+++ b/aws/data_source_aws_qldb_ledger_test.go
@@ -31,22 +31,22 @@ func TestAccDataSourceAwsQLDBLedger_basic(t *testing.T) {
 func testAccDataSourceAwsQLDBLedgerConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_qldb_ledger" "tf_wrong1" {
-  name = "%[1]s1"
+  name                = "%[1]s1"
   deletion_protection = false
 }
 
 resource "aws_qldb_ledger" "tf_test" {
-  name = "%[1]s2"
+  name                = "%[1]s2"
   deletion_protection = false
 }
 
 resource "aws_qldb_ledger" "tf_wrong2" {
- name = "%[1]s3"
- deletion_protection = false
+  name                = "%[1]s3"
+  deletion_protection = false
 }
 
 data "aws_qldb_ledger" "by_name" {
- name = "${aws_qldb_ledger.tf_test.name}"
+  name = aws_qldb_ledger.tf_test.name
 }
 `, rName)
 }

--- a/aws/data_source_aws_ram_resource_share_test.go
+++ b/aws/data_source_aws_ram_resource_share_test.go
@@ -66,7 +66,7 @@ resource "aws_ram_resource_share" "test" {
 }
 
 data "aws_ram_resource_share" "test" {
-  name           = "${aws_ram_resource_share.test.name}"
+  name           = aws_ram_resource_share.test.name
   resource_owner = "SELF"
 }
 `, rName, rName)
@@ -83,7 +83,7 @@ resource "aws_ram_resource_share" "test" {
 }
 
 data "aws_ram_resource_share" "test" {
-  name           = "${aws_ram_resource_share.test.name}"
+  name           = aws_ram_resource_share.test.name
   resource_owner = "SELF"
 
   filter {
@@ -96,7 +96,7 @@ data "aws_ram_resource_share" "test" {
 
 const testAccDataSourceAwsRamResourceShareConfig_NonExistent = `
 data "aws_ram_resource_share" "test" {
-	name = "tf-acc-test-does-not-exist"
-	resource_owner = "SELF"
+  name           = "tf-acc-test-does-not-exist"
+  resource_owner = "SELF"
 }
 `

--- a/aws/data_source_aws_rds_cluster_test.go
+++ b/aws/data_source_aws_rds_cluster_test.go
@@ -42,7 +42,7 @@ resource "aws_rds_cluster" "test" {
   cluster_identifier              = "%s"
   database_name                   = "mydb"
   db_cluster_parameter_group_name = "default.aurora5.6"
-  db_subnet_group_name            = "${aws_db_subnet_group.test.name}"
+  db_subnet_group_name            = aws_db_subnet_group.test.name
   master_password                 = "mustbeeightcharacters"
   master_username                 = "foo"
   skip_final_snapshot             = true
@@ -61,7 +61,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "a" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.0.0/24"
   availability_zone = "us-west-2a"
 
@@ -71,7 +71,7 @@ resource "aws_subnet" "a" {
 }
 
 resource "aws_subnet" "b" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2b"
 
@@ -82,11 +82,11 @@ resource "aws_subnet" "b" {
 
 resource "aws_db_subnet_group" "test" {
   name       = "%s"
-  subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
+  subnet_ids = [aws_subnet.a.id, aws_subnet.b.id]
 }
 
 data "aws_rds_cluster" "test" {
-  cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
+  cluster_identifier = aws_rds_cluster.test.cluster_identifier
 }
 `, clusterName, clusterName)
 }

--- a/aws/data_source_aws_redshift_cluster_test.go
+++ b/aws/data_source_aws_redshift_cluster_test.go
@@ -92,7 +92,7 @@ resource "aws_redshift_cluster" "test" {
 }
 
 data "aws_redshift_cluster" "test" {
-  cluster_identifier = "${aws_redshift_cluster.test.cluster_identifier}"
+  cluster_identifier = aws_redshift_cluster.test.cluster_identifier
 }
 `, rInt)
 }
@@ -106,23 +106,23 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
 }
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2b"
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
 }
 
 resource "aws_redshift_subnet_group" "test" {
   name       = "tf-redshift-subnet-group-%d"
-  subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  subnet_ids = [aws_subnet.foo.id, aws_subnet.bar.id]
 }
 
 resource "aws_security_group" "test" {
   name   = "tf-redshift-sg-%d"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_redshift_cluster" "test" {
@@ -135,13 +135,13 @@ resource "aws_redshift_cluster" "test" {
   cluster_type              = "multi-node"
   number_of_nodes           = 2
   publicly_accessible       = false
-  cluster_subnet_group_name = "${aws_redshift_subnet_group.test.name}"
-  vpc_security_group_ids    = ["${aws_security_group.test.id}"]
+  cluster_subnet_group_name = aws_redshift_subnet_group.test.name
+  vpc_security_group_ids    = [aws_security_group.test.id]
   skip_final_snapshot       = true
 }
 
 data "aws_redshift_cluster" "test" {
-  cluster_identifier = "${aws_redshift_cluster.test.cluster_identifier}"
+  cluster_identifier = aws_redshift_cluster.test.cluster_identifier
 }
 `, rInt, rInt, rInt)
 }
@@ -161,25 +161,25 @@ data "aws_iam_policy_document" "test" {
     resources = ["${aws_s3_bucket.test.arn}/*"]
 
     principals {
-      identifiers = ["${data.aws_redshift_service_account.test.arn}"]
+      identifiers = [data.aws_redshift_service_account.test.arn]
       type        = "AWS"
     }
   }
 
   statement {
     actions   = ["s3:GetBucketAcl"]
-    resources = ["${aws_s3_bucket.test.arn}"]
+    resources = [aws_s3_bucket.test.arn]
 
     principals {
-      identifiers = ["${data.aws_redshift_service_account.test.arn}"]
+      identifiers = [data.aws_redshift_service_account.test.arn]
       type        = "AWS"
     }
   }
 }
 
 resource "aws_s3_bucket_policy" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
-  policy = "${data.aws_iam_policy_document.test.json}"
+  bucket = aws_s3_bucket.test.bucket
+  policy = data.aws_iam_policy_document.test.json
 }
 
 resource "aws_redshift_cluster" "test" {
@@ -194,14 +194,14 @@ resource "aws_redshift_cluster" "test" {
   skip_final_snapshot = true
 
   logging {
-    bucket_name   = "${aws_s3_bucket.test.id}"
+    bucket_name   = aws_s3_bucket.test.id
     enable        = true
     s3_key_prefix = "cluster-logging/"
   }
 }
 
 data "aws_redshift_cluster" "test" {
-  cluster_identifier = "${aws_redshift_cluster.test.cluster_identifier}"
+  cluster_identifier = aws_redshift_cluster.test.cluster_identifier
 }
 `, rInt)
 }

--- a/aws/data_source_aws_redshift_service_account_test.go
+++ b/aws/data_source_aws_redshift_service_account_test.go
@@ -47,13 +47,13 @@ func TestAccAWSRedshiftServiceAccount_Region(t *testing.T) {
 }
 
 const testAccCheckAwsRedshiftServiceAccountConfig = `
-data "aws_redshift_service_account" "main" { }
+data "aws_redshift_service_account" "main" {}
 `
 
 const testAccCheckAwsRedshiftServiceAccountExplicitRegionConfig = `
 data "aws_region" "current" {}
 
 data "aws_redshift_service_account" "regional" {
-	region = data.aws_region.current.name
+  region = data.aws_region.current.name
 }
 `

--- a/aws/data_source_aws_regions_test.go
+++ b/aws/data_source_aws_regions_test.go
@@ -100,7 +100,7 @@ data "aws_regions" "empty" {}
 func testAccDataSourceAwsRegionsConfig_allRegions() string {
 	return `
 data "aws_regions" "all_regions" {
-	all_regions = "true"
+  all_regions = "true"
 }
 `
 }
@@ -108,10 +108,10 @@ data "aws_regions" "all_regions" {
 func testAccDataSourceAwsRegionsConfig_allRegionsFiltered(filter string) string {
 	return fmt.Sprintf(`
 data "aws_regions" "opt_in_status" {
-	filter {
-       name   = "opt-in-status"
-       values = ["%s"]
-    }
+  filter {
+    name   = "opt-in-status"
+    values = ["%s"]
+  }
 }
 `, filter)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8950

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing:

(Note that `TestAccDataSourceAWSLambdaFunction_vpc` failed on TC, re-ran locally and it passed.)
```
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (9.35s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (26.39s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (26.71s)
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (27.65s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (29.03s)
--- PASS: TestAccDataSourceAwsNetworkAcls_VpcID (31.90s)
--- PASS: TestAccDataSourceAwsNetworkInterface_filters (32.51s)
--- PASS: TestAccDataSourceAwsNetworkAcls_Filter (33.99s)
--- PASS: TestAccDataSourceAwsNetworkInterface_basic (34.55s)
--- PASS: TestAccDataSourceAwsNetworkAcls_Tags (35.78s)
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Filter (32.27s)
--- PASS: TestAccAWSPartition_basic (19.25s)
--- PASS: TestAccDataSourceAwsNetworkAcls_basic (47.57s)
--- PASS: TestAccDataSourceAwsPrefixList_basic (20.88s)
--- PASS: TestAccDataSourceAwsPrefixList_filter (20.32s)
--- PASS: TestAccDataSourceAWSLambdaFunction_layers (50.93s)
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (51.36s)
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Tags (26.90s)
--- PASS: TestAccDataSourceAwsPricingProduct_ec2 (24.80s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (56.90s)
--- PASS: TestAccDataSourceAwsPricingProduct_redshift (25.01s)
--- PASS: TestAccDataSourceAwsRamResourceShare_Tags (23.26s)
--- PASS: TestAccAWSRedshiftServiceAccount_basic (13.30s)
--- PASS: TestAccDataSourceAWSLambdaFunction_environment (63.26s)
--- PASS: TestAccAWSRedshiftServiceAccount_Region (13.04s)
--- PASS: TestAccDataSourceAwsRegions_basic (12.90s)
--- PASS: TestAccDataSourceAwsRegions_Filter (12.22s)
--- PASS: TestAccDataSourceAWSLambdaFunction_alias (65.60s)
--- PASS: TestAccDataSourceAwsRegions_AllRegions (10.15s)
--- PASS: TestAccDataSourceAWSLambdaFunction_version (71.14s)
--- PASS: TestAccDataSourceAwsRamResourceShare_basic (38.99s)
--- PASS: TestAccDataSourceAwsQLDBLedger_basic (55.82s)
--- PASS: TestAccDataSourceAwsNatGateway_basic (201.02s)
--- PASS: TestAccDataSourceAWSRDSCluster_basic (180.35s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_basic (365.11s)
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (414.08s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_logging (421.25s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_vpc (521.89s)
--- PASS: TestAccDataSourceAWSLambdaFunction_fileSystemConfig (654.90s)
```
