### PR TITLE
Fix data source test configs (up to s3 bucket)

### DIFF
--- a/aws/data_source_aws_autoscaling_groups_test.go
+++ b/aws/data_source_aws_autoscaling_groups_test.go
@@ -243,7 +243,6 @@ resource "aws_autoscaling_group" "barbaz" {
 }
 
 data "aws_autoscaling_groups" "group_list" {
-
   filter {
     name   = "key"
     values = ["Foo"]

--- a/aws/data_source_aws_availability_zone_test.go
+++ b/aws/data_source_aws_availability_zone_test.go
@@ -133,7 +133,6 @@ data "aws_availability_zones" "test" {
 }
 
 data "aws_availability_zone" "test" {
-
   filter {
     name   = "zone-name"
     values = [data.aws_availability_zones.test.names[0]]

--- a/aws/data_source_aws_availability_zones_test.go
+++ b/aws/data_source_aws_availability_zones_test.go
@@ -310,7 +310,6 @@ data "aws_availability_zones" "test" {
 func testAccCheckAwsAvailabilityZonesConfigFilter() string {
 	return `
 data "aws_availability_zones" "test" {
-
   filter {
     name   = "state"
     values = ["available"]

--- a/aws/data_source_aws_ebs_snapshot_test.go
+++ b/aws/data_source_aws_ebs_snapshot_test.go
@@ -134,7 +134,6 @@ resource "aws_ebs_snapshot" "test" {
 }
 
 data "aws_ebs_snapshot" "test" {
-
   filter {
     name   = "snapshot-id"
     values = [aws_ebs_snapshot.test.id]

--- a/aws/data_source_aws_ebs_volumes_test.go
+++ b/aws/data_source_aws_ebs_volumes_test.go
@@ -37,7 +37,6 @@ func testAccDataSourceAwsEbsVolumeIDsConfigWithDataSource(rInt int) string {
 %s
 
 data "aws_ebs_volumes" "subject_under_test" {
-
   tags = {
     TestIdentifierSet = "testAccDataSourceAwsEbsVolumes-%d"
   }

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -113,9 +113,11 @@ POLICY
     instance_type            = "t2.small.elasticsearch"
     instance_count           = 2
     dedicated_master_enabled = false
+
     zone_awareness_config {
       availability_zone_count = 2
     }
+
     zone_awareness_enabled = true
   }
 
@@ -238,9 +240,11 @@ POLICY
     instance_type            = "t2.small.elasticsearch"
     instance_count           = 2
     dedicated_master_enabled = false
+
     zone_awareness_config {
       availability_zone_count = 2
     }
+
     zone_awareness_enabled = true
   }
 

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -367,89 +367,89 @@ var testAccAWSIAMPolicyDocumentExpectedJSON = `{
 
 var testAccAWSIAMPolicyDocumentSourceConfig = `
 data "aws_iam_policy_document" "test" {
-    policy_id = "policy_id"
+  policy_id = "policy_id"
 
-    statement {
-        sid = "1"
-        actions = [
-            "s3:ListAllMyBuckets",
-            "s3:GetBucketLocation",
-        ]
-        resources = [
-            "arn:aws:s3:::*",
-        ]
+  statement {
+    sid = "1"
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::foo",
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        "home/",
+        "home/&{aws:username}/",
+      ]
     }
 
-    statement {
-        actions = [
-            "s3:ListBucket",
-        ]
-
-        resources = [
-            "arn:aws:s3:::foo",
-        ]
-
-        condition {
-            test = "StringLike"
-            variable = "s3:prefix"
-            values = [
-                "home/",
-                "home/&{aws:username}/",
-            ]
-        }
-
-        not_principals {
-            type = "AWS"
-            identifiers = ["arn:blahblah:example"]
-        }
+    not_principals {
+      type        = "AWS"
+      identifiers = ["arn:blahblah:example"]
     }
+  }
 
-    statement {
-        actions = [
-            "s3:*",
-        ]
+  statement {
+    actions = [
+      "s3:*",
+    ]
 
-        resources = [
-            "arn:aws:s3:::foo/home/&{aws:username}",
-            "arn:aws:s3:::foo/home/&{aws:username}/*",
-        ]
+    resources = [
+      "arn:aws:s3:::foo/home/&{aws:username}",
+      "arn:aws:s3:::foo/home/&{aws:username}/*",
+    ]
 
-        principals {
-            type = "AWS"
-            identifiers = [
-              "arn:blahblah:example",
-              "arn:blahblahblah:example",
-			      ]
-        }
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:blahblah:example",
+        "arn:blahblahblah:example",
+      ]
     }
+  }
 
-    statement {
-        effect = "Deny"
-        not_actions = ["s3:*"]
-        not_resources = ["arn:aws:s3:::*"]
+  statement {
+    effect        = "Deny"
+    not_actions   = ["s3:*"]
+    not_resources = ["arn:aws:s3:::*"]
+  }
+
+  # Normalization of wildcard principals
+
+  statement {
+    effect  = "Allow"
+    actions = ["kinesis:*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
     }
+  }
 
-    # Normalization of wildcard principals
+  statement {
+    effect  = "Allow"
+    actions = ["firehose:*"]
 
-    statement {
-        effect = "Allow"
-        actions = ["kinesis:*"]
-
-        principals {
-            type = "AWS"
-            identifiers = ["*"]
-        }
+    principals {
+      type        = "*"
+      identifiers = ["*"]
     }
-
-    statement {
-        effect = "Allow"
-        actions = ["firehose:*"]
-
-        principals {
-            type = "*"
-            identifiers = ["*"]
-        }
-    }
+  }
 }
 
 data "aws_iam_policy_document" "test_source" {
@@ -595,7 +595,6 @@ var testAccAWSIAMPolicyDocumentSourceConflictingExpectedJSON = `{
 
 var testAccAWSIAMPolicyDocumentOverrideConfig = `
 data "aws_iam_policy_document" "override" {
-
   statement {
     sid = "SidToOverwrite"
 
@@ -646,7 +645,7 @@ var testAccAWSIAMPolicyDocumentOverrideExpectedJSON = `{
 var testAccAWSIAMPolicyDocumentNoStatementMergeConfig = `
 data "aws_iam_policy_document" "source" {
   statement {
-    sid = ""
+    sid       = ""
     actions   = ["ec2:DescribeAccountAttributes"]
     resources = ["*"]
   }
@@ -654,14 +653,14 @@ data "aws_iam_policy_document" "source" {
 
 data "aws_iam_policy_document" "override" {
   statement {
-    sid = "OverridePlaceholder"
+    sid       = "OverridePlaceholder"
     actions   = ["s3:GetObject"]
     resources = ["*"]
   }
 }
 
 data "aws_iam_policy_document" "yak_politik" {
-  source_json = data.aws_iam_policy_document.source.json
+  source_json   = data.aws_iam_policy_document.source.json
   override_json = data.aws_iam_policy_document.override.json
 }
 `
@@ -687,7 +686,7 @@ var testAccAWSIAMPolicyDocumentNoStatementMergeExpectedJSON = `{
 var testAccAWSIAMPolicyDocumentNoStatementOverrideConfig = `
 data "aws_iam_policy_document" "source" {
   statement {
-    sid = "OverridePlaceholder"
+    sid       = "OverridePlaceholder"
     actions   = ["ec2:DescribeAccountAttributes"]
     resources = ["*"]
   }
@@ -695,14 +694,14 @@ data "aws_iam_policy_document" "source" {
 
 data "aws_iam_policy_document" "override" {
   statement {
-    sid = "OverridePlaceholder"
+    sid       = "OverridePlaceholder"
     actions   = ["s3:GetObject"]
     resources = ["*"]
   }
 }
 
 data "aws_iam_policy_document" "yak_politik" {
-  source_json = data.aws_iam_policy_document.source.json
+  source_json   = data.aws_iam_policy_document.source.json
   override_json = data.aws_iam_policy_document.override.json
 }
 `
@@ -722,16 +721,16 @@ var testAccAWSIAMPolicyDocumentNoStatementOverrideExpectedJSON = `{
 var testAccAWSIAMPolicyDocumentDuplicateSidConfig = `
 data "aws_iam_policy_document" "test" {
   statement {
-    sid    = "1"
-    effect = "Allow"
-    actions = ["ec2:DescribeAccountAttributes"]
+    sid       = "1"
+    effect    = "Allow"
+    actions   = ["ec2:DescribeAccountAttributes"]
     resources = ["*"]
   }
 
   statement {
-    sid    = "1"
-    effect = "Allow"
-    actions = ["s3:GetObject"]
+    sid       = "1"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
     resources = ["*"]
   }
 }
@@ -777,7 +776,7 @@ const testAccAWSIAMPolicyDocumentDataSourceConfigVersion20081017 = `
 data "aws_iam_policy_document" "test" {
   version = "2008-10-17"
 
-   statement {
+  statement {
     actions   = ["ec2:*"]
     resources = ["*"]
   }
@@ -800,12 +799,12 @@ const testAccAWSIAMPolicyDocumentDataSourceConfigVersion20081017ConversionCondit
 data "aws_iam_policy_document" "test" {
   version = "2008-10-17"
 
-   statement {
+  statement {
     actions   = ["*"]
     resources = ["*"]
 
     condition {
-      test   = "StringLike"
+      test = "StringLike"
       values = [
         "home/",
         "home/&{aws:username}/",

--- a/aws/data_source_aws_kms_key_test.go
+++ b/aws/data_source_aws_kms_key_test.go
@@ -57,7 +57,7 @@ resource "aws_kms_key" "test" {
 }
 
 data "aws_kms_key" "test" {
-  key_id = "${aws_kms_key.test.key_id}"
+  key_id = aws_kms_key.test.key_id
 }
 `, rName)
 }

--- a/aws/data_source_aws_route53_delegation_set_test.go
+++ b/aws/data_source_aws_route53_delegation_set_test.go
@@ -40,10 +40,10 @@ resource "aws_route53_delegation_set" "dset" {
 
 resource "aws_route53_zone" "primary" {
   name              = "example.xyz"
-  delegation_set_id = "${aws_route53_delegation_set.dset.id}"
+  delegation_set_id = aws_route53_delegation_set.dset.id
 }
 
 data "aws_route53_delegation_set" "dset" {
-  id = "${aws_route53_delegation_set.dset.id}"
+  id = aws_route53_delegation_set.dset.id
 }
 `

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -173,16 +173,16 @@ resource "aws_route53_resolver_rule" "example" {
 }
 
 data "aws_route53_resolver_rule" "by_resolver_rule_id" {
-  resolver_rule_id = "${aws_route53_resolver_rule.example.id}"
+  resolver_rule_id = aws_route53_resolver_rule.example.id
 }
 
 data "aws_route53_resolver_rule" "by_domain_name" {
-  domain_name = "${aws_route53_resolver_rule.example.domain_name}"
+  domain_name = aws_route53_resolver_rule.example.domain_name
 }
 
 data "aws_route53_resolver_rule" "by_name_and_rule_type" {
-  name      = "${aws_route53_resolver_rule.example.name}"
-  rule_type = "${aws_route53_resolver_rule.example.rule_type}"
+  name      = aws_route53_resolver_rule.example.name
+  rule_type = aws_route53_resolver_rule.example.rule_type
 }
 `, rName)
 }
@@ -194,7 +194,7 @@ resource "aws_route53_resolver_rule" "example" {
   rule_type   = "FORWARD"
   name        = %[1]q
 
-  resolver_endpoint_id = "${aws_route53_resolver_endpoint.bar.id}"
+  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -207,7 +207,7 @@ resource "aws_route53_resolver_rule" "example" {
 }
 
 data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
-  resolver_endpoint_id = "${aws_route53_resolver_rule.example.resolver_endpoint_id}"
+  resolver_endpoint_id = aws_route53_resolver_rule.example.resolver_endpoint_id
 }
 `, rName)
 }
@@ -219,7 +219,7 @@ resource "aws_route53_resolver_rule" "example" {
   rule_type   = "FORWARD"
   name        = %[1]q
 
-  resolver_endpoint_id = "${aws_route53_resolver_endpoint.bar.id}"
+  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -237,19 +237,19 @@ resource "aws_ram_resource_share" "test" {
 }
 
 resource "aws_ram_resource_association" "test" {
-  resource_arn       = "${aws_route53_resolver_rule.example.arn}"
-  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+  resource_arn       = aws_route53_resolver_rule.example.arn
+  resource_share_arn = aws_ram_resource_share.test.arn
 }
 
 data "aws_organizations_organization" "test" {}
 
 resource "aws_ram_principal_association" "test" {
-  principal          = "${data.aws_organizations_organization.test.arn}"
-  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+  principal          = data.aws_organizations_organization.test.arn
+  resource_share_arn = aws_ram_resource_share.test.arn
 }
 
 data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
-  resolver_endpoint_id = "${aws_route53_resolver_rule.example.resolver_endpoint_id}"
+  resolver_endpoint_id = aws_route53_resolver_rule.example.resolver_endpoint_id
 
   depends_on = ["aws_ram_resource_association.test", "aws_ram_principal_association.test"]
 }
@@ -263,7 +263,7 @@ resource "aws_route53_resolver_rule" "example" {
   rule_type   = "FORWARD"
   name        = %[1]q
 
-  resolver_endpoint_id = "${aws_route53_resolver_endpoint.bar.id}"
+  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -281,21 +281,21 @@ resource "aws_ram_resource_share" "test" {
 }
 
 resource "aws_ram_resource_association" "test" {
-  resource_arn       = "${aws_route53_resolver_rule.example.arn}"
-  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+  resource_arn       = aws_route53_resolver_rule.example.arn
+  resource_share_arn = aws_ram_resource_share.test.arn
 }
 
 data "aws_organizations_organization" "test" {}
 
 resource "aws_ram_principal_association" "test" {
-  principal          = "${data.aws_organizations_organization.test.arn}"
-  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+  principal          = data.aws_organizations_organization.test.arn
+  resource_share_arn = aws_ram_resource_share.test.arn
 }
 
 data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
   provider = "awsalternate"
 
-  resolver_endpoint_id = "${aws_route53_resolver_rule.example.resolver_endpoint_id}"
+  resolver_endpoint_id = aws_route53_resolver_rule.example.resolver_endpoint_id
 
   depends_on = ["aws_ram_resource_association.test", "aws_ram_principal_association.test"]
 }

--- a/aws/data_source_aws_route53_resolver_rules_test.go
+++ b/aws/data_source_aws_route53_resolver_rules_test.go
@@ -66,7 +66,7 @@ resource "aws_route53_resolver_rule" "forward" {
   rule_type   = "FORWARD"
   name        = %[1]q
 
-  resolver_endpoint_id = "${aws_route53_resolver_endpoint.bar.id}"
+  resolver_endpoint_id = aws_route53_resolver_endpoint.bar.id
 
   target_ip {
     ip = "192.0.2.7"
@@ -80,15 +80,15 @@ resource "aws_route53_resolver_rule" "recursive" {
 }
 
 data "aws_route53_resolver_rules" "by_resolver_endpoint_id" {
-  owner_id             = "${aws_route53_resolver_rule.forward.owner_id}"
-  resolver_endpoint_id = "${aws_route53_resolver_rule.forward.resolver_endpoint_id}"
+  owner_id             = aws_route53_resolver_rule.forward.owner_id
+  resolver_endpoint_id = aws_route53_resolver_rule.forward.resolver_endpoint_id
 }
 
 data "aws_route53_resolver_rules" "by_resolver_endpoint_id_rule_type_share_status" {
-  owner_id             = "${aws_route53_resolver_rule.recursive.owner_id}"
-  resolver_endpoint_id = "${aws_route53_resolver_rule.recursive.resolver_endpoint_id}"
-  rule_type            = "${aws_route53_resolver_rule.recursive.rule_type}"
-  share_status         = "${aws_route53_resolver_rule.recursive.share_status}"
+  owner_id             = aws_route53_resolver_rule.recursive.owner_id
+  resolver_endpoint_id = aws_route53_resolver_rule.recursive.resolver_endpoint_id
+  rule_type            = aws_route53_resolver_rule.recursive.rule_type
+  share_status         = aws_route53_resolver_rule.recursive.share_status
 }
 
 data "aws_route53_resolver_rules" "by_invalid_owner_id" {

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -129,7 +129,7 @@ resource "aws_route53_zone" "test" {
 }
 
 data "aws_route53_zone" "test" {
-  zone_id = "${aws_route53_zone.test.zone_id}"
+  zone_id = aws_route53_zone.test.zone_id
 }
 `, rInt)
 }
@@ -141,7 +141,7 @@ resource "aws_route53_zone" "test" {
 }
 
 data "aws_route53_zone" "test" {
-  name = "${aws_route53_zone.test.name}"
+  name = aws_route53_zone.test.name
 }
 `, rInt)
 }
@@ -158,20 +158,21 @@ resource "aws_vpc" "test" {
 
 resource "aws_route53_zone" "test" {
   name = "terraformtestacchz-%[1]d.com."
+
   vpc {
-    vpc_id = "${aws_vpc.test.id}"
+    vpc_id = aws_vpc.test.id
   }
 
   tags = {
-	Environment = "tf-acc-test-%[1]d"
-	Name        = "tf-acc-test-%[1]d"
+    Environment = "tf-acc-test-%[1]d"
+    Name        = "tf-acc-test-%[1]d"
   }
 }
 
 data "aws_route53_zone" "test" {
-  name         = "${aws_route53_zone.test.name}"
+  name         = aws_route53_zone.test.name
   private_zone = true
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id       = aws_vpc.test.id
 
   tags = {
     Environment = "tf-acc-test-%[1]d"
@@ -194,7 +195,7 @@ resource "aws_route53_zone" "test" {
   name = "test.acc-%[1]d."
 
   vpc {
-    vpc_id = "${aws_vpc.test.id}"
+    vpc_id = aws_vpc.test.id
   }
 
   tags = {
@@ -203,9 +204,9 @@ resource "aws_route53_zone" "test" {
 }
 
 data "aws_route53_zone" "test" {
-  name   = "${aws_route53_zone.test.name}"
+  name         = aws_route53_zone.test.name
   private_zone = true
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id       = aws_vpc.test.id
 }
 `, rInt)
 }
@@ -221,13 +222,13 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
-  name        = "test.acc-sd-%[1]d"
-  vpc         = "${aws_vpc.test.id}"
+  name = "test.acc-sd-%[1]d"
+  vpc  = aws_vpc.test.id
 }
 
 data "aws_route53_zone" "test" {
-  name   = "${aws_service_discovery_private_dns_namespace.test.name}"
-  vpc_id = "${aws_vpc.test.id}"
+  name   = aws_service_discovery_private_dns_namespace.test.name
+  vpc_id = aws_vpc.test.id
 }
 `, rInt)
 }

--- a/aws/data_source_aws_route_table_test.go
+++ b/aws/data_source_aws_route_table_test.go
@@ -169,26 +169,29 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   cidr_block = "172.16.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  vpc_id     = aws_vpc.test.id
+
   tags = {
     Name = "tf-acc-route-table-data-source"
   }
 }
 
 resource "aws_route_table" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
+
   tags = {
     Name = "terraform-testacc-routetable-data-source"
   }
 }
 
 resource "aws_route_table_association" "a" {
-  subnet_id      = "${aws_subnet.test.id}"
-  route_table_id = "${aws_route_table.test.id}"
+  subnet_id      = aws_subnet.test.id
+  route_table_id = aws_route_table.test.id
 }
 
 resource "aws_internet_gateway" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
+
   tags = {
     Name = "terraform-testacc-routetable-data-source"
   }
@@ -201,19 +204,21 @@ resource "aws_route_table_association" "b" {
 
 data "aws_route_table" "by_filter" {
   filter {
-    name = "association.route-table-association-id"
-    values = ["${aws_route_table_association.a.id}"]
+    name   = "association.route-table-association-id"
+    values = [aws_route_table_association.a.id]
   }
+
   depends_on = [
-	"aws_route_table_association.a",
-	"aws_route_table_association.b"
+    "aws_route_table_association.a",
+    "aws_route_table_association.b"
   ]
 }
 
 data "aws_route_table" "by_tag" {
   tags = {
-    Name = "${aws_route_table.test.tags["Name"]}"
+    Name = aws_route_table.test.tags["Name"]
   }
+
   depends_on = [
     "aws_route_table_association.a",
     "aws_route_table_association.b"
@@ -221,26 +226,26 @@ data "aws_route_table" "by_tag" {
 }
 
 data "aws_route_table" "by_subnet" {
-  subnet_id = "${aws_subnet.test.id}"
+  subnet_id = aws_subnet.test.id
   depends_on = [
-	"aws_route_table_association.a",
-	"aws_route_table_association.b"
+    "aws_route_table_association.a",
+    "aws_route_table_association.b"
   ]
 }
 
 data "aws_route_table" "by_gateway" {
-  gateway_id = "${aws_internet_gateway.test.id}"
+  gateway_id = aws_internet_gateway.test.id
   depends_on = [
-	  "aws_route_table_association.a",
-	  "aws_route_table_association.b"
+    "aws_route_table_association.a",
+    "aws_route_table_association.b"
   ]
 }
-  
+
 data "aws_route_table" "by_id" {
-  route_table_id = "${aws_route_table.test.id}"
+  route_table_id = aws_route_table.test.id
   depends_on = [
-	"aws_route_table_association.a",
-	"aws_route_table_association.b"
+    "aws_route_table_association.a",
+    "aws_route_table_association.b"
   ]
 }
 `
@@ -256,12 +261,13 @@ resource "aws_vpc" "test" {
 
 data "aws_route_table" "by_filter" {
   filter {
-    name = "association.main"
+    name   = "association.main"
     values = ["true"]
   }
+
   filter {
-    name = "vpc-id"
-    values = ["${aws_vpc.test.id}"]
+    name   = "vpc-id"
+    values = [aws_vpc.test.id]
   }
 }
 `

--- a/aws/data_source_aws_route_tables_test.go
+++ b/aws/data_source_aws_route_tables_test.go
@@ -50,7 +50,7 @@ resource "aws_vpc" "test2" {
 }
 
 resource "aws_route_table" "test_public_a" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name      = "tf-acc-route-tables-data-source-public-a"
@@ -60,7 +60,7 @@ resource "aws_route_table" "test_public_a" {
 }
 
 resource "aws_route_table" "test_private_a" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name      = "tf-acc-route-tables-data-source-private-a"
@@ -70,7 +70,7 @@ resource "aws_route_table" "test_private_a" {
 }
 
 resource "aws_route_table" "test_private_b" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name      = "tf-acc-route-tables-data-source-private-b"
@@ -80,7 +80,7 @@ resource "aws_route_table" "test_private_b" {
 }
 
 resource "aws_route_table" "test_private_c" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name      = "tf-acc-route-tables-data-source-private-c"
@@ -90,15 +90,15 @@ resource "aws_route_table" "test_private_c" {
 }
 
 data "aws_route_tables" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 
 data "aws_route_tables" "test2" {
-  vpc_id = "${aws_vpc.test2.id}"
+  vpc_id = aws_vpc.test2.id
 }
 
 data "aws_route_tables" "private" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Tier = "Private"
@@ -106,7 +106,7 @@ data "aws_route_tables" "private" {
 }
 
 data "aws_route_tables" "filter_test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   filter {
     name   = "tag:Component"
@@ -127,7 +127,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_route_table" "test_public_a" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name      = "tf-acc-route-tables-data-source-public-a"
@@ -137,7 +137,7 @@ resource "aws_route_table" "test_public_a" {
 }
 
 resource "aws_route_table" "test_private_a" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name      = "tf-acc-route-tables-data-source-private-a"
@@ -147,7 +147,7 @@ resource "aws_route_table" "test_private_a" {
 }
 
 resource "aws_route_table" "test_private_b" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name      = "tf-acc-route-tables-data-source-private-b"
@@ -157,7 +157,7 @@ resource "aws_route_table" "test_private_b" {
 }
 
 resource "aws_route_table" "test_private_c" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name      = "tf-acc-route-tables-data-source-private-c"

--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -155,6 +155,7 @@ resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = "10.0.1.0/24"
   instance_id            = aws_instance.web.id
+
   timeouts {
     create = "5m"
   }

--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -161,7 +161,7 @@ func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
 					testAccCheckAwsS3ObjectDataSourceExists(dataSourceName, &dsObj),
-					resource.TestCheckResourceAttr(dataSourceName, "content_length", "21"),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "25"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
 					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
@@ -437,7 +437,7 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket       = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket       = aws_s3_bucket.object_bucket.bucket
   key          = "tf-testing-obj-%[1]d-readable"
   content      = "yes"
   content_type = "text/plain"
@@ -480,22 +480,27 @@ func testAccAWSDataSourceS3ObjectConfig_allParams(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%[1]d"
+
   versioning {
     enabled = true
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket              = "${aws_s3_bucket.object_bucket.bucket}"
-  key                 = "tf-testing-obj-%[1]d-all-params"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "tf-testing-obj-%[1]d-all-params"
+
   content             = <<CONTENT
-{"msg": "Hi there!"}
+{
+  "msg": "Hi there!"
+}
 CONTENT
   content_type        = "application/unknown"
   cache_control       = "no-cache"
   content_disposition = "attachment"
   content_encoding    = "identity"
   content_language    = "en-GB"
+
   tags = {
     Key1 = "Value 1"
   }
@@ -523,7 +528,7 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket                        = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket                        = aws_s3_bucket.object_bucket.bucket
   key                           = "tf-testing-obj-%[1]d"
   content                       = "Hello World"
   object_lock_legal_hold_status = "OFF"
@@ -551,7 +556,7 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket                        = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket                        = aws_s3_bucket.object_bucket.bucket
   key                           = "tf-testing-obj-%[1]d"
   content                       = "Hello World"
   force_destroy                 = true
@@ -610,7 +615,7 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object1" {
-  bucket       = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket       = aws_s3_bucket.object_bucket.bucket
   key          = "first//second///third//"
   content      = "yes"
   content_type = "text/plain"

--- a/aws/data_source_aws_s3_bucket_objects_test.go
+++ b/aws/data_source_aws_s3_bucket_objects_test.go
@@ -238,43 +238,43 @@ resource "aws_s3_bucket" "objects_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object1" {
-  bucket  = "${aws_s3_bucket.objects_bucket.id}"
+  bucket  = aws_s3_bucket.objects_bucket.id
   key     = "arch/three_gossips/turret"
   content = "Delicate"
 }
 
 resource "aws_s3_bucket_object" "object2" {
-  bucket  = "${aws_s3_bucket.objects_bucket.id}"
+  bucket  = aws_s3_bucket.objects_bucket.id
   key     = "arch/three_gossips/broken"
   content = "Dark Angel"
 }
 
 resource "aws_s3_bucket_object" "object3" {
-  bucket  = "${aws_s3_bucket.objects_bucket.id}"
+  bucket  = aws_s3_bucket.objects_bucket.id
   key     = "arch/navajo/north_window"
   content = "Balanced Rock"
 }
 
 resource "aws_s3_bucket_object" "object4" {
-  bucket  = "${aws_s3_bucket.objects_bucket.id}"
+  bucket  = aws_s3_bucket.objects_bucket.id
   key     = "arch/navajo/sand_dune"
   content = "Queen Victoria Rock"
 }
 
 resource "aws_s3_bucket_object" "object5" {
-  bucket  = "${aws_s3_bucket.objects_bucket.id}"
+  bucket  = aws_s3_bucket.objects_bucket.id
   key     = "arch/partition/park_avenue"
   content = "Double-O"
 }
 
 resource "aws_s3_bucket_object" "object6" {
-  bucket  = "${aws_s3_bucket.objects_bucket.id}"
+  bucket  = aws_s3_bucket.objects_bucket.id
   key     = "arch/courthouse_towers/landscape"
   content = "Fiery Furnace"
 }
 
 resource "aws_s3_bucket_object" "object7" {
-  bucket  = "${aws_s3_bucket.objects_bucket.id}"
+  bucket  = aws_s3_bucket.objects_bucket.id
   key     = "arch/rubicon"
   content = "Devils Garden"
 }
@@ -284,7 +284,7 @@ resource "aws_s3_bucket_object" "object7" {
 func testAccAWSDataSourceS3ObjectsConfigResourcesPlusAccessPoint(randInt int) string {
 	return testAccAWSDataSourceS3ObjectsConfigResources(randInt) + fmt.Sprintf(`
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.objects_bucket.bucket}"
+  bucket = aws_s3_bucket.objects_bucket.bucket
   name   = "tf-objects-test-access-point-%[1]d"
 }
 `, randInt)
@@ -295,7 +295,7 @@ func testAccAWSDataSourceS3ObjectsConfigBasic(randInt int) string {
 %s
 
 data "aws_s3_bucket_objects" "yesh" {
-  bucket    = "${aws_s3_bucket.objects_bucket.id}"
+  bucket    = aws_s3_bucket.objects_bucket.id
   prefix    = "arch/navajo/"
   delimiter = "/"
 }
@@ -305,7 +305,7 @@ data "aws_s3_bucket_objects" "yesh" {
 func testAccAWSDataSourceS3ObjectsConfigBasicViaAccessPoint(randInt int) string {
 	return testAccAWSDataSourceS3ObjectsConfigResourcesPlusAccessPoint(randInt) + `
 data "aws_s3_bucket_objects" "yesh" {
-  bucket    = "${aws_s3_access_point.test.arn}"
+  bucket    = aws_s3_access_point.test.arn
   prefix    = "arch/navajo/"
   delimiter = "/"
 }
@@ -317,7 +317,7 @@ func testAccAWSDataSourceS3ObjectsConfigAll(randInt int) string {
 %s
 
 data "aws_s3_bucket_objects" "yesh" {
-  bucket    = "${aws_s3_bucket.objects_bucket.id}"
+  bucket = aws_s3_bucket.objects_bucket.id
 }
 `, testAccAWSDataSourceS3ObjectsConfigResources(randInt))
 }
@@ -327,7 +327,7 @@ func testAccAWSDataSourceS3ObjectsConfigPrefixes(randInt int) string {
 %s
 
 data "aws_s3_bucket_objects" "yesh" {
-  bucket    = "${aws_s3_bucket.objects_bucket.id}"
+  bucket    = aws_s3_bucket.objects_bucket.id
   prefix    = "arch/"
   delimiter = "/"
 }
@@ -339,7 +339,7 @@ func testAccAWSDataSourceS3ObjectsConfigExtraResource(randInt int) string {
 %s
 
 resource "aws_s3_bucket_object" "object8" {
-  bucket  = "${aws_s3_bucket.objects_bucket.id}"
+  bucket  = aws_s3_bucket.objects_bucket.id
   key     = "arch/ru b ic on"
   content = "Goose Island"
 }
@@ -351,7 +351,7 @@ func testAccAWSDataSourceS3ObjectsConfigEncoded(randInt int) string {
 %s
 
 data "aws_s3_bucket_objects" "yesh" {
-  bucket        = "${aws_s3_bucket.objects_bucket.id}"
+  bucket        = aws_s3_bucket.objects_bucket.id
   encoding_type = "url"
   prefix        = "arch/ru"
 }
@@ -363,7 +363,7 @@ func testAccAWSDataSourceS3ObjectsConfigMaxKeys(randInt int) string {
 %s
 
 data "aws_s3_bucket_objects" "yesh" {
-  bucket   = "${aws_s3_bucket.objects_bucket.id}"
+  bucket   = aws_s3_bucket.objects_bucket.id
   max_keys = 2
 }
 `, testAccAWSDataSourceS3ObjectsConfigResources(randInt))
@@ -374,7 +374,7 @@ func testAccAWSDataSourceS3ObjectsConfigStartAfter(randInt int) string {
 %s
 
 data "aws_s3_bucket_objects" "yesh" {
-  bucket      = "${aws_s3_bucket.objects_bucket.id}"
+  bucket      = aws_s3_bucket.objects_bucket.id
   start_after = "arch/three_gossips/broken"
 }
 `, testAccAWSDataSourceS3ObjectsConfigResources(randInt))
@@ -385,7 +385,7 @@ func testAccAWSDataSourceS3ObjectsConfigOwners(randInt int) string {
 %s
 
 data "aws_s3_bucket_objects" "yesh" {
-  bucket      = "${aws_s3_bucket.objects_bucket.id}"
+  bucket      = aws_s3_bucket.objects_bucket.id
   prefix      = "arch/three_gossips/"
   fetch_owner = true
 }

--- a/aws/data_source_aws_s3_bucket_test.go
+++ b/aws/data_source_aws_s3_bucket_test.go
@@ -60,7 +60,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 data "aws_s3_bucket" "bucket" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 }
 `, bucketName)
 }
@@ -78,7 +78,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 data "aws_s3_bucket" "bucket" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 }
 `, bucketName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8950

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

The output from acceptance testing:

(Note that initially `TestAccDataSourceAwsRouteTable_basic` and `TestAccDataSourceAWSS3BucketObject_allParams` did not pass on TC. A minor fix was needed for one. They both passed on local re-run.)

```
--- PASS: TestAvailabilityZonesSort (0.40s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basic (12.02s)
--- PASS: TestAccDataSourceAWSS3BucketObject_kmsEncrypted (12.35s)
--- PASS: TestAccDataSourceAWSS3BucketObject_readableBody (12.51s)
--- PASS: TestAccDataSourceAWSS3BucketObject_basicViaAccessPoint (13.99s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOff (14.23s)
--- PASS: TestAccDataSourceS3Bucket_website (15.18s)
--- PASS: TestAccDataSourceS3Bucket_basic (15.18s)
--- PASS: TestAccDataSourceAWSS3BucketObject_ObjectLockLegalHoldOn (15.75s)
--- PASS: TestAccDataSourceAwsRouteTables_basic (20.84s)
--- PASS: TestAccDataSourceAWSS3BucketObjects_fetchOwner (20.87s)
--- PASS: TestAccDataSourceAWSS3BucketObjects_startAfter (20.88s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (21.41s)
--- PASS: TestAccDataSourceAWSS3BucketObjects_maxKeys (22.03s)
--- PASS: TestAccDataSourceAWSS3BucketObject_MultipleSlashes (22.19s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipals (22.28s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice (22.50s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (22.56s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (22.60s)
--- PASS: TestAccDataSourceAWSS3BucketObjects_basicViaAccessPoint (22.62s)
--- PASS: TestAccDataSourceAWSS3BucketObjects_basic (23.00s)
--- PASS: TestAccDataSourceAWSS3BucketObjects_all (23.72s)
--- PASS: TestAccDataSourceAwsKmsKey_basic (23.82s)
--- PASS: TestAccDataSourceAWSS3BucketObjects_encoded (24.10s)
--- PASS: TestAccDataSourceAWSS3BucketObject_LeadingSlash (24.77s)
--- PASS: TestAccDataSourceAWSS3BucketObjects_prefixes (24.99s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRules_basic (25.54s)
--- PASS: TestAccAWSAvailabilityZones_basic (25.93s)
--- PASS: TestAccDataSourceAwsAvailabilityZone_ZoneId (25.96s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (26.16s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (26.16s)
--- PASS: TestAccAWSAvailabilityZones_stateFilter (26.55s)
--- PASS: TestAccAWSAvailabilityZones_Filter (26.63s)
--- PASS: TestAccDataSourceAwsAvailabilityZone_AllAvailabilityZones (26.74s)
--- PASS: TestAccDataSourceAwsAvailabilityZone_Filter (26.80s)
--- PASS: TestAccAWSAvailabilityZones_ExcludeNames (27.41s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (27.52s)
--- PASS: TestAccAWSAvailabilityZones_AllAvailabilityZones (27.65s)
--- PASS: TestAccDataSourceAwsAvailabilityZone_Name (27.72s)
--- PASS: TestAccAWSAvailabilityZones_ExcludeZoneIds (28.36s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (35.76s)
--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (35.90s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (40.86s)
--- PASS: TestAccDataSourceAwsRouteTable_basic (40.86s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_basic (42.64s)
--- PASS: TestAccDataSourceAwsRouteTable_main (44.33s)
--- PASS: TestAccAWSEbsSnapshotDataSource_Filter (53.07s)
--- PASS: TestAccAWSEbsSnapshotDataSource_basic (53.25s)
--- PASS: TestAccDataSourceRoute53DelegationSet_basic (60.47s)
--- PASS: TestAccDataSourceAwsEbsVolumes_basic (60.65s)
--- PASS: TestAccAWSAutoscalingGroups_basic (71.21s)
--- PASS: TestAccDataSourceAwsRoute53Zone_id (73.08s)
--- PASS: TestAccDataSourceAwsRoute53Zone_name (83.81s)
--- PASS: TestAccAWSRouteDataSource_basic (103.02s)
--- PASS: TestAccAWSEbsSnapshotDataSource_MostRecent (107.47s)
--- PASS: TestAccDataSourceAwsRoute53Zone_vpc (108.23s)
--- PASS: TestAccDataSourceAwsRoute53Zone_tags (110.09s)
--- PASS: TestAccDataSourceAwsRoute53Zone_serviceDiscovery (111.48s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId (212.42s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe (228.46s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_SharedByMe (232.14s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags (234.37s)
--- PASS: TestAccAWSRouteDataSource_TransitGatewayID (336.83s)
--- PASS: TestAccAWSDataElasticsearchDomain_basic (1043.20s)
--- PASS: TestAccAWSDataElasticsearchDomain_advanced (1086.66s)
```
