### PR TITLE
r/aws_dms_replication_instance: Support allow_major_version_upgrade a…

### DIFF
--- a/aws/resource_aws_dms_replication_instance.go
+++ b/aws/resource_aws_dms_replication_instance.go
@@ -290,8 +290,8 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 		}
 	}
 
-	if d.HasChange("allow_major_version_upgrade") {
-		request.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
+	if v, ok := d.GetOk("allow_major_version_upgrade"); ok {
+		request.AllowMajorVersionUpgrade = aws.Bool(v.(bool))
 		// Having allowing_major_version_upgrade by itself should not trigger ModifyReplicationInstance
 		// as it results in InvalidParameterCombination: No modifications were requested
 	}

--- a/aws/resource_aws_dms_replication_instance.go
+++ b/aws/resource_aws_dms_replication_instance.go
@@ -37,6 +37,10 @@ func resourceAwsDmsReplicationInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(5, 6144),
 			},
+			"allow_major_version_upgrade": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"apply_immediately": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -286,9 +290,16 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 		}
 	}
 
+	if d.HasChange("allow_major_version_upgrade") {
+		request.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
+		// Having allowing_major_version_upgrade by itself should not trigger ModifyReplicationInstance
+		// as it results in InvalidParameterCombination: No modifications were requested
+	}
+
 	if d.HasChange("engine_version") {
 		if v, ok := d.GetOk("engine_version"); ok {
 			request.EngineVersion = aws.String(v.(string))
+			request.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
 			hasChanges = true
 		}
 	}

--- a/aws/resource_aws_dms_replication_instance.go
+++ b/aws/resource_aws_dms_replication_instance.go
@@ -299,7 +299,6 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 	if d.HasChange("engine_version") {
 		if v, ok := d.GetOk("engine_version"); ok {
 			request.EngineVersion = aws.String(v.(string))
-			request.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
 			hasChanges = true
 		}
 	}

--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -236,7 +236,7 @@ func TestAccAWSDmsReplicationInstance_EngineVersion(t *testing.T) {
 			ResourceName:            resourceName,
 			ImportState:             true,
 			ImportStateVerify:       true,
-			ImportStateVerifyIgnore: []string{"apply_immediately"},
+			ImportStateVerifyIgnore: []string{"allow_major_version_upgrade", "apply_immediately"},
 		},
 	}
 
@@ -714,6 +714,7 @@ data "aws_partition" "current" {
 
 resource "aws_dms_replication_instance" "test" {
   apply_immediately          = true
+  allow_major_version_upgrade = true
   engine_version             = %q
   replication_instance_class = data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"
   replication_instance_id    = %q

--- a/website/docs/r/dms_replication_instance.html.markdown
+++ b/website/docs/r/dms_replication_instance.html.markdown
@@ -91,6 +91,7 @@ resource "aws_dms_replication_instance" "test" {
 The following arguments are supported:
 
 * `allocated_storage` - (Optional, Default: 50, Min: 5, Max: 6144) The amount of storage (in gigabytes) to be initially allocated for the replication instance.
+* `allow_major_version_upgrade` - (Optional, Default: false) Indicates that major version upgrades are allowed.
 * `apply_immediately` - (Optional, Default: false) Indicates whether the changes should be applied immediately or during the next maintenance window. Only used when updating an existing resource.
 * `auto_minor_version_upgrade` - (Optional, Default: false) Indicates that minor engine upgrades will be applied automatically to the replication instance during the maintenance window.
 * `availability_zone` - (Optional) The EC2 Availability Zone that the replication instance will be created in.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14438

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_dms_replication_instance: Support `allow_major_version_upgrade` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDmsReplicationInstance_EngineVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSDmsReplicationInstance_EngineVersion -timeout 120m
=== RUN   TestAccAWSDmsReplicationInstance_EngineVersion
=== PAUSE TestAccAWSDmsReplicationInstance_EngineVersion
=== CONT  TestAccAWSDmsReplicationInstance_EngineVersion
--- PASS: TestAccAWSDmsReplicationInstance_EngineVersion (599.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	601.643s

...
```

Thank you for your review! 👍 