### PR TITLE
Fix acc test configs (up to VPC endpoint)

### DIFF
--- a/aws/data_source_aws_secretsmanager_secret_rotation_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_rotation_test.go
@@ -47,15 +47,15 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s-1"
   handler       = "exports.example"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test" {
-  action         = "lambda:InvokeFunction"
-  function_name  = "${aws_lambda_function.test.function_name}"
-  principal      = "secretsmanager.amazonaws.com"
-  statement_id   = "AllowExecutionFromSecretsManager"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager"
 }
 
 resource "aws_secretsmanager_secret" "test" {
@@ -63,16 +63,16 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_rotation" "test" {
-	secret_id 					= "${aws_secretsmanager_secret.test.id}"
-	rotation_lambda_arn = "${aws_lambda_function.test.arn}"
+  secret_id           = aws_secretsmanager_secret.test.id
+  rotation_lambda_arn = aws_lambda_function.test.arn
 
-	rotation_rules {
+  rotation_rules {
     automatically_after_days = %[2]d
-	}
+  }
 }
 
 data "aws_secretsmanager_secret_rotation" "test" {
-  secret_id = "${aws_secretsmanager_secret_rotation.test.secret_id}"
+  secret_id = aws_secretsmanager_secret_rotation.test.secret_id
 }
 `, rName, automaticallyAfterDays)
 }

--- a/aws/data_source_aws_secretsmanager_secret_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_test.go
@@ -138,7 +138,7 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 data "aws_secretsmanager_secret" "test" {
-  arn = "${aws_secretsmanager_secret.test.arn}"
+  arn = aws_secretsmanager_secret.test.arn
 }
 `, rName)
 }
@@ -165,7 +165,7 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 data "aws_secretsmanager_secret" "test" {
-  name = "${aws_secretsmanager_secret.test.name}"
+  name = aws_secretsmanager_secret.test.name
 }
 `, rName)
 }
@@ -179,22 +179,22 @@ resource "aws_secretsmanager_secret" "test" {
 {
   "Version": "2012-10-17",
   "Statement": [
-	{
-	  "Sid": "EnableAllPermissions",
-	  "Effect": "Allow",
-	  "Principal": {
-		"AWS": "*"
-	  },
-	  "Action": "secretsmanager:GetSecretValue",
-	  "Resource": "*"
-	}
+    {
+      "Sid": "EnableAllPermissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "*"
+    }
   ]
 }
 POLICY
 }
 
 data "aws_secretsmanager_secret" "test" {
-  name = "${aws_secretsmanager_secret.test.name}"
+  name = aws_secretsmanager_secret.test.name
 }
 `, rName)
 }

--- a/aws/data_source_aws_secretsmanager_secret_version_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_version_test.go
@@ -116,13 +116,13 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.test.id}"
+  secret_id     = aws_secretsmanager_secret.test.id
   secret_string = "test-string"
 }
 
 data "aws_secretsmanager_secret_version" "test" {
-  secret_id  = "${aws_secretsmanager_secret.test.id}"
-  version_id = "${aws_secretsmanager_secret_version.test.version_id}"
+  secret_id  = aws_secretsmanager_secret.test.id
+  version_id = aws_secretsmanager_secret_version.test.version_id
 }
 `, rName)
 }
@@ -134,13 +134,13 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id      = "${aws_secretsmanager_secret.test.id}"
+  secret_id      = aws_secretsmanager_secret.test.id
   secret_string  = "test-string"
   version_stages = ["test-stage", "AWSCURRENT"]
 }
 
 data "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret_version.test.secret_id}"
+  secret_id     = aws_secretsmanager_secret_version.test.secret_id
   version_stage = "test-stage"
 }
 `, rName)
@@ -153,12 +153,12 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.test.id}"
+  secret_id     = aws_secretsmanager_secret.test.id
   secret_string = "test-string"
 }
 
 data "aws_secretsmanager_secret_version" "test" {
-  secret_id = "${aws_secretsmanager_secret_version.test.secret_id}"
+  secret_id = aws_secretsmanager_secret_version.test.secret_id
 }
 `, rName)
 }

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -113,7 +113,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
   name   = "test-%d"
 
   tags = {
@@ -125,28 +125,28 @@ resource "aws_security_group" "test" {
 }
 
 data "aws_security_group" "by_id" {
-  id = "${aws_security_group.test.id}"
+  id = aws_security_group.test.id
 }
 
 data "aws_security_group" "by_name" {
-  name = "${aws_security_group.test.name}"
+  name = aws_security_group.test.name
 }
 
 data "aws_security_group" "default_by_name" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
   name   = "default"
 }
 
 data "aws_security_group" "by_tag" {
   tags = {
-    Seed = "${aws_security_group.test.tags["Seed"]}"
+    Seed = aws_security_group.test.tags["Seed"]
   }
 }
 
 data "aws_security_group" "by_filter" {
   filter {
     name   = "group-name"
-    values = ["${aws_security_group.test.name}"]
+    values = [aws_security_group.test.name]
   }
 }
 `, rInt, rInt)

--- a/aws/data_source_aws_security_groups_test.go
+++ b/aws/data_source_aws_security_groups_test.go
@@ -54,7 +54,7 @@ resource "aws_vpc" "test_tag" {
 
 resource "aws_security_group" "test" {
   count  = 3
-  vpc_id = "${aws_vpc.test_tag.id}"
+  vpc_id = aws_vpc.test_tag.id
   name   = "tf-%[1]d-${count.index}"
 
   tags = {
@@ -64,7 +64,7 @@ resource "aws_security_group" "test" {
 
 data "aws_security_groups" "by_tag" {
   tags = {
-    Seed = "${aws_security_group.test.0.tags["Seed"]}"
+    Seed = aws_security_group.test.0.tags["Seed"]
   }
 }
 `, rInt)
@@ -82,7 +82,7 @@ resource "aws_vpc" "test_filter" {
 
 resource "aws_security_group" "test" {
   count  = 3
-  vpc_id = "${aws_vpc.test_filter.id}"
+  vpc_id = aws_vpc.test_filter.id
   name   = "tf-%[1]d-${count.index}"
 
   tags = {
@@ -93,7 +93,7 @@ resource "aws_security_group" "test" {
 data "aws_security_groups" "by_filter" {
   filter {
     name   = "vpc-id"
-    values = ["${aws_vpc.test_filter.id}"]
+    values = [aws_vpc.test_filter.id]
   }
 
   filter {

--- a/aws/data_source_aws_sfn_activity_test.go
+++ b/aws/data_source_aws_sfn_activity_test.go
@@ -42,8 +42,9 @@ func testAccCheckAWSStepFunctionsActivityDataSourceConfig_ActivityArn(rName stri
 resource aws_sfn_activity "test" {
   name = "%s"
 }
+
 data aws_sfn_activity "test" {
-  arn = "${aws_sfn_activity.test.id}"
+  arn = aws_sfn_activity.test.id
 }
 `, rName)
 }
@@ -53,8 +54,9 @@ func testAccCheckAWSStepFunctionsActivityDataSourceConfig_ActivityName(rName str
 resource aws_sfn_activity "test" {
   name = "%s"
 }
+
 data aws_sfn_activity "test" {
-  name = "${aws_sfn_activity.test.name}"
+  name = aws_sfn_activity.test.name
 }
 `, rName)
 }

--- a/aws/data_source_aws_sfn_state_machine_test.go
+++ b/aws/data_source_aws_sfn_state_machine_test.go
@@ -57,7 +57,7 @@ EOF
 
 resource "aws_sfn_state_machine" "test" {
   name     = "test_sfn_%s"
-  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+  role_arn = aws_iam_role.iam_for_sfn.arn
 
   definition = <<EOF
 {
@@ -72,7 +72,7 @@ EOF
 }
 
 data "aws_sfn_state_machine" "test" {
-  name = "${aws_sfn_state_machine.test.name}"
+  name = aws_sfn_state_machine.test.name
 }
 `, rName, rName)
 }

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -61,6 +61,6 @@ resource "aws_sns_topic" "tf_wrong2" {
 }
 
 data "aws_sns_topic" "by_name" {
-  name = "${aws_sns_topic.tf_test.name}"
+  name = aws_sns_topic.tf_test.name
 }
 `

--- a/aws/data_source_aws_sqs_queue_test.go
+++ b/aws/data_source_aws_sqs_queue_test.go
@@ -95,7 +95,7 @@ resource "aws_sqs_queue" "test" {
 }
 
 data "aws_sqs_queue" "by_name" {
-  name = "${aws_sqs_queue.test.name}"
+  name = aws_sqs_queue.test.name
 }
 `, rName)
 }
@@ -113,7 +113,7 @@ resource "aws_sqs_queue" "test" {
 }
 
 data "aws_sqs_queue" "by_name" {
-  name = "${aws_sqs_queue.test.name}"
+  name = aws_sqs_queue.test.name
 }
 `, rName)
 }

--- a/aws/data_source_aws_ssm_document_test.go
+++ b/aws/data_source_aws_ssm_document_test.go
@@ -49,28 +49,28 @@ resource "aws_ssm_document" "test" {
   document_type = "Command"
 
   content = <<DOC
-  {
-    "schemaVersion": "1.2",
-    "description": "Check ip configuration of a Linux instance.",
-    "parameters": {
-
-    },
-    "runtimeConfig": {
-      "aws:runShellScript": {
-        "properties": [
-          {
-            "id": "0.aws:runShellScript",
-            "runCommand": ["ifconfig"]
-          }
-        ]
-      }
+{
+  "schemaVersion": "1.2",
+  "description": "Check ip configuration of a Linux instance.",
+  "parameters": {},
+  "runtimeConfig": {
+    "aws:runShellScript": {
+      "properties": [
+        {
+          "id": "0.aws:runShellScript",
+          "runCommand": [
+            "ifconfig"
+          ]
+        }
+      ]
     }
   }
+}
 DOC
 }
 
 data "aws_ssm_document" "test" {
-  name            = "${aws_ssm_document.test.name}"
+  name            = aws_ssm_document.test.name
   document_format = "%s"
 }
 `, name, documentFormat)

--- a/aws/data_source_aws_ssm_parameter_test.go
+++ b/aws/data_source_aws_ssm_parameter_test.go
@@ -76,7 +76,7 @@ resource "aws_ssm_parameter" "test" {
 }
 
 data "aws_ssm_parameter" "test" {
-  name            = "${aws_ssm_parameter.test.name}"
+  name            = aws_ssm_parameter.test.name
   with_decryption = %s
 }
 `, name, withDecryption)

--- a/aws/data_source_aws_ssm_patch_baseline_test.go
+++ b/aws/data_source_aws_ssm_patch_baseline_test.go
@@ -51,9 +51,9 @@ func TestAccAWSSsmPatchBaselineDataSource_newBaseline(t *testing.T) {
 func testAccCheckAwsSsmPatchBaselineDataSourceConfig_existingBaseline() string {
 	return `
 data "aws_ssm_patch_baseline" "test_existing" {
-	owner            = "AWS"
-	name_prefix	     = "AWS-"
-	operating_system = "CENTOS"
+  owner            = "AWS"
+  name_prefix      = "AWS-"
+  operating_system = "CENTOS"
 }
 `
 }
@@ -62,23 +62,23 @@ data "aws_ssm_patch_baseline" "test_existing" {
 func testAccCheckAwsSsmPatchBaselineDataSourceConfig_newBaseline(name string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_patch_baseline" "test_new" {
-	name             = "%s"
-	operating_system = "AMAZON_LINUX_2"
-	description      = "Test"
+  name             = "%s"
+  operating_system = "AMAZON_LINUX_2"
+  description      = "Test"
 
-	approval_rule {
-		approve_after_days = 5
-		patch_filter {
-			key    = "CLASSIFICATION"
-			values = ["*"]
-		}
-	}
+  approval_rule {
+    approve_after_days = 5
+    patch_filter {
+      key    = "CLASSIFICATION"
+      values = ["*"]
+    }
+  }
 }
 
 data "aws_ssm_patch_baseline" "test_new" {
-	owner            = "Self"
-	name_prefix      = "${aws_ssm_patch_baseline.test_new.name}"
-	operating_system = "AMAZON_LINUX_2"
+  owner            = "Self"
+  name_prefix      = aws_ssm_patch_baseline.test_new.name
+  operating_system = "AMAZON_LINUX_2"
 }
 `, name)
 }

--- a/aws/data_source_aws_subnet_ids_test.go
+++ b/aws/data_source_aws_subnet_ids_test.go
@@ -59,7 +59,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test_public_a" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.123.0/24"
   availability_zone = "us-west-2a"
 
@@ -70,7 +70,7 @@ resource "aws_subnet" "test_public_a" {
 }
 
 resource "aws_subnet" "test_private_a" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.125.0/24"
   availability_zone = "us-west-2a"
 
@@ -81,7 +81,7 @@ resource "aws_subnet" "test_private_a" {
 }
 
 resource "aws_subnet" "test_private_b" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.126.0/24"
   availability_zone = "us-west-2b"
 
@@ -92,11 +92,11 @@ resource "aws_subnet" "test_private_b" {
 }
 
 data "aws_subnet_ids" "selected" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 
 data "aws_subnet_ids" "private" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Tier = "Private"
@@ -116,7 +116,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test_public_a" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.123.0/24"
   availability_zone = "us-west-2a"
 
@@ -127,7 +127,7 @@ resource "aws_subnet" "test_public_a" {
 }
 
 resource "aws_subnet" "test_private_a" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.125.0/24"
   availability_zone = "us-west-2a"
 
@@ -138,7 +138,7 @@ resource "aws_subnet" "test_private_a" {
 }
 
 resource "aws_subnet" "test_private_b" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.126.0/24"
   availability_zone = "us-west-2b"
 
@@ -161,29 +161,29 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test_a_one" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.1.0/24"
   availability_zone = "us-west-2a"
 }
 
 resource "aws_subnet" "test_a_two" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.2.0/24"
   availability_zone = "us-west-2a"
 }
 
 resource "aws_subnet" "test_b" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.3.0/24"
   availability_zone = "us-west-2b"
 }
 
 data "aws_subnet_ids" "test" {
-  vpc_id = "${aws_subnet.test_a_two.vpc_id}"
+  vpc_id = aws_subnet.test_a_two.vpc_id
 
   filter {
     name   = "availabilityZone"
-    values = ["${aws_subnet.test_a_one.availability_zone}"]
+    values = [aws_subnet.test_a_one.availability_zone]
   }
 }
 `, rInt, rInt, rInt, rInt)

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -154,9 +154,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.123.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-subnet-data-source"
@@ -164,36 +164,36 @@ resource "aws_subnet" "test" {
 }
 
 data "aws_subnet" "by_id" {
-  id = "${aws_subnet.test.id}"
+  id = aws_subnet.test.id
 }
 
 data "aws_subnet" "by_cidr" {
-  vpc_id     = "${aws_subnet.test.vpc_id}"
-  cidr_block = "${aws_subnet.test.cidr_block}"
+  vpc_id     = aws_subnet.test.vpc_id
+  cidr_block = aws_subnet.test.cidr_block
 }
 
 data "aws_subnet" "by_tag" {
-  vpc_id = "${aws_subnet.test.vpc_id}"
+  vpc_id = aws_subnet.test.vpc_id
 
   tags = {
-    Name = "${aws_subnet.test.tags["Name"]}"
+    Name = aws_subnet.test.tags["Name"]
   }
 }
 
 data "aws_subnet" "by_vpc" {
-  vpc_id = "${aws_subnet.test.vpc_id}"
+  vpc_id = aws_subnet.test.vpc_id
 }
 
 data "aws_subnet" "by_filter" {
   filter {
     name   = "vpc-id"
-    values = ["${aws_subnet.test.vpc_id}"]
+    values = [aws_subnet.test.vpc_id]
   }
 }
 
 data "aws_subnet" "by_az_id" {
-  vpc_id               = "${aws_subnet.test.vpc_id}"
-  availability_zone_id = "${aws_subnet.test.availability_zone_id}"
+  vpc_id               = aws_subnet.test.vpc_id
+  availability_zone_id = aws_subnet.test.availability_zone_id
 }
 `, rInt, rInt)
 }
@@ -219,10 +219,10 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.123.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  ipv6_cidr_block   = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
     Name = "tf-acc-subnet-data-source-ipv6"
@@ -252,10 +252,10 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.123.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  ipv6_cidr_block   = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
     Name = "tf-acc-subnet-data-source-ipv6-with-ds-filter"
@@ -265,7 +265,7 @@ resource "aws_subnet" "test" {
 data "aws_subnet" "by_ipv6_cidr" {
   filter {
     name   = "ipv6-cidr-block-association.ipv6-cidr-block"
-    values = ["${aws_subnet.test.ipv6_cidr_block}"]
+    values = [aws_subnet.test.ipv6_cidr_block]
   }
 }
 `, rInt, rInt)
@@ -292,10 +292,10 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "172.%d.123.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  ipv6_cidr_block   = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
     Name = "tf-acc-subnet-data-source-ipv6-cidr-block"
@@ -303,7 +303,7 @@ resource "aws_subnet" "test" {
 }
 
 data "aws_subnet" "by_ipv6_cidr" {
-  ipv6_cidr_block = "${aws_subnet.test.ipv6_cidr_block}"
+  ipv6_cidr_block = aws_subnet.test.ipv6_cidr_block
 }
 `, rInt, rInt)
 }

--- a/aws/data_source_aws_transfer_server_test.go
+++ b/aws/data_source_aws_transfer_server_test.go
@@ -79,7 +79,7 @@ const testAccDataSourceAwsTransferServerConfig_basic = `
 resource "aws_transfer_server" "test" {}
 
 data "aws_transfer_server" "test" {
-  server_id = "${aws_transfer_server.test.id}"
+  server_id = aws_transfer_server.test.id
 }
 `
 
@@ -90,48 +90,48 @@ resource "aws_iam_role" "test" {
 
   assume_role_policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-		"Effect": "Allow",
-		"Principal": {
-			"Service": "transfer.amazonaws.com"
-		},
-		"Action": "sts:AssumeRole"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "transfer.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_iam_role_policy" "test" {
   name = "tf-test-transfer-server-iam-policy-%s"
-  role = "${aws_iam_role.test.id}"
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-		"Sid": "AllowFullAccesstoCloudWatchLogs",
-		"Effect": "Allow",
-		"Action": [
-			"logs:*"
-		],
-		"Resource": "*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowFullAccesstoCloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:*"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 POLICY
 }
 
 resource "aws_transfer_server" "test" {
   identity_provider_type = "SERVICE_MANAGED"
-  logging_role           = "${aws_iam_role.test.arn}"
+  logging_role           = aws_iam_role.test.arn
 }
 
 data "aws_transfer_server" "test" {
-  server_id = "${aws_transfer_server.test.id}"
+  server_id = aws_transfer_server.test.id
 }
 `, rName, rName)
 }
@@ -143,29 +143,29 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   type                    = "HTTP"
   uri                     = "https://www.google.de"
@@ -173,16 +173,16 @@ resource "aws_api_gateway_integration" "test" {
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_integration.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.error.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_integration.test.http_method
+  status_code = aws_api_gateway_method_response.error.status_code
 }
 
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
-  rest_api_id       = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id       = aws_api_gateway_rest_api.test.id
   stage_name        = "test"
   description       = "%s"
   stage_description = "%s"
@@ -197,37 +197,37 @@ resource "aws_iam_role" "test" {
 
   assume_role_policy = <<EOF
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-		"Effect": "Allow",
-		"Principal": {
-			"Service": "transfer.amazonaws.com"
-		},
-		"Action": "sts:AssumeRole"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "transfer.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_iam_role_policy" "test" {
   name = "tf-test-transfer-server-iam-policy-%s"
-  role = "${aws_iam_role.test.id}"
+  role = aws_iam_role.test.id
 
   policy = <<POLICY
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-		"Sid": "AllowFullAccesstoCloudWatchLogs",
-		"Effect": "Allow",
-		"Action": [
-			"logs:*"
-		],
-		"Resource": "*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowFullAccesstoCloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:*"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 POLICY
 }
@@ -235,12 +235,12 @@ POLICY
 resource "aws_transfer_server" "test" {
   identity_provider_type = "API_GATEWAY"
   url                    = "https://${aws_api_gateway_rest_api.test.id}.execute-api.us-west-2.amazonaws.com${aws_api_gateway_resource.test.path}"
-  invocation_role        = "${aws_iam_role.test.arn}"
-  logging_role           = "${aws_iam_role.test.arn}"
+  invocation_role        = aws_iam_role.test.arn
+  logging_role           = aws_iam_role.test.arn
 }
 
 data "aws_transfer_server" "test" {
-  server_id = "${aws_transfer_server.test.id}"
+  server_id = aws_transfer_server.test.id
 }
 `, rName, rName, rName, rName)
 }

--- a/aws/data_source_aws_vpc_dhcp_options_test.go
+++ b/aws/data_source_aws_vpc_dhcp_options_test.go
@@ -110,7 +110,7 @@ resource "aws_vpc_dhcp_options" "test" {
 }
 
 data "aws_vpc_dhcp_options" "test" {
-  dhcp_options_id = "${aws_vpc_dhcp_options.test.id}"
+  dhcp_options_id = aws_vpc_dhcp_options.test.id
 }
 `
 
@@ -142,7 +142,7 @@ data "aws_vpc_dhcp_options" "test" {
 
   filter {
     name   = "value"
-    values = ["${aws_vpc_dhcp_options.test.0.domain_name}"]
+    values = [aws_vpc_dhcp_options.test.0.domain_name]
   }
 }
 `, count, rInt, rInt)

--- a/aws/data_source_aws_vpc_endpoint_service_test.go
+++ b/aws/data_source_aws_vpc_endpoint_service_test.go
@@ -170,8 +170,8 @@ resource "aws_lb" "test" {
   name = %[1]q
 
   subnets = [
-    "${aws_subnet.test1.id}",
-    "${aws_subnet.test2.id}",
+    aws_subnet.test1.id,
+    aws_subnet.test2.id,
   ]
 
   load_balancer_type         = "network"
@@ -194,9 +194,9 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_subnet" "test1" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = %[1]q
@@ -204,9 +204,9 @@ resource "aws_subnet" "test1" {
 }
 
 resource "aws_subnet" "test2" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.2.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = %[1]q
@@ -217,7 +217,7 @@ resource "aws_vpc_endpoint_service" "test" {
   acceptance_required = true
 
   network_load_balancer_arns = [
-    "${aws_lb.test.id}",
+    aws_lb.test.id,
   ]
 
   tags = {
@@ -230,7 +230,7 @@ resource "aws_vpc_endpoint_service" "test" {
 func testAccDataSourceAwsVpcEndpointServiceCustomConfig(rName string) string {
 	return testAccDataSourceAwsVpcEndpointServiceCustomConfigBase(rName) + `
 data "aws_vpc_endpoint_service" "test" {
-  service_name = "${aws_vpc_endpoint_service.test.service_name}"
+  service_name = aws_vpc_endpoint_service.test.service_name
 }
 `
 }
@@ -240,7 +240,7 @@ func testAccDataSourceAwsVpcEndpointServiceCustomConfigFilter(rName string) stri
 data "aws_vpc_endpoint_service" "test" {
   filter {
     name   = "service-name"
-    values = ["${aws_vpc_endpoint_service.test.service_name}"]
+    values = [aws_vpc_endpoint_service.test.service_name]
   }
 }
 `
@@ -250,7 +250,7 @@ func testAccDataSourceAwsVpcEndpointServiceCustomConfigFilterTags(rName string) 
 	return testAccDataSourceAwsVpcEndpointServiceCustomConfigBase(rName) + `
 data "aws_vpc_endpoint_service" "test" {
   tags = {
-    Name  = "${aws_vpc_endpoint_service.test.tags["Name"]}"
+    Name = aws_vpc_endpoint_service.test.tags["Name"]
   }
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8950

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing:

(Note that `TestAccDataSourceAwsSubnetIDs_basic` failed on TC but passed locally.)

```
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_basic (18.80s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (19.47s)
--- PASS: TestAccDataSourceAwsTransferServer_service_managed (26.14s)
--- PASS: TestAccAWSSsmPatchBaselineDataSource_newBaseline (27.26s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_Filter (27.38s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (27.52s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_Name (27.88s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_basic (28.25s)
--- PASS: TestAccDataSourceAwsSubnet_basic (28.26s)
--- PASS: TestAccAWSSsmPatchBaselineDataSource_existingBaseline (29.09s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecretVersion_VersionStage (29.46s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_Policy (29.86s)
--- PASS: TestAccAWSSsmParameterDataSource_fullPath (30.06s)
--- PASS: TestAccDataSourceAwsTransferServer_apigateway (30.84s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecretVersion_VersionID (31.33s)
--- PASS: TestAccDataSourceAwsSqsQueue_tags (31.74s)
--- PASS: TestAccDataSourceAwsSecurityGroups_tag (34.26s)
--- PASS: TestAccDataSourceAwsSecurityGroup_basic (35.83s)
--- PASS: TestAccDataSourceAwsSecurityGroups_filter (36.45s)
--- PASS: TestAccDataSourceAwsTransferServer_basic (37.23s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (37.23s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (37.40s)
--- PASS: TestAccDataSourceAwsSnsTopic_basic (40.15s)
--- PASS: TestAccDataSourceAwsSubnetIDs_basic (41.13s)
--- PASS: TestAccDataSourceAwsSubnetIDs_filter (44.03s)
--- PASS: TestAccAWSSsmDocumentDataSource_basic (44.37s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecretVersion_basic (45.98s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_ARN (46.93s)
--- PASS: TestAccDataSourceAwsSqsQueue_basic (47.12s)
--- PASS: TestAccAWSStepFunctionsActivityDataSource_basic (51.83s)
--- PASS: TestAccAWSSsmParameterDataSource_basic (53.85s)
--- PASS: TestAccDataSourceAwsSecretsManagerSecretRotation_basic (58.30s)
--- PASS: TestAccDataSourceAwsSfnStateMachine_basic (92.02s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (248.13s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter_tags (248.17s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter (278.55s)
```
