### PR TITLE
r/aws_organizations_organization: Add support for AISERVICES_OPT_OUT_POLICY

### DIFF
--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -144,6 +144,7 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
+						organizations.PolicyTypeAiservicesOptOutPolicy,
 						organizations.PolicyTypeBackupPolicy,
 						organizations.PolicyTypeServiceControlPolicy,
 						organizations.PolicyTypeTagPolicy,

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -109,6 +109,7 @@ func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.0", organizations.PolicyTypeServiceControlPolicy),
 				),
 			},
 			{
@@ -124,10 +125,19 @@ func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(organizations.PolicyTypeAiservicesOptOutPolicy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.0", organizations.PolicyTypeAiservicesOptOutPolicy),
+				),
+			},
+			{
 				Config: testAccAwsOrganizationsOrganizationConfigEnabledPolicyTypes1(organizations.PolicyTypeServiceControlPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.0", organizations.PolicyTypeServiceControlPolicy),
 				),
 			},
 			{
@@ -135,6 +145,7 @@ func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.0", organizations.PolicyTypeBackupPolicy),
 				),
 			},
 			{
@@ -142,6 +153,7 @@ func testAccAwsOrganizationsOrganization_EnabledPolicyTypes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_policy_types.0", organizations.PolicyTypeTagPolicy),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14142

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/aws_organizations_organization: Add support for AISERVICES_OPT_OUT_POLICY
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSOrganizations_serial'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSOrganizations_serial -timeout 120m
=== RUN   TestAccAWSOrganizations_serial
=== RUN   TestAccAWSOrganizations_serial/Policy
=== RUN   TestAccAWSOrganizations_serial/Policy/concurrent
=== RUN   TestAccAWSOrganizations_serial/Policy/Description
=== RUN   TestAccAWSOrganizations_serial/Policy/Type_AI_OPT_OUT
=== RUN   TestAccAWSOrganizations_serial/Policy/Type_Backup
=== RUN   TestAccAWSOrganizations_serial/Policy/Type_SCP
=== RUN   TestAccAWSOrganizations_serial/Policy/Type_Tag
=== RUN   TestAccAWSOrganizations_serial/Policy/basic
=== RUN   TestAccAWSOrganizations_serial/PolicyAttachment
=== RUN   TestAccAWSOrganizations_serial/PolicyAttachment/OrganizationalUnit
=== RUN   TestAccAWSOrganizations_serial/PolicyAttachment/Root
=== RUN   TestAccAWSOrganizations_serial/PolicyAttachment/Account
=== RUN   TestAccAWSOrganizations_serial/Organization
=== RUN   TestAccAWSOrganizations_serial/Organization/FeatureSet
=== RUN   TestAccAWSOrganizations_serial/Organization/DataSource
=== RUN   TestAccAWSOrganizations_serial/Organization/basic
=== RUN   TestAccAWSOrganizations_serial/Organization/AwsServiceAccessPrincipals
=== RUN   TestAccAWSOrganizations_serial/Organization/EnabledPolicyTypes
=== RUN   TestAccAWSOrganizations_serial/Account
=== RUN   TestAccAWSOrganizations_serial/Account/basic
    TestAccAWSOrganizations_serial/Account/basic: provider_test.go:31: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
=== RUN   TestAccAWSOrganizations_serial/Account/ParentId
    TestAccAWSOrganizations_serial/Account/ParentId: provider_test.go:31: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
=== RUN   TestAccAWSOrganizations_serial/Account/Tags
    TestAccAWSOrganizations_serial/Account/Tags: provider_test.go:31: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
=== RUN   TestAccAWSOrganizations_serial/OrganizationalUnit
=== RUN   TestAccAWSOrganizations_serial/OrganizationalUnit/basic
=== RUN   TestAccAWSOrganizations_serial/OrganizationalUnit/Name
=== RUN   TestAccAWSOrganizations_serial/OrganizationalUnits
=== RUN   TestAccAWSOrganizations_serial/OrganizationalUnits/DataSource
=== PAUSE TestAccAWSOrganizations_serial/OrganizationalUnits/DataSource
=== CONT  TestAccAWSOrganizations_serial/OrganizationalUnits/DataSource
--- PASS: TestAccAWSOrganizations_serial (1474.47s)
    --- PASS: TestAccAWSOrganizations_serial/Policy (454.25s)
        --- PASS: TestAccAWSOrganizations_serial/Policy/concurrent (57.52s)
        --- PASS: TestAccAWSOrganizations_serial/Policy/Description (80.83s)
        --- PASS: TestAccAWSOrganizations_serial/Policy/Type_AI_OPT_OUT (49.93s)
        --- PASS: TestAccAWSOrganizations_serial/Policy/Type_Backup (49.87s)
        --- PASS: TestAccAWSOrganizations_serial/Policy/Type_SCP (80.47s)
        --- PASS: TestAccAWSOrganizations_serial/Policy/Type_Tag (50.86s)
        --- PASS: TestAccAWSOrganizations_serial/Policy/basic (84.77s)
    --- PASS: TestAccAWSOrganizations_serial/PolicyAttachment (215.46s)
        --- PASS: TestAccAWSOrganizations_serial/PolicyAttachment/OrganizationalUnit (61.47s)
        --- PASS: TestAccAWSOrganizations_serial/PolicyAttachment/Root (56.62s)
        --- PASS: TestAccAWSOrganizations_serial/PolicyAttachment/Account (97.37s)
    --- PASS: TestAccAWSOrganizations_serial/Organization (610.79s)
        --- PASS: TestAccAWSOrganizations_serial/Organization/FeatureSet (45.07s)
        --- PASS: TestAccAWSOrganizations_serial/Organization/DataSource (93.76s)
        --- PASS: TestAccAWSOrganizations_serial/Organization/basic (46.80s)
        --- PASS: TestAccAWSOrganizations_serial/Organization/AwsServiceAccessPrincipals (114.98s)
        --- PASS: TestAccAWSOrganizations_serial/Organization/EnabledPolicyTypes (310.18s)
    --- PASS: TestAccAWSOrganizations_serial/Account (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/basic (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/ParentId (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/Tags (0.00s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit (145.83s)
        --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit/basic (53.89s)
        --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit/Name (91.95s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnits (0.00s)
        --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnits/DataSource (48.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1476.242s
```

Thank you for your review! 👍 
