### PR TITLE
Remove references to AmazonEKSServicePolicy

### DIFF
--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -245,7 +245,7 @@ func resourceAwsEksClusterCreate(d *schema.ResourceData, meta interface{}) error
 			if isAWSErr(err, eks.ErrCodeInvalidParameterException, "Role could not be assumed because the trusted entity is not correct") {
 				return resource.RetryableError(err)
 			}
-			// InvalidParameterException: The provided role doesn't have the Amazon EKS Managed Policies associated with it. Please ensure the following policies [arn:aws:iam::aws:policy/AmazonEKSClusterPolicy, arn:aws:iam::aws:policy/AmazonEKSServicePolicy] are attached
+			// InvalidParameterException: The provided role doesn't have the Amazon EKS Managed Policies associated with it. Please ensure the following policy is attached: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
 			if isAWSErr(err, eks.ErrCodeInvalidParameterException, "The provided role doesn't have the Amazon EKS Managed Policies associated with it") {
 				return resource.RetryableError(err)
 			}

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -552,11 +552,6 @@ resource "aws_iam_role_policy_attachment" "test-AmazonEKSClusterPolicy" {
   role       = "${aws_iam_role.test.name}"
 }
 
-resource "aws_iam_role_policy_attachment" "test-AmazonEKSServicePolicy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
-  role       = "${aws_iam_role.test.name}"
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -593,7 +588,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, testAccAWSEksClusterConfig_Base(rName), rName)
 }
@@ -611,7 +606,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, testAccAWSEksClusterConfig_Base(rName), rName, version)
 }
@@ -629,7 +624,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, testAccAWSEksClusterConfig_Base(rName), rName, strings.Join(logTypes, "\", \""))
 }
@@ -648,7 +643,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, rName, tagKey1, tagValue1)
 }
@@ -668,7 +663,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
@@ -696,7 +691,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids = aws_subnet.test[*].id
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, rName)
 }
@@ -722,7 +717,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids         = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, testAccAWSEksClusterConfig_Base(rName), rName)
 }
@@ -741,7 +736,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids              = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, testAccAWSEksClusterConfig_Base(rName), rName, endpointPrivateAccess)
 }
@@ -760,7 +755,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids              = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, testAccAWSEksClusterConfig_Base(rName), rName, endpointPublicAccess)
 }
@@ -780,7 +775,7 @@ resource "aws_eks_cluster" "test" {
     subnet_ids              = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
-  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
 }
 `, testAccAWSEksClusterConfig_Base(rName), rName, publicAccessCidr)
 }

--- a/aws/resource_aws_eks_fargate_profile_test.go
+++ b/aws/resource_aws_eks_fargate_profile_test.go
@@ -377,11 +377,6 @@ resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSClusterPolicy" {
   role       = aws_iam_role.cluster.name
 }
 
-resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSServicePolicy" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSServicePolicy"
-  role       = aws_iam_role.cluster.name
-}
-
 resource "aws_iam_role" "pod" {
   name = "%[1]s-pod"
   
@@ -499,7 +494,6 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [
     aws_iam_role_policy_attachment.cluster-AmazonEKSClusterPolicy,
-    aws_iam_role_policy_attachment.cluster-AmazonEKSServicePolicy,
     aws_main_route_table_association.test,
   ]
 }

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -722,11 +722,6 @@ resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSClusterPolicy" {
   role       = aws_iam_role.cluster.name
 }
 
-resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSServicePolicy" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSServicePolicy"
-  role       = aws_iam_role.cluster.name
-}
-
 resource "aws_iam_role" "node" {
   name = "%[1]s-node"
   
@@ -835,7 +830,6 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [
     "aws_iam_role_policy_attachment.cluster-AmazonEKSClusterPolicy",
-    "aws_iam_role_policy_attachment.cluster-AmazonEKSServicePolicy",
     "aws_main_route_table_association.test",
   ]
 }
@@ -857,7 +851,6 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [
     "aws_iam_role_policy_attachment.cluster-AmazonEKSClusterPolicy",
-    "aws_iam_role_policy_attachment.cluster-AmazonEKSServicePolicy",
     "aws_main_route_table_association.test",
   ]
 }

--- a/docs/contributing/contribution-checklists.md
+++ b/docs/contributing/contribution-checklists.md
@@ -402,7 +402,7 @@ More details about this code generation, including fixes for potential error mes
       subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
     }
 
-    depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+    depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
   }
   `, rName, tagKey1, tagValue1)
   }
@@ -422,7 +422,7 @@ More details about this code generation, including fixes for potential error mes
       subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
     }
 
-    depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+    depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy"]
   }
   `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
   }

--- a/examples/eks-getting-started/eks-cluster.tf
+++ b/examples/eks-getting-started/eks-cluster.tf
@@ -29,11 +29,6 @@ resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSClusterPolicy" 
   role       = aws_iam_role.demo-cluster.name
 }
 
-resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSServicePolicy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
-  role       = aws_iam_role.demo-cluster.name
-}
-
 resource "aws_security_group" "demo-cluster" {
   name        = "terraform-eks-demo-cluster"
   description = "Cluster communication with worker nodes"
@@ -72,6 +67,5 @@ resource "aws_eks_cluster" "demo" {
 
   depends_on = [
     aws_iam_role_policy_attachment.demo-cluster-AmazonEKSClusterPolicy,
-    aws_iam_role_policy_attachment.demo-cluster-AmazonEKSServicePolicy,
   ]
 }

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -27,7 +27,6 @@ resource "aws_eks_cluster" "example" {
   # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
   depends_on = [
     aws_iam_role_policy_attachment.example-AmazonEKSClusterPolicy,
-    aws_iam_role_policy_attachment.example-AmazonEKSServicePolicy,
   ]
 }
 
@@ -64,11 +63,6 @@ POLICY
 
 resource "aws_iam_role_policy_attachment" "example-AmazonEKSClusterPolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
-  role       = aws_iam_role.example.name
-}
-
-resource "aws_iam_role_policy_attachment" "example-AmazonEKSServicePolicy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
   role       = aws_iam_role.example.name
 }
 ```


### PR DESCRIPTION
Per https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html the
AmazonEKSServicePolicy is no longer required. Remove references to this policy
from the examples and tests. Relevant excerpt:

> Prior to April 16, 2020, AmazonEKSServicePolicy was also required and the
> suggested name was eksServiceRole. With the AWSServiceRoleForAmazonEKS
> service-linked role, that policy is no longer required.

I had originally only set out to update the examples in documentation but then fell down the rabbit hole when I realized that the policy was referenced all over the tests. ~~I'm not really set up to run the tests.~~

~~I have not run the tests.~~

I can split the doc and test changes into separate PRs if you'd like but I think it makes sense to keep them together - if the tests start failing without the policy then perhaps the documentation change is not advisable after all.

That said, I have been successfully deploying clusters like this at work without the AmazonEKSServicePolicy which is how I noticed the discrepancy in the docs so I'm reasonably confident that the tests will pass without it as well.

UPDATE:

I have a test environment set up and have been able to run some of the tests. Waiting on a couple VPC service limit increases to get some of the others to run successfully. Will update further as I get those running.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Remove references to AmazonEKSServicePolicy
```

Output from acceptance testing:

```
wedge@we3:~/development/terraform-providers/terraform-provider-aws$ make testacc TESTARGS='-run=TestAccAWSEksCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksCluster -timeout 120m
=== RUN   TestAccAWSEksClusterAuthDataSource_basic
=== PAUSE TestAccAWSEksClusterAuthDataSource_basic
=== RUN   TestAccAWSEksClusterDataSource_basic
=== PAUSE TestAccAWSEksClusterDataSource_basic
=== RUN   TestAccAWSEksCluster_basic
=== PAUSE TestAccAWSEksCluster_basic
=== RUN   TestAccAWSEksCluster_EncryptionConfig
=== PAUSE TestAccAWSEksCluster_EncryptionConfig
=== RUN   TestAccAWSEksCluster_Version
=== PAUSE TestAccAWSEksCluster_Version
=== RUN   TestAccAWSEksCluster_Logging
=== PAUSE TestAccAWSEksCluster_Logging
=== RUN   TestAccAWSEksCluster_Tags
=== PAUSE TestAccAWSEksCluster_Tags
=== RUN   TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== PAUSE TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== RUN   TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== PAUSE TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== RUN   TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== PAUSE TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== RUN   TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
=== PAUSE TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
=== CONT  TestAccAWSEksClusterAuthDataSource_basic
=== CONT  TestAccAWSEksCluster_Tags
=== CONT  TestAccAWSEksCluster_VpcConfig_SecurityGroupIds
=== CONT  TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess
=== CONT  TestAccAWSEksCluster_EncryptionConfig
=== CONT  TestAccAWSEksCluster_Logging
=== CONT  TestAccAWSEksCluster_Version
=== CONT  TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess
=== CONT  TestAccAWSEksClusterDataSource_basic
=== CONT  TestAccAWSEksCluster_basic
=== CONT  TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (25.62s)
=== CONT  TestAccAWSEksCluster_Version
    testing.go:684: Step 0 error: errors during apply:
        
        Error: error creating EKS Cluster (tf-acc-test-0gr02): InvalidParameterException: unsupported Kubernetes version
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "51e3414e-28d1-413b-8d66-e2edbfb82a48"
          },
          ClusterName: "tf-acc-test-0gr02",
          Message_: "unsupported Kubernetes version"
        }
        
          on /tmp/tf-test412005617/main.tf line 59:
          (source code not available)
        
        
--- FAIL: TestAccAWSEksCluster_Version (35.74s)
--- PASS: TestAccAWSEksClusterDataSource_basic (671.40s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig (740.42s)
--- PASS: TestAccAWSEksCluster_basic (764.02s)
--- PASS: TestAccAWSEksCluster_Tags (827.33s)
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (875.34s)
--- PASS: TestAccAWSEksCluster_Logging (963.53s)
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (1124.02s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1690.07s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2126.62s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	2126.674s
FAIL
GNUmakefile:26: recipe for target 'testacc' failed
make: *** [testacc] Error 1

wedge@we3:~/development/terraform-providers/terraform-provider-aws$ make testacc TESTARGS='-run=TestAccAWSEksFargateProfile'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSEksFargateProfile -timeout 120m
=== RUN   TestAccAWSEksFargateProfile_basic
=== PAUSE TestAccAWSEksFargateProfile_basic
=== RUN   TestAccAWSEksFargateProfile_disappears
=== PAUSE TestAccAWSEksFargateProfile_disappears
=== RUN   TestAccAWSEksFargateProfile_Selector_Labels
=== PAUSE TestAccAWSEksFargateProfile_Selector_Labels
=== RUN   TestAccAWSEksFargateProfile_Tags
=== PAUSE TestAccAWSEksFargateProfile_Tags
=== CONT  TestAccAWSEksFargateProfile_basic
=== CONT  TestAccAWSEksFargateProfile_Tags
--- PASS: TestAccAWSEksFargateProfile_basic (1132.88s)
=== CONT  TestAccAWSEksFargateProfile_Selector_Labels
--- PASS: TestAccAWSEksFargateProfile_Tags (1190.43s)
=== CONT  TestAccAWSEksFargateProfile_disappears
--- PASS: TestAccAWSEksFargateProfile_Selector_Labels (1092.12s)
--- PASS: TestAccAWSEksFargateProfile_disappears (1100.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2290.684s

```

That TestAccAWSEksCluster_Version failure seems to be unrelated but looks pretty easy to fix. I'll open another PR for that.
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
