### PR TITLE
tech-debt/cognito_user_pool_domain: add sweeper

### DIFF
--- a/aws/resource_aws_cognito_user_pool_domain_test.go
+++ b/aws/resource_aws_cognito_user_pool_domain_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
@@ -12,6 +13,65 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_cognito_user_pool_domain", &resource.Sweeper{
+		Name: "aws_cognito_user_pool_domain",
+		F:    testSweepCognitoUserPoolDomains,
+	})
+}
+
+func testSweepCognitoUserPoolDomains(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).cognitoidpconn
+
+	input := &cognitoidentityprovider.ListUserPoolsInput{
+		MaxResults: aws.Int64(int64(50)),
+	}
+
+	err = conn.ListUserPoolsPages(input, func(resp *cognitoidentityprovider.ListUserPoolsOutput, isLast bool) bool {
+		if len(resp.UserPools) == 0 {
+			log.Print("[DEBUG] No Cognito user pools (i.e. domains) to sweep")
+			return false
+		}
+
+		for _, u := range resp.UserPools {
+			output, err := conn.DescribeUserPool(&cognitoidentityprovider.DescribeUserPoolInput{
+				UserPoolId: u.Id,
+			})
+			if err != nil {
+				log.Printf("[ERROR] Failed describing Cognito user pool (%s): %s", aws.StringValue(u.Name), err)
+				continue
+			}
+			if output.UserPool != nil && output.UserPool.Domain != nil {
+				domain := aws.StringValue(output.UserPool.Domain)
+
+				log.Printf("[INFO] Deleting Cognito user pool domain: %s", domain)
+				_, err := conn.DeleteUserPoolDomain(&cognitoidentityprovider.DeleteUserPoolDomainInput{
+					Domain:     output.UserPool.Domain,
+					UserPoolId: u.Id,
+				})
+				if err != nil {
+					log.Printf("[ERROR] Failed deleting Cognito user pool domain (%s): %s", domain, err)
+				}
+			}
+		}
+		return !isLast
+	})
+
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Cognito User Pool Domain sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Cognito User Pools: %s", err)
+	}
+
+	return nil
+}
 
 func TestAccAWSCognitoUserPoolDomain_basic(t *testing.T) {
 	domainName := fmt.Sprintf("tf-acc-test-domain-%d", acctest.RandInt())

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -21,6 +21,9 @@ func init() {
 	resource.AddTestSweepers("aws_cognito_user_pool", &resource.Sweeper{
 		Name: "aws_cognito_user_pool",
 		F:    testSweepCognitoUserPools,
+		Dependencies: []string{
+			"aws_cognito_user_pool_domain",
+		},
 	})
 }
 
@@ -35,37 +38,32 @@ func testSweepCognitoUserPools(region string) error {
 		MaxResults: aws.Int64(int64(50)),
 	}
 
-	for {
-		output, err := conn.ListUserPools(input)
-		if err != nil {
-			if testSweepSkipSweepError(err) {
-				log.Printf("[WARN] Skipping Cognito User Pool sweep for %s: %s", region, err)
-				return nil
-			}
-			return fmt.Errorf("Error retrieving Cognito User Pools: %s", err)
-		}
-
-		if len(output.UserPools) == 0 {
+	err = conn.ListUserPoolsPages(input, func(resp *cognitoidentityprovider.ListUserPoolsOutput, isLast bool) bool {
+		if len(resp.UserPools) == 0 {
 			log.Print("[DEBUG] No Cognito User Pools to sweep")
-			return nil
+			return false
 		}
 
-		for _, userPool := range output.UserPools {
+		for _, userPool := range resp.UserPools {
 			name := aws.StringValue(userPool.Name)
 
-			log.Printf("[INFO] Deleting Cognito User Pool %s", name)
+			log.Printf("[INFO] Deleting Cognito User Pool: %s", name)
 			_, err := conn.DeleteUserPool(&cognitoidentityprovider.DeleteUserPoolInput{
 				UserPoolId: userPool.Id,
 			})
 			if err != nil {
-				return fmt.Errorf("Error deleting Cognito User Pool %s: %s", name, err)
+				log.Printf("[ERROR] Failed deleting Cognito User Pool (%s): %s", name, err)
 			}
 		}
+		return !isLast
+	})
 
-		if output.NextToken == nil {
-			break
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Cognito User Pool sweep for %s: %s", region, err)
+			return nil
 		}
-		input.NextToken = output.NextToken
+		return fmt.Errorf("Error retrieving Cognito User Pools: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14102 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt/cognito_user_pool_domain: add sweeper
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
go test ./aws -v -timeout=10h -sweep-allow-failures -sweep=us-west-2 -sweep-run=aws_cognito_user_pool
2020/08/13 18:04:00 [DEBUG] No Cognito user pools (i.e. domains) to sweep
2020/08/13 18:04:00 [DEBUG] Sweeper (aws_cognito_user_pool) has dependency (aws_cognito_user_pool_domain), running..
2020/08/13 18:04:00 [DEBUG] Sweeper (aws_cognito_user_pool_domain) already ran in region (us-east-1)
2020/08/13 18:04:00 [DEBUG] Running Sweeper (aws_cognito_user_pool) in region (us-east-1)
2020/08/13 18:04:00 [DEBUG] No Cognito User Pools to sweep
2020/08/13 18:04:00 Sweeper Tests ran successfully:
	- aws_cognito_user_pool_domain
	- aws_cognito_user_pool
```
