### PR TITLE
Fix TestAccAWSSESIdentityPolicy_* tests

### DIFF
--- a/aws/resource_aws_ses_identity_policy_test.go
+++ b/aws/resource_aws_ses_identity_policy_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccAWSSESIdentityPolicy_basic(t *testing.T) {
 	domain := fmt.Sprintf(
-		"%s.terraformtesting.com.",
+		"%s.terraformtesting.com",
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resourceName := "aws_ses_identity_policy.test"
 
@@ -65,7 +65,7 @@ func TestAccAWSSESIdentityPolicy_Identity_Email(t *testing.T) {
 
 func TestAccAWSSESIdentityPolicy_Policy(t *testing.T) {
 	domain := fmt.Sprintf(
-		"%s.terraformtesting.com.",
+		"%s.terraformtesting.com",
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	resourceName := "aws_ses_identity_policy.test"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14510

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSESIdentityPolicy_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSESIdentityPolicy_* -timeout 120m
=== RUN   TestAccAWSSESIdentityPolicy_basic
=== PAUSE TestAccAWSSESIdentityPolicy_basic
=== RUN   TestAccAWSSESIdentityPolicy_Identity_Email
=== PAUSE TestAccAWSSESIdentityPolicy_Identity_Email
=== RUN   TestAccAWSSESIdentityPolicy_Policy
=== PAUSE TestAccAWSSESIdentityPolicy_Policy
=== CONT  TestAccAWSSESIdentityPolicy_basic
=== CONT  TestAccAWSSESIdentityPolicy_Policy
=== CONT  TestAccAWSSESIdentityPolicy_Identity_Email
--- PASS: TestAccAWSSESIdentityPolicy_basic (20.72s)
--- PASS: TestAccAWSSESIdentityPolicy_Identity_Email (20.78s)
--- PASS: TestAccAWSSESIdentityPolicy_Policy (33.38s)

...
```
