### PR TITLE
service/s3: Passthrough provider s3_force_path_style configuration for s3manager.GetBucketRegion calls

### DIFF
--- a/aws/data_source_aws_s3_bucket.go
+++ b/aws/data_source_aws_s3_bucket.go
@@ -95,7 +95,11 @@ func dataSourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 
 func bucketLocation(client *AWSClient, d *schema.ResourceData, bucket string) error {
 	region, err := s3manager.GetBucketRegionWithClient(context.Background(), client.s3conn, bucket, func(r *request.Request) {
-		r.Config.S3ForcePathStyle = aws.Bool(false)
+		// By default, GetBucketRegion forces virtual host addressing, which
+		// is not compatible with many non-AWS implementations. Instead, pass
+		// the provider s3_force_path_style configuration, which defaults to
+		// false, but allows override.
+		r.Config.S3ForcePathStyle = client.s3conn.Config.S3ForcePathStyle
 	})
 	if err != nil {
 		return err

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1276,7 +1276,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	// Add the region as an attribute
 	discoveredRegion, err := retryOnAwsCode("NotFound", func() (interface{}, error) {
 		return s3manager.GetBucketRegionWithClient(context.Background(), s3conn, d.Id(), func(r *request.Request) {
-			r.Config.S3ForcePathStyle = aws.Bool(false)
+			// By default, GetBucketRegion forces virtual host addressing, which
+			// is not compatible with many non-AWS implementations. Instead, pass
+			// the provider s3_force_path_style configuration, which defaults to
+			// false, but allows override.
+			r.Config.S3ForcePathStyle = s3conn.Config.S3ForcePathStyle
 		})
 	})
 	if err != nil {

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -130,7 +130,11 @@ func testSweepS3Buckets(region string) error {
 
 func testS3BucketRegion(conn *s3.S3, bucket string) (string, error) {
 	region, err := s3manager.GetBucketRegionWithClient(context.Background(), conn, bucket, func(r *request.Request) {
-		r.Config.S3ForcePathStyle = aws.Bool(false)
+		// By default, GetBucketRegion forces virtual host addressing, which
+		// is not compatible with many non-AWS implementations. Instead, pass
+		// the provider s3_force_path_style configuration, which defaults to
+		// false, but allows override.
+		r.Config.S3ForcePathStyle = conn.Config.S3ForcePathStyle
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14427

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_s3_bucket: Ensure provider `s3_force_path_style` configuration is passed through for getting S3 Bucket location with non-AWS implementations
* resource/aws_s3_bucket: Ensure provider `s3_force_path_style` configuration is passed through for getting S3 Bucket location with non-AWS implementations
```

Previously on or after 3.0.0:

```terraform
terraform {
  required_providers {
    aws = "3.0.0"
  }

  required_version = "0.12.29"
}

provider "aws" {
  region = "eu-west-1"

  access_key = "fakeKey"
  secret_key = "fakeKey"

  s3_force_path_style         = true
  skip_credentials_validation = true
  skip_metadata_api_check     = true
  skip_requesting_account_id  = true

  endpoints {
    s3 = "http://localhost:9090"
  }
}

resource "aws_s3_bucket" "test" {
  bucket = "test-bucket"
}
```

```console
$ docker run -p 9090:9090 -t adobe/s3mock
$ terraform apply
...
aws_s3_bucket.test: Creating...
aws_s3_bucket.test: Still creating... [10s elapsed]
aws_s3_bucket.test: Still creating... [20s elapsed]

Error: error getting S3 Bucket location: RequestError: send request failed
caused by: dial tcp: lookup test-bucket.localhost on 192.168.1.1:53: no such host

  on main.tf line 25, in resource "aws_s3_bucket" "test":
  25: resource "aws_s3_bucket" "test" {
```

Now:

```console
$ terraform apply
...
aws_s3_bucket.test: Creating...
aws_s3_bucket.test: Creation complete after 0s [id=test-bucket]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSS3Bucket_acceleration (53.30s)
--- PASS: TestAccAWSS3Bucket_AclToGrant (51.07s)
--- PASS: TestAccAWSS3Bucket_basic (31.56s)
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (31.65s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (25.97s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (33.67s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (55.10s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (56.01s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (31.69s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (38.29s)
--- PASS: TestAccAWSS3Bucket_forceDestroy (32.49s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithEmptyPrefixes (29.00s)
--- PASS: TestAccAWSS3Bucket_forceDestroyWithObjectLockEnabled (31.61s)
--- PASS: TestAccAWSS3Bucket_generatedName (30.69s)
--- PASS: TestAccAWSS3Bucket_GrantToAcl (48.35s)
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (79.24s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (52.70s)
--- PASS: TestAccAWSS3Bucket_LifecycleRule_Expiration_EmptyConfigurationBlock (25.59s)
--- PASS: TestAccAWSS3Bucket_Logging (50.13s)
--- PASS: TestAccAWSS3Bucket_namePrefix (30.79s)
--- PASS: TestAccAWSS3Bucket_objectLock (54.26s)
--- PASS: TestAccAWSS3Bucket_Policy (73.69s)
--- PASS: TestAccAWSS3Bucket_Replication (111.61s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (66.43s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation (64.58s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (19.21s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (114.21s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (38.67s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (39.78s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (56.71s)
--- PASS: TestAccAWSS3Bucket_SameRegionReplicationSchemaV2 (51.20s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (12.38s)
--- PASS: TestAccAWSS3Bucket_tagsWithNoSystemTags (99.87s)
--- PASS: TestAccAWSS3Bucket_tagsWithSystemTags (148.81s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (50.58s)
--- PASS: TestAccAWSS3Bucket_UpdateGrant (80.43s)
--- PASS: TestAccAWSS3Bucket_Versioning (77.33s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (79.51s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (79.03s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (55.56s)

--- PASS: TestAccDataSourceS3Bucket_basic (28.96s)
--- PASS: TestAccDataSourceS3Bucket_website (29.28s)
```