### PR TITLE
tests/provider: Update data source testing to 0.12 syntax (A Data Sources)

### DIFF
--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -705,7 +705,7 @@ resource "aws_acmpca_certificate_authority" "test" {
 
 resource "aws_acm_certificate" "cert" {
   domain_name               = "%s.terraformtesting.com"
-  certificate_authority_arn = "${aws_acmpca_certificate_authority.test.arn}"
+  certificate_authority_arn = aws_acmpca_certificate_authority.test.arn
 }
 `, rName)
 }
@@ -715,7 +715,7 @@ func testAccAcmCertificateConfig_subjectAlternativeNames(domainName, subjectAlte
 resource "aws_acm_certificate" "cert" {
   domain_name               = "%s"
   subject_alternative_names = [%s]
-  validation_method = "%s"
+  validation_method         = "%s"
 }
 `, domainName, subjectAlternativeNames, validationMethod)
 }
@@ -762,8 +762,8 @@ resource "aws_acm_certificate" "test" {
 func testAccAcmCertificateConfigPrivateKey(certificate, privateKey, chain string) string {
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
-  certificate_body =  "%[1]s"
-  private_key      =  "%[2]s"
+  certificate_body  = "%[1]s"
+  private_key       = "%[2]s"
   certificate_chain = "%[3]s"
 }
 `, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(privateKey), tlsPemEscapeNewlines(chain))
@@ -774,8 +774,9 @@ func testAccAcmCertificateConfig_disableCTLogging(domainName, validationMethod s
 resource "aws_acm_certificate" "cert" {
   domain_name       = "%s"
   validation_method = "%s"
+
   options {
-	  certificate_transparency_logging_preference = "DISABLED"
+    certificate_transparency_logging_preference = "DISABLED"
   }
 }
 `, domainName, validationMethod)

--- a/aws/resource_aws_acmpca_certificate_authority_test.go
+++ b/aws/resource_aws_acmpca_certificate_authority_test.go
@@ -571,7 +571,7 @@ resource "aws_acmpca_certificate_authority" "test" {
     }
   }
 
-  depends_on = ["aws_s3_bucket_policy.test"]
+  depends_on = [aws_s3_bucket_policy.test]
 }
 `, testAccAwsAcmpcaCertificateAuthorityConfig_S3Bucket(rName), customCname)
 }

--- a/aws/resource_aws_acmpca_certificate_authority_test.go
+++ b/aws/resource_aws_acmpca_certificate_authority_test.go
@@ -567,7 +567,7 @@ resource "aws_acmpca_certificate_authority" "test" {
       custom_cname       = "%s"
       enabled            = true
       expiration_in_days = 1
-      s3_bucket_name     = "${aws_s3_bucket.test.id}"
+      s3_bucket_name     = aws_s3_bucket.test.id
     }
   }
 
@@ -596,7 +596,7 @@ resource "aws_acmpca_certificate_authority" "test" {
     crl_configuration {
       enabled            = %t
       expiration_in_days = 1
-      s3_bucket_name     = "${aws_s3_bucket.test.id}"
+      s3_bucket_name     = aws_s3_bucket.test.id
     }
   }
 }
@@ -623,7 +623,7 @@ resource "aws_acmpca_certificate_authority" "test" {
     crl_configuration {
       enabled            = true
       expiration_in_days = %d
-      s3_bucket_name     = "${aws_s3_bucket.test.id}"
+      s3_bucket_name     = aws_s3_bucket.test.id
     }
   }
 }
@@ -647,7 +647,7 @@ data "aws_iam_policy_document" "acmpca_bucket_access" {
     ]
 
     resources = [
-      "${aws_s3_bucket.test.arn}",
+      aws_s3_bucket.test.arn,
       "${aws_s3_bucket.test.arn}/*",
     ]
 
@@ -659,8 +659,8 @@ data "aws_iam_policy_document" "acmpca_bucket_access" {
 }
 
 resource "aws_s3_bucket_policy" "test" {
-  bucket = "${aws_s3_bucket.test.id}"
-  policy = "${data.aws_iam_policy_document.acmpca_bucket_access.json}"
+  bucket = aws_s3_bucket.test.id
+  policy = data.aws_iam_policy_document.acmpca_bucket_access.json
 }
 `, rName)
 }

--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -906,11 +906,12 @@ func testAccAWSALBTargetGroupConfig_stickiness(targetGroupName string, addSticki
 	var stickinessBlock string
 
 	if addStickinessBlock {
-		stickinessBlock = fmt.Sprintf(`stickiness {
-	    enabled = "%t"
-	    type = "lb_cookie"
-	    cookie_duration = 10000
-	  }
+		stickinessBlock = fmt.Sprintf(`
+  stickiness {
+    enabled         = "%t"
+    type            = "lb_cookie"
+    cookie_duration = 10000
+  }
 `, enabled)
 	}
 
@@ -960,7 +961,6 @@ resource "aws_alb_target_group" "test" {
   port     = 443
   protocol = "HTTPS"
   vpc_id   = aws_vpc.test.id
-
   %s
 }
 

--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -652,28 +652,29 @@ func TestAccAWSALBTargetGroup_missingPortProtocolVpc(t *testing.T) {
 }
 
 func testAccAWSALBTargetGroupConfig_basic(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTPS"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
   stickiness {
-    type = "lb_cookie"
+    type            = "lb_cookie"
     cookie_duration = 10000
   }
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 
   tags = {
@@ -687,32 +688,34 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
-}`, targetGroupName)
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 442
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 442
   protocol = "HTTPS"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
   stickiness {
-    type = "lb_cookie"
+    type            = "lb_cookie"
     cookie_duration = 10000
   }
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 
   tags = {
@@ -726,32 +729,34 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
-}`, targetGroupName)
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTP"
-  vpc_id = "${aws_vpc.test2.id}"
+  vpc_id   = aws_vpc.test2.id
 
   deregistration_delay = 200
 
   stickiness {
-    type = "lb_cookie"
+    type            = "lb_cookie"
     cookie_duration = 10000
   }
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 
   tags = {
@@ -773,32 +778,34 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
-}`, targetGroupName)
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTPS"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
   stickiness {
-    type = "lb_cookie"
+    type            = "lb_cookie"
     cookie_duration = 10000
   }
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 
   tags = {
@@ -812,37 +819,39 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
-}`, targetGroupName)
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_updateTags(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTPS"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
   stickiness {
-    type = "lb_cookie"
+    type            = "lb_cookie"
     cookie_duration = 10000
   }
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 
   tags = {
     Environment = "Production"
-    Type = "ALB Target Group"
+    Type        = "ALB Target Group"
   }
 }
 
@@ -852,32 +861,34 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
-}`, targetGroupName)
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_updateHealthCheck(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTPS"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
   stickiness {
-    type = "lb_cookie"
+    type            = "lb_cookie"
     cookie_duration = 10000
   }
 
   health_check {
-    path = "/health2"
-    interval = 30
-    port = 8082
-    protocol = "HTTPS"
-    timeout = 4
-    healthy_threshold = 4
+    path                = "/health2"
+    interval            = 30
+    port                = 8082
+    protocol            = "HTTPS"
+    timeout             = 4
+    healthy_threshold   = 4
     unhealthy_threshold = 4
-    matcher = "200"
+    matcher             = "200"
   }
 }
 
@@ -887,7 +898,8 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
-}`, targetGroupName)
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_stickiness(targetGroupName string, addStickinessBlock bool, enabled bool) string {
@@ -898,28 +910,30 @@ func testAccAWSALBTargetGroupConfig_stickiness(targetGroupName string, addSticki
 	    enabled = "%t"
 	    type = "lb_cookie"
 	    cookie_duration = 10000
-	  }`, enabled)
+	  }
+`, enabled)
 	}
 
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTPS"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
   %s
 
   health_check {
-    path = "/health2"
-    interval = 30
-    port = 8082
-    protocol = "HTTPS"
-    timeout = 4
-    healthy_threshold = 4
+    path                = "/health2"
+    interval            = 30
+    port                = 8082
+    protocol            = "HTTPS"
+    timeout             = 4
+    healthy_threshold   = 4
     unhealthy_threshold = 4
-    matcher = "200"
+    matcher             = "200"
   }
 }
 
@@ -929,7 +943,8 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-stickiness"
   }
-}`, targetGroupName, stickinessBlock)
+}
+`, targetGroupName, stickinessBlock)
 }
 
 func testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName string, nonDefault bool, algoType string) string {
@@ -939,14 +954,14 @@ func testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName strin
 		algoTypeParam = fmt.Sprintf(`load_balancing_algorithm_type = "%s"`, algoType)
 	}
 
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTPS"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   %s
-
 }
 
 resource "aws_vpc" "test" {
@@ -955,33 +970,35 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-load-balancing-algo"
   }
-}`, targetGroupName, algoTypeParam)
+}
+`, targetGroupName, algoTypeParam)
 }
 
 func testAccAWSALBTargetGroupConfig_updateSlowStart(targetGroupName string, slowStartDuration int) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
-  port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTP"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
-  slow_start = %d
+  slow_start           = %d
 
   stickiness {
-    type = "lb_cookie"
+    type            = "lb_cookie"
     cookie_duration = 10000
   }
 
   health_check {
-    path = "/health"
-    interval = 60
-    port = 8081
-    protocol = "HTTP"
-    timeout = 3
-    healthy_threshold = 3
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
 
   tags = {
@@ -995,55 +1012,57 @@ resource "aws_vpc" "test" {
   tags = {
     Name = "terraform-testacc-alb-target-group-slowstart"
   }
-}`, targetGroupName, slowStartDuration)
+}
+`, targetGroupName, slowStartDuration)
 }
 
 const testAccAWSALBTargetGroupConfig_namePrefix = `
 resource "aws_alb_target_group" "test" {
   name_prefix = "tf-"
-  port = 80
-  protocol = "HTTP"
-  vpc_id = "${aws_vpc.test.id}"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.test.id
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-alb-target-group-name-prefix"
-	}
+  tags = {
+    Name = "terraform-testacc-alb-target-group-name-prefix"
+  }
 }
 `
 
 const testAccAWSALBTargetGroupConfig_generatedName = `
 resource "aws_alb_target_group" "test" {
-  port = 80
+  port     = 80
   protocol = "HTTP"
-	vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
-	health_check {
-    path = "/health"
-    interval = 60
-    timeout = 3
-    healthy_threshold = 3
+  health_check {
+    path                = "/health"
+    interval            = 60
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    matcher = "200-299"
+    matcher             = "200-299"
   }
-
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-alb-target-group-generated-name"
-	}
+  tags = {
+    Name = "terraform-testacc-alb-target-group-generated-name"
+  }
 }
 `
 
 func testAccAWSALBTargetGroupConfig_lambda(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-	name = "%s"
-	target_type = "lambda"
-}`, targetGroupName)
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name        = "%s"
+  target_type = "lambda"
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_lambdaMultiValueHeadersEnabled(rName string, lambdaMultiValueHadersEnabled bool) string {
@@ -1057,33 +1076,38 @@ resource "aws_alb_target_group" "test" {
 }
 
 func testAccAWSALBTargetGroupConfig_missing_port(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-  name = "%s"
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
   protocol = "HTTPS"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-}`, targetGroupName)
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_missing_protocol(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-	name = "%s"
-	port = 443
-  vpc_id = "${aws_vpc.test.id}"
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name   = "%s"
+  port   = 443
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-}`, targetGroupName)
+}
+`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupConfig_missing_vpc(targetGroupName string) string {
-	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
-	name = "%s"
-	port = 443
+	return fmt.Sprintf(`
+resource "aws_alb_target_group" "test" {
+  name     = "%s"
+  port     = 443
   protocol = "HTTPS"
 }
 `, targetGroupName)

--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -224,7 +224,7 @@ data "aws_availability_zones" "available" {
 data "aws_region" "current" {}
 
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
   size              = 1
 
   tags = {
@@ -233,7 +233,7 @@ resource "aws_ebs_volume" "test" {
 }
 
 resource "aws_ebs_snapshot" "test" {
-  volume_id = "${aws_ebs_volume.test.id}"
+  volume_id = aws_ebs_volume.test.id
 
   tags = {
     Name = %[1]q
@@ -251,14 +251,14 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 }
 
 resource "aws_ami_copy" "test" {
   name              = %[1]q
-  source_ami_id     = "${aws_ami.test.id}"
-  source_ami_region = "${data.aws_region.current.name}"
+  source_ami_id     = aws_ami.test.id
+  source_ami_region = data.aws_region.current.name
 
   tags = {
     %[2]q = %[3]q
@@ -276,14 +276,14 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 }
 
 resource "aws_ami_copy" "test" {
   name              = %[1]q
-  source_ami_id     = "${aws_ami.test.id}"
-  source_ami_region = "${data.aws_region.current.name}"
+  source_ami_id     = aws_ami.test.id
+  source_ami_region = data.aws_region.current.name
 
   tags = {
     %[2]q = %[3]q
@@ -302,14 +302,14 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 }
 
 resource "aws_ami_copy" "test" {
   name              = %q
-  source_ami_id     = "${aws_ami.test.id}"
-  source_ami_region = "${data.aws_region.current.name}"
+  source_ami_id     = aws_ami.test.id
+  source_ami_region = data.aws_region.current.name
 }
 `, rName, rName)
 }
@@ -323,15 +323,15 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 }
 
 resource "aws_ami_copy" "test" {
   description       = %q
   name              = %q
-  source_ami_id     = "${aws_ami.test.id}"
-  source_ami_region = "${data.aws_region.current.name}"
+  source_ami_id     = aws_ami.test.id
+  source_ami_region = data.aws_region.current.name
 }
 `, rName, description, rName)
 }
@@ -346,14 +346,14 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 }
 
 resource "aws_ami_copy" "test" {
-    name              = "%s-copy"
-    source_ami_id     = "${aws_ami.test.id}"
-    source_ami_region = "${data.aws_region.current.name}"
+  name              = "%s-copy"
+  source_ami_id     = aws_ami.test.id
+  source_ami_region = data.aws_region.current.name
 }
 `, rName, rName)
 }

--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -221,7 +221,9 @@ data "aws_availability_zones" "available" {
     values = ["opt-in-not-required"]
   }
 }
-data "aws_region" "current" {}
+
+data "aws_region" "current" {
+}
 
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]

--- a/aws/resource_aws_ami_from_instance_test.go
+++ b/aws/resource_aws_ami_from_instance_test.go
@@ -152,7 +152,7 @@ func testAccAWSAMIFromInstanceConfig(rName string) string {
 resource "aws_ami_from_instance" "test" {
   name               = %[1]q
   description        = "Testing Terraform aws_ami_from_instance resource"
-  source_instance_id = "${aws_instance.test.id}"
+  source_instance_id = aws_instance.test.id
 }
 `, rName))
 }
@@ -164,7 +164,7 @@ func testAccAWSAMIFromInstanceConfigTags1(rName, tagKey1, tagValue1 string) stri
 resource "aws_ami_from_instance" "test" {
   name               = %[1]q
   description        = "Testing Terraform aws_ami_from_instance resource"
-  source_instance_id = "${aws_instance.test.id}"
+  source_instance_id = aws_instance.test.id
 
   tags = {
     %[2]q = %[3]q
@@ -180,7 +180,7 @@ func testAccAWSAMIFromInstanceConfigTags2(rName, tagKey1, tagValue1, tagKey2, ta
 resource "aws_ami_from_instance" "test" {
   name               = %[1]q
   description        = "Testing Terraform aws_ami_from_instance resource"
-  source_instance_id = "${aws_instance.test.id}"
+  source_instance_id = aws_instance.test.id
 
   tags = {
     %[2]q = %[3]q

--- a/aws/resource_aws_ami_launch_permission_test.go
+++ b/aws/resource_aws_ami_launch_permission_test.go
@@ -280,13 +280,13 @@ data "aws_region" "current" {}
 resource "aws_ami_copy" "test" {
   description       = %q
   name              = %q
-  source_ami_id     = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
-  source_ami_region = "${data.aws_region.current.name}"
+  source_ami_id     = data.aws_ami.amzn-ami-minimal-hvm.id
+  source_ami_region = data.aws_region.current.name
 }
 
 resource "aws_ami_launch_permission" "test" {
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  image_id   = "${aws_ami_copy.test.id}"
+  account_id = data.aws_caller_identity.current.account_id
+  image_id   = aws_ami_copy.test.id
 }
 `, rName, rName)
 }

--- a/aws/resource_aws_ami_launch_permission_test.go
+++ b/aws/resource_aws_ami_launch_permission_test.go
@@ -273,9 +273,11 @@ data "aws_ami" "amzn-ami-minimal-hvm" {
   }
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
 resource "aws_ami_copy" "test" {
   description       = %q

--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -339,7 +339,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_ebs_volume" "test" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
   size              = %d
 
   tags = {
@@ -348,13 +348,12 @@ resource "aws_ebs_volume" "test" {
 }
 
 resource "aws_ebs_snapshot" "test" {
-  volume_id = "${aws_ebs_volume.test.id}"
+  volume_id = aws_ebs_volume.test.id
 
   tags = {
     Name = "%[2]s"
   }
 }
-
 `, size, rName)
 }
 
@@ -368,7 +367,7 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 }
 `, rName)
@@ -385,7 +384,7 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 }
 `, rName, desc)
@@ -401,7 +400,7 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 
   tags = {
@@ -421,7 +420,7 @@ resource "aws_ami" "test" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    snapshot_id = "${aws_ebs_snapshot.test.id}"
+    snapshot_id = aws_ebs_snapshot.test.id
   }
 
   tags = {

--- a/aws/resource_aws_api_gateway_account_test.go
+++ b/aws/resource_aws_api_gateway_account_test.go
@@ -122,7 +122,7 @@ resource "aws_api_gateway_account" "test" {
 func testAccAWSAPIGatewayAccountConfig_updated(randName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_account" "test" {
-  cloudwatch_role_arn = "${aws_iam_role.cloudwatch.arn}"
+  cloudwatch_role_arn = aws_iam_role.cloudwatch.arn
 }
 
 resource "aws_iam_role" "cloudwatch" {
@@ -147,26 +147,26 @@ EOF
 
 resource "aws_iam_role_policy" "cloudwatch" {
   name = "default"
-  role = "${aws_iam_role.cloudwatch.id}"
+  role = aws_iam_role.cloudwatch.id
 
   policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:DescribeLogGroups",
-                "logs:DescribeLogStreams",
-                "logs:PutLogEvents",
-                "logs:GetLogEvents",
-                "logs:FilterLogEvents"
-            ],
-            "Resource": "*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:PutLogEvents",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }
@@ -176,7 +176,7 @@ EOF
 func testAccAWSAPIGatewayAccountConfig_updated2(randName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_account" "test" {
-  cloudwatch_role_arn = "${aws_iam_role.second.arn}"
+  cloudwatch_role_arn = aws_iam_role.second.arn
 }
 
 resource "aws_iam_role" "second" {
@@ -201,26 +201,26 @@ EOF
 
 resource "aws_iam_role_policy" "cloudwatch" {
   name = "default"
-  role = "${aws_iam_role.second.id}"
+  role = aws_iam_role.second.id
 
   policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:DescribeLogGroups",
-                "logs:DescribeLogStreams",
-                "logs:PutLogEvents",
-                "logs:GetLogEvents",
-                "logs:FilterLogEvents"
-            ],
-            "Resource": "*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:PutLogEvents",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }

--- a/aws/resource_aws_api_gateway_account_test.go
+++ b/aws/resource_aws_api_gateway_account_test.go
@@ -143,6 +143,7 @@ resource "aws_iam_role" "cloudwatch" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "cloudwatch" {
@@ -169,6 +170,7 @@ resource "aws_iam_role_policy" "cloudwatch" {
   ]
 }
 EOF
+
 }
 `, randName)
 }
@@ -197,6 +199,7 @@ resource "aws_iam_role" "second" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "cloudwatch" {
@@ -223,6 +226,7 @@ resource "aws_iam_role_policy" "cloudwatch" {
   ]
 }
 EOF
+
 }
 `, randName)
 }

--- a/aws/resource_aws_api_gateway_api_key_test.go
+++ b/aws/resource_aws_api_gateway_api_key_test.go
@@ -291,7 +291,7 @@ resource "aws_api_gateway_api_key" "test" {
   name = %[1]q
 
   tags = {
-	%[2]q = %[3]q
+    %[2]q = %[3]q
   }
 }
 `, rName, tagKey1, tagValue1)
@@ -303,8 +303,8 @@ resource "aws_api_gateway_api_key" "test" {
   name = %[1]q
 
   tags = {
-	%[2]q = %[3]q
-	%[4]q = %[5]q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_api_gateway_base_path_mapping_test.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping_test.go
@@ -262,7 +262,7 @@ resource "aws_api_gateway_integration" "test" {
 resource "aws_api_gateway_deployment" "test" {
   rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "test"
-  depends_on  = ["aws_api_gateway_integration.test"]
+  depends_on  = [aws_api_gateway_integration.test]
 }
 `, domainName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key))
 }

--- a/aws/resource_aws_api_gateway_base_path_mapping_test.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping_test.go
@@ -222,7 +222,7 @@ resource "aws_acm_certificate" "test" {
 
 resource "aws_api_gateway_domain_name" "test" {
   domain_name              = %[1]q
-  regional_certificate_arn = "${aws_acm_certificate.test.arn}"
+  regional_certificate_arn = aws_acm_certificate.test.arn
 
   endpoint_configuration {
     types = ["REGIONAL"]
@@ -240,27 +240,27 @@ resource "aws_api_gateway_rest_api" "test" {
 
 # API gateway won't let us deploy an empty API
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "tf-acc"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   type        = "MOCK"
 }
 
 resource "aws_api_gateway_deployment" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "test"
   depends_on  = ["aws_api_gateway_integration.test"]
 }
@@ -270,10 +270,10 @@ resource "aws_api_gateway_deployment" "test" {
 func testAccAWSAPIGatewayBasePathConfigBasePath(domainName, key, certificate, basePath string) string {
 	return testAccAWSAPIGatewayBasePathConfigBase(domainName, key, certificate) + fmt.Sprintf(`
 resource "aws_api_gateway_base_path_mapping" "test" {
-  api_id      = "${aws_api_gateway_rest_api.test.id}"
+  api_id      = aws_api_gateway_rest_api.test.id
   base_path   = %[1]q
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
-  domain_name = "${aws_api_gateway_domain_name.test.domain_name}"
+  stage_name  = aws_api_gateway_deployment.test.stage_name
+  domain_name = aws_api_gateway_domain_name.test.domain_name
 }
 `, basePath)
 }

--- a/aws/resource_aws_api_gateway_client_certificate_test.go
+++ b/aws/resource_aws_api_gateway_client_certificate_test.go
@@ -185,7 +185,7 @@ resource "aws_api_gateway_client_certificate" "test" {
   description = "Hello from TF acceptance test"
 
   tags = {
-	%q = %q
+    %q = %q
   }
 }
 `, tagKey1, tagValue1)
@@ -197,8 +197,8 @@ resource "aws_api_gateway_client_certificate" "test" {
   description = "Hello from TF acceptance test"
 
   tags = {
-	%q = %q
-	%q = %q
+    %q = %q
+    %q = %q
   }
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_api_gateway_deployment_test.go
+++ b/aws/resource_aws_api_gateway_deployment_test.go
@@ -418,7 +418,7 @@ resource "aws_api_gateway_deployment" "test" {
 func testAccAWSAPIGatewayDeploymentConfigDescription(description string) string {
 	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + fmt.Sprintf(`
 resource "aws_api_gateway_deployment" "test" {
-  depends_on = ["aws_api_gateway_integration.test"]
+  depends_on = [aws_api_gateway_integration.test]
 
   description = %q
   rest_api_id = aws_api_gateway_rest_api.test.id
@@ -429,7 +429,7 @@ resource "aws_api_gateway_deployment" "test" {
 func testAccAWSAPIGatewayDeploymentConfigRequired() string {
 	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + `
 resource "aws_api_gateway_deployment" "test" {
-  depends_on = ["aws_api_gateway_integration.test"]
+  depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
 }
@@ -439,7 +439,7 @@ resource "aws_api_gateway_deployment" "test" {
 func testAccAWSAPIGatewayDeploymentConfigStageDescription(stageDescription string) string {
 	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + fmt.Sprintf(`
 resource "aws_api_gateway_deployment" "test" {
-  depends_on = ["aws_api_gateway_integration.test"]
+  depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id       = aws_api_gateway_rest_api.test.id
   stage_description = %q
@@ -451,7 +451,7 @@ resource "aws_api_gateway_deployment" "test" {
 func testAccAWSAPIGatewayDeploymentConfigStageName(stageName string) string {
 	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + fmt.Sprintf(`
 resource "aws_api_gateway_deployment" "test" {
-  depends_on = ["aws_api_gateway_integration.test"]
+  depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = %q
@@ -462,7 +462,7 @@ resource "aws_api_gateway_deployment" "test" {
 func testAccAWSAPIGatewayDeploymentConfigVariables(key1, value1 string) string {
 	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + fmt.Sprintf(`
 resource "aws_api_gateway_deployment" "test" {
-  depends_on = ["aws_api_gateway_integration.test"]
+  depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
 

--- a/aws/resource_aws_api_gateway_deployment_test.go
+++ b/aws/resource_aws_api_gateway_deployment_test.go
@@ -356,29 +356,29 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   type                    = "HTTP"
   uri                     = "%s"
@@ -386,10 +386,10 @@ resource "aws_api_gateway_integration" "test" {
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_integration.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.error.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_integration.test.http_method
+  status_code = aws_api_gateway_method_response.error.status_code
 }
 `, uri)
 }
@@ -421,7 +421,7 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
   description = %q
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 `, description)
 }
@@ -431,7 +431,7 @@ func testAccAWSAPIGatewayDeploymentConfigRequired() string {
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 `
 }
@@ -441,7 +441,7 @@ func testAccAWSAPIGatewayDeploymentConfigStageDescription(stageDescription strin
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
-  rest_api_id       = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id       = aws_api_gateway_rest_api.test.id
   stage_description = %q
   stage_name        = "tf-acc-test"
 }
@@ -453,7 +453,7 @@ func testAccAWSAPIGatewayDeploymentConfigStageName(stageName string) string {
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = %q
 }
 `, stageName)
@@ -464,7 +464,7 @@ func testAccAWSAPIGatewayDeploymentConfigVariables(key1, value1 string) string {
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 
   variables = {
     %q = %q

--- a/aws/resource_aws_api_gateway_documentation_part_test.go
+++ b/aws/resource_aws_api_gateway_documentation_part_test.go
@@ -251,8 +251,9 @@ resource "aws_api_gateway_documentation_part" "test" {
   location {
     type = "API"
   }
-  properties = %v
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+
+  properties  = %v
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 
 resource "aws_api_gateway_rest_api" "test" {
@@ -265,12 +266,13 @@ func testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, properties strin
 	return fmt.Sprintf(`
 resource "aws_api_gateway_documentation_part" "test" {
   location {
-    type = "METHOD"
+    type   = "METHOD"
     method = "GET"
-    path = "/terraform-acc-test"
+    path   = "/terraform-acc-test"
   }
-  properties = %v
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+
+  properties  = %v
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 
 resource "aws_api_gateway_rest_api" "test" {
@@ -283,14 +285,15 @@ func testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, properti
 	return fmt.Sprintf(`
 resource "aws_api_gateway_documentation_part" "test" {
   location {
-    type = "RESPONSE_HEADER"
-    method = "GET"
-    name = "tfacc"
-    path = "/terraform-acc-test"
+    type        = "RESPONSE_HEADER"
+    method      = "GET"
+    name        = "tfacc"
+    path        = "/terraform-acc-test"
     status_code = "200"
   }
-  properties = %v
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+
+  properties  = %v
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 
 resource "aws_api_gateway_rest_api" "test" {

--- a/aws/resource_aws_api_gateway_documentation_part_test.go
+++ b/aws/resource_aws_api_gateway_documentation_part_test.go
@@ -266,9 +266,9 @@ func testAccAWSAPIGatewayDocumentationPartMethodConfig(apiName, properties strin
 	return fmt.Sprintf(`
 resource "aws_api_gateway_documentation_part" "test" {
   location {
-    type   = "METHOD"
     method = "GET"
     path   = "/terraform-acc-test"
+    type   = "METHOD"
   }
 
   properties  = %v
@@ -285,11 +285,11 @@ func testAccAWSAPIGatewayDocumentationPartResponseHeaderConfig(apiName, properti
 	return fmt.Sprintf(`
 resource "aws_api_gateway_documentation_part" "test" {
   location {
-    type        = "RESPONSE_HEADER"
     method      = "GET"
     name        = "tfacc"
     path        = "/terraform-acc-test"
     status_code = "200"
+    type        = "RESPONSE_HEADER"
   }
 
   properties  = %v

--- a/aws/resource_aws_api_gateway_documentation_version_test.go
+++ b/aws/resource_aws_api_gateway_documentation_version_test.go
@@ -179,7 +179,7 @@ func testAccAWSAPIGatewayDocumentationVersionBasicConfig(version, apiName string
 	return fmt.Sprintf(`
 resource "aws_api_gateway_documentation_version" "test" {
   version     = "%s"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   depends_on  = ["aws_api_gateway_documentation_part.test"]
 }
 
@@ -189,7 +189,7 @@ resource "aws_api_gateway_documentation_part" "test" {
   }
 
   properties  = "{\"description\":\"Terraform Acceptance Test\"}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 
 resource "aws_api_gateway_rest_api" "test" {
@@ -202,7 +202,7 @@ func testAccAWSAPIGatewayDocumentationVersionAllFieldsConfig(version, apiName, s
 	return fmt.Sprintf(`
 resource "aws_api_gateway_documentation_version" "test" {
   version     = "%s"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   description = "%s"
   depends_on  = ["aws_api_gateway_documentation_part.test"]
 }
@@ -213,33 +213,33 @@ resource "aws_api_gateway_documentation_part" "test" {
   }
 
   properties  = "{\"description\":\"Terraform Acceptance Test\"}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   type                    = "HTTP"
   uri                     = "https://www.google.co.uk"
@@ -247,23 +247,23 @@ resource "aws_api_gateway_integration" "test" {
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_integration.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.error.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_integration.test.http_method
+  status_code = aws_api_gateway_method_response.error.status_code
 }
 
 resource "aws_api_gateway_deployment" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "first"
   depends_on  = ["aws_api_gateway_integration_response.test"]
 }
 
 resource "aws_api_gateway_stage" "test" {
   stage_name            = "%s"
-  rest_api_id           = "${aws_api_gateway_rest_api.test.id}"
-  deployment_id         = "${aws_api_gateway_deployment.test.id}"
-  documentation_version = "${aws_api_gateway_documentation_version.test.version}"
+  rest_api_id           = aws_api_gateway_rest_api.test.id
+  deployment_id         = aws_api_gateway_deployment.test.id
+  documentation_version = aws_api_gateway_documentation_version.test.version
 }
 
 resource "aws_api_gateway_rest_api" "test" {

--- a/aws/resource_aws_api_gateway_documentation_version_test.go
+++ b/aws/resource_aws_api_gateway_documentation_version_test.go
@@ -180,7 +180,7 @@ func testAccAWSAPIGatewayDocumentationVersionBasicConfig(version, apiName string
 resource "aws_api_gateway_documentation_version" "test" {
   version     = "%s"
   rest_api_id = aws_api_gateway_rest_api.test.id
-  depends_on  = ["aws_api_gateway_documentation_part.test"]
+  depends_on  = [aws_api_gateway_documentation_part.test]
 }
 
 resource "aws_api_gateway_documentation_part" "test" {
@@ -204,7 +204,7 @@ resource "aws_api_gateway_documentation_version" "test" {
   version     = "%s"
   rest_api_id = aws_api_gateway_rest_api.test.id
   description = "%s"
-  depends_on  = ["aws_api_gateway_documentation_part.test"]
+  depends_on  = [aws_api_gateway_documentation_part.test]
 }
 
 resource "aws_api_gateway_documentation_part" "test" {
@@ -256,7 +256,7 @@ resource "aws_api_gateway_integration_response" "test" {
 resource "aws_api_gateway_deployment" "test" {
   rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "first"
-  depends_on  = ["aws_api_gateway_integration_response.test"]
+  depends_on  = [aws_api_gateway_integration_response.test]
 }
 
 resource "aws_api_gateway_stage" "test" {

--- a/aws/resource_aws_api_gateway_domain_name_test.go
+++ b/aws/resource_aws_api_gateway_domain_name_test.go
@@ -382,7 +382,7 @@ resource "aws_acm_certificate" "test" {
 
 resource "aws_api_gateway_domain_name" "test" {
   domain_name              = %[1]q
-  regional_certificate_arn = "${aws_acm_certificate.test.arn}"
+  regional_certificate_arn = aws_acm_certificate.test.arn
 
   endpoint_configuration {
     types = ["REGIONAL"]
@@ -416,7 +416,7 @@ resource "aws_acm_certificate" "test" {
 
 resource "aws_api_gateway_domain_name" "test" {
   domain_name              = %[1]q
-  regional_certificate_arn = "${aws_acm_certificate.test.arn}"
+  regional_certificate_arn = aws_acm_certificate.test.arn
   security_policy          = %[4]q
 
   endpoint_configuration {
@@ -435,14 +435,14 @@ resource "aws_acm_certificate" "test" {
 
 resource "aws_api_gateway_domain_name" "test" {
   domain_name              = %[1]q
-  regional_certificate_arn = "${aws_acm_certificate.test.arn}"
+  regional_certificate_arn = aws_acm_certificate.test.arn
 
   endpoint_configuration {
     types = ["REGIONAL"]
   }
 
   tags = {
-	%[4]q = %[5]q
+    %[4]q = %[5]q
   }
 }
 `, domainName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key), tagKey1, tagValue1)
@@ -457,15 +457,15 @@ resource "aws_acm_certificate" "test" {
 
 resource "aws_api_gateway_domain_name" "test" {
   domain_name              = %[1]q
-  regional_certificate_arn = "${aws_acm_certificate.test.arn}"
+  regional_certificate_arn = aws_acm_certificate.test.arn
 
   endpoint_configuration {
     types = ["REGIONAL"]
   }
 
   tags = {
-	%[4]q = %[5]q
-	%[6]q = %[7]q
+    %[4]q = %[5]q
+    %[6]q = %[7]q
   }
 }
 `, domainName, tlsPemEscapeNewlines(certificate), tlsPemEscapeNewlines(key), tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_api_gateway_gateway_response_test.go
+++ b/aws/resource_aws_api_gateway_gateway_response_test.go
@@ -155,7 +155,7 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_gateway_response" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
   status_code   = "401"
   response_type = "UNAUTHORIZED"
 
@@ -177,7 +177,7 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_gateway_response" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
   status_code   = "477"
   response_type = "UNAUTHORIZED"
 

--- a/aws/resource_aws_api_gateway_integration_response_test.go
+++ b/aws/resource_aws_api_gateway_integration_response_test.go
@@ -206,15 +206,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -223,48 +223,48 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 
   response_models = {
     "application/json" = "Error"
   }
 
-	response_parameters = {
-		"method.response.header.Content-Type" = true
-	}
+  response_parameters = {
+    "method.response.header.Content-Type" = true
+  }
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = ""
-    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+    "application/xml"  = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
   type = "MOCK"
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.error.status_code}"
+  rest_api_id       = aws_api_gateway_rest_api.test.id
+  resource_id       = aws_api_gateway_resource.test.id
+  http_method       = aws_api_gateway_method.test.http_method
+  status_code       = aws_api_gateway_method_response.error.status_code
   selection_pattern = ".*"
 
   response_templates = {
     "application/json" = ""
-    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+    "application/xml"  = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
-	response_parameters = {
-		"method.response.header.Content-Type" = "integration.response.body.type"
-	}
+  response_parameters = {
+    "method.response.header.Content-Type" = "integration.response.body.type"
+  }
 }
 `, rName)
 }
@@ -276,15 +276,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -293,46 +293,45 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 
   response_models = {
     "application/json" = "Error"
   }
 
-	response_parameters = {
-		"method.response.header.Content-Type" = true
-	}
+  response_parameters = {
+    "method.response.header.Content-Type" = true
+  }
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = ""
-    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+    "application/xml"  = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
   type = "MOCK"
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.error.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
+  status_code = aws_api_gateway_method_response.error.status_code
 
   response_templates = {
     "application/json" = "$input.path('$')"
-    "application/xml" = ""
+    "application/xml"  = ""
   }
 
   content_handling = "CONVERT_TO_BINARY"
-
 }
 `, rName)
 }

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -391,15 +391,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -408,25 +408,25 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = ""
-    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+    "application/xml"  = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
   request_parameters = {
     "integration.request.header.X-Authorization" = "'static'"
-    "integration.request.header.X-Foo" = "'Bar'"
+    "integration.request.header.X-Foo"           = "'Bar'"
   }
 
-  type = "HTTP"
-  uri = "https://www.google.de"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
   integration_http_method = "GET"
-  passthrough_behavior = "WHEN_NO_MATCH"
-	content_handling = "CONVERT_TO_TEXT"
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  content_handling        = "CONVERT_TO_TEXT"
 }
 `, rName)
 }
@@ -438,15 +438,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -455,26 +455,26 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = "{'foobar': 'bar}"
-    "text/html" = "<html>Foo</html>"
+    "text/html"        = "<html>Foo</html>"
   }
 
   request_parameters = {
     "integration.request.header.X-Authorization" = "'updated'"
-    "integration.request.header.X-FooBar" = "'Baz'"
+    "integration.request.header.X-FooBar"        = "'Baz'"
   }
 
-  type = "HTTP"
-  uri = "https://www.google.de"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
   integration_http_method = "GET"
-  passthrough_behavior = "WHEN_NO_MATCH"
-	content_handling = "CONVERT_TO_TEXT"
-	timeout_milliseconds = 2000
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  content_handling        = "CONVERT_TO_TEXT"
+  timeout_milliseconds    = 2000
 }
 `, rName)
 }
@@ -486,15 +486,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -503,26 +503,26 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = ""
-    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+    "application/xml"  = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
   request_parameters = {
     "integration.request.header.X-Authorization" = "'static'"
-    "integration.request.header.X-Foo" = "'Bar'"
+    "integration.request.header.X-Foo"           = "'Bar'"
   }
 
-  type = "HTTP"
-  uri = "https://www.google.de/updated"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de/updated"
   integration_http_method = "GET"
-  passthrough_behavior = "WHEN_NO_MATCH"
-	content_handling = "CONVERT_TO_TEXT"
-	timeout_milliseconds = 2000
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  content_handling        = "CONVERT_TO_TEXT"
+  timeout_milliseconds    = 2000
 }
 `, rName)
 }
@@ -534,15 +534,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -551,26 +551,26 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = ""
-    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+    "application/xml"  = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
   request_parameters = {
     "integration.request.header.X-Authorization" = "'static'"
-    "integration.request.header.X-Foo" = "'Bar'"
+    "integration.request.header.X-Foo"           = "'Bar'"
   }
 
-  type = "HTTP"
-  uri = "https://www.google.de"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
   integration_http_method = "GET"
-  passthrough_behavior = "WHEN_NO_MATCH"
-	content_handling = "CONVERT_TO_BINARY"
-	timeout_milliseconds = 2000
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  content_handling        = "CONVERT_TO_BINARY"
+  timeout_milliseconds    = 2000
 }
 `, rName)
 }
@@ -582,15 +582,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -599,25 +599,25 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = ""
-    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+    "application/xml"  = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
   request_parameters = {
     "integration.request.header.X-Authorization" = "'static'"
-    "integration.request.header.X-Foo" = "'Bar'"
+    "integration.request.header.X-Foo"           = "'Bar'"
   }
 
-  type = "HTTP"
-  uri = "https://www.google.de"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
   integration_http_method = "GET"
-	passthrough_behavior = "WHEN_NO_MATCH"
-	timeout_milliseconds = 2000
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  timeout_milliseconds    = 2000
 }
 `, rName)
 }
@@ -629,15 +629,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -646,16 +646,16 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
-  type = "HTTP"
-  uri = "https://www.google.de"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
   integration_http_method = "GET"
-  passthrough_behavior = "WHEN_NO_MATCH"
-	content_handling = "CONVERT_TO_TEXT"
-	timeout_milliseconds = 2000
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  content_handling        = "CONVERT_TO_TEXT"
+  timeout_milliseconds    = 2000
 }
 `, rName)
 }
@@ -667,15 +667,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "{param}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "{param}"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -688,30 +688,30 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   request_templates = {
     "application/json" = ""
-    "application/xml" = "#set($inputRoot = $input.path('$'))\n{ }"
+    "application/xml"  = "#set($inputRoot = $input.path('$'))\n{ }"
   }
 
   request_parameters = {
     "integration.request.header.X-Authorization" = "'static'"
-    "integration.request.header.X-Foo" = "'Bar'"
-    "integration.request.path.param" = "method.request.path.param"
+    "integration.request.header.X-Foo"           = "'Bar'"
+    "integration.request.path.param"             = "method.request.path.param"
   }
 
   cache_key_parameters = ["method.request.path.param"]
-  cache_namespace = "foobar"
+  cache_namespace      = "foobar"
 
-  type = "HTTP"
-  uri = "https://www.google.de"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
   integration_http_method = "GET"
-  passthrough_behavior = "WHEN_NO_MATCH"
-	content_handling = "CONVERT_TO_TEXT"
-	timeout_milliseconds = 2000
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  content_handling        = "CONVERT_TO_TEXT"
+  timeout_milliseconds    = 2000
 }
 `, rName)
 }
@@ -735,29 +735,29 @@ resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
 
   tags = {
-    Name = "${var.name}"
+    Name = var.name
   }
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.10.0.0/24"
-  availability_zone = "${data.aws_availability_zones.test.names[0]}"
+  availability_zone = data.aws_availability_zones.test.names[0]
 }
 
 resource "aws_api_gateway_rest_api" "test" {
-  name = "${var.name}"
+  name = var.name
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 
@@ -767,15 +767,15 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_lb" "test" {
-  name               = "${var.name}"
+  name               = var.name
   internal           = true
   load_balancer_type = "network"
-  subnets            = ["${aws_subnet.test.id}"]
+  subnets            = [aws_subnet.test.id]
 }
 
 resource "aws_api_gateway_vpc_link" "test" {
-  name        = "${var.name}"
-  target_arns = ["${aws_lb.test.arn}"]
+  name        = var.name
+  target_arns = [aws_lb.test.arn]
 }
 `, rName)
 }
@@ -783,9 +783,9 @@ resource "aws_api_gateway_vpc_link" "test" {
 func testAccAWSAPIGatewayIntegrationConfig_IntegrationTypeVpcLink(rName string) string {
 	return testAccAWSAPIGatewayIntegrationConfig_IntegrationTypeBase(rName) + `
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   type                    = "HTTP"
   uri                     = "https://www.google.de"
@@ -794,7 +794,7 @@ resource "aws_api_gateway_integration" "test" {
   content_handling        = "CONVERT_TO_TEXT"
 
   connection_type = "VPC_LINK"
-  connection_id   = "${aws_api_gateway_vpc_link.test.id}"
+  connection_id   = aws_api_gateway_vpc_link.test.id
 }
 `
 }
@@ -802,9 +802,9 @@ resource "aws_api_gateway_integration" "test" {
 func testAccAWSAPIGatewayIntegrationConfig_IntegrationTypeInternet(rName string) string {
 	return testAccAWSAPIGatewayIntegrationConfig_IntegrationTypeBase(rName) + `
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   type                    = "HTTP"
   uri                     = "https://www.google.de"

--- a/aws/resource_aws_api_gateway_method_response_test.go
+++ b/aws/resource_aws_api_gateway_method_response_test.go
@@ -201,15 +201,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -218,9 +218,9 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 
   response_models = {
@@ -241,15 +241,15 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 
   request_models = {
@@ -258,9 +258,9 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 
   response_models = {

--- a/aws/resource_aws_api_gateway_method_settings_test.go
+++ b/aws/resource_aws_api_gateway_method_settings_test.go
@@ -695,11 +695,12 @@ resource "aws_api_gateway_integration" "test" {
    "body" : $input.json('$')
 }
 EOF
+
   }
 }
 
 resource "aws_api_gateway_deployment" "test" {
-  depends_on  = ["aws_api_gateway_integration.test"]
+  depends_on  = [aws_api_gateway_integration.test]
   rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "dev"
 }

--- a/aws/resource_aws_api_gateway_method_settings_test.go
+++ b/aws/resource_aws_api_gateway_method_settings_test.go
@@ -662,14 +662,14 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 
@@ -684,9 +684,9 @@ resource "aws_api_gateway_method" "test" {
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   type        = "MOCK"
 
   request_templates = {
@@ -700,7 +700,7 @@ EOF
 
 resource "aws_api_gateway_deployment" "test" {
   depends_on  = ["aws_api_gateway_integration.test"]
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "dev"
 }
 `, rName)
@@ -710,8 +710,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsCacheDataEncrypted(rName st
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     cache_data_encrypted = %t
@@ -724,8 +724,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsCacheTtlInSeconds(rName str
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     cache_ttl_in_seconds = %d
@@ -738,8 +738,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsCachingEnabled(rName string
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     caching_enabled = %t
@@ -752,8 +752,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsDataTraceEnabled(rName stri
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     data_trace_enabled = %t
@@ -766,8 +766,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsLoggingLevel(rName, logging
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     logging_level = %q
@@ -780,8 +780,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsMetricsEnabled(rName string
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     metrics_enabled = %t
@@ -793,8 +793,8 @@ resource "aws_api_gateway_method_settings" "test" {
 func testAccAWSAPIGatewayMethodSettingsConfigSettingsMultiple(rName, loggingLevel string, metricsEnabled bool) string {
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
 
   settings {
@@ -809,8 +809,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsRequireAuthorizationForCach
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     require_authorization_for_cache_control = %t
@@ -823,8 +823,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsThrottlingBurstLimit(rName 
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     throttling_burst_limit = %d
@@ -837,8 +837,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsThrottlingRateLimit(rName s
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     throttling_rate_limit = %f
@@ -851,8 +851,8 @@ func testAccAWSAPIGatewayMethodSettingsConfigSettingsUnauthorizedCacheControlHea
 	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = aws_api_gateway_deployment.test.stage_name
 
   settings {
     unauthorized_cache_control_header_strategy = %q

--- a/aws/resource_aws_api_gateway_method_test.go
+++ b/aws/resource_aws_api_gateway_method_test.go
@@ -348,7 +348,7 @@ EOF
 
 resource "aws_iam_role_policy" "invocation_policy" {
   name = "tf-acc-api-gateway-%d"
-  role = "${aws_iam_role.invocation_role.id}"
+  role = aws_iam_role.invocation_role.id
 
   policy = <<EOF
 {
@@ -386,32 +386,32 @@ EOF
 
 resource "aws_lambda_function" "authorizer" {
   filename         = "test-fixtures/lambdatest.zip"
-  source_code_hash = "${filebase64sha256("test-fixtures/lambdatest.zip")}"
+  source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   function_name    = "tf_acc_api_gateway_authorizer_%d"
-  role             = "${aws_iam_role.iam_for_lambda.arn}"
+  role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
   runtime          = "nodejs12.x"
 }
 
 resource "aws_api_gateway_authorizer" "test" {
   name                   = "tf-acc-test-authorizer"
-  rest_api_id            = "${aws_api_gateway_rest_api.test.id}"
-  authorizer_uri         = "${aws_lambda_function.authorizer.invoke_arn}"
-  authorizer_credentials = "${aws_iam_role.invocation_role.arn}"
+  rest_api_id            = aws_api_gateway_rest_api.test.id
+  authorizer_uri         = aws_lambda_function.authorizer.invoke_arn
+  authorizer_credentials = aws_iam_role.invocation_role.arn
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "CUSTOM"
-  authorizer_id = "${aws_api_gateway_authorizer.test.id}"
+  authorizer_id = aws_api_gateway_authorizer.test.id
 
   request_models = {
     "application/json" = "Error"
@@ -478,24 +478,24 @@ resource "aws_cognito_user_pool" "pool" {
 
 resource "aws_api_gateway_authorizer" "test" {
   name            = "tf-acc-test-cognito-authorizer"
-  rest_api_id     = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id     = aws_api_gateway_rest_api.test.id
   identity_source = "method.request.header.Authorization"
-  provider_arns   = ["${aws_cognito_user_pool.pool.arn}"]
+  provider_arns   = [aws_cognito_user_pool.pool.arn]
   type            = "COGNITO_USER_POOLS"
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id          = "${aws_api_gateway_rest_api.test.id}"
-  resource_id          = "${aws_api_gateway_resource.test.id}"
+  rest_api_id          = aws_api_gateway_rest_api.test.id
+  resource_id          = aws_api_gateway_resource.test.id
   http_method          = "GET"
   authorization        = "COGNITO_USER_POOLS"
-  authorizer_id        = "${aws_api_gateway_authorizer.test.id}"
+  authorizer_id        = aws_api_gateway_authorizer.test.id
   authorization_scopes = ["test.read", "test.write"]
 
   request_models = {
@@ -563,24 +563,24 @@ resource "aws_cognito_user_pool" "pool" {
 
 resource "aws_api_gateway_authorizer" "test" {
   name            = "tf-acc-test-cognito-authorizer"
-  rest_api_id     = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id     = aws_api_gateway_rest_api.test.id
   identity_source = "method.request.header.Authorization"
-  provider_arns   = ["${aws_cognito_user_pool.pool.arn}"]
+  provider_arns   = [aws_cognito_user_pool.pool.arn]
   type            = "COGNITO_USER_POOLS"
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id          = "${aws_api_gateway_rest_api.test.id}"
-  resource_id          = "${aws_api_gateway_resource.test.id}"
+  rest_api_id          = aws_api_gateway_rest_api.test.id
+  resource_id          = aws_api_gateway_resource.test.id
   http_method          = "GET"
   authorization        = "COGNITO_USER_POOLS"
-  authorizer_id        = "${aws_api_gateway_authorizer.test.id}"
+  authorizer_id        = aws_api_gateway_authorizer.test.id
   authorization_scopes = ["test.read", "test.write", "test.delete"]
 
   request_models = {
@@ -601,14 +601,14 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 
@@ -631,14 +631,14 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 
@@ -660,20 +660,20 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_request_validator" "validator" {
-  rest_api_id                 = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id                 = aws_api_gateway_rest_api.test.id
   name                        = "paramsValidator"
   validate_request_parameters = true
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 
@@ -686,7 +686,7 @@ resource "aws_api_gateway_method" "test" {
     "method.request.querystring.page"    = true
   }
 
-  request_validator_id = "${aws_api_gateway_request_validator.validator.id}"
+  request_validator_id = aws_api_gateway_request_validator.validator.id
 }
 `, rInt)
 }
@@ -698,20 +698,20 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_request_validator" "validator" {
-  rest_api_id                 = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id                 = aws_api_gateway_rest_api.test.id
   name                        = "paramsValidator"
   validate_request_parameters = true
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 

--- a/aws/resource_aws_api_gateway_method_test.go
+++ b/aws/resource_aws_api_gateway_method_test.go
@@ -344,6 +344,7 @@ resource "aws_iam_role" "invocation_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "invocation_policy" {
@@ -362,6 +363,7 @@ resource "aws_iam_role_policy" "invocation_policy" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -382,6 +384,7 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 EOF
+
 }
 
 resource "aws_lambda_function" "authorizer" {
@@ -450,6 +453,7 @@ resource "aws_iam_role" "invocation_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -470,6 +474,7 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 EOF
+
 }
 
 resource "aws_cognito_user_pool" "pool" {
@@ -535,6 +540,7 @@ resource "aws_iam_role" "invocation_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -555,6 +561,7 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 EOF
+
 }
 
 resource "aws_cognito_user_pool" "pool" {

--- a/aws/resource_aws_api_gateway_model_test.go
+++ b/aws/resource_aws_api_gateway_model_test.go
@@ -180,6 +180,7 @@ resource "aws_api_gateway_model" "test" {
   "type": "object"
 }
 EOF
+
 }
 `, rName, modelName)
 }

--- a/aws/resource_aws_api_gateway_model_test.go
+++ b/aws/resource_aws_api_gateway_model_test.go
@@ -170,10 +170,11 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_model" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  name = "%s"
-  description = "a test schema"
+  rest_api_id  = aws_api_gateway_rest_api.test.id
+  name         = "%s"
+  description  = "a test schema"
   content_type = "application/json"
+
   schema = <<EOF
 {
   "type": "object"

--- a/aws/resource_aws_api_gateway_request_validator_test.go
+++ b/aws/resource_aws_api_gateway_request_validator_test.go
@@ -196,8 +196,8 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccAWSAPIGatewayRequestValidatorConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayRequestValidatorConfig_base(rName) + `
 resource "aws_api_gateway_request_validator" "test" {
-  name = "tf-acc-test-request-validator"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  name        = "tf-acc-test-request-validator"
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 `)
 }
@@ -205,9 +205,9 @@ resource "aws_api_gateway_request_validator" "test" {
 func testAccAWSAPIGatewayRequestValidatorUpdatedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayRequestValidatorConfig_base(rName) + `
 resource "aws_api_gateway_request_validator" "test" {
-  name = "tf-acc-test-request-validator_modified"
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  validate_request_body = true
+  name                        = "tf-acc-test-request-validator_modified"
+  rest_api_id                 = aws_api_gateway_rest_api.test.id
+  validate_request_body       = true
   validate_request_parameters = true
 }
 `)

--- a/aws/resource_aws_api_gateway_resource_test.go
+++ b/aws/resource_aws_api_gateway_resource_test.go
@@ -202,9 +202,9 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 `, rName)
 }
@@ -216,9 +216,9 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test_changed"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test_changed"
 }
 `, rName)
 }

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -734,7 +734,7 @@ resource "aws_api_gateway_rest_api" "test" {
 
   endpoint_configuration {
     types            = ["PRIVATE"]
-    vpc_endpoint_ids = [aws_vpc_endpoint.test.id]
+	vpc_endpoint_ids = [aws_vpc_endpoint.test.id]
   }
 }
 `, rName)
@@ -776,7 +776,8 @@ resource "aws_subnet" "test" {
   }
 }
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
@@ -888,6 +889,7 @@ resource "aws_api_gateway_rest_api" "test" {
   ]
 }
 EOF
+
 }
 `, rName)
 }
@@ -913,6 +915,7 @@ resource "aws_api_gateway_rest_api" "test" {
   ]
 }
 EOF
+
 }
 `, rName)
 }
@@ -977,6 +980,7 @@ resource "aws_api_gateway_rest_api" "test" {
   }
 }
 EOF
+
 }
 `, rName, rName)
 }
@@ -1019,6 +1023,7 @@ resource "aws_api_gateway_rest_api" "test" {
   }
 }
 EOF
+
 }
 `, rName, rName)
 }

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -650,7 +650,7 @@ func testAccCheckAWSAPIGatewayRestAPIDestroy(s *terraform.State) error {
 func testAccAWSAPIGatewayRestAPIConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "%s"
+  name                     = "%s"
   minimum_compression_size = 0
 }
 `, rName)
@@ -679,7 +679,7 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccAWSAPIGatewayRestAPIConfig_VPCEndpointConfiguration(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "11.0.0.0/16"
+  cidr_block           = "11.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 
@@ -689,7 +689,7 @@ resource "aws_vpc" "test" {
 }
 
 data "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
   name   = "default"
 }
 
@@ -703,9 +703,9 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
-  cidr_block        = "${aws_vpc.test.cidr_block}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = aws_vpc.test.cidr_block
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = %[1]q
@@ -715,17 +715,17 @@ resource "aws_subnet" "test" {
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.execute-api"
-  vpc_endpoint_type = "Interface"
+  vpc_id              = aws_vpc.test.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  vpc_endpoint_type   = "Interface"
   private_dns_enabled = false
 
   subnet_ids = [
-    "${aws_subnet.test.id}",
+    aws_subnet.test.id,
   ]
 
   security_group_ids = [
-    "${data.aws_security_group.test.id}",
+    data.aws_security_group.test.id,
   ]
 }
 
@@ -733,8 +733,8 @@ resource "aws_api_gateway_rest_api" "test" {
   name = %[1]q
 
   endpoint_configuration {
-    types = ["PRIVATE"]
-	vpc_endpoint_ids = ["${aws_vpc_endpoint.test.id}"]
+    types            = ["PRIVATE"]
+    vpc_endpoint_ids = [aws_vpc_endpoint.test.id]
   }
 }
 `, rName)
@@ -743,7 +743,7 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccAWSAPIGatewayRestAPIConfig_VPCEndpointConfiguration2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "11.0.0.0/16"
+  cidr_block           = "11.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 
@@ -753,7 +753,7 @@ resource "aws_vpc" "test" {
 }
 
 data "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
   name   = "default"
 }
 
@@ -767,9 +767,9 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
-  cidr_block        = "${aws_vpc.test.cidr_block}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = aws_vpc.test.cidr_block
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = %[1]q
@@ -779,32 +779,32 @@ resource "aws_subnet" "test" {
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.execute-api"
-  vpc_endpoint_type = "Interface"
+  vpc_id              = aws_vpc.test.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  vpc_endpoint_type   = "Interface"
   private_dns_enabled = false
 
   subnet_ids = [
-    "${aws_subnet.test.id}",
+    aws_subnet.test.id,
   ]
 
   security_group_ids = [
-    "${data.aws_security_group.test.id}",
+    data.aws_security_group.test.id,
   ]
 }
 
 resource "aws_vpc_endpoint" "test2" {
-  vpc_id            = "${aws_vpc.test.id}"
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.execute-api"
-  vpc_endpoint_type = "Interface"
+  vpc_id              = aws_vpc.test.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  vpc_endpoint_type   = "Interface"
   private_dns_enabled = false
 
   subnet_ids = [
-    "${aws_subnet.test.id}",
+    aws_subnet.test.id,
   ]
 
   security_group_ids = [
-    "${data.aws_security_group.test.id}",
+    data.aws_security_group.test.id,
   ]
 }
 
@@ -812,8 +812,8 @@ resource "aws_api_gateway_rest_api" "test" {
   name = %[1]q
 
   endpoint_configuration {
-    types = ["PRIVATE"]
-	vpc_endpoint_ids = ["${aws_vpc_endpoint.test.id}", "${aws_vpc_endpoint.test2.id}"]
+    types            = ["PRIVATE"]
+    vpc_endpoint_ids = [aws_vpc_endpoint.test.id, aws_vpc_endpoint.test2.id]
   }
 }
 `, rName)
@@ -825,7 +825,7 @@ resource "aws_api_gateway_rest_api" "test" {
   name = "%s"
 
   tags = {
-	%q = %q
+    %q = %q
   }
 }
 `, rName, tagKey1, tagValue1)
@@ -837,8 +837,8 @@ resource "aws_api_gateway_rest_api" "test" {
   name = "%s"
 
   tags = {
-	%q = %q
-	%q = %q
+    %q = %q
+    %q = %q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
@@ -847,8 +847,8 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccAWSAPIGatewayRestAPIConfigWithAPIKeySource(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "%s"
-	api_key_source = "HEADER"
+  name           = "%s"
+  api_key_source = "HEADER"
 }
 `, rName)
 }
@@ -856,8 +856,8 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccAWSAPIGatewayRestAPIConfigWithUpdateAPIKeySource(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "%s"
-	api_key_source = "AUTHORIZER"
+  name           = "%s"
+  api_key_source = "AUTHORIZER"
 }
 `, rName)
 }
@@ -865,8 +865,9 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccAWSAPIGatewayRestAPIConfigWithPolicy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "%s"
+  name                     = "%s"
   minimum_compression_size = 0
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -894,21 +895,22 @@ EOF
 func testAccAWSAPIGatewayRestAPIConfigUpdatePolicy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "%s"
+  name                     = "%s"
   minimum_compression_size = 0
+
   policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Deny",
-            "Principal": {
-                "AWS": "*"
-            },
-            "Action": "execute-api:Invoke",
-            "Resource": "*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "execute-api:Invoke",
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }
@@ -918,9 +920,9 @@ EOF
 func testAccAWSAPIGatewayRestAPIUpdateConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "%s"
-  description = "test"
-  binary_media_types = ["application/octet-stream"]
+  name                     = "%s"
+  description              = "test"
+  binary_media_types       = ["application/octet-stream"]
   minimum_compression_size = 10485760
 }
 `, rName)
@@ -929,9 +931,9 @@ resource "aws_api_gateway_rest_api" "test" {
 func testAccAWSAPIGatewayRestAPIDisableCompressionConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "%s"
-  description = "test"
-  binary_media_types = ["application/octet-stream"]
+  name                     = "%s"
+  description              = "test"
+  binary_media_types       = ["application/octet-stream"]
   minimum_compression_size = -1
 }
 `, rName)
@@ -941,6 +943,7 @@ func testAccAWSAPIGatewayRestAPIConfigOpenAPI(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = "%s"
+
   body = <<EOF
 {
   "swagger": "2.0",
@@ -982,6 +985,7 @@ func testAccAWSAPIGatewayRestAPIUpdateConfigOpenAPI(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = "%s"
+
   body = <<EOF
 {
   "swagger": "2.0",

--- a/aws/resource_aws_api_gateway_stage_test.go
+++ b/aws/resource_aws_api_gateway_stage_test.go
@@ -374,7 +374,7 @@ resource "aws_api_gateway_integration_response" "test" {
 }
 
 resource "aws_api_gateway_deployment" "dev" {
-  depends_on = ["aws_api_gateway_integration.test"]
+  depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "dev"

--- a/aws/resource_aws_api_gateway_stage_test.go
+++ b/aws/resource_aws_api_gateway_stage_test.go
@@ -337,29 +337,29 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id   = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
   path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  resource_id   = "${aws_api_gateway_resource.test.id}"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
   http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
   type                    = "HTTP"
   uri                     = "https://www.google.co.uk"
@@ -367,16 +367,16 @@ resource "aws_api_gateway_integration" "test" {
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_integration.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.error.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_integration.test.http_method
+  status_code = aws_api_gateway_method_response.error.status_code
 }
 
 resource "aws_api_gateway_deployment" "dev" {
   depends_on = ["aws_api_gateway_integration.test"]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "dev"
   description = "This is a dev env"
 
@@ -466,16 +466,18 @@ resource "aws_api_gateway_deployment" "test2" {
 func testAccAWSAPIGatewayStageConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayStageConfig_base(rName) + `
 resource "aws_api_gateway_stage" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "prod"
-  deployment_id = "${aws_api_gateway_deployment.dev.id}"
+  rest_api_id           = aws_api_gateway_rest_api.test.id
+  stage_name            = "prod"
+  deployment_id         = aws_api_gateway_deployment.dev.id
   cache_cluster_enabled = true
-  cache_cluster_size = "0.5"
-  xray_tracing_enabled = true
+  cache_cluster_size    = "0.5"
+  xray_tracing_enabled  = true
+
   variables = {
     one = "1"
     two = "2"
   }
+
   tags = {
     Name = "tf-test"
   }
@@ -486,18 +488,20 @@ resource "aws_api_gateway_stage" "test" {
 func testAccAWSAPIGatewayStageConfig_updated(rName string) string {
 	return testAccAWSAPIGatewayStageConfig_base(rName) + `
 resource "aws_api_gateway_stage" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "prod"
-  deployment_id = "${aws_api_gateway_deployment.dev.id}"
+  rest_api_id           = aws_api_gateway_rest_api.test.id
+  stage_name            = "prod"
+  deployment_id         = aws_api_gateway_deployment.dev.id
   cache_cluster_enabled = false
-  description = "Hello world"
-  xray_tracing_enabled = false
+  description           = "Hello world"
+  xray_tracing_enabled  = false
+
   variables = {
-    one = "1"
+    one   = "1"
     three = "3"
   }
+
   tags = {
-    Name = "tf-test"
+    Name      = "tf-test"
     ExtraName = "tf-test"
   }
 }
@@ -511,21 +515,24 @@ resource "aws_cloudwatch_log_group" "test" {
 }
 
 resource "aws_api_gateway_stage" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "prod"
-  deployment_id = "${aws_api_gateway_deployment.dev.id}"
+  rest_api_id           = aws_api_gateway_rest_api.test.id
+  stage_name            = "prod"
+  deployment_id         = aws_api_gateway_deployment.dev.id
   cache_cluster_enabled = true
-  cache_cluster_size = "0.5"
+  cache_cluster_size    = "0.5"
+
   variables = {
     one = "1"
     two = "2"
   }
+
   tags = {
     Name = "tf-test"
-	}
+  }
+
   access_log_settings {
-    destination_arn = "${aws_cloudwatch_log_group.test.arn}"
-    format = %q
+    destination_arn = aws_cloudwatch_log_group.test.arn
+    format          = %q
   }
 }
 `, rName, format)
@@ -560,32 +567,33 @@ EOF
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
-  name = "amazon-apigateway-%[1]s"
+  name        = "amazon-apigateway-%[1]s"
 
   extended_s3_configuration {
-    role_arn   = "${aws_iam_role.test.arn}"
-    bucket_arn = "${aws_s3_bucket.test.arn}"
+    role_arn   = aws_iam_role.test.arn
+    bucket_arn = aws_s3_bucket.test.arn
   }
-
-
 }
 
 resource "aws_api_gateway_stage" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "prod"
-  deployment_id = "${aws_api_gateway_deployment.dev.id}"
+  rest_api_id           = aws_api_gateway_rest_api.test.id
+  stage_name            = "prod"
+  deployment_id         = aws_api_gateway_deployment.dev.id
   cache_cluster_enabled = true
-  cache_cluster_size = "0.5"
+  cache_cluster_size    = "0.5"
+
   variables = {
     one = "1"
     two = "2"
   }
+
   tags = {
     Name = "tf-test"
-	}
+  }
+
   access_log_settings {
-    destination_arn = "${aws_kinesis_firehose_delivery_stream.test.arn}"
-    format = %q
+    destination_arn = aws_kinesis_firehose_delivery_stream.test.arn
+    format          = %q
   }
 }
 `, rName, format)

--- a/aws/resource_aws_api_gateway_usage_plan_key_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_key_test.go
@@ -215,7 +215,7 @@ resource "aws_api_gateway_integration_response" "test" {
 }
 
 resource "aws_api_gateway_deployment" "test" {
-  depends_on = ["aws_api_gateway_integration.test"]
+  depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "test"
@@ -228,8 +228,8 @@ resource "aws_api_gateway_deployment" "test" {
 
 resource "aws_api_gateway_deployment" "foo" {
   depends_on = [
-    "aws_api_gateway_deployment.test",
-    "aws_api_gateway_integration.test",
+    aws_api_gateway_deployment.test,
+    aws_api_gateway_integration.test,
   ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id

--- a/aws/resource_aws_api_gateway_usage_plan_key_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_key_test.go
@@ -178,47 +178,47 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
-  type = "HTTP"
-  uri = "https://www.google.de"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
   integration_http_method = "GET"
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_integration.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.error.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_integration.test.http_method
+  status_code = aws_api_gateway_method_response.error.status_code
 }
 
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = "test"
   description = "This is a test"
 
   variables = {
@@ -232,8 +232,8 @@ resource "aws_api_gateway_deployment" "foo" {
     "aws_api_gateway_integration.test",
   ]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "foo"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = "foo"
   description = "This is a prod stage"
 }
 
@@ -241,8 +241,8 @@ resource "aws_api_gateway_usage_plan" "main" {
   name = "%[1]s"
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.test.id}"
-    stage  = "${aws_api_gateway_deployment.test.stage_name}"
+    api_id = aws_api_gateway_rest_api.test.id
+    stage  = aws_api_gateway_deployment.test.stage_name
   }
 }
 
@@ -250,8 +250,8 @@ resource "aws_api_gateway_usage_plan" "secondary" {
   name = "secondary-%[1]s"
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.test.id}"
-    stage  = "${aws_api_gateway_deployment.foo.stage_name}"
+    api_id = aws_api_gateway_rest_api.test.id
+    stage  = aws_api_gateway_deployment.foo.stage_name
   }
 }
 
@@ -264,9 +264,9 @@ resource "aws_api_gateway_api_key" "mykey" {
 func testAccAWSApiGatewayUsagePlanKeyBasicConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanKeyConfig(rName) + `
 resource "aws_api_gateway_usage_plan_key" "main" {
-  key_id        = "${aws_api_gateway_api_key.mykey.id}"
+  key_id        = aws_api_gateway_api_key.mykey.id
   key_type      = "API_KEY"
-  usage_plan_id = "${aws_api_gateway_usage_plan.main.id}"
+  usage_plan_id = aws_api_gateway_usage_plan.main.id
 }
 `)
 }
@@ -274,9 +274,9 @@ resource "aws_api_gateway_usage_plan_key" "main" {
 func testAccAWSApiGatewayUsagePlanKeyBasicUpdatedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanKeyConfig(rName) + `
 resource "aws_api_gateway_usage_plan_key" "main" {
-  key_id        = "${aws_api_gateway_api_key.mykey.id}"
+  key_id        = aws_api_gateway_api_key.mykey.id
   key_type      = "API_KEY"
-  usage_plan_id = "${aws_api_gateway_usage_plan.secondary.id}"
+  usage_plan_id = aws_api_gateway_usage_plan.secondary.id
 }
 `)
 }

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -536,7 +536,7 @@ resource "aws_api_gateway_integration_response" "test" {
 }
 
 resource "aws_api_gateway_deployment" "test" {
-  depends_on = ["aws_api_gateway_integration.test"]
+  depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "test"
@@ -548,7 +548,10 @@ resource "aws_api_gateway_deployment" "test" {
 }
 
 resource "aws_api_gateway_deployment" "foo" {
-  depends_on = ["aws_api_gateway_deployment.test", "aws_api_gateway_integration.test"]
+  depends_on = [
+    aws_api_gateway_deployment.test,
+    aws_api_gateway_integration.test,
+  ]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
   stage_name  = "foo"

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -499,47 +499,47 @@ resource "aws_api_gateway_rest_api" "test" {
 }
 
 resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "test"
 }
 
 resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_method_response" "error" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
   status_code = "400"
 }
 
 resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_method.test.http_method
 
-  type = "HTTP"
-  uri = "https://www.google.de"
+  type                    = "HTTP"
+  uri                     = "https://www.google.de"
   integration_http_method = "GET"
 }
 
 resource "aws_api_gateway_integration_response" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_integration.test.http_method}"
-  status_code = "${aws_api_gateway_method_response.error.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  resource_id = aws_api_gateway_resource.test.id
+  http_method = aws_api_gateway_integration.test.http_method
+  status_code = aws_api_gateway_method_response.error.status_code
 }
 
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "test"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = "test"
   description = "This is a test"
 
   variables = {
@@ -550,8 +550,8 @@ resource "aws_api_gateway_deployment" "test" {
 resource "aws_api_gateway_deployment" "foo" {
   depends_on = ["aws_api_gateway_deployment.test", "aws_api_gateway_integration.test"]
 
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "foo"
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  stage_name  = "foo"
   description = "This is a prod stage"
 }
 `, rName)
@@ -571,7 +571,7 @@ resource "aws_api_gateway_usage_plan" "main" {
   name = "%s"
 
   tags = {
-	%q = %q
+    %q = %q
   }
 }
 `, rName, tagKey1, tagValue1)
@@ -583,8 +583,8 @@ resource "aws_api_gateway_usage_plan" "main" {
   name = "%s"
 
   tags = {
-	%q = %q
-	%q = %q
+    %q = %q
+    %q = %q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
@@ -637,7 +637,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 func testAccAWSApiGatewayUsagePlanThrottlingConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig(rName)+`
 resource "aws_api_gateway_usage_plan" "test" {
-  name        = "%s"
+  name = "%s"
 
   throttle_settings {
     burst_limit = 2
@@ -650,7 +650,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 func testAccAWSApiGatewayUsagePlanThrottlingModifiedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig(rName)+`
 resource "aws_api_gateway_usage_plan" "test" {
-  name        = "%s"
+  name = "%s"
 
   throttle_settings {
     burst_limit = 3
@@ -663,7 +663,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 func testAccAWSApiGatewayUsagePlanQuotaConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig(rName)+`
 resource "aws_api_gateway_usage_plan" "test" {
-  name        = "%s"
+  name = "%s"
 
   quota_settings {
     limit  = 100
@@ -677,7 +677,7 @@ resource "aws_api_gateway_usage_plan" "test" {
 func testAccAWSApiGatewayUsagePlanQuotaModifiedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig(rName)+`
 resource "aws_api_gateway_usage_plan" "test" {
-  name        = "%s"
+  name = "%s"
 
   quota_settings {
     limit  = 200
@@ -691,11 +691,11 @@ resource "aws_api_gateway_usage_plan" "test" {
 func testAccAWSApiGatewayUsagePlanApiStagesConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig(rName)+`
 resource "aws_api_gateway_usage_plan" "test" {
-  name        = "%s"
+  name = "%s"
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.test.id}"
-    stage  = "${aws_api_gateway_deployment.test.stage_name}"
+    api_id = aws_api_gateway_rest_api.test.id
+    stage  = aws_api_gateway_deployment.test.stage_name
   }
 }
 `, rName)
@@ -704,11 +704,11 @@ resource "aws_api_gateway_usage_plan" "test" {
 func testAccAWSApiGatewayUsagePlanApiStagesModifiedConfig(rName string) string {
 	return fmt.Sprintf(testAccAWSAPIGatewayUsagePlanConfig(rName)+`
 resource "aws_api_gateway_usage_plan" "test" {
-  name        = "%s"
+  name = "%s"
 
   api_stages {
-    api_id = "${aws_api_gateway_rest_api.test.id}"
-    stage  = "${aws_api_gateway_deployment.foo.stage_name}"
+    api_id = aws_api_gateway_rest_api.test.id
+    stage  = aws_api_gateway_deployment.foo.stage_name
   }
 }
 `, rName)

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -224,11 +224,12 @@ resource "aws_lb" "test_a" {
   name               = "tf-lb-%s"
   internal           = true
   load_balancer_type = "network"
-  subnets            = ["${aws_subnet.test.id}"]
+  subnets            = [aws_subnet.test.id]
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
+
   tags = {
     Name = "tf-acc-api-gateway-vpc-link-%s"
   }
@@ -244,9 +245,9 @@ data "aws_availability_zones" "test" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.10.0.0/21"
-  availability_zone = "${data.aws_availability_zones.test.names[0]}"
+  availability_zone = data.aws_availability_zones.test.names[0]
 
   tags = {
     Name = "tf-acc-api-gateway-vpc-link"
@@ -258,9 +259,9 @@ resource "aws_subnet" "test" {
 func testAccAPIGatewayVpcLinkConfig(rName, description string) string {
 	return testAccAPIGatewayVpcLinkConfig_basis(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_vpc_link" "test" {
-  name = "tf-apigateway-%s"
+  name        = "tf-apigateway-%s"
   description = %q
-  target_arns = ["${aws_lb.test_a.arn}"]
+  target_arns = [aws_lb.test_a.arn]
 }
 `, rName, description)
 }
@@ -268,12 +269,12 @@ resource "aws_api_gateway_vpc_link" "test" {
 func testAccAPIGatewayVpcLinkConfigTags1(rName, description, tagKey1, tagValue1 string) string {
 	return testAccAPIGatewayVpcLinkConfig_basis(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_vpc_link" "test" {
-  name = "tf-apigateway-%s"
+  name        = "tf-apigateway-%s"
   description = %q
-  target_arns = ["${aws_lb.test_a.arn}"]
+  target_arns = [aws_lb.test_a.arn]
 
   tags = {
-  	%q = %q
+    %q = %q
   }
 }
 `, rName, description, tagKey1, tagValue1)
@@ -282,13 +283,13 @@ resource "aws_api_gateway_vpc_link" "test" {
 func testAccAPIGatewayVpcLinkConfigTags2(rName, description, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccAPIGatewayVpcLinkConfig_basis(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_vpc_link" "test" {
- name = "tf-apigateway-%s"
- description = %q
- target_arns = ["${aws_lb.test_a.arn}"]
+  name        = "tf-apigateway-%s"
+  description = %q
+  target_arns = [aws_lb.test_a.arn]
 
   tags = {
-  	%q = %q
-	%q = %q
+    %q = %q
+    %q = %q
   }
 }
 `, rName, description, tagKey1, tagValue1, tagKey2, tagValue2)
@@ -297,9 +298,9 @@ resource "aws_api_gateway_vpc_link" "test" {
 func testAccAPIGatewayVpcLinkConfig_Update(rName, description string) string {
 	return testAccAPIGatewayVpcLinkConfig_basis(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_vpc_link" "test" {
-  name = "tf-apigateway-update-%s"
+  name        = "tf-apigateway-update-%s"
   description = %q
-  target_arns = ["${aws_lb.test_a.arn}"]
+  target_arns = [aws_lb.test_a.arn]
 }
 `, rName, description)
 }

--- a/aws/resource_aws_apigatewayv2_api_mapping_test.go
+++ b/aws/resource_aws_apigatewayv2_api_mapping_test.go
@@ -266,9 +266,9 @@ resource "aws_apigatewayv2_domain_name" "test" {
 func testAccAWSAPIGatewayV2ApiMappingConfig_basic(rName, certificateArn string) string {
 	return testAccAWSAPIGatewayV2ApiMappingConfig_base(rName, certificateArn) + testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName) + `
 resource "aws_apigatewayv2_api_mapping" "test" {
-  api_id      = "${aws_apigatewayv2_api.test.id}"
-  domain_name = "${aws_apigatewayv2_domain_name.test.id}"
-  stage       = "${aws_apigatewayv2_stage.test.id}"
+  api_id      = aws_apigatewayv2_api.test.id
+  domain_name = aws_apigatewayv2_domain_name.test.id
+  stage       = aws_apigatewayv2_stage.test.id
 }
 `
 }
@@ -276,9 +276,9 @@ resource "aws_apigatewayv2_api_mapping" "test" {
 func testAccAWSAPIGatewayV2ApiMappingConfig_apiMappingKey(rName, certificateArn, apiMappingKey string) string {
 	return testAccAWSAPIGatewayV2ApiMappingConfig_base(rName, certificateArn) + testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_api_mapping" "test" {
-  api_id      = "${aws_apigatewayv2_api.test.id}"
-  domain_name = "${aws_apigatewayv2_domain_name.test.id}"
-  stage       = "${aws_apigatewayv2_stage.test.id}"
+  api_id      = aws_apigatewayv2_api.test.id
+  domain_name = aws_apigatewayv2_domain_name.test.id
+  stage       = aws_apigatewayv2_stage.test.id
 
   api_mapping_key = %[1]q
 }

--- a/aws/resource_aws_apigatewayv2_authorizer_test.go
+++ b/aws/resource_aws_apigatewayv2_authorizer_test.go
@@ -268,7 +268,7 @@ func testAccAWSAPIGatewayV2AuthorizerConfig_baseWebSocket(rName string) string {
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
   runtime       = "nodejs10.x"
 }
@@ -286,11 +286,15 @@ resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Action": "sts:AssumeRole",
-    "Principal": {"Service": "apigateway.amazonaws.com"},
-    "Effect": "Allow"
-  }]
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "apigateway.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
 }
 EOF
 }
@@ -313,9 +317,9 @@ resource "aws_cognito_user_pool" "test" {
 func testAccAWSAPIGatewayV2AuthorizerConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_baseWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "REQUEST"
-  authorizer_uri   = "${aws_lambda_function.test.invoke_arn}"
+  authorizer_uri   = aws_lambda_function.test.invoke_arn
   identity_sources = ["route.request.header.Auth"]
   name             = %[1]q
 }
@@ -325,13 +329,13 @@ resource "aws_apigatewayv2_authorizer" "test" {
 func testAccAWSAPIGatewayV2AuthorizerConfig_credentials(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_baseWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "REQUEST"
-  authorizer_uri   = "${aws_lambda_function.test.invoke_arn}"
+  authorizer_uri   = aws_lambda_function.test.invoke_arn
   identity_sources = ["route.request.header.Auth"]
   name             = %[1]q
 
-  authorizer_credentials_arn = "${aws_iam_role.test.arn}"
+  authorizer_credentials_arn = aws_iam_role.test.arn
 }
 `, rName)
 }
@@ -339,13 +343,13 @@ resource "aws_apigatewayv2_authorizer" "test" {
 func testAccAWSAPIGatewayV2AuthorizerConfig_credentialsUpdated(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_baseWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "REQUEST"
-  authorizer_uri   = "${aws_lambda_function.test.invoke_arn}"
+  authorizer_uri   = aws_lambda_function.test.invoke_arn
   identity_sources = ["route.request.header.Auth", "route.request.querystring.Name"]
   name             = "%[1]s-updated"
 
-  authorizer_credentials_arn = "${aws_iam_role.test.arn}"
+  authorizer_credentials_arn = aws_iam_role.test.arn
 }
 `, rName)
 }
@@ -353,7 +357,7 @@ resource "aws_apigatewayv2_authorizer" "test" {
 func testAccAWSAPIGatewayV2AuthorizerConfig_jwt(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_baseHttp(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "JWT"
   identity_sources = ["$request.header.Authorization"]
   name             = %[1]q
@@ -369,7 +373,7 @@ resource "aws_apigatewayv2_authorizer" "test" {
 func testAccAWSAPIGatewayV2AuthorizerConfig_jwtUpdated(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_baseHttp(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "JWT"
   identity_sources = ["$request.header.Authorization"]
   name             = %[1]q

--- a/aws/resource_aws_apigatewayv2_deployment_test.go
+++ b/aws/resource_aws_apigatewayv2_deployment_test.go
@@ -224,10 +224,10 @@ func testAccAWSAPIGatewayV2DeploymentImportStateIdFunc(resourceName string) reso
 func testAccAWSAPIGatewayV2DeploymentConfig_basic(rName, description string) string {
 	return testAccAWSAPIGatewayV2RouteConfig_target(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_deployment" "test" {
-  api_id      = "${aws_apigatewayv2_api.test.id}"
+  api_id      = aws_apigatewayv2_api.test.id
   description = %[1]q
 
-  depends_on  = ["aws_apigatewayv2_route.test"]
+  depends_on = ["aws_apigatewayv2_route.test"]
 }
 `, description)
 }
@@ -241,7 +241,7 @@ resource "aws_apigatewayv2_api" "test" {
 }
 
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "MOCK"
 }
 
@@ -253,7 +253,7 @@ resource "aws_apigatewayv2_route" "test" {
 }
 
 resource "aws_apigatewayv2_deployment" "test" {
-  api_id      = aws_apigatewayv2_api.test.id
+  api_id = aws_apigatewayv2_api.test.id
 
   triggers = {
     redeployment = sha1(join(",", list(

--- a/aws/resource_aws_apigatewayv2_deployment_test.go
+++ b/aws/resource_aws_apigatewayv2_deployment_test.go
@@ -227,7 +227,7 @@ resource "aws_apigatewayv2_deployment" "test" {
   api_id      = aws_apigatewayv2_api.test.id
   description = %[1]q
 
-  depends_on = ["aws_apigatewayv2_route.test"]
+  depends_on  = [aws_apigatewayv2_route.test]
 }
 `, description)
 }

--- a/aws/resource_aws_apigatewayv2_domain_name_test.go
+++ b/aws/resource_aws_apigatewayv2_domain_name_test.go
@@ -333,7 +333,7 @@ resource "aws_apigatewayv2_domain_name" "test" {
   domain_name = "%[1]s.example.com"
 
   domain_name_configuration {
-    certificate_arn = "${aws_acm_certificate.test.*.arn[%[2]d]}"
+    certificate_arn = aws_acm_certificate.test.*.arn[%[2]d]
     endpoint_type   = "REGIONAL"
     security_policy = "TLS_1_2"
   }
@@ -347,7 +347,7 @@ resource "aws_apigatewayv2_domain_name" "test" {
   domain_name = "%[1]s.example.com"
 
   domain_name_configuration {
-    certificate_arn = "${aws_acm_certificate.test.*.arn[%[2]d]}"
+    certificate_arn = aws_acm_certificate.test.*.arn[%[2]d]
     endpoint_type   = "REGIONAL"
     security_policy = "TLS_1_2"
   }

--- a/aws/resource_aws_apigatewayv2_integration_response_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_response_test.go
@@ -200,8 +200,8 @@ func testAccAWSAPIGatewayV2IntegrationResponseImportStateIdFunc(resourceName str
 func testAccAWSAPIGatewayV2IntegrationResponseConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_basic(rName) + `
 resource "aws_apigatewayv2_integration_response" "test" {
-  api_id                   = "${aws_apigatewayv2_api.test.id}"
-  integration_id           = "${aws_apigatewayv2_integration.test.id}"
+  api_id                   = aws_apigatewayv2_api.test.id
+  integration_id           = aws_apigatewayv2_integration.test.id
   integration_response_key = "/200/"
 }
 `
@@ -210,8 +210,8 @@ resource "aws_apigatewayv2_integration_response" "test" {
 func testAccAWSAPIGatewayV2IntegrationResponseConfig_allAttributes(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_basic(rName) + `
 resource "aws_apigatewayv2_integration_response" "test" {
-  api_id                   = "${aws_apigatewayv2_api.test.id}"
-  integration_id           = "${aws_apigatewayv2_integration.test.id}"
+  api_id                   = aws_apigatewayv2_api.test.id
+  integration_id           = aws_apigatewayv2_integration.test.id
   integration_response_key = "$default"
 
   content_handling_strategy     = "CONVERT_TO_TEXT"
@@ -227,8 +227,8 @@ resource "aws_apigatewayv2_integration_response" "test" {
 func testAccAWSAPIGatewayV2IntegrationResponseConfig_allAttributesUpdated(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_basic(rName) + `
 resource "aws_apigatewayv2_integration_response" "test" {
-  api_id                   = "${aws_apigatewayv2_api.test.id}"
-  integration_id           = "${aws_apigatewayv2_integration.test.id}"
+  api_id                   = aws_apigatewayv2_api.test.id
+  integration_id           = aws_apigatewayv2_integration.test.id
   integration_response_key = "/404/"
 
   content_handling_strategy     = "CONVERT_TO_BINARY"

--- a/aws/resource_aws_apigatewayv2_integration_test.go
+++ b/aws/resource_aws_apigatewayv2_integration_test.go
@@ -501,7 +501,7 @@ resource "aws_lb" "test" {
 
   internal           = true
   load_balancer_type = "network"
-  subnets            = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  subnets            = [aws_subnet.test[0].id, aws_subnet.test[1].id]
 
   tags = {
     Name = %[1]q
@@ -512,7 +512,7 @@ resource "aws_lb_target_group" "test" {
   name     = %[1]q
   port     = 80
   protocol = "TCP"
-  vpc_id   = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   health_check {
     port     = 80
@@ -525,12 +525,12 @@ resource "aws_lb_target_group" "test" {
 }
 
 resource "aws_lb_listener" "test" {
-  load_balancer_arn = "${aws_lb.test.arn}"
+  load_balancer_arn = aws_lb.test.arn
   port              = "80"
   protocol          = "TCP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.test.arn}"
+    target_group_arn = aws_lb_target_group.test.arn
     type             = "forward"
   }
 }
@@ -540,7 +540,7 @@ resource "aws_lb_listener" "test" {
 func testAccAWSAPIGatewayV2IntegrationConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName) + `
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "MOCK"
 }
 `
@@ -549,7 +549,7 @@ resource "aws_apigatewayv2_integration" "test" {
 func testAccAWSAPIGatewayV2IntegrationConfig_integrationTypeHttp(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName) + `
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "HTTP"
 
   connection_type               = "INTERNET"
@@ -575,7 +575,7 @@ resource "aws_apigatewayv2_integration" "test" {
 func testAccAWSAPIGatewayV2IntegrationConfig_integrationTypeHttpUpdated(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_apiWebSocket(rName) + `
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "HTTP"
 
   connection_type               = "INTERNET"
@@ -588,8 +588,8 @@ resource "aws_apigatewayv2_integration" "test" {
   timeout_milliseconds          = 51
 
   request_parameters = {
-	"integration.request.header.x-userid" = "'value2'"
-	"integration.request.path.op"         = "'value3'"
+    "integration.request.header.x-userid" = "'value2'"
+    "integration.request.path.op"         = "'value3'"
   }
 
   request_templates = {
@@ -610,20 +610,20 @@ data "aws_caller_identity" "current" {}
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
   runtime       = "nodejs10.x"
 }
 
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "AWS"
 
   connection_type           = "INTERNET"
   content_handling_strategy = "CONVERT_TO_TEXT"
-  credentials_arn           = "${data.aws_caller_identity.current.arn}"
+  credentials_arn           = data.aws_caller_identity.current.arn
   description               = "Test Lambda"
-  integration_uri           = "${aws_lambda_function.test.invoke_arn}"
+  integration_uri           = aws_lambda_function.test.invoke_arn
   passthrough_behavior      = "WHEN_NO_MATCH"
 }
 `, rName))
@@ -639,19 +639,19 @@ data "aws_caller_identity" "current" {}
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
   runtime       = "nodejs10.x"
 }
 
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "AWS_PROXY"
 
-  connection_type  = "INTERNET"
-  credentials_arn  = "${data.aws_caller_identity.current.arn}"
-  description      = "Test Lambda"
-  integration_uri  = "${aws_lambda_function.test.invoke_arn}"
+  connection_type = "INTERNET"
+  credentials_arn = data.aws_caller_identity.current.arn
+  description     = "Test Lambda"
+  integration_uri = aws_lambda_function.test.invoke_arn
 
   payload_format_version = "2.0"
 }
@@ -661,7 +661,7 @@ resource "aws_apigatewayv2_integration" "test" {
 func testAccAWSAPIGatewayV2IntegrationConfig_httpProxy(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_apiHttp(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "HTTP_PROXY"
 
   integration_method = "GET"
@@ -675,14 +675,14 @@ func testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttp(rName string) string {
 		testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpBase(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "HTTP_PROXY"
 
   connection_type      = "VPC_LINK"
-  connection_id        = "${aws_apigatewayv2_vpc_link.test.id}"
+  connection_id        = aws_apigatewayv2_vpc_link.test.id
   description          = "Test private integration"
   integration_method   = "GET"
-  integration_uri      = "${aws_lb_listener.test.arn}"
+  integration_uri      = aws_lb_listener.test.arn
   timeout_milliseconds = 5001
 
   tls_config {
@@ -697,14 +697,14 @@ func testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpUpdated(rName string) st
 		testAccAWSAPIGatewayV2IntegrationConfig_vpcLinkHttpBase(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "HTTP_PROXY"
 
   connection_type      = "VPC_LINK"
-  connection_id        = "${aws_apigatewayv2_vpc_link.test.id}"
+  connection_id        = aws_apigatewayv2_vpc_link.test.id
   description          = "Test private integration updated"
   integration_method   = "POST"
-  integration_uri      = "${aws_lb_listener.test.arn}"
+  integration_uri      = aws_lb_listener.test.arn
   timeout_milliseconds = 4999
 
   tls_config {
@@ -736,9 +736,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
+  vpc_id            = aws_vpc.test.id
   cidr_block        = "10.10.0.0/24"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = %[1]q
@@ -749,7 +749,7 @@ resource "aws_lb" "test" {
   name               = %[1]q
   internal           = true
   load_balancer_type = "network"
-  subnets            = ["${aws_subnet.test.id}"]
+  subnets            = [aws_subnet.test.id]
 
   tags = {
     Name = %[1]q
@@ -758,21 +758,21 @@ resource "aws_lb" "test" {
 
 resource "aws_api_gateway_vpc_link" "test" {
   name        = %[1]q
-  target_arns = ["${aws_lb.test.arn}"]
+  target_arns = [aws_lb.test.arn]
 }
 
 resource "aws_apigatewayv2_integration" "test" {
-  api_id           = "${aws_apigatewayv2_api.test.id}"
+  api_id           = aws_apigatewayv2_api.test.id
   integration_type = "HTTP_PROXY"
 
-  connection_id                 = "${aws_api_gateway_vpc_link.test.id}"
-  connection_type               = "VPC_LINK"
-  content_handling_strategy     = "CONVERT_TO_TEXT"
-  description                   = "Test VPC Link"
-  integration_method            = "PUT"
-  integration_uri               = "http://www.example.net"
-  passthrough_behavior          = "NEVER"
-  timeout_milliseconds          = 12345
+  connection_id             = aws_api_gateway_vpc_link.test.id
+  connection_type           = "VPC_LINK"
+  content_handling_strategy = "CONVERT_TO_TEXT"
+  description               = "Test VPC Link"
+  integration_method        = "PUT"
+  integration_uri           = "http://www.example.net"
+  passthrough_behavior      = "NEVER"
+  timeout_milliseconds      = 12345
 }
 `, rName))
 }

--- a/aws/resource_aws_apigatewayv2_model_test.go
+++ b/aws/resource_aws_apigatewayv2_model_test.go
@@ -18,8 +18,7 @@ func TestAccAWSAPIGatewayV2Model_basic(t *testing.T) {
 	resourceName := "aws_apigatewayv2_model.test"
 	rName := strings.ReplaceAll(acctest.RandomWithPrefix("tf-acc-test"), "-", "")
 
-	schema := `
-{
+	schema := `{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "ExampleModel",
   "type": "object",
@@ -28,8 +27,7 @@ func TestAccAWSAPIGatewayV2Model_basic(t *testing.T) {
       "type": "string"
     }
   }
-}
-`
+}`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -62,8 +60,7 @@ func TestAccAWSAPIGatewayV2Model_disappears(t *testing.T) {
 	resourceName := "aws_apigatewayv2_model.test"
 	rName := strings.ReplaceAll(acctest.RandomWithPrefix("tf-acc-test"), "-", "")
 
-	schema := `
-{
+	schema := `{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "ExampleModel",
   "type": "object",
@@ -72,8 +69,7 @@ func TestAccAWSAPIGatewayV2Model_disappears(t *testing.T) {
       "type": "string"
     }
   }
-}
-`
+}`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -98,8 +94,7 @@ func TestAccAWSAPIGatewayV2Model_AllAttributes(t *testing.T) {
 	resourceName := "aws_apigatewayv2_model.test"
 	rName := strings.ReplaceAll(acctest.RandomWithPrefix("tf-acc-test"), "-", "")
 
-	schema1 := `
-{
+	schema1 := `{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "ExampleModel1",
   "type": "object",
@@ -108,23 +103,21 @@ func TestAccAWSAPIGatewayV2Model_AllAttributes(t *testing.T) {
       "type": "string"
     }
   }
-}
-`
-	schema2 := `
-{
+}`
+
+	schema2 := `{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "ExampleModel",
   "type": "object",
   "properties": {
     "ids": {
       "type": "array",
-        "items":{
-          "type": "integer"
-        }
+      "items": {
+        "type": "integer"
+      }
     }
   }
-}
-`
+}`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -262,7 +255,7 @@ resource "aws_apigatewayv2_api" "test" {
 func testAccAWSAPIGatewayV2ModelConfig_basic(rName, schema string) string {
 	return testAccAWSAPIGatewayV2ModelConfig_api(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_model" "test" {
-  api_id       = "${aws_apigatewayv2_api.test.id}"
+  api_id       = aws_apigatewayv2_api.test.id
   content_type = "application/json"
   name         = %[1]q
   schema       = %[2]q
@@ -273,7 +266,7 @@ resource "aws_apigatewayv2_model" "test" {
 func testAccAWSAPIGatewayV2ModelConfig_allAttributes(rName, schema string) string {
 	return testAccAWSAPIGatewayV2ModelConfig_api(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_model" "test" {
-  api_id       = "${aws_apigatewayv2_api.test.id}"
+  api_id       = aws_apigatewayv2_api.test.id
   content_type = "text/x-json"
   name         = %[1]q
   description  = "test"

--- a/aws/resource_aws_apigatewayv2_route_response_test.go
+++ b/aws/resource_aws_apigatewayv2_route_response_test.go
@@ -188,8 +188,8 @@ func testAccAWSAPIGatewayV2RouteResponseImportStateIdFunc(resourceName string) r
 func testAccAWSAPIGatewayV2RouteResponseConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2RouteConfig_basic(rName) + `
 resource "aws_apigatewayv2_route_response" "test" {
-  api_id             = "${aws_apigatewayv2_api.test.id}"
-  route_id           = "${aws_apigatewayv2_route.test.id}"
+  api_id             = aws_apigatewayv2_api.test.id
+  route_id           = aws_apigatewayv2_route.test.id
   route_response_key = "$default"
 }
 `
@@ -198,14 +198,14 @@ resource "aws_apigatewayv2_route_response" "test" {
 func testAccAWSAPIGatewayV2RouteResponseConfig_model(rName string) string {
 	return testAccAWSAPIGatewayV2RouteConfig_model(rName) + `
 resource "aws_apigatewayv2_route_response" "test" {
-  api_id             = "${aws_apigatewayv2_api.test.id}"
-  route_id           = "${aws_apigatewayv2_route.test.id}"
+  api_id             = aws_apigatewayv2_api.test.id
+  route_id           = aws_apigatewayv2_route.test.id
   route_response_key = "$default"
 
   model_selection_expression = "action"
 
   response_models = {
-    "test" = "${aws_apigatewayv2_model.test.name}"
+    "test" = aws_apigatewayv2_model.test.name
   }
 }
 `

--- a/aws/resource_aws_apigatewayv2_route_test.go
+++ b/aws/resource_aws_apigatewayv2_route_test.go
@@ -471,7 +471,7 @@ resource "aws_apigatewayv2_api" "test" {
 func testAccAWSAPIGatewayV2RouteConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2RouteConfig_apiWebSocket(rName) + `
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "$default"
 }
 `
@@ -480,11 +480,11 @@ resource "aws_apigatewayv2_route" "test" {
 func testAccAWSAPIGatewayV2RouteConfig_authorizer(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_basic(rName) + `
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "$connect"
 
   authorization_type = "CUSTOM"
-  authorizer_id      = "${aws_apigatewayv2_authorizer.test.id}"
+  authorizer_id      = aws_apigatewayv2_authorizer.test.id
 }
 `
 }
@@ -492,7 +492,7 @@ resource "aws_apigatewayv2_route" "test" {
 func testAccAWSAPIGatewayV2RouteConfig_authorizerUpdated(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_basic(rName) + `
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "$connect"
 
   authorization_type = "AWS_IAM"
@@ -503,11 +503,11 @@ resource "aws_apigatewayv2_route" "test" {
 func testAccAWSAPIGatewayV2RouteConfig_jwtAuthorization(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_jwt(rName) + `
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "GET /test"
 
   authorization_type = "JWT"
-  authorizer_id      = "${aws_apigatewayv2_authorizer.test.id}"
+  authorizer_id      = aws_apigatewayv2_authorizer.test.id
 
   authorization_scopes = ["user.id", "user.email"]
 }
@@ -517,11 +517,11 @@ resource "aws_apigatewayv2_route" "test" {
 func testAccAWSAPIGatewayV2RouteConfig_jwtAuthorizationUpdated(rName string) string {
 	return testAccAWSAPIGatewayV2AuthorizerConfig_jwt(rName) + `
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "GET /test"
 
   authorization_type = "JWT"
-  authorizer_id      = "${aws_apigatewayv2_authorizer.test.id}"
+  authorizer_id      = aws_apigatewayv2_authorizer.test.id
 
   authorization_scopes = ["user.email"]
 }
@@ -529,8 +529,7 @@ resource "aws_apigatewayv2_route" "test" {
 }
 
 func testAccAWSAPIGatewayV2RouteConfig_model(rName string) string {
-	schema := `
-{
+	schema := `{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "ExampleModel",
   "type": "object",
@@ -539,18 +538,17 @@ func testAccAWSAPIGatewayV2RouteConfig_model(rName string) string {
       "type": "string"
     }
   }
-}
-`
+}`
 
 	return testAccAWSAPIGatewayV2ModelConfig_basic(rName, schema) + `
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "$default"
 
   model_selection_expression = "action"
 
   request_models = {
-    "test" = "${aws_apigatewayv2_model.test.name}"
+    "test" = aws_apigatewayv2_model.test.name
   }
 }
 `
@@ -561,7 +559,7 @@ func testAccAWSAPIGatewayV2RouteConfig_routeKey(rName, routeKey string) string {
 		testAccAWSAPIGatewayV2RouteConfig_apiHttp(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = %[1]q
 }
 `, routeKey))
@@ -571,7 +569,7 @@ resource "aws_apigatewayv2_route" "test" {
 func testAccAWSAPIGatewayV2RouteConfig_simpleAttributes(rName string) string {
 	return testAccAWSAPIGatewayV2RouteConfig_apiWebSocket(rName) + `
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "$default"
 
   api_key_required                    = true
@@ -584,7 +582,7 @@ resource "aws_apigatewayv2_route" "test" {
 func testAccAWSAPIGatewayV2RouteConfig_target(rName string) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_basic(rName) + `
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "$default"
 
   target = "integrations/${aws_apigatewayv2_integration.test.id}"

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -1063,7 +1063,7 @@ resource "aws_apigatewayv2_api" "test" {
 func testAccAWSAPIGatewayV2StageConfig_basicWebSocket(rName string) string {
 	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 }
 `, rName)
@@ -1072,7 +1072,7 @@ resource "aws_apigatewayv2_stage" "test" {
 func testAccAWSAPIGatewayV2StageConfig_basicHttp(rName string) string {
 	return testAccAWSAPIGatewayV2StageConfig_apiHttp(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 }
 `, rName)
@@ -1081,7 +1081,7 @@ resource "aws_apigatewayv2_stage" "test" {
 func testAccAWSAPIGatewayV2StageConfig_defaultHttpStage(rName string) string {
 	return testAccAWSAPIGatewayV2StageConfig_apiHttp(rName) + `
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = "$default"
 }
 `
@@ -1090,13 +1090,13 @@ resource "aws_apigatewayv2_stage" "test" {
 func testAccAWSAPIGatewayV2StageConfig_autoDeployHttp(rName string, autoDeploy bool) string {
 	return testAccAWSAPIGatewayV2IntegrationConfig_httpProxy(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_route" "test" {
-  api_id    = "${aws_apigatewayv2_api.test.id}"
+  api_id    = aws_apigatewayv2_api.test.id
   route_key = "GET /test"
   target    = "integrations/${aws_apigatewayv2_integration.test.id}"
 }
 
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   auto_deploy = %[2]t
@@ -1112,41 +1112,47 @@ resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Principal": {"Service": "apigateway.amazonaws.com"},
-    "Action": "sts:AssumeRole"
-  }]
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "apigateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_iam_role_policy" "test" {
   name = %[1]q
-  role = "${aws_iam_role.test.id}"
+  role = aws_iam_role.test.id
 
-policy = <<EOF
+  policy = <<EOF
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:DescribeLogGroups",
-      "logs:DescribeLogStreams",
-      "logs:PutLogEvents",
-      "logs:GetLogEvents",
-      "logs:FilterLogEvents"
-    ],
-    "Resource": "*"
-  }]
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:PutLogEvents",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_api_gateway_account" "test" {
-  cloudwatch_role_arn = "${aws_iam_role.test.arn}"
+  cloudwatch_role_arn = aws_iam_role.test.arn
 }
 
 resource "aws_cloudwatch_log_group" "test" {
@@ -1154,11 +1160,11 @@ resource "aws_cloudwatch_log_group" "test" {
 }
 
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   access_log_settings {
-    destination_arn = "${aws_cloudwatch_log_group.test.arn}"
+    destination_arn = aws_cloudwatch_log_group.test.arn
     format          = %[2]q
   }
 
@@ -1174,10 +1180,10 @@ resource "aws_api_gateway_client_certificate" "test" {
 }
 
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
-  client_certificate_id = "${aws_api_gateway_client_certificate.test.id}"
+  client_certificate_id = aws_api_gateway_client_certificate.test.id
   description           = "Test stage"
 }
 `, rName)
@@ -1190,7 +1196,7 @@ resource "aws_api_gateway_client_certificate" "test" {
 }
 
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   description = "Test stage updated"
@@ -1203,7 +1209,7 @@ func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsWebSocket(rName strin
 		testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   default_route_settings {
@@ -1222,7 +1228,7 @@ func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsWebSocketUpdated(rNam
 		testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   default_route_settings {
@@ -1241,7 +1247,7 @@ func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsHttp(rName string) st
 		testAccAWSAPIGatewayV2StageConfig_apiHttp(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   default_route_settings {
@@ -1258,7 +1264,7 @@ func testAccAWSAPIGatewayV2StageConfig_defaultRouteSettingsHttpUpdated(rName str
 		testAccAWSAPIGatewayV2StageConfig_apiHttp(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   default_route_settings {
@@ -1272,10 +1278,10 @@ resource "aws_apigatewayv2_stage" "test" {
 func testAccAWSAPIGatewayV2StageConfig_deployment(rName string) string {
 	return testAccAWSAPIGatewayV2DeploymentConfig_basic(rName, rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
-  deployment_id = "${aws_apigatewayv2_deployment.test.id}"
+  deployment_id = aws_apigatewayv2_deployment.test.id
 }
 `, rName)
 }
@@ -1285,7 +1291,7 @@ func testAccAWSAPIGatewayV2StageConfig_routeSettingsWebSocket(rName string) stri
 		testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   route_settings {
@@ -1310,7 +1316,7 @@ func testAccAWSAPIGatewayV2StageConfig_routeSettingsWebSocketUpdated(rName strin
 		testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   route_settings {
@@ -1338,7 +1344,7 @@ func testAccAWSAPIGatewayV2StageConfig_routeSettingsHttp(rName string) string {
 		testAccAWSAPIGatewayV2StageConfig_apiHttp(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   route_settings {
@@ -1357,7 +1363,7 @@ func testAccAWSAPIGatewayV2StageConfig_routeSettingsHttpUpdated(rName string) st
 		testAccAWSAPIGatewayV2StageConfig_apiHttp(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   route_settings {
@@ -1373,7 +1379,7 @@ resource "aws_apigatewayv2_stage" "test" {
 func testAccAWSAPIGatewayV2StageConfig_stageVariables(rName string) string {
 	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   stage_variables = {
@@ -1387,7 +1393,7 @@ resource "aws_apigatewayv2_stage" "test" {
 func testAccAWSAPIGatewayV2StageConfig_tags(rName string) string {
 	return testAccAWSAPIGatewayV2StageConfig_apiWebSocket(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_stage" "test" {
-  api_id = "${aws_apigatewayv2_api.test.id}"
+  api_id = aws_apigatewayv2_api.test.id
   name   = %[1]q
 
   tags = {

--- a/aws/resource_aws_apigatewayv2_stage_test.go
+++ b/aws/resource_aws_apigatewayv2_stage_test.go
@@ -1168,7 +1168,7 @@ resource "aws_apigatewayv2_stage" "test" {
     format          = %[2]q
   }
 
-  depends_on = ["aws_api_gateway_account.test"]
+  depends_on = [aws_api_gateway_account.test]
 }
 `, rName, format)
 }

--- a/aws/resource_aws_apigatewayv2_vpc_link_test.go
+++ b/aws/resource_aws_apigatewayv2_vpc_link_test.go
@@ -275,9 +275,9 @@ data "aws_availability_zones" "available" {
 resource "aws_subnet" "test" {
   count = 2
 
-  vpc_id            = "${aws_vpc.test.id}"
-  cidr_block        = "${cidrsubnet(aws_vpc.test.cidr_block, 2, count.index)}"
-  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
 
   tags = {
     Name = %[1]q
@@ -285,7 +285,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
@@ -298,8 +298,8 @@ func testAccAWSAPIGatewayV2VpcLinkConfig_basic(rName string) string {
 	return testAccAWSAPIGatewayV2VpcLinkConfig_base(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_vpc_link" "test" {
   name               = %[1]q
-  security_group_ids = ["${aws_security_group.test.id}"]
-  subnet_ids         = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  security_group_ids = [aws_security_group.test.id]
+  subnet_ids         = [aws_subnet.test[0].id, aws_subnet.test[1].id]
 }
 `, rName)
 }
@@ -308,8 +308,8 @@ func testAccAWSAPIGatewayV2VpcLinkConfig_tags(rName string) string {
 	return testAccAWSAPIGatewayV2VpcLinkConfig_base(rName) + fmt.Sprintf(`
 resource "aws_apigatewayv2_vpc_link" "test" {
   name               = %[1]q
-  security_group_ids = ["${aws_security_group.test.id}"]
-  subnet_ids         = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  security_group_ids = [aws_security_group.test.id]
+  subnet_ids         = [aws_subnet.test[0].id, aws_subnet.test[1].id]
 
   tags = {
     Key1 = "Value1"

--- a/aws/resource_aws_app_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_app_cookie_stickiness_policy_test.go
@@ -204,7 +204,7 @@ resource "aws_elb" "lb" {
 
 resource "aws_app_cookie_stickiness_policy" "foo" {
   name          = "foo-policy"
-  load_balancer = "${aws_elb.lb.id}"
+  load_balancer = aws_elb.lb.id
   lb_port       = 80
   cookie_name   = "MyAppCookie"
 }
@@ -228,7 +228,7 @@ resource "aws_elb" "lb" {
 
 resource "aws_app_cookie_stickiness_policy" "foo" {
   name          = "foo-policy"
-  load_balancer = "${aws_elb.lb.id}"
+  load_balancer = aws_elb.lb.id
   lb_port       = 80
   cookie_name   = "MyOtherAppCookie"
 }

--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -514,12 +514,12 @@ EOF
 }
 
 resource "aws_ecs_service" "test" {
-  cluster                            = "${aws_ecs_cluster.test.id}"
+  cluster                            = aws_ecs_cluster.test.id
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50
   desired_count                      = 0
   name                               = %[1]q
-  task_definition                    = "${aws_ecs_task_definition.test.arn}"
+  task_definition                    = aws_ecs_task_definition.test.arn
 }
 
 resource "aws_appautoscaling_target" "test" {
@@ -532,9 +532,9 @@ resource "aws_appautoscaling_target" "test" {
 
 resource "aws_appautoscaling_policy" "test" {
   name               = %[1]q
-  resource_id        = "${aws_appautoscaling_target.test.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.test.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.test.service_namespace}"
+  resource_id        = aws_appautoscaling_target.test.resource_id
+  scalable_dimension = aws_appautoscaling_target.test.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.test.service_namespace
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
@@ -560,7 +560,7 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
     name   = "name"
     values = ["amzn-ami-minimal-hvm-*"]
   }
-  
+
   filter {
     name   = "root-device-type"
     values = ["ebs"]
@@ -590,12 +590,12 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "fleet_role_policy" {
-  role       = "${aws_iam_role.fleet_role.name}"
+  role       = aws_iam_role.fleet_role.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }
 
 resource "aws_spot_fleet_request" "test" {
-  iam_fleet_role                      = "${aws_iam_role.fleet_role.arn}"
+  iam_fleet_role                      = aws_iam_role.fleet_role.arn
   spot_price                          = "0.005"
   target_capacity                     = 2
   valid_until                         = %[2]q
@@ -603,7 +603,7 @@ resource "aws_spot_fleet_request" "test" {
 
   launch_specification {
     instance_type = "m3.medium"
-    ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+    ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   }
 }
 
@@ -617,9 +617,9 @@ resource "aws_appautoscaling_target" "test" {
 
 resource "aws_appautoscaling_policy" "test" {
   name               = %[1]q
-  resource_id        = "${aws_appautoscaling_target.test.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.test.scalable_dimension}"
-  service_namespace  = "${aws_appautoscaling_target.test.service_namespace}"
+  resource_id        = aws_appautoscaling_target.test.resource_id
+  scalable_dimension = aws_appautoscaling_target.test.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.test.service_namespace
 
   step_scaling_policy_configuration {
     adjustment_type         = "ChangeInCapacity"
@@ -659,10 +659,10 @@ resource "aws_appautoscaling_target" "dynamo_test" {
 }
 
 resource "aws_appautoscaling_policy" "dynamo_test" {
-  name = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.dynamo_test.resource_id}"
-  policy_type = "TargetTrackingScaling"
-  service_namespace = "dynamodb"
-  resource_id = "table/${aws_dynamodb_table.dynamodb_table_test.name}"
+  name               = "DynamoDBWriteCapacityUtilization:${aws_appautoscaling_target.dynamo_test.resource_id}"
+  policy_type        = "TargetTrackingScaling"
+  service_namespace  = "dynamodb"
+  resource_id        = "table/${aws_dynamodb_table.dynamodb_table_test.name}"
   scalable_dimension = "dynamodb:table:WriteCapacityUnits"
 
   target_tracking_scaling_policy_configuration {
@@ -781,8 +781,8 @@ resource "aws_appautoscaling_policy" "read1" {
   name               = "%[3]s-read"
   policy_type        = "TargetTrackingScaling"
   service_namespace  = "dynamodb"
-  resource_id        = "${aws_appautoscaling_target.read1.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.read1.scalable_dimension}"
+  resource_id        = aws_appautoscaling_target.read1.resource_id
+  scalable_dimension = aws_appautoscaling_target.read1.scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -808,7 +808,7 @@ resource "aws_appautoscaling_policy" "read2" {
   policy_type        = "TargetTrackingScaling"
   service_namespace  = "dynamodb"
   resource_id        = "table/${aws_dynamodb_table.dynamodb_table_test2.name}"
-  scalable_dimension = "${aws_appautoscaling_target.read2.scalable_dimension}"
+  scalable_dimension = aws_appautoscaling_target.read2.scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     predefined_metric_specification {
@@ -908,21 +908,21 @@ resource "aws_ecs_task_definition" "task" {
 
   container_definitions = <<EOF
 [
-	{
-		"name": "busybox",
-		"image": "busybox:latest",
-		"cpu": 10,
-		"memory": 128,
-		"essential": true
-	}
+  {
+    "name": "busybox",
+    "image": "busybox:latest",
+    "cpu": 10,
+    "memory": 128,
+    "essential": true
+  }
 ]
 EOF
 }
 
 resource "aws_ecs_service" "service" {
   name                               = "foobar"
-  cluster                            = "${aws_ecs_cluster.foo.id}"
-  task_definition                    = "${aws_ecs_task_definition.task.arn}"
+  cluster                            = aws_ecs_cluster.foo.id
+  task_definition                    = aws_ecs_task_definition.task.arn
   desired_count                      = 1
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50
@@ -1025,21 +1025,21 @@ EOF
 }
 
 resource "aws_ecs_service" "test1" {
-  cluster                            = "${aws_ecs_cluster.test.id}"
+  cluster                            = aws_ecs_cluster.test.id
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50
   desired_count                      = 0
   name                               = "%[1]s-1"
-  task_definition                    = "${aws_ecs_task_definition.test.arn}"
+  task_definition                    = aws_ecs_task_definition.test.arn
 }
 
 resource "aws_ecs_service" "test2" {
-  cluster                            = "${aws_ecs_cluster.test.id}"
+  cluster                            = aws_ecs_cluster.test.id
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50
   desired_count                      = 0
   name                               = "%[1]s-2"
-  task_definition                    = "${aws_ecs_task_definition.test.arn}"
+  task_definition                    = aws_ecs_task_definition.test.arn
 }
 `, rName)
 }
@@ -1076,7 +1076,7 @@ resource "aws_appautoscaling_policy" "test" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "test" {
-  alarm_actions       = ["${aws_appautoscaling_policy.test.arn}"]
+  alarm_actions       = [aws_appautoscaling_policy.test.arn]
   alarm_name          = %[1]q
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "5"
@@ -1087,7 +1087,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   threshold           = "0"
 
   dimensions = {
-    ClusterName = "${aws_ecs_cluster.test.name}"
+    ClusterName = aws_ecs_cluster.test.name
   }
 }
 `, rName)
@@ -1125,7 +1125,7 @@ resource "aws_appautoscaling_policy" "test" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "test" {
-  alarm_actions       = ["${aws_appautoscaling_policy.test.arn}"]
+  alarm_actions       = [aws_appautoscaling_policy.test.arn]
   alarm_name          = %[1]q
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "5"
@@ -1136,7 +1136,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   threshold           = "0"
 
   dimensions = {
-    ClusterName = "${aws_ecs_cluster.test.name}"
+    ClusterName = aws_ecs_cluster.test.name
   }
 }
 `, rName)

--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -511,6 +511,7 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 EOF
+
 }
 
 resource "aws_ecs_service" "test" {
@@ -567,7 +568,8 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   }
 }
 
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+}
 
 resource "aws_iam_role" "fleet_role" {
   assume_role_policy = <<EOF
@@ -587,6 +589,7 @@ resource "aws_iam_role" "fleet_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "fleet_role_policy" {
@@ -675,7 +678,7 @@ resource "aws_appautoscaling_policy" "dynamo_test" {
     target_value       = 70
   }
 
-  depends_on = ["aws_appautoscaling_target.dynamo_test"]
+  depends_on = [aws_appautoscaling_target.dynamo_test]
 }
 `, randPolicyName)
 }
@@ -862,7 +865,7 @@ resource "aws_appautoscaling_policy" "write" {
     target_value       = 70
   }
 
-  depends_on = ["aws_appautoscaling_target.write"]
+  depends_on = [aws_appautoscaling_target.write]
 }
 
 resource "aws_appautoscaling_target" "read" {
@@ -890,7 +893,7 @@ resource "aws_appautoscaling_policy" "read" {
     target_value       = 70
   }
 
-  depends_on = ["aws_appautoscaling_target.read"]
+  depends_on = [aws_appautoscaling_target.read]
 }
 `, tableName, namePrefix, namePrefix)
 }
@@ -917,6 +920,7 @@ resource "aws_ecs_task_definition" "task" {
   }
 ]
 EOF
+
 }
 
 resource "aws_ecs_service" "service" {
@@ -965,7 +969,7 @@ resource "aws_appautoscaling_policy" "foobar_out" {
     }
   }
 
-  depends_on = ["aws_appautoscaling_target.tgt"]
+  depends_on = [aws_appautoscaling_target.tgt]
 }
 
 resource "aws_appautoscaling_policy" "foobar_in" {
@@ -997,7 +1001,7 @@ resource "aws_appautoscaling_policy" "foobar_in" {
     }
   }
 
-  depends_on = ["aws_appautoscaling_target.tgt"]
+  depends_on = [aws_appautoscaling_target.tgt]
 }
 `, randClusterName, randPolicyNamePrefix, randPolicyNamePrefix)
 }
@@ -1022,6 +1026,7 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 EOF
+
 }
 
 resource "aws_ecs_service" "test1" {
@@ -1056,7 +1061,7 @@ resource "aws_appautoscaling_target" "test" {
 
 resource "aws_appautoscaling_policy" "test" {
   # The usage of depends_on here is intentional as this used to be a documented example
-  depends_on = ["aws_appautoscaling_target.test"]
+  depends_on = [aws_appautoscaling_target.test]
 
   name               = %[1]q
   resource_id        = "service/${aws_ecs_cluster.test.name}/${aws_ecs_service.test1.name}"
@@ -1105,7 +1110,7 @@ resource "aws_appautoscaling_target" "test" {
 
 resource "aws_appautoscaling_policy" "test" {
   # The usage of depends_on here is intentional as this used to be a documented example
-  depends_on = ["aws_appautoscaling_target.test"]
+  depends_on = [aws_appautoscaling_target.test]
 
   name               = %[1]q
   resource_id        = "service/${aws_ecs_cluster.test.name}/${aws_ecs_service.test2.name}"

--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -161,9 +161,9 @@ resource "aws_appautoscaling_target" "read" {
 
 resource "aws_appautoscaling_scheduled_action" "hoge" {
   name               = "tf-appauto-%s"
-  service_namespace  = "${aws_appautoscaling_target.read.service_namespace}"
-  resource_id        = "${aws_appautoscaling_target.read.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.read.scalable_dimension}"
+  service_namespace  = aws_appautoscaling_target.read.service_namespace
+  resource_id        = aws_appautoscaling_target.read.resource_id
+  scalable_dimension = aws_appautoscaling_target.read.scalable_dimension
   schedule           = "at(%s)"
 
   scalable_target_action {
@@ -198,8 +198,8 @@ EOF
 
 resource "aws_ecs_service" "hoge" {
   name            = "tf-ecs-service-%s"
-  cluster         = "${aws_ecs_cluster.hoge.id}"
-  task_definition = "${aws_ecs_task_definition.hoge.arn}"
+  cluster         = aws_ecs_cluster.hoge.id
+  task_definition = aws_ecs_task_definition.hoge.arn
   desired_count   = 1
 
   deployment_maximum_percent         = 200
@@ -216,9 +216,9 @@ resource "aws_appautoscaling_target" "hoge" {
 
 resource "aws_appautoscaling_scheduled_action" "hoge" {
   name               = "tf-appauto-%s"
-  service_namespace  = "${aws_appautoscaling_target.hoge.service_namespace}"
-  resource_id        = "${aws_appautoscaling_target.hoge.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.hoge.scalable_dimension}"
+  service_namespace  = aws_appautoscaling_target.hoge.service_namespace
+  resource_id        = aws_appautoscaling_target.hoge.resource_id
+  scalable_dimension = aws_appautoscaling_target.hoge.scalable_dimension
   schedule           = "at(%s)"
 
   scalable_target_action {
@@ -250,10 +250,10 @@ resource "aws_emr_cluster" "hoge" {
   applications  = ["Spark"]
 
   ec2_attributes {
-    subnet_id                         = "${aws_subnet.hoge.id}"
-    emr_managed_master_security_group = "${aws_security_group.hoge.id}"
-    emr_managed_slave_security_group  = "${aws_security_group.hoge.id}"
-    instance_profile                  = "${aws_iam_instance_profile.instance_profile.arn}"
+    subnet_id                         = aws_subnet.hoge.id
+    emr_managed_master_security_group = aws_security_group.hoge.id
+    emr_managed_slave_security_group  = aws_security_group.hoge.id
+    instance_profile                  = aws_iam_instance_profile.instance_profile.arn
   }
 
   master_instance_group {
@@ -284,12 +284,12 @@ resource "aws_emr_cluster" "hoge" {
 
   depends_on = ["aws_main_route_table_association.hoge"]
 
-  service_role     = "${aws_iam_role.emr_role.arn}"
-  autoscaling_role = "${aws_iam_role.autoscale_role.arn}"
+  service_role     = aws_iam_role.emr_role.arn
+  autoscaling_role = aws_iam_role.autoscale_role.arn
 }
 
 resource "aws_emr_instance_group" "hoge" {
-  cluster_id     = "${aws_emr_cluster.hoge.id}"
+  cluster_id     = aws_emr_cluster.hoge.id
   instance_count = 1
   instance_type  = "c4.large"
 }
@@ -297,7 +297,7 @@ resource "aws_emr_instance_group" "hoge" {
 resource "aws_security_group" "hoge" {
   name        = "tf-sg-%s"
   description = "Allow all inbound traffic"
-  vpc_id      = "${aws_vpc.hoge.id}"
+  vpc_id      = aws_vpc.hoge.id
 
   ingress {
     from_port = 0
@@ -330,9 +330,9 @@ resource "aws_vpc" "hoge" {
 }
 
 resource "aws_subnet" "hoge" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "168.31.0.0/20"
-  vpc_id            = "${aws_vpc.hoge.id}"
+  vpc_id            = aws_vpc.hoge.id
 
   tags = {
     Name = "tf-acc-appautoscaling-scheduled-action"
@@ -340,21 +340,21 @@ resource "aws_subnet" "hoge" {
 }
 
 resource "aws_internet_gateway" "hoge" {
-  vpc_id = "${aws_vpc.hoge.id}"
+  vpc_id = aws_vpc.hoge.id
 }
 
 resource "aws_route_table" "hoge" {
-  vpc_id = "${aws_vpc.hoge.id}"
+  vpc_id = aws_vpc.hoge.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.hoge.id}"
+    gateway_id = aws_internet_gateway.hoge.id
   }
 }
 
 resource "aws_main_route_table_association" "hoge" {
-  vpc_id         = "${aws_vpc.hoge.id}"
-  route_table_id = "${aws_route_table.hoge.id}"
+  vpc_id         = aws_vpc.hoge.id
+  route_table_id = aws_route_table.hoge.id
 }
 
 resource "aws_iam_role" "emr_role" {
@@ -376,73 +376,75 @@ EOT
 }
 
 resource "aws_iam_role_policy_attachment" "emr_role" {
-  role       = "${aws_iam_role.emr_role.id}"
-  policy_arn = "${aws_iam_policy.emr_policy.arn}"
+  role       = aws_iam_role.emr_role.id
+  policy_arn = aws_iam_policy.emr_policy.arn
 }
 
 resource "aws_iam_policy" "emr_policy" {
   policy = <<EOT
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Resource": "*",
-    "Action": [
-      "ec2:AuthorizeSecurityGroupEgress",
-      "ec2:AuthorizeSecurityGroupIngress",
-      "ec2:CancelSpotInstanceRequests",
-      "ec2:CreateNetworkInterface",
-      "ec2:CreateSecurityGroup",
-      "ec2:CreateTags",
-      "ec2:DeleteNetworkInterface",
-      "ec2:DeleteSecurityGroup",
-      "ec2:DeleteTags",
-      "ec2:DescribeAvailabilityZones",
-      "ec2:DescribeAccountAttributes",
-      "ec2:DescribeDhcpOptions",
-      "ec2:DescribeInstanceStatus",
-      "ec2:DescribeInstances",
-      "ec2:DescribeKeyPairs",
-      "ec2:DescribeNetworkAcls",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DescribePrefixLists",
-      "ec2:DescribeRouteTables",
-      "ec2:DescribeSecurityGroups",
-      "ec2:DescribeSpotInstanceRequests",
-      "ec2:DescribeSpotPriceHistory",
-      "ec2:DescribeSubnets",
-      "ec2:DescribeVpcAttribute",
-      "ec2:DescribeVpcEndpoints",
-      "ec2:DescribeVpcEndpointServices",
-      "ec2:DescribeVpcs",
-      "ec2:DetachNetworkInterface",
-      "ec2:ModifyImageAttribute",
-      "ec2:ModifyInstanceAttribute",
-      "ec2:RequestSpotInstances",
-      "ec2:RevokeSecurityGroupEgress",
-      "ec2:RunInstances",
-      "ec2:TerminateInstances",
-      "ec2:DeleteVolume",
-      "ec2:DescribeVolumeStatus",
-      "ec2:DescribeVolumes",
-      "ec2:DetachVolume",
-      "iam:GetRole",
-      "iam:GetRolePolicy",
-      "iam:ListInstanceProfiles",
-      "iam:ListRolePolicies",
-      "iam:PassRole",
-      "s3:CreateBucket",
-      "s3:Get*",
-      "s3:List*",
-      "sdb:BatchPutAttributes",
-      "sdb:Select",
-      "sqs:CreateQueue",
-      "sqs:Delete*",
-      "sqs:GetQueue*",
-      "sqs:PurgeQueue",
-      "sqs:ReceiveMessage"
-    ]
-  }]
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CancelSpotInstanceRequests",
+        "ec2:CreateNetworkInterface",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteTags",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeDhcpOptions",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstances",
+        "ec2:DescribeKeyPairs",
+        "ec2:DescribeNetworkAcls",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribePrefixLists",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSpotInstanceRequests",
+        "ec2:DescribeSpotPriceHistory",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcEndpoints",
+        "ec2:DescribeVpcEndpointServices",
+        "ec2:DescribeVpcs",
+        "ec2:DetachNetworkInterface",
+        "ec2:ModifyImageAttribute",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:RequestSpotInstances",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:DeleteVolume",
+        "ec2:DescribeVolumeStatus",
+        "ec2:DescribeVolumes",
+        "ec2:DetachVolume",
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:ListInstanceProfiles",
+        "iam:ListRolePolicies",
+        "iam:PassRole",
+        "s3:CreateBucket",
+        "s3:Get*",
+        "s3:List*",
+        "sdb:BatchPutAttributes",
+        "sdb:Select",
+        "sqs:CreateQueue",
+        "sqs:Delete*",
+        "sqs:GetQueue*",
+        "sqs:PurgeQueue",
+        "sqs:ReceiveMessage"
+      ]
+    }
+  ]
 }
 EOT
 }
@@ -468,53 +470,55 @@ EOT
 
 resource "aws_iam_instance_profile" "instance_profile" {
   name = "tf-emr-profile-%s"
-  role = "${aws_iam_role.instance_role.name}"
+  role = aws_iam_role.instance_role.name
 }
 
 resource "aws_iam_role_policy_attachment" "instance_role" {
-  role       = "${aws_iam_role.instance_role.id}"
-  policy_arn = "${aws_iam_policy.instance_policy.arn}"
+  role       = aws_iam_role.instance_role.id
+  policy_arn = aws_iam_policy.instance_policy.arn
 }
 
 resource "aws_iam_policy" "instance_policy" {
   policy = <<EOT
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Resource": "*",
-    "Action": [
-      "cloudwatch:*",
-      "dynamodb:*",
-      "ec2:Describe*",
-      "elasticmapreduce:Describe*",
-      "elasticmapreduce:ListBootstrapActions",
-      "elasticmapreduce:ListClusters",
-      "elasticmapreduce:ListInstanceGroups",
-      "elasticmapreduce:ListInstances",
-      "elasticmapreduce:ListSteps",
-      "kinesis:CreateStream",
-      "kinesis:DeleteStream",
-      "kinesis:DescribeStream",
-      "kinesis:GetRecords",
-      "kinesis:GetShardIterator",
-      "kinesis:MergeShards",
-      "kinesis:PutRecord",
-      "kinesis:SplitShard",
-      "rds:Describe*",
-      "s3:*",
-      "sdb:*",
-      "sns:*",
-      "sqs:*"
-    ]
-  }]
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": [
+        "cloudwatch:*",
+        "dynamodb:*",
+        "ec2:Describe*",
+        "elasticmapreduce:Describe*",
+        "elasticmapreduce:ListBootstrapActions",
+        "elasticmapreduce:ListClusters",
+        "elasticmapreduce:ListInstanceGroups",
+        "elasticmapreduce:ListInstances",
+        "elasticmapreduce:ListSteps",
+        "kinesis:CreateStream",
+        "kinesis:DeleteStream",
+        "kinesis:DescribeStream",
+        "kinesis:GetRecords",
+        "kinesis:GetShardIterator",
+        "kinesis:MergeShards",
+        "kinesis:PutRecord",
+        "kinesis:SplitShard",
+        "rds:Describe*",
+        "s3:*",
+        "sdb:*",
+        "sns:*",
+        "sqs:*"
+      ]
+    }
+  ]
 }
 EOT
 }
 
 # IAM Role for autoscaling
 resource "aws_iam_role" "autoscale_role" {
-  assume_role_policy = "${data.aws_iam_policy_document.autoscale_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.autoscale_role.json
 }
 
 data "aws_iam_policy_document" "autoscale_role" {
@@ -530,7 +534,7 @@ data "aws_iam_policy_document" "autoscale_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "autoscale_role" {
-  role       = "${aws_iam_role.autoscale_role.name}"
+  role       = aws_iam_role.autoscale_role.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
 
@@ -538,16 +542,16 @@ resource "aws_appautoscaling_target" "hoge" {
   service_namespace  = "elasticmapreduce"
   resource_id        = "instancegroup/${aws_emr_cluster.hoge.id}/${aws_emr_instance_group.hoge.id}"
   scalable_dimension = "elasticmapreduce:instancegroup:InstanceCount"
-  role_arn           = "${aws_iam_role.autoscale_role.arn}"
+  role_arn           = aws_iam_role.autoscale_role.arn
   min_capacity       = 1
   max_capacity       = 5
 }
 
 resource "aws_appautoscaling_scheduled_action" "hoge" {
   name               = "tf-appauto-%s"
-  service_namespace  = "${aws_appautoscaling_target.hoge.service_namespace}"
-  resource_id        = "${aws_appautoscaling_target.hoge.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.hoge.scalable_dimension}"
+  service_namespace  = aws_appautoscaling_target.hoge.service_namespace
+  resource_id        = aws_appautoscaling_target.hoge.resource_id
+  scalable_dimension = aws_appautoscaling_target.hoge.scalable_dimension
   schedule           = "at(%s)"
 
   scalable_target_action {
@@ -668,12 +672,12 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "fleet_role_policy" {
-  role       = "${aws_iam_role.fleet_role.name}"
+  role       = aws_iam_role.fleet_role.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }
 
 resource "aws_spot_fleet_request" "hoge" {
-  iam_fleet_role                      = "${aws_iam_role.fleet_role.arn}"
+  iam_fleet_role                      = aws_iam_role.fleet_role.arn
   spot_price                          = "0.005"
   target_capacity                     = 2
   valid_until                         = %[3]q
@@ -681,7 +685,7 @@ resource "aws_spot_fleet_request" "hoge" {
 
   launch_specification {
     instance_type = "m3.medium"
-    ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+    ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   }
 }
 
@@ -695,9 +699,9 @@ resource "aws_appautoscaling_target" "hoge" {
 
 resource "aws_appautoscaling_scheduled_action" "hoge" {
   name               = "tf-appauto-%[1]s"
-  service_namespace  = "${aws_appautoscaling_target.hoge.service_namespace}"
-  resource_id        = "${aws_appautoscaling_target.hoge.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.hoge.scalable_dimension}"
+  service_namespace  = aws_appautoscaling_target.hoge.service_namespace
+  resource_id        = aws_appautoscaling_target.hoge.resource_id
+  scalable_dimension = aws_appautoscaling_target.hoge.scalable_dimension
   schedule           = "at(%[2]s)"
 
   scalable_target_action {

--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -194,6 +194,7 @@ resource "aws_ecs_task_definition" "hoge" {
   }
 ]
 EOF
+
 }
 
 resource "aws_ecs_service" "hoge" {
@@ -242,7 +243,8 @@ data "aws_availability_zones" "available" {
   }
 }
 
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+}
 
 resource "aws_emr_cluster" "hoge" {
   name          = "tf-emr-%s"
@@ -282,7 +284,7 @@ resource "aws_emr_cluster" "hoge" {
 
   configurations = "test-fixtures/emr_configurations.json"
 
-  depends_on = ["aws_main_route_table_association.hoge"]
+  depends_on = [aws_main_route_table_association.hoge]
 
   service_role     = aws_iam_role.emr_role.arn
   autoscaling_role = aws_iam_role.autoscale_role.arn
@@ -313,10 +315,13 @@ resource "aws_security_group" "hoge" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  depends_on = ["aws_subnet.hoge"]
+  depends_on = [aws_subnet.hoge]
 
   lifecycle {
-    ignore_changes = ["ingress", "egress"]
+    ignore_changes = [
+      ingress,
+      egress,
+    ]
   }
 }
 
@@ -373,6 +378,7 @@ resource "aws_iam_role" "emr_role" {
   ]
 }
 EOT
+
 }
 
 resource "aws_iam_role_policy_attachment" "emr_role" {
@@ -447,6 +453,7 @@ resource "aws_iam_policy" "emr_policy" {
   ]
 }
 EOT
+
 }
 
 # IAM Role for EC2 Instance Profile
@@ -466,6 +473,7 @@ resource "aws_iam_role" "instance_role" {
   ]
 }
 EOT
+
 }
 
 resource "aws_iam_instance_profile" "instance_profile" {
@@ -514,6 +522,7 @@ resource "aws_iam_policy" "instance_policy" {
   ]
 }
 EOT
+
 }
 
 # IAM Role for autoscaling
@@ -649,7 +658,8 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   }
 }
 
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+}
 
 resource "aws_iam_role" "fleet_role" {
   assume_role_policy = <<EOF
@@ -669,6 +679,7 @@ resource "aws_iam_role" "fleet_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "fleet_role_policy" {

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -275,6 +275,7 @@ resource "aws_ecs_task_definition" "task" {
   }
 ]
 EOF
+
 }
 
 resource "aws_ecs_service" "service" {
@@ -318,6 +319,7 @@ resource "aws_ecs_task_definition" "task" {
   }
 ]
 EOF
+
 }
 
 resource "aws_ecs_service" "service" {
@@ -393,7 +395,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
   configurations = "test-fixtures/emr_configurations.json"
 
-  depends_on = ["aws_main_route_table_association.a"]
+  depends_on = [aws_main_route_table_association.a]
 
   service_role     = aws_iam_role.iam_emr_default_role.arn
   autoscaling_role = aws_iam_role.emr-autoscaling-role.arn
@@ -424,7 +426,7 @@ resource "aws_security_group" "allow_all" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  depends_on = ["aws_subnet.main"]
+  depends_on = [aws_subnet.main]
 
   lifecycle {
     ignore_changes = ["ingress", "egress"]
@@ -690,7 +692,8 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   }
 }
 
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+}
 
 resource "aws_iam_role" "fleet_role" {
   assume_role_policy = <<EOF
@@ -710,6 +713,7 @@ resource "aws_iam_role" "fleet_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "fleet_role_policy" {

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -266,21 +266,21 @@ resource "aws_ecs_task_definition" "task" {
 
   container_definitions = <<EOF
 [
-    {
-        "name": "busybox",
-        "image": "busybox:latest",
-        "cpu": 10,
-        "memory": 128,
-        "essential": true
-    }
+  {
+    "name": "busybox",
+    "image": "busybox:latest",
+    "cpu": 10,
+    "memory": 128,
+    "essential": true
+  }
 ]
 EOF
 }
 
 resource "aws_ecs_service" "service" {
   name            = "foobar"
-  cluster         = "${aws_ecs_cluster.foo.id}"
-  task_definition = "${aws_ecs_task_definition.task.arn}"
+  cluster         = aws_ecs_cluster.foo.id
+  task_definition = aws_ecs_task_definition.task.arn
   desired_count   = 1
 
   deployment_maximum_percent         = 200
@@ -309,21 +309,21 @@ resource "aws_ecs_task_definition" "task" {
 
   container_definitions = <<EOF
 [
-    {
-        "name": "busybox",
-        "image": "busybox:latest",
-        "cpu": 10,
-        "memory": 128,
-        "essential": true
-    }
+  {
+    "name": "busybox",
+    "image": "busybox:latest",
+    "cpu": 10,
+    "memory": 128,
+    "essential": true
+  }
 ]
 EOF
 }
 
 resource "aws_ecs_service" "service" {
   name            = "foobar"
-  cluster         = "${aws_ecs_cluster.foo.id}"
-  task_definition = "${aws_ecs_task_definition.task.arn}"
+  cluster         = aws_ecs_cluster.foo.id
+  task_definition = aws_ecs_task_definition.task.arn
   desired_count   = 2
 
   deployment_maximum_percent         = 200
@@ -361,10 +361,10 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   applications  = ["Spark"]
 
   ec2_attributes {
-    subnet_id                         = "${aws_subnet.main.id}"
-    emr_managed_master_security_group = "${aws_security_group.allow_all.id}"
-    emr_managed_slave_security_group  = "${aws_security_group.allow_all.id}"
-    instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
+    subnet_id                         = aws_subnet.main.id
+    emr_managed_master_security_group = aws_security_group.allow_all.id
+    emr_managed_slave_security_group  = aws_security_group.allow_all.id
+    instance_profile                  = aws_iam_instance_profile.emr_profile.arn
   }
 
   master_instance_group {
@@ -395,12 +395,12 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
   depends_on = ["aws_main_route_table_association.a"]
 
-  service_role     = "${aws_iam_role.iam_emr_default_role.arn}"
-  autoscaling_role = "${aws_iam_role.emr-autoscaling-role.arn}"
+  service_role     = aws_iam_role.iam_emr_default_role.arn
+  autoscaling_role = aws_iam_role.emr-autoscaling-role.arn
 }
 
 resource "aws_emr_instance_group" "task" {
-  cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
+  cluster_id     = aws_emr_cluster.tf-test-cluster.id
   instance_count = 1
   instance_type  = "m3.xlarge"
 }
@@ -408,7 +408,7 @@ resource "aws_emr_instance_group" "task" {
 resource "aws_security_group" "allow_all" {
   name        = "allow_all_%d"
   description = "Allow all inbound traffic"
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
 
   ingress {
     from_port = 0
@@ -445,9 +445,9 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "main" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "168.31.0.0/20"
-  vpc_id            = "${aws_vpc.main.id}"
+  vpc_id            = aws_vpc.main.id
 
   tags = {
     Name = "tf-acc-appautoscaling-target-emr-cluster"
@@ -455,21 +455,21 @@ resource "aws_subnet" "main" {
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_route_table" "r" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gw.id}"
+    gateway_id = aws_internet_gateway.gw.id
   }
 }
 
 resource "aws_main_route_table_association" "a" {
-  vpc_id         = "${aws_vpc.main.id}"
-  route_table_id = "${aws_route_table.r.id}"
+  vpc_id         = aws_vpc.main.id
+  route_table_id = aws_route_table.r.id
 }
 
 resource "aws_iam_role" "iam_emr_default_role" {
@@ -493,8 +493,8 @@ EOT
 }
 
 resource "aws_iam_role_policy_attachment" "service-attach" {
-  role       = "${aws_iam_role.iam_emr_default_role.id}"
-  policy_arn = "${aws_iam_policy.iam_emr_default_policy.arn}"
+  role       = aws_iam_role.iam_emr_default_role.id
+  policy_arn = aws_iam_policy.iam_emr_default_policy.arn
 }
 
 resource "aws_iam_policy" "iam_emr_default_policy" {
@@ -502,66 +502,68 @@ resource "aws_iam_policy" "iam_emr_default_policy" {
 
   policy = <<EOT
 {
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Effect": "Allow",
-        "Resource": "*",
-        "Action": [
-            "ec2:AuthorizeSecurityGroupEgress",
-            "ec2:AuthorizeSecurityGroupIngress",
-            "ec2:CancelSpotInstanceRequests",
-            "ec2:CreateNetworkInterface",
-            "ec2:CreateSecurityGroup",
-            "ec2:CreateTags",
-            "ec2:DeleteNetworkInterface",
-            "ec2:DeleteSecurityGroup",
-            "ec2:DeleteTags",
-            "ec2:DescribeAvailabilityZones",
-            "ec2:DescribeAccountAttributes",
-            "ec2:DescribeDhcpOptions",
-            "ec2:DescribeInstanceStatus",
-            "ec2:DescribeInstances",
-            "ec2:DescribeKeyPairs",
-            "ec2:DescribeNetworkAcls",
-            "ec2:DescribeNetworkInterfaces",
-            "ec2:DescribePrefixLists",
-            "ec2:DescribeRouteTables",
-            "ec2:DescribeSecurityGroups",
-            "ec2:DescribeSpotInstanceRequests",
-            "ec2:DescribeSpotPriceHistory",
-            "ec2:DescribeSubnets",
-            "ec2:DescribeVpcAttribute",
-            "ec2:DescribeVpcEndpoints",
-            "ec2:DescribeVpcEndpointServices",
-            "ec2:DescribeVpcs",
-            "ec2:DetachNetworkInterface",
-            "ec2:ModifyImageAttribute",
-            "ec2:ModifyInstanceAttribute",
-            "ec2:RequestSpotInstances",
-            "ec2:RevokeSecurityGroupEgress",
-            "ec2:RunInstances",
-            "ec2:TerminateInstances",
-            "ec2:DeleteVolume",
-            "ec2:DescribeVolumeStatus",
-            "ec2:DescribeVolumes",
-            "ec2:DetachVolume",
-            "iam:GetRole",
-            "iam:GetRolePolicy",
-            "iam:ListInstanceProfiles",
-            "iam:ListRolePolicies",
-            "iam:PassRole",
-            "s3:CreateBucket",
-            "s3:Get*",
-            "s3:List*",
-            "sdb:BatchPutAttributes",
-            "sdb:Select",
-            "sqs:CreateQueue",
-            "sqs:Delete*",
-            "sqs:GetQueue*",
-            "sqs:PurgeQueue",
-            "sqs:ReceiveMessage"
-        ]
-    }]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CancelSpotInstanceRequests",
+        "ec2:CreateNetworkInterface",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteTags",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeDhcpOptions",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstances",
+        "ec2:DescribeKeyPairs",
+        "ec2:DescribeNetworkAcls",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribePrefixLists",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSpotInstanceRequests",
+        "ec2:DescribeSpotPriceHistory",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcEndpoints",
+        "ec2:DescribeVpcEndpointServices",
+        "ec2:DescribeVpcs",
+        "ec2:DetachNetworkInterface",
+        "ec2:ModifyImageAttribute",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:RequestSpotInstances",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:DeleteVolume",
+        "ec2:DescribeVolumeStatus",
+        "ec2:DescribeVolumes",
+        "ec2:DetachVolume",
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:ListInstanceProfiles",
+        "iam:ListRolePolicies",
+        "iam:PassRole",
+        "s3:CreateBucket",
+        "s3:Get*",
+        "s3:List*",
+        "sdb:BatchPutAttributes",
+        "sdb:Select",
+        "sqs:CreateQueue",
+        "sqs:Delete*",
+        "sqs:GetQueue*",
+        "sqs:PurgeQueue",
+        "sqs:ReceiveMessage"
+      ]
+    }
+  ]
 }
 EOT
 }
@@ -593,8 +595,8 @@ resource "aws_iam_instance_profile" "emr_profile" {
 }
 
 resource "aws_iam_role_policy_attachment" "profile-attach" {
-  role       = "${aws_iam_role.iam_emr_profile_role.id}"
-  policy_arn = "${aws_iam_policy.iam_emr_profile_policy.arn}"
+  role       = aws_iam_role.iam_emr_profile_role.id
+  policy_arn = aws_iam_policy.iam_emr_profile_policy.arn
 }
 
 resource "aws_iam_policy" "iam_emr_profile_policy" {
@@ -602,35 +604,37 @@ resource "aws_iam_policy" "iam_emr_profile_policy" {
 
   policy = <<EOT
 {
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Effect": "Allow",
-        "Resource": "*",
-        "Action": [
-            "cloudwatch:*",
-            "dynamodb:*",
-            "ec2:Describe*",
-            "elasticmapreduce:Describe*",
-            "elasticmapreduce:ListBootstrapActions",
-            "elasticmapreduce:ListClusters",
-            "elasticmapreduce:ListInstanceGroups",
-            "elasticmapreduce:ListInstances",
-            "elasticmapreduce:ListSteps",
-            "kinesis:CreateStream",
-            "kinesis:DeleteStream",
-            "kinesis:DescribeStream",
-            "kinesis:GetRecords",
-            "kinesis:GetShardIterator",
-            "kinesis:MergeShards",
-            "kinesis:PutRecord",
-            "kinesis:SplitShard",
-            "rds:Describe*",
-            "s3:*",
-            "sdb:*",
-            "sns:*",
-            "sqs:*"
-        ]
-    }]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": "*",
+      "Action": [
+        "cloudwatch:*",
+        "dynamodb:*",
+        "ec2:Describe*",
+        "elasticmapreduce:Describe*",
+        "elasticmapreduce:ListBootstrapActions",
+        "elasticmapreduce:ListClusters",
+        "elasticmapreduce:ListInstanceGroups",
+        "elasticmapreduce:ListInstances",
+        "elasticmapreduce:ListSteps",
+        "kinesis:CreateStream",
+        "kinesis:DeleteStream",
+        "kinesis:DescribeStream",
+        "kinesis:GetRecords",
+        "kinesis:GetShardIterator",
+        "kinesis:MergeShards",
+        "kinesis:PutRecord",
+        "kinesis:SplitShard",
+        "rds:Describe*",
+        "s3:*",
+        "sdb:*",
+        "sns:*",
+        "sqs:*"
+      ]
+    }
+  ]
 }
 EOT
 }
@@ -638,7 +642,7 @@ EOT
 # IAM Role for autoscaling
 resource "aws_iam_role" "emr-autoscaling-role" {
   name               = "EMR_AutoScaling_DefaultRole_%d"
-  assume_role_policy = "${data.aws_iam_policy_document.emr-autoscaling-role-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.emr-autoscaling-role-policy.json
 }
 
 data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
@@ -654,7 +658,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
-  role       = "${aws_iam_role.emr-autoscaling-role.name}"
+  role       = aws_iam_role.emr-autoscaling-role.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
 
@@ -662,7 +666,7 @@ resource "aws_appautoscaling_target" "bar" {
   service_namespace  = "elasticmapreduce"
   resource_id        = "instancegroup/${aws_emr_cluster.tf-test-cluster.id}/${aws_emr_instance_group.task.id}"
   scalable_dimension = "elasticmapreduce:instancegroup:InstanceCount"
-  role_arn           = "${aws_iam_role.emr-autoscaling-role.arn}"
+  role_arn           = aws_iam_role.emr-autoscaling-role.arn
   min_capacity       = 1
   max_capacity       = 8
 }
@@ -709,29 +713,29 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "fleet_role_policy" {
-  role = "${aws_iam_role.fleet_role.name}"
+  role       = aws_iam_role.fleet_role.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }
 
 resource "aws_spot_fleet_request" "test" {
-  iam_fleet_role = "${aws_iam_role.fleet_role.arn}"
-  spot_price = "0.005"
-  target_capacity = 2
-  valid_until = %[1]q
+  iam_fleet_role                      = aws_iam_role.fleet_role.arn
+  spot_price                          = "0.005"
+  target_capacity                     = 2
+  valid_until                         = %[1]q
   terminate_instances_with_expiration = true
 
   launch_specification {
     instance_type = "m3.medium"
-    ami = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+    ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   }
 }
 
 resource "aws_appautoscaling_target" "test" {
-  service_namespace = "ec2"
-  resource_id = "spot-fleet-request/${aws_spot_fleet_request.test.id}"
+  service_namespace  = "ec2"
+  resource_id        = "spot-fleet-request/${aws_spot_fleet_request.test.id}"
   scalable_dimension = "ec2:spot-fleet-request:TargetCapacity"
-  min_capacity = 1
-  max_capacity = 3
+  min_capacity       = 1
+  max_capacity       = 3
 }
 `, validUntil)
 }

--- a/aws/resource_aws_appmesh_mesh_test.go
+++ b/aws/resource_aws_appmesh_mesh_test.go
@@ -253,8 +253,8 @@ resource "aws_appmesh_mesh" "foo" {
   name = "%s"
 
   tags = {
-	foo = "bar"
-	good = "bad"
+    foo  = "bar"
+    good = "bad"
   }
 }
 `, name)
@@ -266,9 +266,9 @@ resource "aws_appmesh_mesh" "foo" {
   name = "%s"
 
   tags = {
-	foo = "bar"
-	good = "bad2"
-	fizz = "buzz"
+    foo  = "bar"
+    good = "bad2"
+    fizz = "buzz"
   }
 }
 `, name)
@@ -280,7 +280,7 @@ resource "aws_appmesh_mesh" "foo" {
   name = "%s"
 
   tags = {
-	foo = "bar"
+    foo = "bar"
   }
 }
 `, name)

--- a/aws/resource_aws_appmesh_route_test.go
+++ b/aws/resource_aws_appmesh_route_test.go
@@ -560,7 +560,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "test" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -574,16 +574,18 @@ resource "aws_appmesh_virtual_router" "test" {
 
 resource "aws_appmesh_virtual_node" "foo" {
   name      = %[3]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
-  spec {}
+  spec {
+  }
 }
 
 resource "aws_appmesh_virtual_node" "bar" {
   name      = %[4]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
-  spec {}
+  spec {
+  }
 }
 `, meshName, vrName, vn1Name, vn2Name)
 }
@@ -617,8 +619,8 @@ func testAccAppmeshRouteConfig_httpRouteUpdated(meshName, vrName, vn1Name, vn2Na
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -628,12 +630,12 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 90
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          virtual_node = aws_appmesh_virtual_node.bar.name
           weight       = 10
         }
       }
@@ -647,8 +649,8 @@ func testAccAppmeshRouteConfig_httpRouteUpdatedWithZeroWeight(meshName, vrName, 
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -658,12 +660,12 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 99
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          virtual_node = aws_appmesh_virtual_node.bar.name
           weight       = 0
         }
       }
@@ -677,14 +679,14 @@ func testAccAppmeshRouteConfig_tcpRoute(meshName, vrName, vn1Name, vn2Name, rNam
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     tcp_route {
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -698,19 +700,19 @@ func testAccAppmeshRouteConfig_tcpRouteUpdated(meshName, vrName, vn1Name, vn2Nam
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     tcp_route {
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 90
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          virtual_node = aws_appmesh_virtual_node.bar.name
           weight       = 10
         }
       }
@@ -724,19 +726,19 @@ func testAccAppmeshRouteConfig_tcpRouteUpdatedWithZeroWeight(meshName, vrName, v
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     tcp_route {
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 99
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          virtual_node = aws_appmesh_virtual_node.bar.name
           weight       = 0
         }
       }
@@ -750,8 +752,8 @@ func testAccAppmeshRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -761,7 +763,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -780,8 +782,8 @@ func testAccAwsAppmeshRouteConfig_httpHeader(meshName, vrName, vn1Name, vn2Name,
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -797,7 +799,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -811,8 +813,8 @@ func testAccAwsAppmeshRouteConfig_httpHeaderUpdated(meshName, vrName, vn1Name, v
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -841,7 +843,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -855,8 +857,8 @@ func testAccAwsAppmeshRouteConfig_routePriority(meshName, vrName, vn1Name, vn2Na
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -866,7 +868,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }

--- a/aws/resource_aws_appmesh_virtual_node_test.go
+++ b/aws/resource_aws_appmesh_virtual_node_test.go
@@ -414,7 +414,7 @@ func testAccAppmeshVirtualNodeConfig_basic(meshName, vnName string) string {
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
@@ -429,7 +429,7 @@ resource "aws_service_discovery_http_namespace" "test" {
 
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     backend {
@@ -452,7 +452,7 @@ resource "aws_appmesh_virtual_node" "test" {
         }
 
         service_name   = %[2]q
-        namespace_name = "${aws_service_discovery_http_namespace.test.name}"
+        namespace_name = aws_service_discovery_http_namespace.test.name
       }
     }
   }
@@ -464,7 +464,7 @@ func testAccAppmeshVirtualNodeConfig_listenerHealthChecks(meshName, vnName strin
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     backend {
@@ -503,7 +503,7 @@ func testAccAppmeshVirtualNodeConfig_listenerHealthChecksUpdated(meshName, vnNam
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     backend {
@@ -548,7 +548,7 @@ func testAccAppmeshVirtualNodeConfig_logging(meshName, vnName, path string) stri
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     backend {
@@ -586,7 +586,7 @@ func testAccAppmeshVirtualNodeConfig_tags(meshName, vnName, tagKey1, tagValue1, 
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 

--- a/aws/resource_aws_appmesh_virtual_router_test.go
+++ b/aws/resource_aws_appmesh_virtual_router_test.go
@@ -264,7 +264,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "test" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -286,7 +286,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "test" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -308,7 +308,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "test" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {

--- a/aws/resource_aws_appmesh_virtual_service_test.go
+++ b/aws/resource_aws_appmesh_virtual_service_test.go
@@ -284,21 +284,21 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_node" "foo" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_node" "bar" {
   name      = %[3]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_service" "test" {
   name      = %[4]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     provider {
@@ -319,7 +319,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "foo" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -333,7 +333,7 @@ resource "aws_appmesh_virtual_router" "foo" {
 
 resource "aws_appmesh_virtual_router" "bar" {
   name      = %[3]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -347,7 +347,7 @@ resource "aws_appmesh_virtual_router" "bar" {
 
 resource "aws_appmesh_virtual_service" "test" {
   name      = %[4]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     provider {
@@ -368,21 +368,21 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_node" "foo" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_node" "bar" {
   name      = %[3]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_service" "test" {
   name      = %[4]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     provider {

--- a/aws/resource_aws_appsync_api_key_test.go
+++ b/aws/resource_aws_appsync_api_key_test.go
@@ -188,7 +188,7 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_api_key" "test" {
-  api_id      = "${aws_appsync_graphql_api.test.id}"
+  api_id      = aws_appsync_graphql_api.test.id
   description = %q
 }
 `, rName, description)
@@ -202,7 +202,7 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_api_key" "test" {
-  api_id  = "${aws_appsync_graphql_api.test.id}"
+  api_id  = aws_appsync_graphql_api.test.id
   expires = %q
 }
 `, rName, expires)
@@ -216,7 +216,7 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_api_key" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
 }
 `, rName)
 }

--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -473,10 +473,11 @@ resource "aws_iam_role" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "test" {
-  role = "${aws_iam_role.test.id}"
+  role = aws_iam_role.test.id
 
   policy = <<EOF
 {
@@ -494,6 +495,7 @@ resource "aws_iam_role_policy" "test" {
   ]
 }
 EOF
+
 }
 `, rName, rName)
 }
@@ -526,10 +528,11 @@ resource "aws_iam_role" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "test" {
-  role = "${aws_iam_role.test.id}"
+  role = aws_iam_role.test.id
 
   policy = <<EOF
 {
@@ -547,6 +550,7 @@ resource "aws_iam_role_policy" "test" {
   ]
 }
 EOF
+
 }
 `, rName, rName)
 }
@@ -570,13 +574,14 @@ resource "aws_iam_role" "lambda" {
   ]
 }
 EOF
+
 }
 
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %q
   handler       = "exports.test"
-  role          = "${aws_iam_role.lambda.arn}"
+  role          = aws_iam_role.lambda.arn
   runtime       = "nodejs12.x"
 }
 
@@ -597,10 +602,11 @@ resource "aws_iam_role" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "test" {
-  role = "${aws_iam_role.test.id}"
+  role = aws_iam_role.test.id
 
   policy = <<EOF
 {
@@ -618,6 +624,7 @@ resource "aws_iam_role_policy" "test" {
   ]
 }
 EOF
+
 }
 `, rName, rName, rName)
 }
@@ -630,7 +637,7 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id      = "${aws_appsync_graphql_api.test.id}"
+  api_id      = aws_appsync_graphql_api.test.id
   description = %q
   name        = %q
   type        = "HTTP"
@@ -671,13 +678,13 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id           = "${aws_appsync_graphql_api.test.id}"
+  api_id           = aws_appsync_graphql_api.test.id
   name             = %q
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn = aws_iam_role.test.arn
   type             = "AMAZON_DYNAMODB"
 
   dynamodb_config {
-    table_name             = "${aws_dynamodb_table.test.name}"
+    table_name             = aws_dynamodb_table.test.name
     use_caller_credentials = %t
   }
 }
@@ -692,9 +699,9 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id           = "${aws_appsync_graphql_api.test.id}"
+  api_id           = aws_appsync_graphql_api.test.id
   name             = %q
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn = aws_iam_role.test.arn
   type             = "AMAZON_ELASTICSEARCH"
 
   elasticsearch_config {
@@ -713,7 +720,7 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = %q
   type   = "HTTP"
 
@@ -732,13 +739,13 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id           = "${aws_appsync_graphql_api.test.id}"
+  api_id           = aws_appsync_graphql_api.test.id
   name             = %q
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn = aws_iam_role.test.arn
   type             = "AMAZON_DYNAMODB"
 
   dynamodb_config {
-    table_name = "${aws_dynamodb_table.test.name}"
+    table_name = aws_dynamodb_table.test.name
   }
 }
 `, rName, rName)
@@ -752,9 +759,9 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id           = "${aws_appsync_graphql_api.test.id}"
+  api_id           = aws_appsync_graphql_api.test.id
   name             = %q
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn = aws_iam_role.test.arn
   type             = "AMAZON_ELASTICSEARCH"
 
   elasticsearch_config {
@@ -772,7 +779,7 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = %q
   type   = "HTTP"
 
@@ -791,13 +798,13 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id           = "${aws_appsync_graphql_api.test.id}"
+  api_id           = aws_appsync_graphql_api.test.id
   name             = %q
-  service_role_arn = "${aws_iam_role.test.arn}"
+  service_role_arn = aws_iam_role.test.arn
   type             = "AWS_LAMBDA"
 
   lambda_config {
-    function_arn = "${aws_lambda_function.test.arn}"
+    function_arn = aws_lambda_function.test.arn
   }
 }
 `, rName, rName)
@@ -811,7 +818,7 @@ resource "aws_appsync_graphql_api" "test" {
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = %q
   type   = "NONE"
 }

--- a/aws/resource_aws_appsync_function_test.go
+++ b/aws/resource_aws_appsync_function_test.go
@@ -227,10 +227,10 @@ func testAccAWSAppsyncFunctionConfig(r1, r2, region string) string {
 %[1]s
 
 resource "aws_appsync_function" "test" {
-	api_id      = "${aws_appsync_graphql_api.test.id}"
-	data_source = "${aws_appsync_datasource.test.name}"
-	name        = "%[2]s"
-	request_mapping_template = <<EOF
+  api_id                   = aws_appsync_graphql_api.test.id
+  data_source              = aws_appsync_datasource.test.name
+  name                     = "%[2]s"
+  request_mapping_template = <<EOF
 {
 	"version": "2018-05-29",
 	"method": "GET",
@@ -240,15 +240,17 @@ resource "aws_appsync_function" "test" {
 	}
 }
 EOF
-	response_mapping_template = <<EOF
+
+
+  response_mapping_template = <<EOF
 #if($ctx.result.statusCode == 200)
 	$ctx.result.body
 #else
 	$utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
-}
 
+}
 `, testAccAppsyncDatasourceConfig_DynamoDBConfig_Region(r1, region), r2)
 }
 
@@ -257,11 +259,11 @@ func testAccAWSAppsyncFunctionConfigDescription(r1, r2, region, description stri
 %[1]s
 
 resource "aws_appsync_function" "test" {
-	api_id      = "${aws_appsync_graphql_api.test.id}"
-	data_source = "${aws_appsync_datasource.test.name}"
-	name        = "%[2]s"
-	description = "%[3]s"
-	request_mapping_template = <<EOF
+  api_id                   = aws_appsync_graphql_api.test.id
+  data_source              = aws_appsync_datasource.test.name
+  name                     = "%[2]s"
+  description              = "%[3]s"
+  request_mapping_template = <<EOF
 {
 	"version": "2018-05-29",
 	"method": "GET",
@@ -271,15 +273,17 @@ resource "aws_appsync_function" "test" {
 	}
 }
 EOF
-	response_mapping_template = <<EOF
+
+
+  response_mapping_template = <<EOF
 #if($ctx.result.statusCode == 200)
 	$ctx.result.body
 #else
 	$utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
-}
 
+}
 `, testAccAppsyncDatasourceConfig_DynamoDBConfig_Region(r1, region), r2, description)
 }
 
@@ -288,10 +292,10 @@ func testAccAWSAppsyncFunctionConfigResponseMappingTemplate(r1, r2, region strin
 %[1]s
 
 resource "aws_appsync_function" "test" {
-	api_id      = "${aws_appsync_graphql_api.test.id}"
-	data_source = "${aws_appsync_datasource.test.name}"
-	name        = "%[2]s"
-	request_mapping_template = <<EOF
+  api_id                   = aws_appsync_graphql_api.test.id
+  data_source              = aws_appsync_datasource.test.name
+  name                     = "%[2]s"
+  request_mapping_template = <<EOF
 {
 	"version": "2018-05-29",
 	"method": "GET",
@@ -301,14 +305,16 @@ resource "aws_appsync_function" "test" {
 	}
 }
 EOF
-	response_mapping_template = <<EOF
+
+
+  response_mapping_template = <<EOF
 #if($ctx.result.statusCode == 200)
 	$ctx.result.body
 #else
 	$utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
-}
 
+}
 `, testAccAppsyncDatasourceConfig_DynamoDBConfig_Region(r1, region), r2)
 }

--- a/aws/resource_aws_appsync_graphql_api_test.go
+++ b/aws/resource_aws_appsync_graphql_api_test.go
@@ -1054,7 +1054,8 @@ resource "aws_appsync_graphql_api" "test" {
 
 func testAccAppsyncGraphqlApiConfig_LogConfig_FieldLogLevel(rName, fieldLogLevel string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+}
 
 resource "aws_iam_role" "test" {
   name = %q
@@ -1073,11 +1074,12 @@ resource "aws_iam_role" "test" {
     ]
 }
 POLICY
+
 }
 
 resource "aws_iam_role_policy_attachment" "test" {
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
-  role       = "${aws_iam_role.test.name}"
+  role       = aws_iam_role.test.name
 }
 
 resource "aws_appsync_graphql_api" "test" {
@@ -1085,7 +1087,7 @@ resource "aws_appsync_graphql_api" "test" {
   name                = %q
 
   log_config {
-    cloudwatch_logs_role_arn = "${aws_iam_role.test.arn}"
+    cloudwatch_logs_role_arn = aws_iam_role.test.arn
     field_log_level          = %q
   }
 }
@@ -1094,7 +1096,8 @@ resource "aws_appsync_graphql_api" "test" {
 
 func testAccAppsyncGraphqlApiConfig_LogConfig_ExcludeVerboseContent(rName string, excludeVerboseContent bool) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_partition" "current" {
+}
 
 resource "aws_iam_role" "test" {
   name = %q
@@ -1113,11 +1116,12 @@ resource "aws_iam_role" "test" {
     ]
 }
 POLICY
+
 }
 
 resource "aws_iam_role_policy_attachment" "test" {
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
-  role       = "${aws_iam_role.test.name}"
+  role       = aws_iam_role.test.name
 }
 
 resource "aws_appsync_graphql_api" "test" {
@@ -1125,9 +1129,9 @@ resource "aws_appsync_graphql_api" "test" {
   name                = %q
 
   log_config {
-    cloudwatch_logs_role_arn = "${aws_iam_role.test.arn}"
-	field_log_level          = "ALL"
-	exclude_verbose_content  = %t
+    cloudwatch_logs_role_arn = aws_iam_role.test.arn
+    field_log_level          = "ALL"
+    exclude_verbose_content  = %t
   }
 }
 `, rName, rName, excludeVerboseContent)
@@ -1201,7 +1205,7 @@ resource "aws_appsync_graphql_api" "test" {
   user_pool_config {
     aws_region     = %q
     default_action = "ALLOW"
-    user_pool_id   = "${aws_cognito_user_pool.test.id}"
+    user_pool_id   = aws_cognito_user_pool.test.id
   }
 }
 `, rName, rName, awsRegion)
@@ -1219,7 +1223,7 @@ resource "aws_appsync_graphql_api" "test" {
 
   user_pool_config {
     default_action = %q
-    user_pool_id   = "${aws_cognito_user_pool.test.id}"
+    user_pool_id   = aws_cognito_user_pool.test.id
   }
 }
 `, rName, rName, defaultAction)
@@ -1230,7 +1234,7 @@ func testAccAppsyncGraphqlApiConfig_Schema(rName string) string {
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
   name                = %q
-  schema              = "type Mutation {\n\tputPost(id: ID!, title: String!): Post\n}\n\ntype Post {\n\tid: ID!\n\ttitle: String!\n}\n\ntype Query {\n\tsinglePost(id: ID!): Post\n}\n\nschema {\n\tquery: Query\n\tmutation: Mutation\n\n}\n"
+  schema              = "type Mutation {\n	putPost(id: ID!, title: String!): Post\n}\n\ntype Post {\n	id: ID!\n	title: String!\n}\n\ntype Query {\n	singlePost(id: ID!): Post\n}\n\nschema {\n	query: Query\n	mutation: Mutation\n\n}\n"
 }
 `, rName)
 }
@@ -1240,7 +1244,7 @@ func testAccAppsyncGraphqlApiConfig_SchemaUpdate(rName string) string {
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
   name                = %q
-  schema              = "type Mutation {\n\tputPostV2(id: ID!, title: String!): PostV2\n}\n\ntype PostV2 {\n\tid: ID!\n\ttitle: String!\n}\n\ntype Query {\n\tsinglePostV2(id: ID!): PostV2\n}\n\nschema {\n\tquery: Query\n\tmutation: Mutation\n\n}\n"
+  schema              = "type Mutation {\n	putPostV2(id: ID!, title: String!): PostV2\n}\n\ntype PostV2 {\n	id: ID!\n	title: String!\n}\n\ntype Query {\n	singlePostV2(id: ID!): PostV2\n}\n\nschema {\n	query: Query\n	mutation: Mutation\n\n}\n"
 }
 `, rName)
 }
@@ -1298,9 +1302,9 @@ resource "aws_appsync_graphql_api" "test" {
 
   additional_authentication_provider {
     authentication_type = "AMAZON_COGNITO_USER_POOLS"
-    
+
     user_pool_config {
-      user_pool_id = "${aws_cognito_user_pool.test.id}"
+      user_pool_id = aws_cognito_user_pool.test.id
     }
   }
 }
@@ -1332,7 +1336,7 @@ resource "aws_cognito_user_pool" "test" {
 
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
-  name = %q
+  name                = %q
 
   additional_authentication_provider {
     authentication_type = "AWS_IAM"
@@ -1340,9 +1344,9 @@ resource "aws_appsync_graphql_api" "test" {
 
   additional_authentication_provider {
     authentication_type = "AMAZON_COGNITO_USER_POOLS"
-    
+
     user_pool_config {
-      user_pool_id = "${aws_cognito_user_pool.test.id}"
+      user_pool_id = aws_cognito_user_pool.test.id
     }
   }
 

--- a/aws/resource_aws_appsync_resolver_test.go
+++ b/aws/resource_aws_appsync_resolver_test.go
@@ -356,10 +356,11 @@ schema {
 	mutation: Mutation
 }
 EOF
+
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = %q
   type   = "HTTP"
 
@@ -369,10 +370,10 @@ resource "aws_appsync_datasource" "test" {
 }
 
 resource "aws_appsync_resolver" "test" {
-  api_id      = "${aws_appsync_graphql_api.test.id}"
+  api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
   type        = "Query"
-  data_source = "${aws_appsync_datasource.test.name}"
+  data_source = aws_appsync_datasource.test.name
 
   request_template = <<EOF
 {
@@ -385,6 +386,7 @@ resource "aws_appsync_resolver" "test" {
 }
 EOF
 
+
   response_template = <<EOF
 #if($ctx.result.statusCode == 200)
     $ctx.result.body
@@ -392,6 +394,7 @@ EOF
     $utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
+
 }
 `, rName, rName)
 }
@@ -421,10 +424,11 @@ schema {
 	mutation: Mutation
 }
 EOF
+
 }
 
 resource "aws_appsync_datasource" "test_ds_1" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = "test_ds_1"
   type   = "HTTP"
 
@@ -434,7 +438,7 @@ resource "aws_appsync_datasource" "test_ds_1" {
 }
 
 resource "aws_appsync_datasource" "test_ds_2" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = "test_ds_2"
   type   = "HTTP"
 
@@ -444,10 +448,10 @@ resource "aws_appsync_datasource" "test_ds_2" {
 }
 
 resource "aws_appsync_resolver" "test" {
-  api_id      = "${aws_appsync_graphql_api.test.id}"
+  api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
   type        = "Query"
-  data_source = "${aws_appsync_datasource.%s.name}"
+  data_source = aws_appsync_datasource.%s.name
 
   request_template = <<EOF
 {
@@ -460,6 +464,7 @@ resource "aws_appsync_resolver" "test" {
 }
 EOF
 
+
   response_template = <<EOF
 #if($ctx.result.statusCode == 200)
     $ctx.result.body
@@ -467,6 +472,7 @@ EOF
     $utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
+
 }
 `, rName, dataSource)
 }
@@ -496,10 +502,11 @@ schema {
 	mutation: Mutation
 }
 EOF
+
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = %q
   type   = "HTTP"
 
@@ -509,10 +516,10 @@ resource "aws_appsync_datasource" "test" {
 }
 
 resource "aws_appsync_resolver" "test" {
-  api_id      = "${aws_appsync_graphql_api.test.id}"
+  api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
   type        = "Query"
-  data_source = "${aws_appsync_datasource.test.name}"
+  data_source = aws_appsync_datasource.test.name
 
   request_template = <<EOF
 {
@@ -525,6 +532,7 @@ resource "aws_appsync_resolver" "test" {
 }
 EOF
 
+
   response_template = <<EOF
 #if($ctx.result.statusCode == 200)
     $ctx.result.body
@@ -532,6 +540,7 @@ EOF
     $utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
+
 }
 `, rName, rName, resourcePath)
 }
@@ -561,10 +570,11 @@ schema {
 	mutation: Mutation
 }
 EOF
+
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = %q
   type   = "HTTP"
 
@@ -574,10 +584,10 @@ resource "aws_appsync_datasource" "test" {
 }
 
 resource "aws_appsync_resolver" "test" {
-  api_id      = "${aws_appsync_graphql_api.test.id}"
+  api_id      = aws_appsync_graphql_api.test.id
   field       = "singlePost"
   type        = "Query"
-  data_source = "${aws_appsync_datasource.test.name}"
+  data_source = aws_appsync_datasource.test.name
 
   request_template = <<EOF
 {
@@ -591,6 +601,7 @@ resource "aws_appsync_resolver" "test" {
 }
 EOF
 
+
   response_template = <<EOF
 #if($ctx.result.statusCode == %d)
     $ctx.result.body
@@ -598,6 +609,7 @@ EOF
     $utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
+
 }
 `, rName, rName, statusCode)
 }
@@ -611,10 +623,10 @@ func testAccAppsyncResolver_multipleResolvers(rName string) string {
 `, i)
 		resolverResources = resolverResources + fmt.Sprintf(`
 resource "aws_appsync_resolver" "test%d" {
-  api_id           = "${aws_appsync_graphql_api.test.id}"
+  api_id           = aws_appsync_graphql_api.test.id
   field            = "singlePost%d"
   type             = "Query"
-  data_source      = "${aws_appsync_datasource.test.name}"
+  data_source      = aws_appsync_datasource.test.name
   request_template = <<EOF
 {
     "version": "2018-05-29",
@@ -660,10 +672,11 @@ schema {
 	mutation: Mutation
 }
 EOF
+
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
+  api_id = aws_appsync_graphql_api.test.id
   name   = %q
   type   = "HTTP"
 
@@ -672,17 +685,15 @@ resource "aws_appsync_datasource" "test" {
   }
 }
 
-%s
-
-`, rName, queryFields, rName, resolverResources)
+%s`, rName, queryFields, rName, resolverResources)
 }
 
 func testAccAppsyncResolver_pipelineConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
-	authentication_type = "API_KEY"
-	name                = "%[1]s"
-	schema              = <<EOF
+  authentication_type = "API_KEY"
+  name                = "%[1]s"
+  schema              = <<EOF
 type Mutation {
 		putPost(id: ID!, title: String!): Post
 }
@@ -701,23 +712,24 @@ schema {
 		mutation: Mutation
 }
 EOF
+
 }
 
 resource "aws_appsync_datasource" "test" {
-	api_id      = "${aws_appsync_graphql_api.test.id}"
-	name        = "%[1]s"
-	type        = "HTTP"
+  api_id = aws_appsync_graphql_api.test.id
+  name   = "%[1]s"
+  type   = "HTTP"
 
-	http_config {
-		endpoint = "http://example.com"
-	}
+  http_config {
+    endpoint = "http://example.com"
+  }
 }
 
 resource "aws_appsync_function" "test" {
-	api_id      = "${aws_appsync_graphql_api.test.id}"
-	data_source = "${aws_appsync_datasource.test.name}"
-	name        = "%[1]s"
-	request_mapping_template = <<EOF
+  api_id                   = aws_appsync_graphql_api.test.id
+  data_source              = aws_appsync_datasource.test.name
+  name                     = "%[1]s"
+  request_mapping_template = <<EOF
 {
 		"version": "2018-05-29",
 		"method": "GET",
@@ -727,21 +739,24 @@ resource "aws_appsync_function" "test" {
 		}
 }
 EOF
-	response_mapping_template = <<EOF
+
+
+  response_mapping_template = <<EOF
 #if($ctx.result.statusCode == 200)
 		$ctx.result.body
 #else
 		$utils.appendError($ctx.result.body, $ctx.result.statusCode)
 #end
 EOF
+
 }
 
 resource "aws_appsync_resolver" "test" {
-	api_id           = "${aws_appsync_graphql_api.test.id}"
-	field            = "singlePost"
-	type             = "Query"
-	kind					   = "PIPELINE"
-	request_template = <<EOF
+  api_id           = aws_appsync_graphql_api.test.id
+  field            = "singlePost"
+  type             = "Query"
+  kind             = "PIPELINE"
+  request_template = <<EOF
 {
 		"version": "2018-05-29",
 		"method": "GET",
@@ -751,7 +766,9 @@ resource "aws_appsync_resolver" "test" {
 		}
 }
 EOF
-	response_template = <<EOF
+
+
+  response_template = <<EOF
 #if($ctx.result.statusCode == 200)
 		$ctx.result.body
 #else
@@ -759,11 +776,11 @@ EOF
 #end
 EOF
 
-	pipeline_config {
-		functions = ["${aws_appsync_function.test.function_id}"]
-	}
-}
 
+  pipeline_config {
+    functions = [aws_appsync_function.test.function_id]
+  }
+}
 `, rName)
 }
 
@@ -791,12 +808,13 @@ schema {
 	mutation: Mutation
 }
 EOF
+
 }
 
 resource "aws_appsync_datasource" "test" {
-  api_id      = "${aws_appsync_graphql_api.test.id}"
-  name        = "%[1]s"
-  type        = "HTTP"
+  api_id = aws_appsync_graphql_api.test.id
+  name   = "%[1]s"
+  type   = "HTTP"
 
   http_config {
     endpoint = "http://example.com"
@@ -804,11 +822,11 @@ resource "aws_appsync_datasource" "test" {
 }
 
 resource "aws_appsync_resolver" "test" {
-  api_id           = "${aws_appsync_graphql_api.test.id}"
+  api_id           = aws_appsync_graphql_api.test.id
   field            = "singlePost"
   type             = "Query"
   kind             = "UNIT"
-  data_source      = "${aws_appsync_datasource.test.name}"
+  data_source      = aws_appsync_datasource.test.name
   request_template = <<EOF
 {
     "version": "2018-05-29",
@@ -819,6 +837,8 @@ resource "aws_appsync_resolver" "test" {
     }
 }
 EOF
+
+
   response_template = <<EOF
 #if($ctx.result.statusCode == 200)
     $ctx.result.body
@@ -827,10 +847,11 @@ EOF
 #end
 EOF
 
+
   caching_config {
     caching_keys = [
       "$context.identity.sub",
-      "$context.arguments.id"
+      "$context.arguments.id",
     ]
     ttl = 60
   }

--- a/aws/resource_aws_athena_database_test.go
+++ b/aws/resource_aws_athena_database_test.go
@@ -339,7 +339,7 @@ resource "aws_s3_bucket" "hoge" {
 
 resource "aws_athena_database" "hoge" {
   name          = "%[2]s"
-  bucket        = "${aws_s3_bucket.hoge.bucket}"
+  bucket        = aws_s3_bucket.hoge.bucket
   force_destroy = %[3]t
 }
 `, randInt, dbName, forceDestroy)
@@ -358,7 +358,7 @@ resource "aws_s3_bucket" "hoge" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = "${aws_kms_key.hoge.arn}"
+        kms_master_key_id = aws_kms_key.hoge.arn
         sse_algorithm     = "aws:kms"
       }
     }
@@ -367,12 +367,12 @@ resource "aws_s3_bucket" "hoge" {
 
 resource "aws_athena_database" "hoge" {
   name          = "%[2]s"
-  bucket        = "${aws_s3_bucket.hoge.bucket}"
+  bucket        = aws_s3_bucket.hoge.bucket
   force_destroy = %[3]t
 
   encryption_configuration {
     encryption_option = "SSE_KMS"
-    kms_key           = "${aws_kms_key.hoge.arn}"
+    kms_key           = aws_kms_key.hoge.arn
   }
 }
 `, randInt, dbName, forceDestroy)

--- a/aws/resource_aws_athena_named_query_test.go
+++ b/aws/resource_aws_athena_named_query_test.go
@@ -109,12 +109,12 @@ resource "aws_s3_bucket" "test" {
 
 resource "aws_athena_database" "test" {
   name   = "%s"
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
 }
 
 resource "aws_athena_named_query" "test" {
   name        = "tf-athena-named-query-%s"
-  database    = "${aws_athena_database.test.name}"
+  database    = aws_athena_database.test.name
   query       = "SELECT * FROM ${aws_athena_database.test.name} limit 10;"
   description = "tf test"
 }
@@ -134,13 +134,13 @@ resource "aws_athena_workgroup" "test" {
 
 resource "aws_athena_database" "test" {
   name   = "%s"
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
 }
 
 resource "aws_athena_named_query" "test" {
   name        = "tf-athena-named-query-%s"
-  workgroup   = "${aws_athena_workgroup.test.id}"
-  database    = "${aws_athena_database.test.name}"
+  workgroup   = aws_athena_workgroup.test.id
+  database    = aws_athena_database.test.name
   query       = "SELECT * FROM ${aws_athena_database.test.name} limit 10;"
   description = "tf test"
 }

--- a/aws/resource_aws_athena_workgroup_test.go
+++ b/aws/resource_aws_athena_workgroup_test.go
@@ -623,7 +623,7 @@ resource "aws_athena_workgroup" "test" {
 
 func testAccAthenaWorkGroupConfigConfigurationResultConfigurationOutputLocation(rName string, bucketName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "test"{
+resource "aws_s3_bucket" "test" {
   bucket        = %[2]q
   force_destroy = true
 }
@@ -642,14 +642,14 @@ resource "aws_athena_workgroup" "test" {
 
 func testAccAthenaWorkGroupConfigConfigurationResultConfigurationOutputLocationForceDestroy(rName string, bucketName string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "test"{
+resource "aws_s3_bucket" "test" {
   bucket        = %[2]q
   force_destroy = true
 }
 
 resource "aws_athena_workgroup" "test" {
   name = %[1]q
-  
+
   force_destroy = true
 
   configuration {
@@ -691,7 +691,7 @@ resource "aws_athena_workgroup" "test" {
     result_configuration {
       encryption_configuration {
         encryption_option = %[2]q
-        kms_key_arn       = "${aws_kms_key.test.arn}"
+        kms_key_arn       = aws_kms_key.test.arn
       }
     }
   }
@@ -739,6 +739,7 @@ resource "aws_athena_workgroup" "test" {
   name          = %[1]q
   force_destroy = true
 }
+
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
@@ -746,7 +747,7 @@ resource "aws_s3_bucket" "test" {
 
 resource "aws_athena_database" "test" {
   name          = %[2]q
-  bucket        = "${aws_s3_bucket.test.bucket}"
+  bucket        = aws_s3_bucket.test.bucket
   force_destroy = true
 }
 `, rName, dbName)

--- a/aws/resource_aws_autoscaling_attachment_test.go
+++ b/aws/resource_aws_autoscaling_attachment_test.go
@@ -190,7 +190,7 @@ resource "aws_lb_target_group" "test" {
   name     = "test-alb-%d"
   port     = 443
   protocol = "HTTPS"
-  vpc_id   = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
@@ -219,7 +219,7 @@ resource "aws_lb_target_group" "another_test" {
   name     = "atest-alb-%d"
   port     = 443
   protocol = "HTTPS"
-  vpc_id   = "${aws_vpc.test.id}"
+  vpc_id   = aws_vpc.test.id
 
   deregistration_delay = 200
 
@@ -252,7 +252,7 @@ resource "aws_autoscaling_group" "asg" {
   desired_capacity          = 0
   health_check_grace_period = 300
   force_delete              = true
-  launch_configuration      = "${aws_launch_configuration.as_conf.name}"
+  launch_configuration      = aws_launch_configuration.as_conf.name
 
   tag {
     key                 = "Name"
@@ -328,7 +328,7 @@ resource "aws_autoscaling_group" "asg" {
   desired_capacity          = 0
   health_check_grace_period = 300
   force_delete              = true
-  launch_configuration      = "${aws_launch_configuration.as_conf.name}"
+  launch_configuration      = aws_launch_configuration.as_conf.name
 
   tag {
     key                 = "Name"
@@ -346,31 +346,31 @@ resource "aws_autoscaling_group" "asg" {
 func testAccAWSAutoscalingAttachment_elb_associated(rInt int) string {
 	return testAccAWSAutoscalingAttachment_elb(rInt) + `
 resource "aws_autoscaling_attachment" "asg_attachment_foo" {
-  autoscaling_group_name = "${aws_autoscaling_group.asg.id}"
-  elb                    = "${aws_elb.foo.id}"
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  elb                    = aws_elb.foo.id
 }`
 }
 
 func testAccAWSAutoscalingAttachment_alb_associated(rInt int) string {
 	return testAccAWSAutoscalingAttachment_alb(rInt) + `
 resource "aws_autoscaling_attachment" "asg_attachment_foo" {
-  autoscaling_group_name = "${aws_autoscaling_group.asg.id}"
-  alb_target_group_arn   = "${aws_lb_target_group.test.arn}"
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  alb_target_group_arn   = aws_lb_target_group.test.arn
 }`
 }
 
 func testAccAWSAutoscalingAttachment_elb_double_associated(rInt int) string {
 	return testAccAWSAutoscalingAttachment_elb_associated(rInt) + `
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
-  autoscaling_group_name = "${aws_autoscaling_group.asg.id}"
-  elb                    = "${aws_elb.bar.id}"
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  elb                    = aws_elb.bar.id
 }`
 }
 
 func testAccAWSAutoscalingAttachment_alb_double_associated(rInt int) string {
 	return testAccAWSAutoscalingAttachment_alb_associated(rInt) + `
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
-  autoscaling_group_name = "${aws_autoscaling_group.asg.id}"
-  alb_target_group_arn   = "${aws_lb_target_group.another_test.arn}"
+  autoscaling_group_name = aws_autoscaling_group.asg.id
+  alb_target_group_arn   = aws_lb_target_group.another_test.arn
 }`
 }

--- a/aws/resource_aws_autoscaling_lifecycle_hook_test.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook_test.go
@@ -157,7 +157,7 @@ EOF
 
 resource "aws_iam_role_policy" "foobar" {
   name = "foobar"
-  role = "${aws_iam_role.foobar.id}"
+  role = aws_iam_role.foobar.id
 
   policy = <<EOF
 {
@@ -195,7 +195,7 @@ resource "aws_autoscaling_group" "foobar" {
   health_check_type         = "ELB"
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 
   tag {
     key                 = "Foo"
@@ -206,7 +206,7 @@ resource "aws_autoscaling_group" "foobar" {
 
 resource "aws_autoscaling_lifecycle_hook" "foobar" {
   name                   = "foobar"
-  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  autoscaling_group_name = aws_autoscaling_group.foobar.name
   default_result         = "CONTINUE"
   heartbeat_timeout      = 2000
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
@@ -217,8 +217,8 @@ resource "aws_autoscaling_lifecycle_hook" "foobar" {
 }
 EOF
 
-  notification_target_arn = "${aws_sqs_queue.foobar.arn}"
-  role_arn                = "${aws_iam_role.foobar.arn}"
+  notification_target_arn = aws_sqs_queue.foobar.arn
+  role_arn                = aws_iam_role.foobar.arn
 }
 `, name, name)
 }
@@ -256,7 +256,7 @@ EOF
 
 resource "aws_iam_role_policy" "foobar" {
   name = "foobar-%d"
-  role = "${aws_iam_role.foobar.id}"
+  role = aws_iam_role.foobar.id
 
   policy = <<EOF
 {
@@ -294,7 +294,7 @@ resource "aws_autoscaling_group" "foobar" {
   health_check_type         = "ELB"
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 
   tag {
     key                 = "Foo"
@@ -305,7 +305,7 @@ resource "aws_autoscaling_group" "foobar" {
 
 resource "aws_autoscaling_lifecycle_hook" "foobar" {
   name                   = "foobar-%d"
-  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  autoscaling_group_name = aws_autoscaling_group.foobar.name
   heartbeat_timeout      = 2000
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
 
@@ -315,8 +315,8 @@ resource "aws_autoscaling_lifecycle_hook" "foobar" {
 }
 EOF
 
-  notification_target_arn = "${aws_sqs_queue.foobar.arn}"
-  role_arn                = "${aws_iam_role.foobar.arn}"
+  notification_target_arn = aws_sqs_queue.foobar.arn
+  role_arn                = aws_iam_role.foobar.arn
 }
 `, name, rInt, rInt, rInt, name, rInt)
 }

--- a/aws/resource_aws_autoscaling_notification_test.go
+++ b/aws/resource_aws_autoscaling_notification_test.go
@@ -241,18 +241,18 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity          = 1
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 }
 
 resource "aws_autoscaling_notification" "example" {
-  group_names = ["${aws_autoscaling_group.bar.name}"]
+  group_names = [aws_autoscaling_group.bar.name]
 
   notifications = [
     "autoscaling:EC2_INSTANCE_LAUNCH",
     "autoscaling:EC2_INSTANCE_TERMINATE",
   ]
 
-  topic_arn = "${aws_sns_topic.topic_example.arn}"
+  topic_arn = aws_sns_topic.topic_example.arn
 }
 `, rName, rName, rName)
 }
@@ -288,7 +288,7 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity          = 1
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 }
 
 resource "aws_autoscaling_group" "foo" {
@@ -301,13 +301,13 @@ resource "aws_autoscaling_group" "foo" {
   desired_capacity          = 1
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 }
 
 resource "aws_autoscaling_notification" "example" {
   group_names = [
-    "${aws_autoscaling_group.bar.name}",
-    "${aws_autoscaling_group.foo.name}",
+    aws_autoscaling_group.bar.name,
+    aws_autoscaling_group.foo.name,
   ]
 
   notifications = [
@@ -316,7 +316,7 @@ resource "aws_autoscaling_notification" "example" {
     "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
   ]
 
-  topic_arn = "${aws_sns_topic.topic_example.arn}"
+  topic_arn = aws_sns_topic.topic_example.arn
 }
 `, rName, rName, rName, rName)
 }
@@ -342,48 +342,26 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_autoscaling_group" "bar" {
-  availability_zones = [data.aws_availability_zones.available.names[1]]
-  count = 20
-  name = "foobar3-terraform-test-${count.index}"
-  max_size = 1
-  min_size = 0
+  availability_zones        = [data.aws_availability_zones.available.names[1]]
+  count                     = 20
+  name                      = "foobar3-terraform-test-${count.index}"
+  max_size                  = 1
+  min_size                  = 0
   health_check_grace_period = 300
-  health_check_type = "ELB"
-  desired_capacity = 0
-  force_delete = true
-  termination_policies = ["OldestInstance"]
-  launch_configuration = "${aws_launch_configuration.foobar.name}"
+  health_check_type         = "ELB"
+  desired_capacity          = 0
+  force_delete              = true
+  termination_policies      = ["OldestInstance"]
+  launch_configuration      = aws_launch_configuration.foobar.name
 }
 
 resource "aws_autoscaling_notification" "example" {
-  # TODO: Switch back to simple list reference when test configurations are upgraded to 0.12 syntax
-  group_names = [
-    "${aws_autoscaling_group.bar.*.name[0]}",
-    "${aws_autoscaling_group.bar.*.name[1]}",
-    "${aws_autoscaling_group.bar.*.name[2]}",
-    "${aws_autoscaling_group.bar.*.name[3]}",
-    "${aws_autoscaling_group.bar.*.name[4]}",
-    "${aws_autoscaling_group.bar.*.name[5]}",
-    "${aws_autoscaling_group.bar.*.name[6]}",
-    "${aws_autoscaling_group.bar.*.name[7]}",
-    "${aws_autoscaling_group.bar.*.name[8]}",
-    "${aws_autoscaling_group.bar.*.name[9]}",
-    "${aws_autoscaling_group.bar.*.name[10]}",
-    "${aws_autoscaling_group.bar.*.name[11]}",
-    "${aws_autoscaling_group.bar.*.name[12]}",
-    "${aws_autoscaling_group.bar.*.name[13]}",
-    "${aws_autoscaling_group.bar.*.name[14]}",
-    "${aws_autoscaling_group.bar.*.name[15]}",
-    "${aws_autoscaling_group.bar.*.name[16]}",
-    "${aws_autoscaling_group.bar.*.name[17]}",
-    "${aws_autoscaling_group.bar.*.name[18]}",
-    "${aws_autoscaling_group.bar.*.name[19]}",
-  ]
-  notifications  = [
+  group_names   = aws_autoscaling_group.bar[*].name
+  notifications = [
     "autoscaling:EC2_INSTANCE_LAUNCH",
     "autoscaling:EC2_INSTANCE_TERMINATE",
     "autoscaling:TEST_NOTIFICATION"
   ]
-	topic_arn = "${aws_sns_topic.user_updates.arn}"
+  topic_arn     = aws_sns_topic.user_updates.arn
 }`)
 }

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -359,17 +359,17 @@ data "aws_availability_zones" "available" {
 
 resource "aws_launch_configuration" "test" {
   name          = "%s"
-  image_id      = "${data.aws_ami.amzn.id}"
+  image_id      = data.aws_ami.amzn.id
   instance_type = "t2.micro"
 }
 
 resource "aws_autoscaling_group" "test" {
-  availability_zones   = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
+  availability_zones   = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
   name                 = "%s"
   max_size             = 0
   min_size             = 0
   force_delete         = true
-  launch_configuration = "${aws_launch_configuration.test.name}"
+  launch_configuration = aws_launch_configuration.test.name
 }
 `, name, name)
 }
@@ -382,7 +382,7 @@ resource "aws_autoscaling_policy" "foobar_simple" {
   cooldown               = 300
   policy_type            = "SimpleScaling"
   scaling_adjustment     = 2
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 }
 
 resource "aws_autoscaling_policy" "foobar_step" {
@@ -397,13 +397,13 @@ resource "aws_autoscaling_policy" "foobar_step" {
     metric_interval_lower_bound = 2.0
   }
 
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 }
 
 resource "aws_autoscaling_policy" "foobar_target_tracking" {
   name                   = "%s-foobar_target_tracking"
   policy_type            = "TargetTrackingScaling"
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 
   target_tracking_configuration {
     predefined_metric_specification {
@@ -424,7 +424,7 @@ resource "aws_autoscaling_policy" "foobar_simple" {
   cooldown               = 30
   policy_type            = "SimpleScaling"
   scaling_adjustment     = 2
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 }
 
 resource "aws_autoscaling_policy" "foobar_step" {
@@ -439,13 +439,13 @@ resource "aws_autoscaling_policy" "foobar_step" {
     metric_interval_lower_bound = 2.0
   }
 
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 }
 
 resource "aws_autoscaling_policy" "foobar_target_tracking" {
   name                   = "%s-foobar_target_tracking"
   policy_type            = "TargetTrackingScaling"
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 
   target_tracking_configuration {
     customized_metric_specification {
@@ -473,7 +473,7 @@ resource "aws_autoscaling_policy" "foobar_simple" {
   cooldown               = 300
   policy_type            = "SimpleScaling"
   scaling_adjustment     = 0
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 }
 `, name)
 }
@@ -483,7 +483,7 @@ func testAccAwsAutoscalingPolicyConfig_TargetTracking_Predefined(name string) st
 resource "aws_autoscaling_policy" "test" {
   name                   = "%s-test"
   policy_type            = "TargetTrackingScaling"
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 
   target_tracking_configuration {
     predefined_metric_specification {
@@ -501,7 +501,7 @@ func testAccAwsAutoscalingPolicyConfig_TargetTracking_Custom(name string) string
 resource "aws_autoscaling_policy" "test" {
   name                   = "%s-test"
   policy_type            = "TargetTrackingScaling"
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 
   target_tracking_configuration {
     customized_metric_specification {
@@ -529,7 +529,7 @@ resource "aws_autoscaling_policy" "foobar_simple" {
   cooldown               = 0
   policy_type            = "SimpleScaling"
   scaling_adjustment     = 0
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name = aws_autoscaling_group.test.name
 }
 
 resource "aws_autoscaling_policy" "foobar_step" {
@@ -545,7 +545,7 @@ resource "aws_autoscaling_policy" "foobar_step" {
   }
 
   min_adjustment_magnitude = 1
-  autoscaling_group_name   = "${aws_autoscaling_group.test.name}"
+  autoscaling_group_name   = aws_autoscaling_group.test.name
 }
 `, name, name)
 }

--- a/aws/resource_aws_autoscaling_schedule_test.go
+++ b/aws/resource_aws_autoscaling_schedule_test.go
@@ -292,7 +292,7 @@ resource "aws_autoscaling_group" "foobar" {
   health_check_type         = "ELB"
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 
   tag {
     key                 = "Foo"
@@ -308,7 +308,7 @@ resource "aws_autoscaling_schedule" "foobar" {
   desired_capacity       = 0
   start_time             = "%s"
   end_time               = "%s"
-  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  autoscaling_group_name = aws_autoscaling_group.foobar.name
 }
 `, r, r, start, end)
 }
@@ -339,7 +339,7 @@ resource "aws_autoscaling_group" "foobar" {
   health_check_type         = "ELB"
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 
   tag {
     key                 = "Foo"
@@ -354,7 +354,7 @@ resource "aws_autoscaling_schedule" "foobar" {
   max_size               = 1
   desired_capacity       = 0
   recurrence             = "0 8 * * *"
-  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  autoscaling_group_name = aws_autoscaling_group.foobar.name
 }
 `, r, r)
 }
@@ -385,7 +385,7 @@ resource "aws_autoscaling_group" "foobar" {
   health_check_type         = "ELB"
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 
   tag {
     key                 = "Foo"
@@ -401,7 +401,7 @@ resource "aws_autoscaling_schedule" "foobar" {
   desired_capacity       = 0
   start_time             = "%s"
   end_time               = "%s"
-  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  autoscaling_group_name = aws_autoscaling_group.foobar.name
 }
 `, r, r, start, end)
 }
@@ -432,7 +432,7 @@ resource "aws_autoscaling_group" "foobar" {
   health_check_type         = "ELB"
   force_delete              = true
   termination_policies      = ["OldestInstance"]
-  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+  launch_configuration      = aws_launch_configuration.foobar.name
 
   tag {
     key                 = "Foo"
@@ -448,7 +448,7 @@ resource "aws_autoscaling_schedule" "foobar" {
   desired_capacity       = -1
   start_time             = "%s"
   end_time               = "%s"
-  autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
+  autoscaling_group_name = aws_autoscaling_group.foobar.name
 }
 `, r, r, start, end)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8950

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
Soon...

...
```
