### PR TITLE
Update EKS tests for new versions and supported regions

### DIFF
--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -154,10 +154,10 @@ func TestAccAWSEksCluster_Version(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEksClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEksClusterConfig_Version(rName, "1.13"),
+				Config: testAccAWSEksClusterConfig_Version(rName, "1.16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksClusterExists(resourceName, &cluster1),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.13"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.16"),
 				),
 			},
 			{
@@ -166,11 +166,11 @@ func TestAccAWSEksCluster_Version(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSEksClusterConfig_Version(rName, "1.14"),
+				Config: testAccAWSEksClusterConfig_Version(rName, "1.17"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksClusterExists(resourceName, &cluster2),
 					testAccCheckAWSEksClusterNotRecreated(&cluster1, &cluster2),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.14"),
+					resource.TestCheckResourceAttr(resourceName, "version", "1.17"),
 				),
 			},
 		},

--- a/aws/resource_aws_eks_fargate_profile_test.go
+++ b/aws/resource_aws_eks_fargate_profile_test.go
@@ -317,9 +317,13 @@ func testAccPreCheckAWSEksFargateProfile(t *testing.T) {
 	// we take the least desirable approach of hardcoding allowed regions.
 	allowedRegions := []string{
 		"ap-northeast-1",
+		"ap-southeast-1",
+		"ap-southeast-2",
+		"eu-central-1",
 		"eu-west-1",
 		"us-east-1",
 		"us-east-2",
+		"us-west-2",
 	}
 	region := testAccProvider.Meta().(*AWSClient).region
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

EKS with Fargate now supports additional regions. Added these additional regions to list of allowed regions in EKS Fargate Profile tests.

The TestAccAWSEksCluster_Version test was failing as noted in #14521 due to trying to create a cluster at Kubernetes version 1.13 which is no longer supported. Updated this test to use the two most recent supported Kubernetes versions instead.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
TestAccAWSEksCluster_Version before:

```
wedge@we3:~/development/terraform-providers/terraform-provider-aws$ make testacc TESTARGS='-run=TestAccAWSEksCluster_Version'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksCluster_Version -timeout 120m
=== RUN   TestAccAWSEksCluster_Version
=== PAUSE TestAccAWSEksCluster_Version
=== CONT  TestAccAWSEksCluster_Version
    testing.go:684: Step 0 error: errors during apply:
        
        Error: error creating EKS Cluster (tf-acc-test-3lhae): InvalidParameterException: unsupported Kubernetes version
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "07a4da2e-5a98-4279-b82b-56ef36fe97e4"
          },
          ClusterName: "tf-acc-test-3lhae",
          Message_: "unsupported Kubernetes version"
        }
        
          on /tmp/tf-test784434039/main.tf line 64:
          (source code not available)
        
        
--- FAIL: TestAccAWSEksCluster_Version (15.36s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	15.405s
FAIL
GNUmakefile:26: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

After:

```
wedge@we3:~/development/terraform-providers/terraform-provider-aws$ make testacc TESTARGS='-run=TestAccAWSEksCluster_Version'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksCluster_Version -timeout 120m
=== RUN   TestAccAWSEksCluster_Version
=== PAUSE TestAccAWSEksCluster_Version
=== CONT  TestAccAWSEksCluster_Version
--- PASS: TestAccAWSEksCluster_Version (1414.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1414.807s
```

Fargate profile regions: These tests run in us-west-2:

```
wedge@we3:~/development/terraform-providers/terraform-provider-aws$ make testacc TESTARGS='-run=TestAccAWSEksFargateProfile'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSEksFargateProfile -timeout 120m
=== RUN   TestAccAWSEksFargateProfile_basic
=== PAUSE TestAccAWSEksFargateProfile_basic
=== RUN   TestAccAWSEksFargateProfile_disappears
=== PAUSE TestAccAWSEksFargateProfile_disappears
=== RUN   TestAccAWSEksFargateProfile_Selector_Labels
=== PAUSE TestAccAWSEksFargateProfile_Selector_Labels
=== RUN   TestAccAWSEksFargateProfile_Tags
=== PAUSE TestAccAWSEksFargateProfile_Tags
=== CONT  TestAccAWSEksFargateProfile_basic
=== CONT  TestAccAWSEksFargateProfile_Tags
--- PASS: TestAccAWSEksFargateProfile_basic (1132.88s)
=== CONT  TestAccAWSEksFargateProfile_Selector_Labels
--- PASS: TestAccAWSEksFargateProfile_Tags (1190.43s)
=== CONT  TestAccAWSEksFargateProfile_disappears
--- PASS: TestAccAWSEksFargateProfile_Selector_Labels (1092.12s)
--- PASS: TestAccAWSEksFargateProfile_disappears (1100.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2290.684s
```
