### PR TITLE
resource/aws_eks_node_group: Add launch_template configuration block

### DIFF
--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -77,6 +77,36 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"launch_template": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							Computed:      true,
+							ForceNew:      true,
+							ConflictsWith: []string{"launch_template.0.name"},
+							ValidateFunc:  validateLaunchTemplateId,
+						},
+						"name": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							Computed:      true,
+							ForceNew:      true,
+							ConflictsWith: []string{"launch_template.0.id"},
+							ValidateFunc:  validateLaunchTemplateName,
+						},
+						"version": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+					},
+				},
+			},
 			"node_group_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -213,6 +243,10 @@ func resourceAwsEksNodeGroupCreate(d *schema.ResourceData, meta interface{}) err
 		input.Labels = stringMapToPointers(v)
 	}
 
+	if v := d.Get("launch_template").([]interface{}); len(v) > 0 {
+		input.LaunchTemplate = expandEksLaunchTemplateSpecification(v)
+	}
+
 	if v, ok := d.GetOk("release_version"); ok {
 		input.ReleaseVersion = aws.String(v.(string))
 	}
@@ -303,6 +337,10 @@ func resourceAwsEksNodeGroupRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error setting labels: %s", err)
 	}
 
+	if err := d.Set("launch_template", flattenEksLaunchTemplateSpecification(nodeGroup.LaunchTemplate)); err != nil {
+		return fmt.Errorf("error setting launch_template: %s", err)
+	}
+
 	d.Set("node_group_name", nodeGroup.NodegroupName)
 	d.Set("node_role_arn", nodeGroup.NodeRole)
 	d.Set("release_version", nodeGroup.ReleaseVersion)
@@ -374,7 +412,7 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	if d.HasChanges("release_version", "version") {
+	if d.HasChanges("launch_template", "release_version", "version") {
 		input := &eks.UpdateNodegroupVersionInput{
 			ClientRequestToken: aws.String(resource.UniqueId()),
 			ClusterName:        aws.String(clusterName),
@@ -382,11 +420,31 @@ func resourceAwsEksNodeGroupUpdate(d *schema.ResourceData, meta interface{}) err
 			NodegroupName:      aws.String(nodeGroupName),
 		}
 
+		if v := d.Get("launch_template").([]interface{}); len(v) > 0 {
+			input.LaunchTemplate = expandEksLaunchTemplateSpecification(v)
+
+			// When returning Launch Template information, the API returns all
+			// fields. Since both the id and name are saved to the Terraform
+			// state for drift detection and the API returns the following
+			// error if both are present during update:
+			// InvalidParameterException: Either provide launch template ID or launch template name in the request.
+
+			// Remove the name if there are no changes, to prefer the ID.
+			if input.LaunchTemplate.Id != nil && input.LaunchTemplate.Name != nil && !d.HasChange("launch_template.0.name") {
+				input.LaunchTemplate.Name = nil
+			}
+
+			// Otherwise, remove the ID, but only if both are present still.
+			if input.LaunchTemplate.Id != nil && input.LaunchTemplate.Name != nil && !d.HasChange("launch_template.0.id") {
+				input.LaunchTemplate.Id = nil
+			}
+		}
+
 		if v, ok := d.GetOk("release_version"); ok && d.HasChange("release_version") {
 			input.ReleaseVersion = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("version"); ok {
+		if v, ok := d.GetOk("version"); ok && d.HasChange("version") {
 			input.Version = aws.String(v.(string))
 		}
 
@@ -446,6 +504,30 @@ func resourceAwsEksNodeGroupDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	return nil
+}
+
+func expandEksLaunchTemplateSpecification(l []interface{}) *eks.LaunchTemplateSpecification {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &eks.LaunchTemplateSpecification{}
+
+	if v, ok := m["id"].(string); ok && v != "" {
+		config.Id = aws.String(v)
+	}
+
+	if v, ok := m["name"].(string); ok && v != "" {
+		config.Name = aws.String(v)
+	}
+
+	if v, ok := m["version"].(string); ok && v != "" {
+		config.Version = aws.String(v)
+	}
+
+	return config
 }
 
 func expandEksNodegroupScalingConfig(l []interface{}) *eks.NodegroupScalingConfig {
@@ -533,6 +615,28 @@ func flattenEksAutoScalingGroups(autoScalingGroups []*eks.AutoScalingGroup) []ma
 	}
 
 	return l
+}
+
+func flattenEksLaunchTemplateSpecification(config *eks.LaunchTemplateSpecification) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{}
+
+	if v := config.Id; v != nil {
+		m["id"] = aws.StringValue(v)
+	}
+
+	if v := config.Name; v != nil {
+		m["name"] = aws.StringValue(v)
+	}
+
+	if v := config.Version; v != nil {
+		m["version"] = aws.StringValue(v)
+	}
+
+	return []map[string]interface{}{m}
 }
 
 func flattenEksNodeGroupResources(resources *eks.NodegroupResources) []map[string]interface{} {

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -302,8 +302,123 @@ func TestAccAWSEksNodeGroup_Labels(t *testing.T) {
 	})
 }
 
-func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
+func TestAccAWSEksNodeGroup_LaunchTemplate_Id(t *testing.T) {
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	launchTemplateResourceName1 := "aws_launch_template.test1"
+	launchTemplateResourceName2 := "aws_launch_template.test2"
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigLaunchTemplateId1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName1, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigLaunchTemplateId2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupRecreated(&nodeGroup1, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName2, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_LaunchTemplate_Name(t *testing.T) {
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	launchTemplateResourceName1 := "aws_launch_template.test1"
+	launchTemplateResourceName2 := "aws_launch_template.test2"
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigLaunchTemplateName1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.name", launchTemplateResourceName1, "name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigLaunchTemplateName2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupRecreated(&nodeGroup1, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.name", launchTemplateResourceName2, "name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_LaunchTemplate_Version(t *testing.T) {
 	var nodeGroup1 eks.Nodegroup
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	launchTemplateResourceName := "aws_launch_template.test"
+	resourceName := "aws_eks_node_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksNodeGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksNodeGroupConfigLaunchTemplateVersion1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.version", launchTemplateResourceName, "default_version"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigLaunchTemplateVersion2(rName),
+				// This API error is incorrect and will need to be rectified by the service team.
+				ExpectError: regexp.MustCompile(`User data was not in the MIME multipart format`),
+				// Check: resource.ComposeTestCheckFunc(
+				// 	testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+				// 	testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
+				// 	resource.TestCheckResourceAttr(resourceName, "launch_template.#", "1"),
+				// 	resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.version", launchTemplateResourceName, "default_version"),
+				// ),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	ssmParameterDataSourceName := "data.aws_ssm_parameter.test"
 	resourceName := "aws_eks_node_group.test"
@@ -328,7 +443,8 @@ func TestAccAWSEksNodeGroup_ReleaseVersion(t *testing.T) {
 			{
 				Config: testAccAWSEksNodeGroupConfigReleaseVersion(rName, "1.16"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
 					resource.TestCheckResourceAttrPair(resourceName, "release_version", ssmParameterDataSourceName, "value"),
 				),
 			},
@@ -419,6 +535,7 @@ func TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize(t *testing.T) {
 				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 1, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
@@ -458,6 +575,7 @@ func TestAccAWSEksNodeGroup_ScalingConfig_MaxSize(t *testing.T) {
 				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 1, 1, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "1"),
@@ -497,6 +615,7 @@ func TestAccAWSEksNodeGroup_ScalingConfig_MinSize(t *testing.T) {
 				Config: testAccAWSEksNodeGroupConfigScalingConfigSizes(rName, 2, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.desired_size", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_config.0.max_size", "2"),
@@ -534,6 +653,7 @@ func TestAccAWSEksNodeGroup_Tags(t *testing.T) {
 				Config: testAccAWSEksNodeGroupConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -543,6 +663,7 @@ func TestAccAWSEksNodeGroup_Tags(t *testing.T) {
 				Config: testAccAWSEksNodeGroupConfigTags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup3),
+					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup2, &nodeGroup3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -552,7 +673,7 @@ func TestAccAWSEksNodeGroup_Tags(t *testing.T) {
 }
 
 func TestAccAWSEksNodeGroup_Version(t *testing.T) {
-	var nodeGroup1 eks.Nodegroup
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_node_group.test"
 
@@ -576,7 +697,8 @@ func TestAccAWSEksNodeGroup_Version(t *testing.T) {
 			{
 				Config: testAccAWSEksNodeGroupConfigVersion(rName, "1.16"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup1),
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					testAccCheckAWSEksNodeGroupNotRecreated(&nodeGroup1, &nodeGroup2),
 					resource.TestCheckResourceAttr(resourceName, "version", "1.16"),
 				),
 			},
@@ -683,6 +805,26 @@ func testAccCheckAWSEksNodeGroupDisappears(nodeGroup *eks.Nodegroup) resource.Te
 		}
 
 		return waitForEksNodeGroupDeletion(conn, aws.StringValue(nodeGroup.ClusterName), aws.StringValue(nodeGroup.NodegroupName), 60*time.Minute)
+	}
+}
+
+func testAccCheckAWSEksNodeGroupNotRecreated(i, j *eks.Nodegroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreatedAt) != aws.TimeValue(j.CreatedAt) {
+			return fmt.Errorf("EKS Node Group (%s) was recreated", aws.StringValue(j.NodegroupName))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSEksNodeGroupRecreated(i, j *eks.Nodegroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreatedAt) == aws.TimeValue(j.CreatedAt) {
+			return fmt.Errorf("EKS Node Group (%s) was not recreated", aws.StringValue(j.NodegroupName))
+		}
+
+		return nil
 	}
 }
 
@@ -1030,6 +1172,282 @@ resource "aws_eks_node_group" "test" {
   ]
 }
 `, rName, labelKey1, labelValue1, labelKey2, labelValue2)
+}
+
+func testAccAWSEksNodeGroupConfigLaunchTemplateId1(rName string) string {
+	return composeConfig(
+		testAccAWSEksNodeGroupConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_ssm_parameter" "test" {
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.test.version}/amazon-linux-2/recommended/image_id"
+}
+
+resource "aws_launch_template" "test1" {
+  image_id      = data.aws_ssm_parameter.test.value
+  instance_type = "t3.medium"
+  name          = "%[1]s-1"
+  user_data     = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_launch_template" "test2" {
+  image_id      = data.aws_ssm_parameter.test.value
+  instance_type = "t3.medium"
+  name          = "%[1]s-2"
+  user_data     = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  launch_template {
+    id      = aws_launch_template.test1.id
+    version = aws_launch_template.test1.default_version
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
+}
+`, rName))
+}
+
+func testAccAWSEksNodeGroupConfigLaunchTemplateId2(rName string) string {
+	return composeConfig(
+		testAccAWSEksNodeGroupConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_ssm_parameter" "test" {
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.test.version}/amazon-linux-2/recommended/image_id"
+}
+
+resource "aws_launch_template" "test1" {
+  image_id      = data.aws_ssm_parameter.test.value
+  instance_type = "t3.medium"
+  name          = "%[1]s-1"
+  user_data     = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_launch_template" "test2" {
+  image_id      = data.aws_ssm_parameter.test.value
+  instance_type = "t3.medium"
+  name          = "%[1]s-2"
+  user_data     = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  launch_template {
+    id      = aws_launch_template.test2.id
+    version = aws_launch_template.test2.default_version
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
+}
+`, rName))
+}
+
+func testAccAWSEksNodeGroupConfigLaunchTemplateName1(rName string) string {
+	return composeConfig(
+		testAccAWSEksNodeGroupConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_ssm_parameter" "test" {
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.test.version}/amazon-linux-2/recommended/image_id"
+}
+
+resource "aws_launch_template" "test1" {
+  image_id      = data.aws_ssm_parameter.test.value
+  instance_type = "t3.medium"
+  name          = "%[1]s-1"
+  user_data     = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_launch_template" "test2" {
+  image_id      = data.aws_ssm_parameter.test.value
+  instance_type = "t3.medium"
+  name          = "%[1]s-2"
+  user_data     = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  launch_template {
+    name    = aws_launch_template.test1.name
+    version = aws_launch_template.test1.default_version
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
+}
+`, rName))
+}
+
+func testAccAWSEksNodeGroupConfigLaunchTemplateName2(rName string) string {
+	return composeConfig(
+		testAccAWSEksNodeGroupConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_ssm_parameter" "test" {
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.test.version}/amazon-linux-2/recommended/image_id"
+}
+
+resource "aws_launch_template" "test1" {
+  image_id      = data.aws_ssm_parameter.test.value
+  instance_type = "t3.medium"
+  name          = "%[1]s-1"
+  user_data     = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_launch_template" "test2" {
+  image_id      = data.aws_ssm_parameter.test.value
+  instance_type = "t3.medium"
+  name          = "%[1]s-2"
+  user_data     = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  launch_template {
+    name    = aws_launch_template.test2.name
+    version = aws_launch_template.test2.default_version
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
+}
+`, rName))
+}
+
+func testAccAWSEksNodeGroupConfigLaunchTemplateVersion1(rName string) string {
+	return composeConfig(
+		testAccAWSEksNodeGroupConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_ssm_parameter" "test" {
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.test.version}/amazon-linux-2/recommended/image_id"
+}
+
+resource "aws_launch_template" "test" {
+  image_id               = data.aws_ssm_parameter.test.value
+  instance_type          = "t3.medium"
+  name                   = %[1]q
+  update_default_version = true
+  user_data              = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  launch_template {
+    name    = aws_launch_template.test.name
+    version = aws_launch_template.test.default_version
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
+}
+`, rName))
+}
+
+func testAccAWSEksNodeGroupConfigLaunchTemplateVersion2(rName string) string {
+	return composeConfig(
+		testAccAWSEksNodeGroupConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_ssm_parameter" "test" {
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.test.version}/amazon-linux-2/recommended/image_id"
+}
+
+resource "aws_launch_template" "test" {
+  image_id               = data.aws_ssm_parameter.test.value
+  instance_type          = "t3.large"
+  name                   = %[1]q
+  update_default_version = true
+  user_data              = base64encode(templatefile("testdata/service/eks/node-group-launch-template-user-data.sh.tmpl", {cluster_name = aws_eks_cluster.test.name}))
+}
+
+resource "aws_eks_node_group" "test" {
+  cluster_name    = aws_eks_cluster.test.name
+  node_group_name = %[1]q
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = aws_subnet.test[*].id
+
+  launch_template {
+    name    = aws_launch_template.test.name
+    version = aws_launch_template.test.default_version
+  }
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.node-AmazonEKSWorkerNodePolicy",
+    "aws_iam_role_policy_attachment.node-AmazonEKS_CNI_Policy",
+    "aws_iam_role_policy_attachment.node-AmazonEC2ContainerRegistryReadOnly",
+  ]
+}
+`, rName))
 }
 
 func testAccAWSEksNodeGroupConfigReleaseVersion(rName string, version string) string {

--- a/aws/testdata/service/eks/node-group-launch-template-user-data.sh.tmpl
+++ b/aws/testdata/service/eks/node-group-launch-template-user-data.sh.tmpl
@@ -1,0 +1,8 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="//"
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+#!/bin/bash
+set -ex
+/etc/eks/bootstrap.sh ${cluster_name}
+--//--

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -128,10 +128,19 @@ The following arguments are optional:
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
 * `instance_types` - (Optional) Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
+* `launch_template` - (Optional) Configuration block with Launch Template settings. Detailed below.
 * `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
 * `remote_access` - (Optional) Configuration block with remote access settings. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags.
 * `version` – (Optional) Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided.
+
+### launch_template Configuration Block
+
+~> **NOTE:** Either `id` or `name` must be specified.
+
+* `id` - (Optional) Identifier of the EC2 Launch Template. Conflicts with `name`.
+* `name` - (Optional) Name of the EC2 Launch Template. Conflicts with `id`.
+* `version` - (Required) EC2 Launch Template version number. While the API accepts values like `$Default` and `$Latest`, the API will convert the value to the associated version number (e.g. `1`) on read and Terraform will show a difference on next plan. Using the `default_version` or `latest_version` attribute of the `aws_launch_template` resource or data source is recommended for this argument.
 
 ### remote_access Configuration Block
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_eks_node_group: Add `launch_template` configuration block
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MinSize (1167.16s)
--- PASS: TestAccAWSEksNodeGroup_AmiType (1173.29s)
--- PASS: TestAccAWSEksNodeGroup_disappears (1179.53s)
--- PASS: TestAccAWSEksNodeGroup_basic (1204.59s)
--- PASS: TestAccAWSEksNodeGroup_DiskSize (1217.40s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Version (1217.81s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_Ec2SshKey (1218.04s)
--- PASS: TestAccAWSEksNodeGroup_Tags (1222.27s)
--- PASS: TestAccAWSEksNodeGroup_RemoteAccess_SourceSecurityGroupIds (1228.60s)
--- PASS: TestAccAWSEksNodeGroup_InstanceTypes (1235.81s)
--- PASS: TestAccAWSEksNodeGroup_Labels (1288.05s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_DesiredSize (1293.11s)
--- PASS: TestAccAWSEksNodeGroup_ScalingConfig_MaxSize (1322.00s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Id (1569.19s)
--- PASS: TestAccAWSEksNodeGroup_LaunchTemplate_Name (1632.97s)
--- PASS: TestAccAWSEksNodeGroup_ReleaseVersion (3301.17s)
--- PASS: TestAccAWSEksNodeGroup_ForceUpdateVersion (3331.88s)
--- PASS: TestAccAWSEksNodeGroup_Version (3503.58s)
```
