### PR TITLE
Separate aws_default_security_group definition from aws_security_group

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=aws
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 TEST_COUNT?=1
-ACCTEST_PARALLEL?=20
+ACCTEST_PARALLELISM?=20
 
 default: build
 
@@ -34,7 +34,7 @@ testacc: fmtcheck
 		echo "See the contributing guide for more information: https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/contributing/running-and-writing-acceptance-tests.md"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLEL) $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(TESTARGS) -timeout 120m
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=aws
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 TEST_COUNT?=1
+ACCTEST_PARALLEL?=20
 
 default: build
 
@@ -33,7 +34,7 @@ testacc: fmtcheck
 		echo "See the contributing guide for more information: https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/contributing/running-and-writing-acceptance-tests.md"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test ./$(PKG_NAME) -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLEL) $(TESTARGS) -timeout 120m
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -17,10 +17,14 @@ func ErrCodeEquals(err error, code string) bool {
 	return false
 }
 
-const ErrCodeClientVpnEndpointIdNotFound = "InvalidClientVpnEndpointId.NotFound"
+const (
+	ErrCodeClientVpnEndpointIdNotFound        = "InvalidClientVpnEndpointId.NotFound"
+	ErrCodeClientVpnAuthorizationRuleNotFound = "InvalidClientVpnEndpointAuthorizationRuleNotFound"
+	ErrCodeClientVpnAssociationIdNotFound     = "InvalidClientVpnAssociationId.NotFound"
+	ErrCodeClientVpnRouteNotFound             = "InvalidClientVpnRouteNotFound"
+)
 
-const ErrCodeClientVpnAuthorizationRuleNotFound = "InvalidClientVpnEndpointAuthorizationRuleNotFound"
-
-const ErrCodeClientVpnAssociationIdNotFound = "InvalidClientVpnAssociationId.NotFound"
-
-const ErrCodeClientVpnRouteNotFound = "InvalidClientVpnRouteNotFound"
+const (
+	InvalidSecurityGroupIDNotFound = "InvalidSecurityGroupID.NotFound"
+	InvalidGroupNotFound           = "InvalidGroup.NotFound"
+)

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -54,3 +54,20 @@ func ClientVpnRouteByID(conn *ec2.EC2, routeID string) (*ec2.DescribeClientVpnRo
 
 	return ClientVpnRoute(conn, endpointID, targetSubnetID, destinationCidr)
 }
+
+// SecurityGroupByID looks up a security group by ID. When not found, returns nil and potentially an API error.
+func SecurityGroupByID(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
+	req := &ec2.DescribeSecurityGroupsInput{
+		GroupIds: aws.StringSlice([]string{id}),
+	}
+	result, err := conn.DescribeSecurityGroups(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil || len(result.SecurityGroups) == 0 || result.SecurityGroups[0] == nil {
+		return nil, nil
+	}
+
+	return result.SecurityGroups[0], nil
+}

--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -132,3 +132,20 @@ func ClientVpnRouteDeleted(conn *ec2.EC2, routeID string) (*ec2.ClientVpnRoute, 
 
 	return nil, err
 }
+
+func SecurityGroupCreated(conn *ec2.EC2, id string, timeout time.Duration) (*ec2.SecurityGroup, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{SecurityGroupStatusNotFound},
+		Target:  []string{SecurityGroupStatusCreated},
+		Refresh: SecurityGroupStatus(conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*ec2.SecurityGroup); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/resource_aws_default_security_group.go
+++ b/aws/resource_aws_default_security_group.go
@@ -19,6 +19,7 @@ import (
 const DefaultSecurityGroupName = "default"
 
 func resourceAwsDefaultSecurityGroup() *schema.Resource {
+	//lintignore:R011
 	return &schema.Resource{
 		Create: resourceAwsDefaultSecurityGroupCreate,
 		Read:   resourceAwsDefaultSecurityGroupRead,

--- a/aws/resource_aws_default_security_group.go
+++ b/aws/resource_aws_default_security_group.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
@@ -28,6 +29,7 @@ func resourceAwsDefaultSecurityGroup() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
+		MigrateState:  resourceAwsDefaultSecurityGroupMigrateState,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -293,15 +295,15 @@ func resourceAwsDefaultSecurityGroupRead(d *schema.ResourceData, meta interface{
 	d.Set("vpc_id", group.VpcId)
 
 	if err := d.Set("ingress", ingressRules); err != nil {
-		log.Printf("[WARN] Error setting Ingress rule set for (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting Ingress rule set for (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("egress", egressRules); err != nil {
-		log.Printf("[WARN] Error setting Egress rule set for (%s): %s", d.Id(), err)
+		return fmt.Errorf("error setting Egress rule set for (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(group.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags for (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -452,4 +454,30 @@ func resourceAwsDefaultSecurityGroupRuleHash(v interface{}) int {
 	}
 
 	return hashcode.String(buf.String())
+}
+
+func resourceAwsDefaultSecurityGroupMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS Default Security Group state v0; migrating to v1")
+		return migrateAwsDefaultSecurityGroupStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateAwsDefaultSecurityGroupStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() || is.Attributes == nil {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	// set default for revoke_rules_on_delete
+	is.Attributes["revoke_rules_on_delete"] = "false"
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
 }

--- a/aws/resource_aws_default_security_group.go
+++ b/aws/resource_aws_default_security_group.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )

--- a/aws/resource_aws_default_security_group.go
+++ b/aws/resource_aws_default_security_group.go
@@ -1,40 +1,188 @@
 package aws
 
 import (
+	"bytes"
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
+const DefaultSecurityGroupName = "default"
+
 func resourceAwsDefaultSecurityGroup() *schema.Resource {
-	// reuse aws_security_group_rule schema, and methods for READ, UPDATE
-	dsg := resourceAwsSecurityGroup()
-	dsg.Create = resourceAwsDefaultSecurityGroupCreate
-	dsg.Delete = resourceAwsDefaultSecurityGroupDelete
+	return &schema.Resource{
+		Create: resourceAwsDefaultSecurityGroupCreate,
+		Read:   resourceAwsDefaultSecurityGroupRead,
+		Update: resourceAwsDefaultSecurityGroupUpdate,
+		Delete: resourceAwsDefaultSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
-	// description is a computed value for Default Security Groups and cannot be changed
-	dsg.Schema["description"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
+		SchemaVersion: 1,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"ingress": {
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr_blocks": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
+						},
+						"description": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateSecurityGroupRuleDescription,
+						},
+						"from_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"ipv6_cidr_blocks": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
+						},
+						"prefix_list_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"protocol": {
+							Type:      schema.TypeString,
+							Required:  true,
+							StateFunc: protocolStateFunc,
+						},
+						"security_groups": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"self": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"to_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+				Set: resourceAwsDefaultSecurityGroupRuleHash,
+			},
+			"egress": {
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr_blocks": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
+						},
+						"description": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateSecurityGroupRuleDescription,
+						},
+						"from_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"ipv6_cidr_blocks": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
+						},
+						"prefix_list_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"protocol": {
+							Type:      schema.TypeString,
+							Required:  true,
+							StateFunc: protocolStateFunc,
+						},
+						"security_groups": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"self": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"to_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+				Set: resourceAwsDefaultSecurityGroupRuleHash,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+			// This is not implemented. Added to prevent breaking changes.
+			"revoke_rules_on_delete": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+		},
 	}
-
-	// name is a computed value for Default Security Groups and cannot be changed
-	delete(dsg.Schema, "name_prefix")
-	dsg.Schema["name"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	}
-
-	// We want explicit management of Rules here, so we do not allow them to be
-	// computed. Instead, an empty config will enforce just that; removal of the
-	// rules
-	dsg.Schema["ingress"].Computed = false
-	dsg.Schema["egress"].Computed = false
-	return dsg
 }
 
 func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interface{}) error {
@@ -43,17 +191,17 @@ func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interfac
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("group-name"),
-				Values: []*string{aws.String("default")},
+				Values: aws.StringSlice([]string{DefaultSecurityGroupName}),
 			},
 		},
 	}
 
-	var vpcId string
+	var vpcID string
 	if v, ok := d.GetOk("vpc_id"); ok {
-		vpcId = v.(string)
+		vpcID = v.(string)
 		securityGroupOpts.Filters = append(securityGroupOpts.Filters, &ec2.Filter{
 			Name:   aws.String("vpc-id"),
-			Values: []*string{aws.String(vpcId)},
+			Values: aws.StringSlice([]string{vpcID}),
 		})
 	}
 
@@ -61,11 +209,11 @@ func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interfac
 	log.Printf("[DEBUG] Commandeer Default Security Group: %s", securityGroupOpts)
 	resp, err := conn.DescribeSecurityGroups(securityGroupOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating Default Security Group: %s", err)
+		return fmt.Errorf("Error creating Default Security Group: %w", err)
 	}
 
 	var g *ec2.SecurityGroup
-	if vpcId != "" {
+	if vpcID != "" {
 		// if vpcId contains a value, then we expect just a single Security Group
 		// returned, as default is a protected name for each VPC, and for each
 		// Region on EC2 Classic
@@ -77,8 +225,9 @@ func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interfac
 		// we need to filter through any returned security groups for the group
 		// named "default", and does not belong to a VPC
 		for _, sg := range resp.SecurityGroups {
-			if sg.VpcId == nil && *sg.GroupName == "default" {
+			if sg.VpcId == nil && aws.StringValue(sg.GroupName) == DefaultSecurityGroupName {
 				g = sg
+				break
 			}
 		}
 	}
@@ -87,21 +236,111 @@ func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error finding default security group: no matching group found")
 	}
 
-	d.SetId(*g.GroupId)
+	d.SetId(aws.StringValue(g.GroupId))
 
 	log.Printf("[INFO] Default Security Group ID: %s", d.Id())
 
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
 		if err := keyvaluetags.Ec2CreateTags(conn, d.Id(), v); err != nil {
-			return fmt.Errorf("error adding EC2 Default Security Group (%s) tags: %s", d.Id(), err)
+			return fmt.Errorf("error adding EC2 Default Security Group (%s) tags: %w", d.Id(), err)
 		}
 	}
 
 	if err := revokeDefaultSecurityGroupRules(meta, g); err != nil {
-		return fmt.Errorf("%s", err)
+		return err
 	}
 
-	return resourceAwsSecurityGroupUpdate(d, meta)
+	return resourceAwsDefaultSecurityGroupUpdate(d, meta)
+}
+
+func resourceAwsDefaultSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	group, err := finder.SecurityGroupByID(conn, d.Id())
+	if err != nil {
+		return err
+	}
+	if group == nil {
+		log.Printf("[WARN] Security group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	remoteIngressRules := resourceAwsSecurityGroupIPPermGather(d.Id(), group.IpPermissions, group.OwnerId)
+	remoteEgressRules := resourceAwsSecurityGroupIPPermGather(d.Id(), group.IpPermissionsEgress, group.OwnerId)
+
+	localIngressRules := d.Get("ingress").(*schema.Set).List()
+	localEgressRules := d.Get("egress").(*schema.Set).List()
+
+	// Loop through the local state of rules, doing a match against the remote
+	// ruleSet we built above.
+	ingressRules := matchRules("ingress", localIngressRules, remoteIngressRules)
+	egressRules := matchRules("egress", localEgressRules, remoteEgressRules)
+
+	sgArn := arn.ARN{
+		AccountID: aws.StringValue(group.OwnerId),
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Resource:  fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)),
+		Service:   ec2.ServiceName,
+	}
+
+	d.Set("arn", sgArn.String())
+	d.Set("description", group.Description)
+	d.Set("name", group.GroupName)
+	d.Set("owner_id", group.OwnerId)
+	d.Set("vpc_id", group.VpcId)
+
+	if err := d.Set("ingress", ingressRules); err != nil {
+		log.Printf("[WARN] Error setting Ingress rule set for (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("egress", egressRules); err != nil {
+		log.Printf("[WARN] Error setting Egress rule set for (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(group.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsDefaultSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	group, err := finder.SecurityGroupByID(conn, d.Id())
+	if err != nil {
+		return err
+	}
+	if group == nil {
+		log.Printf("[WARN] Security group (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	err = resourceAwsSecurityGroupUpdateRules(d, "ingress", meta, group)
+	if err != nil {
+		return err
+	}
+
+	if d.Get("vpc_id") != nil {
+		err = resourceAwsSecurityGroupUpdateRules(d, "egress", meta, group)
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("tags") && !d.IsNewResource() {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.Ec2UpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating EC2 Security Group (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceAwsDefaultSecurityGroupRead(d, meta)
 }
 
 func resourceAwsDefaultSecurityGroupDelete(d *schema.ResourceData, meta interface{}) error {
@@ -112,18 +351,17 @@ func resourceAwsDefaultSecurityGroupDelete(d *schema.ResourceData, meta interfac
 func revokeDefaultSecurityGroupRules(meta interface{}, g *ec2.SecurityGroup) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	log.Printf("[WARN] Removing all ingress and egress rules found on Default Security Group (%s)", *g.GroupId)
+	groupID := aws.StringValue(g.GroupId)
+	log.Printf("[WARN] Removing all ingress and egress rules found on Default Security Group (%s)", groupID)
 	if len(g.IpPermissionsEgress) > 0 {
 		req := &ec2.RevokeSecurityGroupEgressInput{
 			GroupId:       g.GroupId,
 			IpPermissions: g.IpPermissionsEgress,
 		}
 
-		log.Printf("[DEBUG] Revoking default egress rules for Default Security Group for %s", *g.GroupId)
+		log.Printf("[DEBUG] Revoking default egress rules for Default Security Group for %s", groupID)
 		if _, err := conn.RevokeSecurityGroupEgress(req); err != nil {
-			return fmt.Errorf(
-				"Error revoking default egress rules for Default Security Group (%s): %s",
-				*g.GroupId, err)
+			return fmt.Errorf("error revoking default egress rules for Default Security Group (%s): %w", groupID, err)
 		}
 	}
 	if len(g.IpPermissions) > 0 {
@@ -141,13 +379,77 @@ func revokeDefaultSecurityGroupRules(meta interface{}, g *ec2.SecurityGroup) err
 			IpPermissions: g.IpPermissions,
 		}
 
-		log.Printf("[DEBUG] Revoking default ingress rules for Default Security Group for (%s): %s", *g.GroupId, req)
+		log.Printf("[DEBUG] Revoking default ingress rules for Default Security Group for (%s): %s", groupID, req)
 		if _, err := conn.RevokeSecurityGroupIngress(req); err != nil {
-			return fmt.Errorf(
-				"Error revoking default ingress rules for Default Security Group (%s): %s",
-				*g.GroupId, err)
+			return fmt.Errorf("Error revoking default ingress rules for Default Security Group (%s): %w", groupID, err)
 		}
 	}
 
 	return nil
+}
+
+func resourceAwsDefaultSecurityGroupRuleHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%d-", m["from_port"].(int)))
+	buf.WriteString(fmt.Sprintf("%d-", m["to_port"].(int)))
+	p := protocolForValue(m["protocol"].(string))
+	buf.WriteString(fmt.Sprintf("%s-", p))
+	buf.WriteString(fmt.Sprintf("%t-", m["self"].(bool)))
+
+	// We need to make sure to sort the strings below so that we always
+	// generate the same hash code no matter what is in the set.
+	if v, ok := m["cidr_blocks"]; ok {
+		vs := v.([]interface{})
+		s := make([]string, len(vs))
+		for i, raw := range vs {
+			s[i] = raw.(string)
+		}
+		sort.Strings(s)
+
+		for _, v := range s {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+	if v, ok := m["ipv6_cidr_blocks"]; ok {
+		vs := v.([]interface{})
+		s := make([]string, len(vs))
+		for i, raw := range vs {
+			s[i] = raw.(string)
+		}
+		sort.Strings(s)
+
+		for _, v := range s {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+	if v, ok := m["prefix_list_ids"]; ok {
+		vs := v.([]interface{})
+		s := make([]string, len(vs))
+		for i, raw := range vs {
+			s[i] = raw.(string)
+		}
+		sort.Strings(s)
+
+		for _, v := range s {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+	if v, ok := m["security_groups"]; ok {
+		vs := v.(*schema.Set).List()
+		s := make([]string, len(vs))
+		for i, raw := range vs {
+			s[i] = raw.(string)
+		}
+		sort.Strings(s)
+
+		for _, v := range s {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+	if m["description"].(string) != "" {
+		buf.WriteString(fmt.Sprintf("%s-", m["description"].(string)))
+	}
+
+	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_default_security_group_test.go
+++ b/aws/resource_aws_default_security_group_test.go
@@ -47,7 +47,7 @@ func TestAccAWSDefaultSecurityGroup_Vpc_basic(t *testing.T) {
 						"cidr_blocks.0": "10.0.0.0/8",
 					}),
 					testAccCheckAWSDefaultSecurityGroupARN(resourceName, &group),
-					testAccCheckAWSDefaultSecurityGroupOwnerID(resourceName),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-acc-test"),
 				),
@@ -102,7 +102,7 @@ func TestAccAWSDefaultSecurityGroup_Classic_basic(t *testing.T) {
 	var group ec2.SecurityGroup
 	resourceName := "aws_default_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
@@ -125,7 +125,7 @@ func TestAccAWSDefaultSecurityGroup_Classic_basic(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
 					testAccCheckAWSDefaultSecurityGroupARN(resourceName, &group),
-					testAccCheckAWSDefaultSecurityGroupOwnerID(resourceName),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-acc-test"),
 				),
@@ -144,34 +144,36 @@ func TestAccAWSDefaultSecurityGroup_Classic_basic(t *testing.T) {
 	})
 }
 
-// This test currently fails because it does not clear tags when adopting the resource, resulting
-// in a non-empty plan.
-// https://github.com/terraform-providers/terraform-provider-aws/issues/14631
-// func TestAccAWSDefaultSecurityGroup_Classic_empty(t *testing.T) {
-// 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-// 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-// 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+func TestAccAWSDefaultSecurityGroup_Classic_empty(t *testing.T) {
 
-// 	var group ec2.SecurityGroup
-// 	resourceName := "aws_default_security_group.test"
+	TestAccSkip(t, "This resource does not currently clear tags when adopting the resource")
+	// Additional references:
+	//  * https://github.com/terraform-providers/terraform-provider-aws/issues/14631
 
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:      func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-// 		IDRefreshName: resourceName,
-// 		Providers:     testAccProviders,
-// 		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccAWSDefaultSecurityGroupConfig_Classic_empty,
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckAWSDefaultSecurityGroupExists(resourceName, &group),
-// 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
-// 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	var group ec2.SecurityGroup
+	resourceName := "aws_default_security_group.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultSecurityGroupConfig_Classic_empty,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDefaultSecurityGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
+				),
+			},
+		},
+	})
+}
 
 func testAccCheckAWSDefaultSecurityGroupDestroy(s *terraform.State) error {
 	// We expect Security Group to still exist
@@ -210,12 +212,6 @@ func testAccCheckAWSDefaultSecurityGroupExists(n string, group *ec2.SecurityGrou
 func testAccCheckAWSDefaultSecurityGroupARN(resourceName string, group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ec2", fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)))(s)
-	}
-}
-
-func testAccCheckAWSDefaultSecurityGroupOwnerID(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		return resource.TestCheckResourceAttr(resourceName, "owner_id", testAccGetAccountID())(s)
 	}
 }
 
@@ -280,8 +276,72 @@ resource "aws_default_security_group" "test" {
 }
 `
 
-// const testAccAWSDefaultSecurityGroupConfig_Classic_empty = `
-// resource "aws_default_security_group" "test" {
-//   # No attributes set.
-// }
-// `
+const testAccAWSDefaultSecurityGroupConfig_Classic_empty = `
+resource "aws_default_security_group" "test" {
+  # No attributes set.
+}
+`
+
+func TestAWSDefaultSecurityGroupMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"v0": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"name": "test",
+			},
+			Expected: map[string]string{
+				"name":                   "test",
+				"revoke_rules_on_delete": "false",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "i-abc123",
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsDefaultSecurityGroupMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}
+
+func TestAWSDefaultSecurityGroupMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta interface{}
+
+	// should handle nil
+	is, err := resourceAwsDefaultSecurityGroupMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	_, err = resourceAwsDefaultSecurityGroupMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}

--- a/aws/resource_aws_default_security_group_test.go
+++ b/aws/resource_aws_default_security_group_test.go
@@ -2,7 +2,7 @@ package aws
 
 import (
 	"fmt"
-	"reflect"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,65 +12,166 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
-func TestAccAWSDefaultSecurityGroup_basic(t *testing.T) {
+func TestAccAWSDefaultSecurityGroup_Vpc_basic(t *testing.T) {
 	var group ec2.SecurityGroup
+	resourceName := "aws_default_security_group.test"
+	vpcResourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_default_security_group.web",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDefaultSecurityGroupConfig,
+				Config: testAccAWSDefaultSecurityGroupConfig_Vpc,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDefaultSecurityGroupExists("aws_default_security_group.web", &group),
-					testAccCheckAWSDefaultSecurityGroupAttributes(&group),
-					resource.TestCheckResourceAttr(
-						"aws_default_security_group.web", "name", "default"),
-					resource.TestCheckResourceAttr(
-						"aws_default_security_group.web", "description", "default VPC security group"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_default_security_group.web", "ingress.*", map[string]string{
+					testAccCheckAWSDefaultSecurityGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", "default"),
+					resource.TestCheckResourceAttr(resourceName, "description", "default VPC security group"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "ingress.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
 						"protocol":      "tcp",
 						"from_port":     "80",
 						"to_port":       "8000",
 						"cidr_blocks.#": "1",
 						"cidr_blocks.0": "10.0.0.0/8",
 					}),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSDefaultSecurityGroup_classic(t *testing.T) {
-	var group ec2.SecurityGroup
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_default_security_group.web",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSDefaultSecurityGroupConfig_classic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSDefaultSecurityGroupExists("aws_default_security_group.web", &group),
-					testAccCheckAWSDefaultSecurityGroupAttributes(&group),
-					resource.TestCheckResourceAttr(
-						"aws_default_security_group.web", "name", "default"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs("aws_default_security_group.web", "ingress.*", map[string]string{
+					resource.TestCheckResourceAttr(resourceName, "egress.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "egress.*", map[string]string{
 						"protocol":      "tcp",
 						"from_port":     "80",
 						"to_port":       "8000",
 						"cidr_blocks.#": "1",
 						"cidr_blocks.0": "10.0.0.0/8",
 					}),
+					testAccCheckAWSDefaultSecurityGroupARN(resourceName, &group),
+					testAccCheckAWSDefaultSecurityGroupOwnerID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-acc-test"),
 				),
+			},
+			{
+				Config:   testAccAWSDefaultSecurityGroupConfig_Vpc,
+				PlanOnly: true,
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
 			},
 		},
 	})
 }
+
+func TestAccAWSDefaultSecurityGroup_Vpc_empty(t *testing.T) {
+	var group ec2.SecurityGroup
+	resourceName := "aws_default_security_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultSecurityGroupConfig_Vpc_empty,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDefaultSecurityGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDefaultSecurityGroup_Classic_basic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	var group ec2.SecurityGroup
+	resourceName := "aws_default_security_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultSecurityGroupConfig_Classic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDefaultSecurityGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", "default"),
+					resource.TestCheckResourceAttr(resourceName, "description", "default group"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ingress.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ingress.*", map[string]string{
+						"protocol":      "tcp",
+						"from_port":     "80",
+						"to_port":       "8000",
+						"cidr_blocks.#": "1",
+						"cidr_blocks.0": "10.0.0.0/8",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
+					testAccCheckAWSDefaultSecurityGroupARN(resourceName, &group),
+					testAccCheckAWSDefaultSecurityGroupOwnerID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-acc-test"),
+				),
+			},
+			{
+				Config:   testAccAWSDefaultSecurityGroupConfig_Classic,
+				PlanOnly: true,
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"revoke_rules_on_delete"},
+			},
+		},
+	})
+}
+
+// This test currently fails because it does not clear tags when adopting the resource, resulting
+// in a non-empty plan.
+// https://github.com/terraform-providers/terraform-provider-aws/issues/14631
+// func TestAccAWSDefaultSecurityGroup_Classic_empty(t *testing.T) {
+// 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+// 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+// 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+// 	var group ec2.SecurityGroup
+// 	resourceName := "aws_default_security_group.test"
+
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:      func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+// 		IDRefreshName: resourceName,
+// 		Providers:     testAccProviders,
+// 		CheckDestroy:  testAccCheckAWSDefaultSecurityGroupDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccAWSDefaultSecurityGroupConfig_Classic_empty,
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccCheckAWSDefaultSecurityGroupExists(resourceName, &group),
+// 					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
+// 					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
 func testAccCheckAWSDefaultSecurityGroupDestroy(s *terraform.State) error {
 	// We expect Security Group to still exist
@@ -106,45 +207,29 @@ func testAccCheckAWSDefaultSecurityGroupExists(n string, group *ec2.SecurityGrou
 	}
 }
 
-func testAccCheckAWSDefaultSecurityGroupAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
+func testAccCheckAWSDefaultSecurityGroupARN(resourceName string, group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		p := &ec2.IpPermission{
-			FromPort:   aws.Int64(80),
-			ToPort:     aws.Int64(8000),
-			IpProtocol: aws.String("tcp"),
-			IpRanges:   []*ec2.IpRange{{CidrIp: aws.String("10.0.0.0/8")}},
-		}
-
-		if *group.GroupName != "default" {
-			return fmt.Errorf("Bad name: %s", *group.GroupName)
-		}
-
-		if len(group.IpPermissions) == 0 {
-			return fmt.Errorf("No IPPerms")
-		}
-
-		// Compare our ingress
-		if !reflect.DeepEqual(group.IpPermissions[0], p) {
-			return fmt.Errorf(
-				"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-				group.IpPermissions[0],
-				p)
-		}
-
-		return nil
+		return testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ec2", fmt.Sprintf("security-group/%s", aws.StringValue(group.GroupId)))(s)
 	}
 }
 
-const testAccAWSDefaultSecurityGroupConfig = `
-resource "aws_vpc" "foo" {
+func testAccCheckAWSDefaultSecurityGroupOwnerID(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return resource.TestCheckResourceAttr(resourceName, "owner_id", testAccGetAccountID())(s)
+	}
+}
+
+const testAccAWSDefaultSecurityGroupConfig_Vpc = `
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+  
   tags = {
     Name = "terraform-testacc-default-security-group"
   }
 }
 
-resource "aws_default_security_group" "web" {
-  vpc_id = aws_vpc.foo.id
+resource "aws_default_security_group" "test" {
+  vpc_id = aws_vpc.test.id
 
   ingress {
     protocol    = "6"
@@ -166,12 +251,22 @@ resource "aws_default_security_group" "web" {
 }
 `
 
-const testAccAWSDefaultSecurityGroupConfig_classic = `
-provider "aws" {
-  region = "us-east-1"
+const testAccAWSDefaultSecurityGroupConfig_Vpc_empty = `
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-default-security-group"
+  }
 }
 
-resource "aws_default_security_group" "web" {
+resource "aws_default_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+}
+`
+
+const testAccAWSDefaultSecurityGroupConfig_Classic = `
+resource "aws_default_security_group" "test" {
   ingress {
     protocol    = "6"
     from_port   = 80
@@ -182,4 +277,11 @@ resource "aws_default_security_group" "web" {
   tags = {
     Name = "tf-acc-test"
   }
-}`
+}
+`
+
+// const testAccAWSDefaultSecurityGroupConfig_Classic_empty = `
+// resource "aws_default_security_group" "test" {
+//   # No attributes set.
+// }
+// `

--- a/website/docs/r/default_security_group.html.markdown
+++ b/website/docs/r/default_security_group.html.markdown
@@ -92,14 +92,34 @@ The arguments of an `aws_default_security_group` differ slightly from `aws_secur
 resources. Namely, the `name` argument is computed, and the `name_prefix` attribute
 removed. The following arguments are still supported:
 
-* `ingress` - (Optional) Can be specified multiple times for each
-   ingress rule. Each ingress block supports fields documented below.
-* `egress` - (Optional, VPC only) Can be specified multiple times for each
-      egress rule. Each egress block supports fields documented below.
-* `vpc_id` - (Optional, Forces new resource) The VPC ID. **Note that changing
-the `vpc_id` will _not_ restore any default security group rules that were
-modified, added, or removed.** It will be left in its current state
+* `ingress` - (Optional) Can be specified multiple times for each ingress rule. Each ingress block supports fields documented [below](#ingress-blocks).
+* `egress` - (Optional, VPC only) Can be specified multiple times for each egress rule. Each egress block supports fields documented [below](#egress-blocks).
+* `vpc_id` - (Optional, Forces new resource) The VPC ID. **Note that changing the `vpc_id` will _not_ restore any default security group rules that were modified, added, or removed.** It will be left in its current state
 * `tags` - (Optional) A map of tags to assign to the resource.
+
+### `ingress` Block
+
+* `cidr_blocks` - (Optional) List of CIDR blocks.
+* `description` - (Optional) Description of this ingress rule.
+* `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp" or "icmpv6")
+* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+* `prefix_list_ids` - (Optional) List of prefix list IDs.
+* `protocol` - (Required) The protocol. If you select a protocol of "-1" (semantically equivalent to `"all"`, which is not a valid value here), you must specify a "from_port" and "to_port" equal to 0. If not icmp, icmpv6, tcp, udp, or "-1" use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
+* `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
+* `self` - (Optional) If true, the security group itself will be added as a source to this ingress rule.
+* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
+
+### `egress` Block
+
+* `cidr_blocks` - (Optional) List of CIDR blocks.
+* `description` - (Optional) Description of this egress rule.
+* `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp")
+* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+* `prefix_list_ids` - (Optional) List of prefix list IDs (for allowing access to VPC endpoints)
+* `protocol` - (Required) The protocol. If you select a protocol of "-1" (semantically equivalent to `"all"`, which is not a valid value here), you must specify a "from_port" and "to_port" equal to 0. If not icmp, tcp, udp, or "-1" use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
+* `security_groups` - (Optional) List of security group Group Names if using EC2-Classic, or Group IDs if using a VPC.
+* `self` - (Optional) If true, the security group itself will be added as a source to this egress rule.
+* `to_port` - (Required) The end range port (or ICMP code if protocol is "icmp").
 
 
 ## Usage
@@ -122,11 +142,10 @@ they are at the time of removal. You can resume managing them via the AWS Consol
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the security group
+* `arn` - The ARN of the security group
 * `vpc_id` - The VPC ID.
 * `owner_id` - The owner ID.
 * `name` - The name of the security group
 * `description` - The description of the security group
-* `ingress` - The ingress rules. See above for more.
-* `egress` - The egress rules. See above for more.
 
 [aws-default-security-groups]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#default-security-group


### PR DESCRIPTION
Separates aws_default_security_group definition from aws_security_group.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14559

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSDefaultSecurityGroup_'

--- PASS: TestAccAWSDefaultSecurityGroup_Vpc_basic (107.00s)
--- PASS: TestAccAWSDefaultSecurityGroup_Classic_basic (76.73s)
--- PASS: TestAccAWSDefaultSecurityGroup_Vpc_empty (57.64s)
```
