### PR TITLE
data-source/aws_launch_template: Fix empty delete_on_termination regression

### DIFF
--- a/aws/data_source_aws_launch_template.go
+++ b/aws/data_source_aws_launch_template.go
@@ -244,7 +244,7 @@ func dataSourceAwsLaunchTemplate() *schema.Resource {
 							Computed: true,
 						},
 						"delete_on_termination": {
-							Type:     schema.TypeBool,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"description": {

--- a/aws/data_source_aws_launch_template_test.go
+++ b/aws/data_source_aws_launch_template_test.go
@@ -160,6 +160,41 @@ func TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplateDataSource_deleteOnTermination(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_launch_template.test"
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_deleteOnTermination(rName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.#", resourceName, "network_interfaces.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.0.delete_on_termination", resourceName, "network_interfaces.0.delete_on_termination"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_deleteOnTermination(rName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.#", resourceName, "network_interfaces.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.0.delete_on_termination", resourceName, "network_interfaces.0.delete_on_termination"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateDataSourceConfig_deleteOnTermination(rName, "null"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.#", resourceName, "network_interfaces.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interfaces.0.delete_on_termination", resourceName, "network_interfaces.0.delete_on_termination"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplateDataSource_NonExistent(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -253,6 +288,22 @@ data "aws_launch_template" "test" {
   name = aws_launch_template.test.name
 }
 `, rName, associatePublicIPAddress)
+}
+
+func testAccAWSLaunchTemplateDataSourceConfig_deleteOnTermination(rName, deleteOnTermination string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  network_interfaces {
+    delete_on_termination = %[2]s
+  }
+}
+
+data "aws_launch_template" "test" {
+  name = aws_launch_template.test.name
+}
+`, rName, deleteOnTermination)
 }
 
 const testAccAWSLaunchTemplateDataSourceConfig_NonExistent = `


### PR DESCRIPTION
This fixes a regression introduced with #8612. With that change, the `aws_launch_template` data source broke when an ENI is set.

This is similar to #12936.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
BUG FIXES:
* data-source/aws_launch_template: Fix error when ENI delete_on_termination is empty
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplateDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchTemplateDataSource_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplateDataSource_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_basic
=== RUN   TestAccAWSLaunchTemplateDataSource_filter_tags
=== PAUSE TestAccAWSLaunchTemplateDataSource_filter_tags
=== RUN   TestAccAWSLaunchTemplateDataSource_metadataOptions
=== PAUSE TestAccAWSLaunchTemplateDataSource_metadataOptions
=== RUN   TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== PAUSE TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== RUN   TestAccAWSLaunchTemplateDataSource_deleteOnTermination
=== PAUSE TestAccAWSLaunchTemplateDataSource_deleteOnTermination
=== RUN   TestAccAWSLaunchTemplateDataSource_NonExistent
=== PAUSE TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
=== CONT  TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress
=== CONT  TestAccAWSLaunchTemplateDataSource_NonExistent
=== CONT  TestAccAWSLaunchTemplateDataSource_deleteOnTermination
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_tags
=== CONT  TestAccAWSLaunchTemplateDataSource_metadataOptions
=== CONT  TestAccAWSLaunchTemplateDataSource_filter_basic
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (4.38s)
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (25.17s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (25.86s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (26.00s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (26.11s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (58.57s)
--- PASS: TestAccAWSLaunchTemplateDataSource_deleteOnTermination (58.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	60.246s
```
