### PR TITLE
tech-debt: redshift cluster snapshot sweeper

### DIFF
--- a/aws/resource_aws_redshift_cluster_snapshot_test.go
+++ b/aws/resource_aws_redshift_cluster_snapshot_test.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_redshift_cluster_snapshot", &resource.Sweeper{
+		Name: "aws_redshift_cluster_snapshot",
+		F:    testSweepRedshiftClusterSnapshots,
+		Dependencies: []string{
+			"aws_redshift_cluster",
+		},
+	})
+}
+
+func testSweepRedshiftClusterSnapshots(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+	conn := client.(*AWSClient).redshiftconn
+
+	err = conn.DescribeClusterSnapshotsPages(&redshift.DescribeClusterSnapshotsInput{}, func(resp *redshift.DescribeClusterSnapshotsOutput, isLast bool) bool {
+		if len(resp.Snapshots) == 0 {
+			log.Print("[DEBUG] No Redshift cluster snapshots to sweep")
+			return false
+		}
+
+		for _, s := range resp.Snapshots {
+			id := aws.StringValue(s.SnapshotIdentifier)
+
+			if !strings.EqualFold(aws.StringValue(s.SnapshotType), "manual") || !strings.EqualFold(aws.StringValue(s.Status), "available") {
+				log.Printf("[INFO] Skipping Redshift cluster snapshot: %s", id)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Redshift cluster snapshot: %s", id)
+			_, err := conn.DeleteClusterSnapshot(&redshift.DeleteClusterSnapshotInput{
+				SnapshotIdentifier: s.SnapshotIdentifier,
+			})
+			if err != nil {
+				log.Printf("[ERROR] Failed deleting Redshift cluster snapshot (%s): %s", id, err)
+			}
+		}
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Redshift Cluster Snapshot sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Redshift cluster snapshots: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14504 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: redshift cluster snapshot sweeper
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
go test ./aws -v -timeout=10h -sweep-allow-failures -sweep=us-west-2 -sweep-run=aws_redshift_cluster_snapshot
2020/08/08 01:02:11 [DEBUG] Running Sweepers for region (us-west-2):
2020/08/08 01:02:11 [DEBUG] Sweeper (aws_redshift_cluster_snapshot) has dependency (aws_redshift_cluster), running..
2020/08/08 01:02:11 [DEBUG] Running Sweeper (aws_redshift_cluster) in region (us-west-2)
2020/08/08 01:02:11 [INFO] AWS Auth provider used: "EnvProvider"
2020/08/08 01:02:11 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/08/08 01:02:12 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/08/08 01:02:13 [DEBUG] No Redshift clusters to sweep
2020/08/08 01:02:13 [DEBUG] Running Sweeper (aws_redshift_cluster_snapshot) in region (us-west-2)
2020/08/08 01:02:22 [DEBUG] Sweeper (aws_redshift_cluster) already ran in region (us-west-2)
2020/08/08 01:02:22 Sweeper Tests ran successfully:
	- aws_redshift_cluster
	- aws_redshift_cluster_snapshot
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.080s
```
