### PR TITLE
Replace 'randIntRange' with 'acctest.RandIntRange'

### DIFF
--- a/aws/data_source_aws_customer_gateway_test.go
+++ b/aws/data_source_aws_customer_gateway_test.go
@@ -12,7 +12,7 @@ func TestAccAWSCustomerGatewayDataSource_Filter(t *testing.T) {
 	dataSourceName := "data.aws_customer_gateway.test"
 	resourceName := "aws_customer_gateway.test"
 
-	asn := randIntRange(64512, 65534)
+	asn := acctest.RandIntRange(64512, 65534)
 	hostOctet := acctest.RandIntRange(1, 254)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -40,7 +40,7 @@ func TestAccAWSCustomerGatewayDataSource_ID(t *testing.T) {
 	dataSourceName := "data.aws_customer_gateway.test"
 	resourceName := "aws_customer_gateway.test"
 
-	asn := randIntRange(64512, 65534)
+	asn := acctest.RandIntRange(64512, 65534)
 	hostOctet := acctest.RandIntRange(1, 254)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/data_source_aws_dx_gateway_test.go
+++ b/aws/data_source_aws_dx_gateway_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceAwsDxGateway_basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Direct Connect Gateway not found`),
 			},
 			{
-				Config: testAccDataSourceAwsDxGatewayConfig_Name(rName, randIntRange(64512, 65534)),
+				Config: testAccDataSourceAwsDxGatewayConfig_Name(rName, acctest.RandIntRange(64512, 65534)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "amazon_side_asn", resourceName, "amazon_side_asn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),

--- a/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_dx_gateway_attachment_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGatewayId(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_dx_gateway_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"
@@ -37,7 +37,7 @@ func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAn
 
 func TestAccAWSEc2TransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	dataSourceName := "data.aws_ec2_transit_gateway_dx_gateway_attachment.test"
 	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"

--- a/aws/resource_aws_customer_gateway_test.go
+++ b/aws/resource_aws_customer_gateway_test.go
@@ -8,13 +8,14 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSCustomerGateway_basic(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -49,7 +50,7 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 
 func TestAccAWSCustomerGateway_tags(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -91,7 +92,7 @@ func TestAccAWSCustomerGateway_tags(t *testing.T) {
 
 func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -120,7 +121,7 @@ func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 }
 
 func TestAccAWSCustomerGateway_disappears(t *testing.T) {
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	var gateway ec2.CustomerGateway
 	resourceName := "aws_customer_gateway.test"
 
@@ -143,7 +144,7 @@ func TestAccAWSCustomerGateway_disappears(t *testing.T) {
 
 func TestAccAWSCustomerGateway_4ByteAsn(t *testing.T) {
 	var gateway ec2.CustomerGateway
-	rBgpAsn := strconv.FormatInt(int64(randIntRange(64512, 65534))*10000, 10)
+	rBgpAsn := strconv.FormatInt(int64(acctest.RandIntRange(64512, 65534))*10000, 10)
 	resourceName := "aws_customer_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_dx_bgp_peer_test.go
+++ b/aws/resource_aws_dx_bgp_peer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -18,7 +19,7 @@ func TestAccAwsDxBgpPeer_basic(t *testing.T) {
 	if vifId == "" {
 		t.Skipf("Environment variable %s is not set", key)
 	}
-	bgpAsn := randIntRange(64512, 65534)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_dx_gateway_association_proposal_test.go
+++ b/aws/resource_aws_dx_gateway_association_proposal_test.go
@@ -81,7 +81,7 @@ func testSweepDirectConnectGatewayAssociationProposals(region string) error {
 func TestAccAwsDxGatewayAssociationProposal_basicVpnGateway(t *testing.T) {
 	var proposal1 directconnect.GatewayAssociationProposal
 	var providers []*schema.Provider
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_dx_gateway_association_proposal.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
@@ -119,7 +119,7 @@ func TestAccAwsDxGatewayAssociationProposal_basicVpnGateway(t *testing.T) {
 func TestAccAwsDxGatewayAssociationProposal_basicTransitGateway(t *testing.T) {
 	var proposal1 directconnect.GatewayAssociationProposal
 	var providers []*schema.Provider
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_dx_gateway_association_proposal.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
@@ -159,7 +159,7 @@ func TestAccAwsDxGatewayAssociationProposal_basicTransitGateway(t *testing.T) {
 func TestAccAwsDxGatewayAssociationProposal_disappears(t *testing.T) {
 	var proposal1 directconnect.GatewayAssociationProposal
 	var providers []*schema.Provider
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_dx_gateway_association_proposal.test"
 
@@ -186,7 +186,7 @@ func TestAccAwsDxGatewayAssociationProposal_disappears(t *testing.T) {
 func TestAccAwsDxGatewayAssociationProposal_AllowedPrefixes(t *testing.T) {
 	var proposal1, proposal2 directconnect.GatewayAssociationProposal
 	var providers []*schema.Provider
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_dx_gateway_association_proposal.test"
 

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -187,7 +187,7 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 func TestAccAwsDxGatewayAssociation_V0StateUpgrade(t *testing.T) {
 	resourceName := "aws_dx_gateway_association.test"
 	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -210,7 +210,7 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount(t *testing.T) {
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -254,7 +254,7 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount(t *testing.T) {
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -288,7 +288,7 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount(t *testing.
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameTgw := "aws_ec2_transit_gateway.test"
 	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -333,7 +333,7 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameTgw := "aws_ec2_transit_gateway.test"
 	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -368,7 +368,7 @@ func TestAccAwsDxGatewayAssociation_multiVpnGatewaysSingleAccount(t *testing.T) 
 	resourceName2 := "aws_dx_gateway_association.test2"
 	rName1 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
 	rName2 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -397,7 +397,7 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewaySingleAccount(t *te
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -434,7 +434,7 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount(t *tes
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/aws/resource_aws_dx_gateway_test.go
+++ b/aws/resource_aws_dx_gateway_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -124,7 +123,7 @@ func TestAccAwsDxGateway_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayConfig(acctest.RandString(5), randIntRange(64512, 65534)),
+				Config: testAccDxGatewayConfig(acctest.RandString(5), acctest.RandIntRange(64512, 65534)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayExists(resourceName),
 					testAccCheckResourceAttrAccountID(resourceName, "owner_account_id"),
@@ -142,7 +141,7 @@ func TestAccAwsDxGateway_basic(t *testing.T) {
 func TestAccAwsDxGateway_complex(t *testing.T) {
 	rName1 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
 	rName2 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_dx_gateway.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -209,13 +208,4 @@ resource "aws_dx_gateway" "test" {
   amazon_side_asn = "%d"
 }
 `, rName, rBgpAsn)
-}
-
-// Local copy of acctest.RandIntRange until https://github.com/hashicorp/terraform/pull/17438 is merged.
-func randIntRange(min int, max int) int {
-	rand.Seed(time.Now().UTC().UnixNano())
-	source := rand.New(rand.NewSource(time.Now().UnixNano()))
-	rangeMax := max - min
-
-	return int(source.Int31n(int32(rangeMax))) + min
 }

--- a/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
@@ -28,8 +28,8 @@ func TestAccAwsDxHostedPrivateVirtualInterface_basic(t *testing.T) {
 	accepterResourceName := "aws_dx_hosted_private_virtual_interface_accepter.test"
 	vpnGatewayResourceName := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(9))
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -86,8 +86,8 @@ func TestAccAwsDxHostedPrivateVirtualInterface_AccepterTags(t *testing.T) {
 	accepterResourceName := "aws_dx_hosted_private_virtual_interface_accepter.test"
 	vpnGatewayResourceName := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(9))
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
@@ -30,8 +30,8 @@ func TestAccAwsDxHostedPublicVirtualInterface_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-public-vif-%s", acctest.RandString(10))
 	amazonAddress := "175.45.176.5/28"
 	customerAddress := "175.45.176.6/28"
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -90,8 +90,8 @@ func TestAccAwsDxHostedPublicVirtualInterface_AccepterTags(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-public-vif-%s", acctest.RandString(10))
 	amazonAddress := "175.45.176.7/28"
 	customerAddress := "175.45.176.8/28"
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/aws/resource_aws_dx_hosted_transit_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_transit_virtual_interface_test.go
@@ -42,9 +42,9 @@ func testAccAwsDxHostedTransitVirtualInterface_basic(t *testing.T) {
 	accepterResourceName := "aws_dx_hosted_transit_virtual_interface_accepter.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(9))
-	amzAsn := randIntRange(64512, 65534)
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	amzAsn := acctest.RandIntRange(64512, 65534)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -101,9 +101,9 @@ func testAccAwsDxHostedTransitVirtualInterface_accepterTags(t *testing.T) {
 	accepterResourceName := "aws_dx_hosted_transit_virtual_interface_accepter.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(9))
-	amzAsn := randIntRange(64512, 65534)
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	amzAsn := acctest.RandIntRange(64512, 65534)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/aws/resource_aws_dx_private_virtual_interface_test.go
+++ b/aws/resource_aws_dx_private_virtual_interface_test.go
@@ -25,8 +25,8 @@ func TestAccAwsDxPrivateVirtualInterface_basic(t *testing.T) {
 	resourceName := "aws_dx_private_virtual_interface.test"
 	vpnGatewayResourceName := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(9))
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -96,8 +96,8 @@ func TestAccAwsDxPrivateVirtualInterface_Tags(t *testing.T) {
 	resourceName := "aws_dx_private_virtual_interface.test"
 	vpnGatewayResourceName := "aws_vpn_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(9))
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -173,9 +173,9 @@ func TestAccAwsDxPrivateVirtualInterface_DxGateway(t *testing.T) {
 	resourceName := "aws_dx_private_virtual_interface.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(9))
-	amzAsn := randIntRange(64512, 65534)
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	amzAsn := acctest.RandIntRange(64512, 65534)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_dx_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_public_virtual_interface_test.go
@@ -31,8 +31,8 @@ func TestAccAwsDxPublicVirtualInterface_basic(t *testing.T) {
 	// DirectConnectClientException: Amazon Address is the broadcast address on its subnet.
 	amazonAddress := "175.45.176.1/28"
 	customerAddress := "175.45.176.2/28"
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,8 +82,8 @@ func TestAccAwsDxPublicVirtualInterface_Tags(t *testing.T) {
 	rName := fmt.Sprintf("tf-testacc-public-vif-%s", acctest.RandString(10))
 	amazonAddress := "175.45.176.3/28"
 	customerAddress := "175.45.176.4/28"
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_dx_transit_virtual_interface_test.go
+++ b/aws/resource_aws_dx_transit_virtual_interface_test.go
@@ -39,9 +39,9 @@ func testAccAwsDxTransitVirtualInterface_basic(t *testing.T) {
 	resourceName := "aws_dx_transit_virtual_interface.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(9))
-	amzAsn := randIntRange(64512, 65534)
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	amzAsn := acctest.RandIntRange(64512, 65534)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -111,9 +111,9 @@ func testAccAwsDxTransitVirtualInterface_Tags(t *testing.T) {
 	resourceName := "aws_dx_transit_virtual_interface.test"
 	dxGatewayResourceName := "aws_dx_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(9))
-	amzAsn := randIntRange(64512, 65534)
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
+	amzAsn := acctest.RandIntRange(64512, 65534)
+	bgpAsn := acctest.RandIntRange(64512, 65534)
+	vlan := acctest.RandIntRange(2049, 4094)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_ec2_local_gateway_route_test.go
+++ b/aws/resource_aws_ec2_local_gateway_route_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAWSEc2LocalGatewayRoute_basic(t *testing.T) {
-	rInt := randIntRange(0, 255)
+	rInt := acctest.RandIntRange(0, 255)
 	destinationCidrBlock := fmt.Sprintf("172.16.%d.0/24", rInt)
 	localGatewayRouteTableDataSourceName := "data.aws_ec2_local_gateway_route_table.test"
 	localGatewayVirtualInterfaceGroupDataSourceName := "data.aws_ec2_local_gateway_virtual_interface_group.test"
@@ -39,7 +40,7 @@ func TestAccAWSEc2LocalGatewayRoute_basic(t *testing.T) {
 }
 
 func TestAccAWSEc2LocalGatewayRoute_disappears(t *testing.T) {
-	rInt := randIntRange(0, 255)
+	rInt := acctest.RandIntRange(0, 255)
 	destinationCidrBlock := fmt.Sprintf("172.16.%d.0/24", rInt)
 	resourceName := "aws_ec2_local_gateway_route.test"
 

--- a/aws/resource_aws_ec2_tag_test.go
+++ b/aws/resource_aws_ec2_tag_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func TestAccAWSEc2Tag_basic(t *testing.T) {
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_ec2_tag.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -36,7 +37,7 @@ func TestAccAWSEc2Tag_basic(t *testing.T) {
 }
 
 func TestAccAWSEc2Tag_disappears(t *testing.T) {
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_ec2_tag.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -57,7 +58,7 @@ func TestAccAWSEc2Tag_disappears(t *testing.T) {
 }
 
 func TestAccAWSEc2Tag_Value(t *testing.T) {
-	rBgpAsn := randIntRange(64512, 65534)
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
 	resourceName := "aws_ec2_tag.test"
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13613.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

##### Data sources that were using `acctest.RandIntRange`:

```console
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccAWSCustomerGatewayDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCustomerGatewayDataSource_ -timeout 120m
=== RUN   TestAccAWSCustomerGatewayDataSource_Filter
=== PAUSE TestAccAWSCustomerGatewayDataSource_Filter
=== RUN   TestAccAWSCustomerGatewayDataSource_ID
=== PAUSE TestAccAWSCustomerGatewayDataSource_ID
=== CONT  TestAccAWSCustomerGatewayDataSource_Filter
=== CONT  TestAccAWSCustomerGatewayDataSource_ID
--- PASS: TestAccAWSCustomerGatewayDataSource_ID (26.75s)
--- PASS: TestAccAWSCustomerGatewayDataSource_Filter (27.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.264s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccDataSourceAwsEbsVolumes_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsEbsVolumes_ -timeout 120m
=== RUN   TestAccDataSourceAwsEbsVolumes_basic
=== PAUSE TestAccDataSourceAwsEbsVolumes_basic
=== CONT  TestAccDataSourceAwsEbsVolumes_basic
--- PASS: TestAccDataSourceAwsEbsVolumes_basic (48.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.823s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_ -timeout 120m
=== RUN   TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId
=== PAUSE TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId
=== RUN   TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter
=== PAUSE TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter
=== CONT  TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId
=== CONT  TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter
--- PASS: TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId (444.86s)
--- PASS: TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_filter (476.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	476.694s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccDataSourceAwsNatGateway_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsNatGateway_ -timeout 120m
=== RUN   TestAccDataSourceAwsNatGateway_basic
=== PAUSE TestAccDataSourceAwsNatGateway_basic
=== CONT  TestAccDataSourceAwsNatGateway_basic
--- PASS: TestAccDataSourceAwsNatGateway_basic (168.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	168.422s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccDataSourceAwsRouteTables_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsRouteTables_ -timeout 120m
=== RUN   TestAccDataSourceAwsRouteTables_basic
=== PAUSE TestAccDataSourceAwsRouteTables_basic
=== CONT  TestAccDataSourceAwsRouteTables_basic
--- PASS: TestAccDataSourceAwsRouteTables_basic (46.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.930s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccDataSourceAwsSubnetIDs_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSubnetIDs_ -timeout 120m
=== RUN   TestAccDataSourceAwsSubnetIDs_basic
=== PAUSE TestAccDataSourceAwsSubnetIDs_basic
=== RUN   TestAccDataSourceAwsSubnetIDs_filter
=== PAUSE TestAccDataSourceAwsSubnetIDs_filter
=== CONT  TestAccDataSourceAwsSubnetIDs_basic
=== CONT  TestAccDataSourceAwsSubnetIDs_filter
--- PASS: TestAccDataSourceAwsSubnetIDs_filter (25.48s)
--- PASS: TestAccDataSourceAwsSubnetIDs_basic (41.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.681s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccDataSourceAwsSubnet_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAwsSubnet_ -timeout 120m
=== RUN   TestAccDataSourceAwsSubnet_basic
=== PAUSE TestAccDataSourceAwsSubnet_basic
=== RUN   TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter
=== PAUSE TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter
=== RUN   TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock
=== PAUSE TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock
=== CONT  TestAccDataSourceAwsSubnet_basic
=== CONT  TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock
=== CONT  TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter
--- PASS: TestAccDataSourceAwsSubnet_basic (30.06s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6CidrBlock (53.98s)
--- PASS: TestAccDataSourceAwsSubnet_ipv6ByIpv6Filter (54.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	54.251s
```

##### Resources that were using `acctest.RandIntRange`:

```console
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccAwsDxGateway_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsDxGateway_basic -timeout 120m
=== RUN   TestAccAwsDxGateway_basic
=== PAUSE TestAccAwsDxGateway_basic
=== CONT  TestAccAwsDxGateway_basic
--- PASS: TestAccAwsDxGateway_basic (36.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.037s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccAWSEc2TrafficMirrorSession_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2TrafficMirrorSession_ -timeout 120m
=== RUN   TestAccAWSEc2TrafficMirrorSession_basic
=== PAUSE TestAccAWSEc2TrafficMirrorSession_basic
=== RUN   TestAccAWSEc2TrafficMirrorSession_tags
=== PAUSE TestAccAWSEc2TrafficMirrorSession_tags
=== RUN   TestAccAWSEc2TrafficMirrorSession_disappears
=== PAUSE TestAccAWSEc2TrafficMirrorSession_disappears
=== CONT  TestAccAWSEc2TrafficMirrorSession_basic
=== CONT  TestAccAWSEc2TrafficMirrorSession_disappears
=== CONT  TestAccAWSEc2TrafficMirrorSession_tags
=== CONT  TestAccAWSEc2TrafficMirrorSession_disappears
    resource_aws_ec2_traffic_mirror_session_test.go:134: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSEc2TrafficMirrorSession_disappears (244.00s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_basic (330.90s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_tags (332.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	332.347s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccAWSVpnConnectionRoute_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSVpnConnectionRoute_ -timeout 120m
=== RUN   TestAccAWSVpnConnectionRoute_basic
=== PAUSE TestAccAWSVpnConnectionRoute_basic
=== CONT  TestAccAWSVpnConnectionRoute_basic
--- PASS: TestAccAWSVpnConnectionRoute_basic (486.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	486.694s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccAWSVpnConnection_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSVpnConnection_ -timeout 120m
=== RUN   TestAccAWSVpnConnection_basic
=== PAUSE TestAccAWSVpnConnection_basic
=== RUN   TestAccAWSVpnConnection_TransitGatewayID
=== PAUSE TestAccAWSVpnConnection_TransitGatewayID
=== RUN   TestAccAWSVpnConnection_tunnelOptions
=== PAUSE TestAccAWSVpnConnection_tunnelOptions
=== RUN   TestAccAWSVpnConnection_withoutStaticRoutes
=== PAUSE TestAccAWSVpnConnection_withoutStaticRoutes
=== RUN   TestAccAWSVpnConnection_tags
=== PAUSE TestAccAWSVpnConnection_tags
=== RUN   TestAccAWSVpnConnection_disappears
=== PAUSE TestAccAWSVpnConnection_disappears
=== CONT  TestAccAWSVpnConnection_basic
=== CONT  TestAccAWSVpnConnection_tags
=== CONT  TestAccAWSVpnConnection_withoutStaticRoutes
=== CONT  TestAccAWSVpnConnection_tunnelOptions
=== CONT  TestAccAWSVpnConnection_TransitGatewayID
=== CONT  TestAccAWSVpnConnection_disappears
=== CONT  TestAccAWSVpnConnection_tunnelOptions
--- PASS: TestAccAWSVpnConnection_tunnelOptions (364.83s)
--- PASS: TestAccAWSVpnConnection_withoutStaticRoutes (329.66s)
=== CONT  TestAccAWSVpnConnection_disappears
    resource_aws_vpn_connection_test.go:311: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSVpnConnection_disappears (410.18s)
--- PASS: TestAccAWSVpnConnection_tags (443.70s)
--- PASS: TestAccAWSVpnConnection_TransitGatewayID (492.28s)
--- PASS: TestAccAWSVpnConnection_basic (638.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	638.769s
+ make testacc TEST=./aws/ TESTARGS=-run=TestAccAWSXraySamplingRule_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSXraySamplingRule_ -timeout 120m
=== RUN   TestAccAWSXraySamplingRule_basic
=== PAUSE TestAccAWSXraySamplingRule_basic
=== RUN   TestAccAWSXraySamplingRule_update
=== PAUSE TestAccAWSXraySamplingRule_update
=== CONT  TestAccAWSXraySamplingRule_basic
=== CONT  TestAccAWSXraySamplingRule_update
--- PASS: TestAccAWSXraySamplingRule_basic (16.34s)
--- PASS: TestAccAWSXraySamplingRule_update (27.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.317s
```