### PR TITLE
Fix TestAccAWSEcsService_withMultipleTargetGroups

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -2785,8 +2785,9 @@ resource "aws_lb_listener_rule" "static" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/static/*"]
+    path_pattern {
+      values = ["/static/*"]
+    }
   }
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14509

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEcsService_withMultipleTargetGroups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEcsService_withMultipleTargetGroups -timeout 120m
=== RUN   TestAccAWSEcsService_withMultipleTargetGroups
=== PAUSE TestAccAWSEcsService_withMultipleTargetGroups
=== CONT  TestAccAWSEcsService_withMultipleTargetGroups
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (297.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	298.944s...
```

Thank you for your review! 👍 