### PR TITLE
r/aws_route53_record: Fix 'TestAccAWSRoute53Record_Alias_VpcEndpoint'

### DIFF
--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1781,8 +1781,13 @@ resource "aws_lb" "test" {
   subnets            = ["${aws_subnet.test.id}"]
 }
 
-resource "aws_default_security_group" "test" {
+resource "aws_security_group" "test" {
+  name   = %[1]q
   vpc_id = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_vpc_endpoint_service" "test" {
@@ -1792,7 +1797,7 @@ resource "aws_vpc_endpoint_service" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
-  security_group_ids  = ["${aws_default_security_group.test.id}"]
+  security_group_ids  = ["${aws_security_group.test.id}"]
   service_name        = "${aws_vpc_endpoint_service.test.service_name}"
   subnet_ids          = ["${aws_subnet.test.id}"]
   vpc_endpoint_type   = "Interface"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14571.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS=-run='TestAccAWSRoute53Record_Alias_VpcEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSRoute53Record_Alias_VpcEndpoint -timeout 120m
=== RUN   TestAccAWSRoute53Record_Alias_VpcEndpoint
=== PAUSE TestAccAWSRoute53Record_Alias_VpcEndpoint
=== CONT  TestAccAWSRoute53Record_Alias_VpcEndpoint
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (516.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	516.677s
```
