### PR TITLE
resource/acm_certificate_validation: safely handle nil resourcerecord or resourcerecord.name data

### DIFF
--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -50,10 +50,14 @@ func resourceAwsAcmCertificateValidationCreate(d *schema.ResourceData, meta inte
 	resp, err := acmconn.DescribeCertificate(params)
 
 	if err != nil {
-		return fmt.Errorf("Error describing certificate: %s", err)
+		return fmt.Errorf("Error describing certificate: %w", err)
 	}
 
-	if *resp.Certificate.Type != "AMAZON_ISSUED" {
+	if resp == nil || resp.Certificate == nil {
+		return fmt.Errorf("Error describing certificate: empty output")
+	}
+
+	if aws.StringValue(resp.Certificate.Type) != acm.CertificateTypeAmazonIssued {
 		return fmt.Errorf("Certificate %s has type %s, no validation necessary", aws.StringValue(resp.Certificate.CertificateArn), aws.StringValue(resp.Certificate.Status))
 	}
 
@@ -70,7 +74,7 @@ func resourceAwsAcmCertificateValidationCreate(d *schema.ResourceData, meta inte
 		resp, err := acmconn.DescribeCertificate(params)
 
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Error describing certificate: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("Error describing certificate: %w", err))
 		}
 
 		if aws.StringValue(resp.Certificate.Status) != acm.CertificateStatusIssued {
@@ -90,7 +94,7 @@ func resourceAwsAcmCertificateValidationCreate(d *schema.ResourceData, meta inte
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("Error describing created certificate: %s", err)
+		return fmt.Errorf("Error describing created certificate: %w", err)
 	}
 	return nil
 }
@@ -105,13 +109,13 @@ func resourceAwsAcmCertificateCheckValidationRecords(validationRecordFqdns []int
 		var err error
 		var output *acm.DescribeCertificateOutput
 		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-			log.Printf("[DEBUG] Certificate domain validation options empty for %q, retrying", *cert.CertificateArn)
+			log.Printf("[DEBUG] Certificate domain validation options empty for %s, retrying", aws.StringValue(cert.CertificateArn))
 			output, err = conn.DescribeCertificate(input)
 			if err != nil {
 				return resource.NonRetryableError(err)
 			}
 			if len(output.Certificate.DomainValidationOptions) == 0 {
-				return resource.RetryableError(fmt.Errorf("Certificate domain validation options empty for %s", *cert.CertificateArn))
+				return resource.RetryableError(fmt.Errorf("Certificate domain validation options empty for %s", aws.StringValue(cert.CertificateArn)))
 			}
 			cert = output.Certificate
 			return nil
@@ -119,24 +123,30 @@ func resourceAwsAcmCertificateCheckValidationRecords(validationRecordFqdns []int
 		if isResourceTimeoutError(err) {
 			output, err = conn.DescribeCertificate(input)
 			if err != nil {
-				return fmt.Errorf("Error describing ACM certificate: %s", err)
+				return fmt.Errorf("Error describing ACM certificate: %w", err)
 			}
 			if len(output.Certificate.DomainValidationOptions) == 0 {
-				return fmt.Errorf("Certificate domain validation options empty for %s", *cert.CertificateArn)
+				return fmt.Errorf("Certificate domain validation options empty for %s", aws.StringValue(cert.CertificateArn))
 			}
 		}
 		if err != nil {
-			return fmt.Errorf("Error checking certificate domain validation options: %s", err)
+			return fmt.Errorf("Error checking certificate domain validation options: %w", err)
 		}
+		if output == nil || output.Certificate == nil {
+			return fmt.Errorf("Error checking certificate domain validation options: empty output")
+		}
+
 		cert = output.Certificate
 	}
 	for _, v := range cert.DomainValidationOptions {
 		if v.ValidationMethod != nil {
-			if *v.ValidationMethod != acm.ValidationMethodDns {
+			if aws.StringValue(v.ValidationMethod) != acm.ValidationMethodDns {
 				return fmt.Errorf("validation_record_fqdns is only valid for DNS validation")
 			}
-			newExpectedFqdn := strings.TrimSuffix(*v.ResourceRecord.Name, ".")
-			expectedFqdns[newExpectedFqdn] = v
+			if v.ResourceRecord != nil && aws.StringValue(v.ResourceRecord.Name) != "" {
+				newExpectedFqdn := strings.TrimSuffix(aws.StringValue(v.ResourceRecord.Name), ".")
+				expectedFqdns[newExpectedFqdn] = v
+			}
 		} else if len(v.ValidationEmails) > 0 {
 			// ACM API sometimes is not sending ValidationMethod for EMAIL validation
 			return fmt.Errorf("validation_record_fqdns is only valid for DNS validation")
@@ -150,7 +160,7 @@ func resourceAwsAcmCertificateCheckValidationRecords(validationRecordFqdns []int
 	if len(expectedFqdns) > 0 {
 		var errors error
 		for expectedFqdn, domainValidation := range expectedFqdns {
-			errors = multierror.Append(errors, fmt.Errorf("missing %s DNS validation record: %s", *domainValidation.DomainName, expectedFqdn))
+			errors = multierror.Append(errors, fmt.Errorf("missing %s DNS validation record: %s", aws.StringValue(domainValidation.DomainName), expectedFqdn))
 		}
 		return errors
 	}
@@ -171,14 +181,14 @@ func resourceAwsAcmCertificateValidationRead(d *schema.ResourceData, meta interf
 		d.SetId("")
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("Error describing certificate: %s", err)
+		return fmt.Errorf("Error describing certificate: %w", err)
 	}
 
 	if aws.StringValue(resp.Certificate.Status) != acm.CertificateStatusIssued {
 		log.Printf("[INFO] Certificate status not issued, was %s, tainting validation", aws.StringValue(resp.Certificate.Status))
 		d.SetId("")
 	} else {
-		d.SetId((*resp.Certificate.IssuedAt).String())
+		d.SetId(aws.TimeValue(resp.Certificate.IssuedAt).String())
 	}
 	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14542 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/acm_validation: safely handle nil ResourceRecord or ResourceRecord.Name data
```

Output from acceptance testing (no new tests added for cases where domain_validation_option.resource_record is nil as unable to reproduce but did note API docs do show a Sample Response where this key and sub-keys are omitted: https://docs.aws.amazon.com/acm/latest/APIReference/API_DescribeCertificate.html)

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAcmCertificateValidation_basic (135.89s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcard (135.90s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsSan (139.22s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdns (141.98s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRootAndWildcard (99.28s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsRoot (155.62s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsEmail (13.56s)
--- PASS: TestAccAWSAcmCertificateValidation_timeout (18.65s)
--- PASS: TestAccAWSAcmCertificateValidation_validationRecordFqdnsWildcardAndRoot (63.39s)
```
