### PR TITLE
d/aws_launch_configuration: Add 'ebs_block_device.no_device' attribute

### DIFF
--- a/aws/data_source_aws_launch_configuration.go
+++ b/aws/data_source_aws_launch_configuration.go
@@ -105,6 +105,11 @@ func dataSourceAwsLaunchConfiguration() *schema.Resource {
 							Computed: true,
 						},
 
+						"no_device": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
 						"iops": {
 							Type:     schema.TypeInt,
 							Computed: true,

--- a/aws/data_source_aws_launch_configuration_test.go
+++ b/aws/data_source_aws_launch_configuration_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSLaunchConfigurationDataSource_basic(t *testing.T) {
@@ -68,8 +67,7 @@ func TestAccAWSLaunchConfigurationDataSource_ebsNoDevice(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "image_id", resourceName, "image_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_type", resourceName, "instance_type"),
-					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*", datasourceName, "device_name"),
-					tfawsresource.TestCheckTypeSetElemAttrPair(resourceName, "ebs_block_device.*", datasourceName, "no_device"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ebs_block_device.#", resourceName, "ebs_block_device.#"),
 				),
 			},
 		},

--- a/website/docs/d/launch_configuration.html.markdown
+++ b/website/docs/d/launch_configuration.html.markdown
@@ -60,6 +60,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `delete_on_termination` - Whether the EBS Volume will be deleted on instance termination.
 * `device_name` - The Name of the device.
+* `no_device` - Whether the device in the block device mapping of the AMI is suppressed.
 * `iops` - The provisioned IOPs of the volume.
 * `snapshot_id` - The Snapshot ID of the mount.
 * `volume_size` - The Size of the volume.

--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -198,6 +198,7 @@ Each `ebs_block_device` supports the following:
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed
   on instance termination (Default: `true`).
 * `encrypted` - (Optional) Whether the volume should be encrypted or not. Do not use this option if you are using `snapshot_id` as the encrypted flag will be determined by the snapshot. (Default: `false`).
+* `no_device` - (Optional) Whether the device in the block device mapping of the AMI is suppressed.
 
 Modifying any `ebs_block_device` currently requires resource replacement.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14572.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_launch_configuration: Add `no_device` attribute to `ebs_block_device` block
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSLaunchConfigurationDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLaunchConfigurationDataSource_ -timeout 120m
=== RUN   TestAccAWSLaunchConfigurationDataSource_basic
=== PAUSE TestAccAWSLaunchConfigurationDataSource_basic
=== RUN   TestAccAWSLaunchConfigurationDataSource_securityGroups
=== PAUSE TestAccAWSLaunchConfigurationDataSource_securityGroups
=== RUN   TestAccAWSLaunchConfigurationDataSource_ebsNoDevice
=== PAUSE TestAccAWSLaunchConfigurationDataSource_ebsNoDevice
=== CONT  TestAccAWSLaunchConfigurationDataSource_basic
=== CONT  TestAccAWSLaunchConfigurationDataSource_securityGroups
=== CONT  TestAccAWSLaunchConfigurationDataSource_ebsNoDevice
--- PASS: TestAccAWSLaunchConfigurationDataSource_ebsNoDevice (22.88s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (23.22s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (32.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.644s
```
