### PR TITLE
r/aws_lb_ssl_negotiation_policy: Fix parsing of resource ID

### DIFF
--- a/aws/resource_aws_lb_ssl_negotiation_policy.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -110,7 +111,10 @@ func resourceAwsLBSSLNegotiationPolicyCreate(d *schema.ResourceData, meta interf
 func resourceAwsLBSSLNegotiationPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
 
-	lbName, lbPort, policyName := resourceAwsLBSSLNegotiationPolicyParseId(d.Id())
+	lbName, lbPort, policyName, err := resourceAwsLBSSLNegotiationPolicyParseId(d.Id())
+	if err != nil {
+		return err
+	}
 
 	request := &elb.DescribeLoadBalancerPoliciesInput{
 		LoadBalancerName: aws.String(lbName),
@@ -160,7 +164,10 @@ func resourceAwsLBSSLNegotiationPolicyRead(d *schema.ResourceData, meta interfac
 func resourceAwsLBSSLNegotiationPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbconn
 
-	lbName, _, policyName := resourceAwsLBSSLNegotiationPolicyParseId(d.Id())
+	lbName, _, policyName, err := resourceAwsLBSSLNegotiationPolicyParseId(d.Id())
+	if err != nil {
+		return err
+	}
 
 	// Perversely, if we Set an empty list of PolicyNames, we detach the
 	// policies attached to a listener, which is required to delete the
@@ -189,7 +196,16 @@ func resourceAwsLBSSLNegotiationPolicyDelete(d *schema.ResourceData, meta interf
 // resourceAwsLBSSLNegotiationPolicyParseId takes an ID and parses it into
 // it's constituent parts. You need three axes (LB name, policy name, and LB
 // port) to create or identify an SSL negotiation policy in AWS's API.
-func resourceAwsLBSSLNegotiationPolicyParseId(id string) (string, string, string) {
+func resourceAwsLBSSLNegotiationPolicyParseId(id string) (string, int, string, error) {
 	parts := strings.SplitN(id, ":", 3)
-	return parts[0], parts[1], parts[2]
+	if n := len(parts); n != 3 {
+		return "", 0, "", fmt.Errorf("incorrect format of SSL negotiation policy resource ID. Expected %d parts, got %d", 3, n)
+	}
+
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", 0, "", fmt.Errorf("error parsing SSL negotiation policy resource ID port: %w", err)
+	}
+
+	return parts[0], port, parts[2], nil
 }

--- a/aws/resource_aws_lb_ssl_negotiation_policy_test.go
+++ b/aws/resource_aws_lb_ssl_negotiation_policy_test.go
@@ -96,8 +96,12 @@ func testAccCheckLBSSLNegotiationPolicyDestroy(s *terraform.State) error {
 			}
 		} else {
 			// Check that the SSL Negotiation Policy is destroyed
-			elbName, _, policyName := resourceAwsLBSSLNegotiationPolicyParseId(rs.Primary.ID)
-			_, err := elbconn.DescribeLoadBalancerPolicies(&elb.DescribeLoadBalancerPoliciesInput{
+			elbName, _, policyName, err := resourceAwsLBSSLNegotiationPolicyParseId(rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+
+			_, err = elbconn.DescribeLoadBalancerPolicies(&elb.DescribeLoadBalancerPoliciesInput{
 				LoadBalancerName: aws.String(elbName),
 				PolicyNames:      []*string{aws.String(policyName)},
 			})
@@ -129,7 +133,11 @@ func testAccCheckLBSSLNegotiationPolicy(elbResource string, policyResource strin
 
 		elbconn := testAccProvider.Meta().(*AWSClient).elbconn
 
-		elbName, _, policyName := resourceAwsLBSSLNegotiationPolicyParseId(policy.Primary.ID)
+		elbName, _, policyName, err := resourceAwsLBSSLNegotiationPolicyParseId(policy.Primary.ID)
+		if err != nil {
+			return err
+		}
+
 		resp, err := elbconn.DescribeLoadBalancerPolicies(&elb.DescribeLoadBalancerPoliciesInput{
 			LoadBalancerName: aws.String(elbName),
 			PolicyNames:      []*string{aws.String(policyName)},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14566.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./aws/ TESTARGS=-run='TestAccAWSLBSSLNegotiationPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLBSSLNegotiationPolicy_ -timeout 120m
=== RUN   TestAccAWSLBSSLNegotiationPolicy_basic
=== PAUSE TestAccAWSLBSSLNegotiationPolicy_basic
=== RUN   TestAccAWSLBSSLNegotiationPolicy_disappears
=== PAUSE TestAccAWSLBSSLNegotiationPolicy_disappears
=== CONT  TestAccAWSLBSSLNegotiationPolicy_basic
=== CONT  TestAccAWSLBSSLNegotiationPolicy_disappears
    resource_aws_lb_ssl_negotiation_policy_test.go:49: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSLBSSLNegotiationPolicy_disappears (36.53s)
--- PASS: TestAccAWSLBSSLNegotiationPolicy_basic (40.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	40.502s
```
