### PR TITLE
Documentation: Replace aws_ec2_instance_spot_price by aws_ec2_spot_price

### DIFF
--- a/website/docs/d/ec2_spot_price.html.markdown
+++ b/website/docs/d/ec2_spot_price.html.markdown
@@ -1,19 +1,19 @@
 ---
 subcategory: "EC2"
 layout: "aws"
-page_title: "AWS: aws_ec2_instance_spot_price"
+page_title: "AWS: aws_ec2_spot_price"
 description: |-
   Information about most recent Spot Price for a given EC2 instance.
 ---
 
-# Data Source: aws_ec2_instance_spot_price
+# Data Source: aws_ec2_spot_price
 
 Information about most recent Spot Price for a given EC2 instance.
 
 ## Example Usage
 
 ```hcl
-data "aws_ec2_instance_spot_price" "example" {
+data "aws_ec2_spot_price" "example" {
   instance_type     = "t3.medium"
   availability_zone = "us-west-2a"
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

The data source is `aws_ec2_spot_price` but the documentation is showing `aws_ec2_instance_spot_price`.
This pull request is related to this issue: https://github.com/terraform-providers/terraform-provider-aws/issues/14674 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Correct the documentation by replacing `aws_ec2_instance_spot_price` by `aws_ec2_spot_price`
```
