### PR TITLE
Adds encryption configuration to ECR repository resource and data source

### DIFF
--- a/aws/data_source_aws_ecr_repository_test.go
+++ b/aws/data_source_aws_ecr_repository_test.go
@@ -27,6 +27,34 @@ func TestAccAWSEcrRepositoryDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
 					resource.TestCheckResourceAttrPair(resourceName, "image_scanning_configuration.#", dataSourceName, "image_scanning_configuration.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "image_tag_mutability", dataSourceName, "image_tag_mutability"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.#", dataSourceName, "encryption_configuration.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcrRepositoryDataSource_encryption(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository.test"
+	dataSourceName := "data.aws_ecr_repository.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsEcrRepositoryDataSourceConfig_encryption(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "registry_id", dataSourceName, "registry_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "repository_url", dataSourceName, "repository_url"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "tags"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_scanning_configuration.#", dataSourceName, "image_scanning_configuration.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "image_tag_mutability", dataSourceName, "image_tag_mutability"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.#", dataSourceName, "encryption_configuration.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.0.encryption_type", dataSourceName, "encryption_configuration.0.encryption_type"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.0.kms_key", dataSourceName, "encryption_configuration.0.kms_key"),
 				),
 			},
 		},
@@ -61,6 +89,25 @@ resource "aws_ecr_repository" "test" {
   tags = {
     Environment = "production"
     Usage       = "original"
+  }
+}
+
+data "aws_ecr_repository" "test" {
+  name = aws_ecr_repository.test.name
+}
+`, rName)
+}
+
+func testAccCheckAwsEcrRepositoryDataSourceConfig_encryption(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {}
+
+resource "aws_ecr_repository" "test" {
+  name = %q
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.test.arn
   }
 }
 

--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -256,12 +256,6 @@ func resourceAwsEcrRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if d.HasChange("encryption_configuration") {
-		if err := resourceAwsEcrRepositoryUpdateImageScanningConfiguration(conn, d); err != nil {
-			return err
-		}
-	}
-
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 

--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -28,19 +28,35 @@ func resourceAwsEcrRepository() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"arn": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Computed: true,
 			},
-			"image_tag_mutability": {
-				Type:     schema.TypeString,
+			"encryption_configuration": {
+				Type:     schema.TypeList,
 				Optional: true,
-				Default:  ecr.ImageTagMutabilityMutable,
-				ValidateFunc: validation.StringInSlice([]string{
-					ecr.ImageTagMutabilityMutable,
-					ecr.ImageTagMutabilityImmutable,
-				}, false),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"encryption_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ecr.EncryptionTypeAes256,
+								ecr.EncryptionTypeKms,
+							}, false),
+							Default:  ecr.EncryptionTypeAes256,
+							ForceNew: true,
+						},
+						"kms_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+				ForceNew:         true,
 			},
 			"image_scanning_configuration": {
 				Type:     schema.TypeList,
@@ -56,10 +72,19 @@ func resourceAwsEcrRepository() *schema.Resource {
 				},
 				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 			},
-			"tags": tagsSchema(),
-			"arn": {
+			"image_tag_mutability": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				Default:  ecr.ImageTagMutabilityMutable,
+				ValidateFunc: validation.StringInSlice([]string{
+					ecr.ImageTagMutabilityMutable,
+					ecr.ImageTagMutabilityImmutable,
+				}, false),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"registry_id": {
 				Type:     schema.TypeString,
@@ -69,6 +94,7 @@ func resourceAwsEcrRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -77,9 +103,10 @@ func resourceAwsEcrRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	conn := meta.(*AWSClient).ecrconn
 
 	input := ecr.CreateRepositoryInput{
-		ImageTagMutability: aws.String(d.Get("image_tag_mutability").(string)),
-		RepositoryName:     aws.String(d.Get("name").(string)),
-		Tags:               keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().EcrTags(),
+		ImageTagMutability:      aws.String(d.Get("image_tag_mutability").(string)),
+		RepositoryName:          aws.String(d.Get("name").(string)),
+		Tags:                    keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().EcrTags(),
+		EncryptionConfiguration: expandEcrRepositoryEncryptionConfiguration(d.Get("encryption_configuration").([]interface{})),
 	}
 
 	imageScanningConfigs := d.Get("image_scanning_configuration").([]interface{})
@@ -153,18 +180,20 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("repository_url", repository.RepositoryUri)
 	d.Set("image_tag_mutability", repository.ImageTagMutability)
 
-	if err := d.Set("image_scanning_configuration", flattenImageScanningConfiguration(repository.ImageScanningConfiguration)); err != nil {
-		return fmt.Errorf("error setting image_scanning_configuration: %s", err)
-	}
-
 	tags, err := keyvaluetags.EcrListTags(conn, arn)
-
 	if err != nil {
-		return fmt.Errorf("error listing tags for ECR Repository (%s): %s", arn, err)
+		return fmt.Errorf("error listing tags for ECR Repository (%s): %w", arn, err)
+	}
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags for ECR Repository (%s): %w", arn, err)
 	}
 
-	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+	if err := d.Set("image_scanning_configuration", flattenImageScanningConfiguration(repository.ImageScanningConfiguration)); err != nil {
+		return fmt.Errorf("error setting image_scanning_configuration for ECR Repository (%s): %w", arn, err)
+	}
+
+	if err := d.Set("encryption_configuration", flattenEcrRepositoryEncryptionConfiguration(repository.EncryptionConfiguration)); err != nil {
+		return fmt.Errorf("error setting encryption_configuration for ECR Repository (%s): %w", arn, err)
 	}
 
 	return nil
@@ -183,6 +212,34 @@ func flattenImageScanningConfiguration(isc *ecr.ImageScanningConfiguration) []ma
 	}
 }
 
+func expandEcrRepositoryEncryptionConfiguration(data []interface{}) *ecr.EncryptionConfiguration {
+	if len(data) == 0 || data[0] == nil {
+		return nil
+	}
+
+	ec := data[0].(map[string]interface{})
+	config := &ecr.EncryptionConfiguration{
+		EncryptionType: aws.String(ec["encryption_type"].(string)),
+	}
+	if v, ok := ec["kms_key"]; ok {
+		if s := v.(string); s != "" {
+			config.KmsKey = aws.String(v.(string))
+		}
+	}
+	return config
+}
+
+func flattenEcrRepositoryEncryptionConfiguration(ec *ecr.EncryptionConfiguration) []map[string]interface{} {
+	config := map[string]interface{}{
+		"encryption_type": aws.StringValue(ec.EncryptionType),
+		"kms_key":         aws.StringValue(ec.KmsKey),
+	}
+
+	return []map[string]interface{}{
+		config,
+	}
+}
+
 func resourceAwsEcrRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
 	arn := d.Get("arn").(string)
 	conn := meta.(*AWSClient).ecrconn
@@ -194,6 +251,12 @@ func resourceAwsEcrRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("image_scanning_configuration") {
+		if err := resourceAwsEcrRepositoryUpdateImageScanningConfiguration(conn, d); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("encryption_configuration") {
 		if err := resourceAwsEcrRepositoryUpdateImageScanningConfiguration(conn, d); err != nil {
 			return err
 		}

--- a/aws/resource_aws_ecr_repository_test.go
+++ b/aws/resource_aws_ecr_repository_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,10 +38,9 @@ func testSweepEcrRepositories(region string) error {
 			repositoryName := aws.StringValue(repository.RepositoryName)
 			log.Printf("[INFO] Deleting ECR repository: %s", repositoryName)
 
-			shouldForce := true
 			_, err = conn.DeleteRepository(&ecr.DeleteRepositoryInput{
 				// We should probably sweep repositories even if there are images.
-				Force:          &shouldForce,
+				Force:          aws.Bool(true),
 				RegistryId:     repository.RegistryId,
 				RepositoryName: repository.RepositoryName,
 			})
@@ -68,8 +68,9 @@ func testSweepEcrRepositories(region string) error {
 }
 
 func TestAccAWSEcrRepository_basic(t *testing.T) {
+	var v ecr.Repository
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_ecr_repository.default"
+	resourceName := "aws_ecr_repository.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -79,11 +80,14 @@ func TestAccAWSEcrRepository_basic(t *testing.T) {
 			{
 				Config: testAccAWSEcrRepositoryConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcrRepositoryExists(resourceName),
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v),
 					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ecr", fmt.Sprintf("repository/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckAWSEcrRepositoryRegistryID(resourceName),
 					testAccCheckAWSEcrRepositoryRepositoryURL(resourceName, rName),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.encryption_type", ecr.EncryptionTypeAes256),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.kms_key", ""),
 				),
 			},
 			{
@@ -96,8 +100,9 @@ func TestAccAWSEcrRepository_basic(t *testing.T) {
 }
 
 func TestAccAWSEcrRepository_tags(t *testing.T) {
+	var v1, v2 ecr.Repository
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_ecr_repository.default"
+	resourceName := "aws_ecr_repository.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,7 +112,7 @@ func TestAccAWSEcrRepository_tags(t *testing.T) {
 			{
 				Config: testAccAWSEcrRepositoryConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcrRepositoryExists(resourceName),
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
@@ -116,7 +121,7 @@ func TestAccAWSEcrRepository_tags(t *testing.T) {
 			{
 				Config: testAccAWSEcrRepositoryConfig_tagsChanged(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcrRepositoryExists(resourceName),
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "changed"),
@@ -127,8 +132,9 @@ func TestAccAWSEcrRepository_tags(t *testing.T) {
 }
 
 func TestAccAWSEcrRepository_immutability(t *testing.T) {
+	var v ecr.Repository
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_ecr_repository.default"
+	resourceName := "aws_ecr_repository.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -138,7 +144,7 @@ func TestAccAWSEcrRepository_immutability(t *testing.T) {
 			{
 				Config: testAccAWSEcrRepositoryConfig_immutability(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcrRepositoryExists(resourceName),
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "image_tag_mutability", "IMMUTABLE"),
 				),
@@ -153,8 +159,9 @@ func TestAccAWSEcrRepository_immutability(t *testing.T) {
 }
 
 func TestAccAWSEcrRepository_image_scanning_configuration(t *testing.T) {
+	var v1, v2 ecr.Repository
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	resourceName := "aws_ecr_repository.default"
+	resourceName := "aws_ecr_repository.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -164,7 +171,7 @@ func TestAccAWSEcrRepository_image_scanning_configuration(t *testing.T) {
 			{
 				Config: testAccAWSEcrRepositoryConfig_image_scanning_configuration(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcrRepositoryExists(resourceName),
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "image_scanning_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "image_scanning_configuration.0.scan_on_push", "true"),
@@ -185,7 +192,7 @@ func TestAccAWSEcrRepository_image_scanning_configuration(t *testing.T) {
 				// Test attribute update
 				Config: testAccAWSEcrRepositoryConfig_image_scanning_configuration(rName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcrRepositoryExists(resourceName),
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, "image_scanning_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "image_scanning_configuration.0.scan_on_push", "false"),
 				),
@@ -195,6 +202,92 @@ func TestAccAWSEcrRepository_image_scanning_configuration(t *testing.T) {
 				Config:             testAccAWSEcrRepositoryConfig(rName),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccAWSEcrRepository_encryption_kms(t *testing.T) {
+	var v1, v2 ecr.Repository
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository.test"
+	kmsKeyDataSourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcrRepositoryConfig_encryption_kms_defaultkey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.encryption_type", ecr.EncryptionTypeKms),
+					// This will be the default ECR service KMS key. We don't currently have a way to look this up.
+					testAccMatchResourceAttrRegionalARN(resourceName, "encryption_configuration.0.kms_key", "kms", regexp.MustCompile(fmt.Sprintf("key/%s$", uuidRegexPattern))),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEcrRepositoryConfig_encryption_kms_customkey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v2),
+					testAccCheckAWSEcrRepositoryRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.encryption_type", ecr.EncryptionTypeKms),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.0.kms_key", kmsKeyDataSourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEcrRepository_encryption_aes256(t *testing.T) {
+	var v1, v2 ecr.Repository
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Test that the addition of the default encryption_configuration doesn't recreation in the next step
+				Config: testAccAWSEcrRepositoryConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v1),
+				),
+			},
+			{
+				Config: testAccAWSEcrRepositoryConfig_encryption_aes256(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryExists(resourceName, &v2),
+					testAccCheckAWSEcrRepositoryNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.encryption_type", ecr.EncryptionTypeAes256),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.kms_key", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test that the removal of the default encryption_configuration doesn't cause any plan changes
+				Config:   testAccAWSEcrRepositoryConfig(rName),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -232,12 +325,30 @@ func testAccCheckAWSEcrRepositoryDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSEcrRepositoryExists(name string) resource.TestCheckFunc {
+func testAccCheckAWSEcrRepositoryExists(name string, res *ecr.Repository) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
 		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ECR repository ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ecrconn
+
+		output, err := conn.DescribeRepositories(&ecr.DescribeRepositoriesInput{
+			RepositoryNames: aws.StringSlice([]string{rs.Primary.ID}),
+		})
+		if err != nil {
+			return err
+		}
+		if len(output.Repositories) == 0 {
+			return fmt.Errorf("ECR repository %s not found", rs.Primary.ID)
+		}
+
+		*res = *output.Repositories[0]
 
 		return nil
 	}
@@ -257,9 +368,29 @@ func testAccCheckAWSEcrRepositoryRepositoryURL(resourceName, repositoryName stri
 	}
 }
 
+func testAccCheckAWSEcrRepositoryRecreated(i, j *ecr.Repository) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreatedAt) == aws.TimeValue(j.CreatedAt) {
+			return fmt.Errorf("ECR repository was not recreated")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSEcrRepositoryNotRecreated(i, j *ecr.Repository) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreatedAt) != aws.TimeValue(j.CreatedAt) {
+			return fmt.Errorf("ECR repository was recreated")
+		}
+
+		return nil
+	}
+}
+
 func testAccAWSEcrRepositoryConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecr_repository" "default" {
+resource "aws_ecr_repository" "test" {
   name = %q
 }
 `, rName)
@@ -267,7 +398,7 @@ resource "aws_ecr_repository" "default" {
 
 func testAccAWSEcrRepositoryConfig_tags(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecr_repository" "default" {
+resource "aws_ecr_repository" "test" {
   name = %q
 
   tags = {
@@ -280,7 +411,7 @@ resource "aws_ecr_repository" "default" {
 
 func testAccAWSEcrRepositoryConfig_tagsChanged(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecr_repository" "default" {
+resource "aws_ecr_repository" "test" {
   name = %q
 
   tags = {
@@ -292,8 +423,8 @@ resource "aws_ecr_repository" "default" {
 
 func testAccAWSEcrRepositoryConfig_immutability(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecr_repository" "default" {
-  name = %q
+resource "aws_ecr_repository" "test" {
+  name                 = %q
   image_tag_mutability = "IMMUTABLE"
 }
 `, rName)
@@ -301,11 +432,50 @@ resource "aws_ecr_repository" "default" {
 
 func testAccAWSEcrRepositoryConfig_image_scanning_configuration(rName string, scanOnPush bool) string {
 	return fmt.Sprintf(`
-resource "aws_ecr_repository" "default" {
+resource "aws_ecr_repository" "test" {
   name = %q
   image_scanning_configuration {
     scan_on_push = %t
   }
 }
 `, rName, scanOnPush)
+}
+
+func testAccAWSEcrRepositoryConfig_encryption_kms_defaultkey(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = %q
+
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+}
+`, rName)
+}
+
+func testAccAWSEcrRepositoryConfig_encryption_kms_customkey(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {}
+
+resource "aws_ecr_repository" "test" {
+  name = %q
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.test.arn
+  }
+}
+`, rName)
+}
+
+func testAccAWSEcrRepositoryConfig_encryption_aes256(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "test" {
+  name = %q
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+`, rName)
 }

--- a/website/docs/d/ecr_repository.html.markdown
+++ b/website/docs/d/ecr_repository.html.markdown
@@ -30,10 +30,16 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Full ARN of the repository.
-* `repository_url` - The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`).
+* `encryption_configuration` - Encryption configuration for the repository. See [Encryption Configuration](#encryption-configuration) below.
+* `image_scanning_configuration` - Configuration block that defines image scanning configuration for the repository. See [Image Scanning Configuration](#image-scanning-configuration) below.
 * `image_tag_mutability` - The tag mutability setting for the repository.
-* `image_scanning_configuration` - Configuration block that defines image scanning configuration for the repository. see [Image Scanning Configuration](#image-scanning-configuration)
+* `repository_url` - The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`).
 * `tags` - A map of tags assigned to the resource.
+
+### Encryption Configuration
+
+* `encryption_type` - The encryption type to use for the repository, either `AES256` or `KMS`.
+* `kms_key` - If `encryption_type` is `KMS`, the ARN of the KMS key used.
 
 ### Image Scanning Configuration
 

--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -28,17 +28,22 @@ resource "aws_ecr_repository" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the repository.
+* `encryption_configuration` - (Optional) Encryption configuration for the repository. See [below for schema](#encryption_configuration).
 * `image_tag_mutability` - (Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`.
 * `image_scanning_configuration` - (Optional) Configuration block that defines image scanning configuration for the repository. By default, image scanning must be manually triggered. See the [ECR User Guide](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html) for more information about image scanning.
     * `scan_on_push` - (Required) Indicates whether images are scanned after being pushed to the repository (true) or not scanned (false).
 * `tags` - (Optional) A map of tags to assign to the resource.
+
+### encryption_configuration
+
+* `encryption_type` - (Optional) The encryption type to use for the repository. Valid values are `AES256` or `KMS`. Defaults to `AES256`.
+* `kms_key` - (Optional) The ARN of the KMS key to use when `encryption_type` is `KMS`. If not specified, uses the default AWS managed key for ECR.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Full ARN of the repository.
-* `name` - The name of the repository.
 * `registry_id` - The registry ID where the repository was created.
 * `repository_url` - The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`).
 


### PR DESCRIPTION
Adds `encryption_configuration` attribute to `aws_ecr_repository` resource and data source.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14414

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_ecr_repository: Add `encryption_configuration` attribute
* resource/aws_ecr_repository: Add `encryption_configuration` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcrRepository_\|TestAccAWSEcrRepositoryDataSource_'

--- PASS: TestAccAWSEcrRepositoryDataSource_nonExistent (3.68s)
--- PASS: TestAccAWSEcrRepository_immutability (13.86s)
--- PASS: TestAccAWSEcrRepository_basic (13.95s)
--- PASS: TestAccAWSEcrRepositoryDataSource_basic (14.88s)
--- PASS: TestAccAWSEcrRepositoryDataSource_encryption (17.83s)
--- PASS: TestAccAWSEcrRepository_tags (20.06s)
--- PASS: TestAccAWSEcrRepository_encryption_kms (25.54s)
--- PASS: TestAccAWSEcrRepository_encryption_aes256 (25.80s)
--- PASS: TestAccAWSEcrRepository_image_scanning_configuration (31.62s)
```
