### PR TITLE
resource/ecr_repository: safely handle nil encryption information returned from API

### DIFF
--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -230,6 +230,10 @@ func expandEcrRepositoryEncryptionConfiguration(data []interface{}) *ecr.Encrypt
 }
 
 func flattenEcrRepositoryEncryptionConfiguration(ec *ecr.EncryptionConfiguration) []map[string]interface{} {
+	if ec == nil {
+		return nil
+	}
+
 	config := map[string]interface{}{
 		"encryption_type": aws.StringValue(ec.EncryptionType),
 		"kms_key":         aws.StringValue(ec.KmsKey),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14536 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/ecr_repository: safely handle nil encryption information returned from API
```

Output from acceptance testing (no new test added; unable to reproduce scenario although API docs do show a Sample Response where the field is omitted: https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_CreateRepository.html):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSEcrRepositoryDataSource_nonExistent (7.02s)
--- PASS: TestAccAWSEcrRepositoryDataSource_basic (29.16s)
--- PASS: TestAccAWSEcrRepositoryDataSource_encryption (31.80s)
--- PASS: TestAccAWSEcrRepository_basic (33.58s)
--- PASS: TestAccAWSEcrRepository_immutability (34.56s)
--- PASS: TestAccAWSEcrRepositoryPolicy_basic (35.06s)
--- PASS: TestAccAWSEcrRepositoryPolicy_iam (43.75s)
--- PASS: TestAccAWSEcrRepository_tags (44.43s)
--- PASS: TestAccAWSEcrRepository_encryption_kms (49.44s)
--- PASS: TestAccAWSEcrRepository_encryption_aes256 (53.68s)
--- PASS: TestAccAWSEcrRepository_image_scanning_configuration (61.71s)
```
