### PR TITLE
resource/aws_accessanalyzer_analyzer: Support ORGANIZATION value in type argument

### DIFF
--- a/aws/resource_aws_accessanalyzer_analyzer.go
+++ b/aws/resource_aws_accessanalyzer_analyzer.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/accessanalyzer"
@@ -10,6 +11,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+const (
+	// Maximum amount of time to wait for Organizations eventual consistency on creation
+	// This timeout value is much higher than usual since the cross-service validation
+	// appears to be consistently caching for 5 minutes:
+	// --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/Type_Organization (315.86s)
+	accessAnalyzerOrganizationCreationTimeout = 10 * time.Minute
 )
 
 func resourceAwsAccessAnalyzerAnalyzer() *schema.Resource {
@@ -37,9 +46,11 @@ func resourceAwsAccessAnalyzerAnalyzer() *schema.Resource {
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  accessanalyzer.TypeAccount,
 				ValidateFunc: validation.StringInSlice([]string{
 					accessanalyzer.TypeAccount,
+					accessanalyzer.TypeOrganization,
 				}, false),
 			},
 		},
@@ -57,7 +68,24 @@ func resourceAwsAccessAnalyzerAnalyzerCreate(d *schema.ResourceData, meta interf
 		Type:         aws.String(d.Get("type").(string)),
 	}
 
-	_, err := conn.CreateAnalyzer(input)
+	// Handle Organizations eventual consistency
+	err := resource.Retry(accessAnalyzerOrganizationCreationTimeout, func() *resource.RetryError {
+		_, err := conn.CreateAnalyzer(input)
+
+		if isAWSErr(err, accessanalyzer.ErrCodeValidationException, "You must create an organization") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.CreateAnalyzer(input)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error creating Access Analyzer Analyzer (%s): %s", analyzerName, err)

--- a/aws/resource_aws_accessanalyzer_test.go
+++ b/aws/resource_aws_accessanalyzer_test.go
@@ -11,9 +11,10 @@ import (
 func TestAccAWSAccessAnalyzer_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Analyzer": {
-			"basic":      testAccAWSAccessAnalyzerAnalyzer_basic,
-			"disappears": testAccAWSAccessAnalyzerAnalyzer_disappears,
-			"Tags":       testAccAWSAccessAnalyzerAnalyzer_Tags,
+			"basic":             testAccAWSAccessAnalyzerAnalyzer_basic,
+			"disappears":        testAccAWSAccessAnalyzerAnalyzer_disappears,
+			"Tags":              testAccAWSAccessAnalyzerAnalyzer_Tags,
+			"Type_Organization": testAccAWSAccessAnalyzerAnalyzer_Type_Organization,
 		},
 	}
 

--- a/website/docs/r/accessanalyzer_analyzer.html.markdown
+++ b/website/docs/r/accessanalyzer_analyzer.html.markdown
@@ -12,9 +12,26 @@ Manages an Access Analyzer Analyzer. More information can be found in the [Acces
 
 ## Example Usage
 
+### Account Analyzer
+
 ```hcl
 resource "aws_accessanalyzer_analyzer" "example" {
   analyzer_name = "example"
+}
+```
+
+### Organization Analyzer
+
+```hcl
+resource "aws_organizations_organization" "example" {
+  aws_service_access_principals = ["access-analyzer.amazonaws.com"]
+}
+
+resource "aws_accessanalyzer_analyzer" "example" {
+  depends_on = [aws_organizations_organization.example]
+
+  analyzer_name = "example"
+  type          = "ORGANIZATION"
 }
 ```
 
@@ -27,7 +44,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `tags` - (Optional) Key-value map of resource tags.
-* `type` - (Optional) Type of Analyzer. Valid value is currently only `ACCOUNT`. Defaults to `ACCOUNT`.
+* `type` - (Optional) Type of Analyzer. Valid values are `ACCOUNT` or `ORGANIZATION`. Defaults to `ACCOUNT`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12593

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_accessanalyzer_analyzer: Support `ORGANIZATION` value in `type` argument
```

Output from acceptance testing in Organizations testing account:

```
--- PASS: TestAccAWSAccessAnalyzer_serial (344.90s)
    --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer (344.90s)
        --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/basic (10.64s)
        --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/disappears (7.41s)
        --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/Tags (22.00s)
        --- PASS: TestAccAWSAccessAnalyzer_serial/Analyzer/Type_Organization (304.86s)
```
