### PR TITLE
Add note on how to use aws_wafv2_web_acl_association with Cloudfront

### DIFF
--- a/website/docs/r/wafv2_web_acl_association.html.markdown
+++ b/website/docs/r/wafv2_web_acl_association.html.markdown
@@ -10,6 +10,11 @@ description: |-
 
 Creates a WAFv2 Web ACL Association.
 
+~> **NOTE on associating a WAFv2 Web ACL with a Cloudfront distribution:** Do not use this resource to associate a WAFv2 Web ACL with a Cloudfront Distribution. The [AWS API call backing this resource][1] notes that you should use the [`web_acl_id`][2] property on the [`cloudfront_distribution`][2] instead.
+
+[1]: https://docs.aws.amazon.com/waf/latest/APIReference/API_AssociateWebACL.html
+[2]: /docs/providers/aws/r/cloudfront_distribution.html#web_acl_id
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
_Only changes Documentation._

The existing docs mention that this resource should only be used with an ALB or API Gateway, but doesn't mention how to get the association to work in Cloudfronts case. This PR ammends that.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
