### PR TITLE
Small iam_policy_document documentation fix

### DIFF
--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -109,8 +109,8 @@ each accept the following arguments:
   does *not* apply to. Used to apply a policy statement to all resources
   *except* those listed.
 * `principals` (Optional) - A nested configuration block (described below)
-  specifying a resource (or resource pattern) to which this statement applies.
-* `not_principals` (Optional) - Like `principals` except gives resources that
+  specifying a principal (or principal pattern) to which this statement applies.
+* `not_principals` (Optional) - Like `principals` except gives principals that
   the statement does *not* apply to.
 * `condition` (Optional) - A nested configuration block (described below)
   that defines a further, possibly-service-specific condition that constrains


### PR DESCRIPTION
The description of the `principals` and `not_principals` arguments refer to resources where
they should refer to principals.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Minor documentation fix
```

Output from acceptance testing:

I did not run this as it is a minor documentation fix.
