### PR TITLE
tech-debt: add and replace acctest method for regex matching in typesets

### DIFF
--- a/aws/internal/tfawsresource/testing_test.go
+++ b/aws/internal/tfawsresource/testing_test.go
@@ -1,6 +1,7 @@
 package tfawsresource
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -954,6 +955,740 @@ func TestTestCheckTypeSetElemAttrPair(t *testing.T) {
 				testCase.FirstResourceAttribute,
 				testCase.SecondResourceAddress,
 				testCase.SecondResourceAttribute)(testCase.TerraformState)
+
+			if err != nil {
+				if testCase.ExpectedError == nil {
+					t.Fatalf("expected no error, got error: %s", err)
+				}
+
+				if !testCase.ExpectedError(err) {
+					t.Fatalf("unexpected error: %s", err)
+				}
+
+				t.Logf("received expected error: %s", err)
+				return
+			}
+
+			if err == nil && testCase.ExpectedError != nil {
+				t.Fatalf("expected error, got no error")
+			}
+		})
+	}
+}
+
+func TestTestMatchTypeSetElemNestedAttrs(t *testing.T) {
+	testCases := []struct {
+		Description       string
+		ResourceAddress   string
+		ResourceAttribute string
+		Values            map[string]*regexp.Regexp
+		TerraformState    *terraform.State
+		ExpectedError     func(err error) bool
+	}{
+		{
+			Description:       "no resources",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values:            map[string]*regexp.Regexp{},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:         []string{"root"},
+						Outputs:      map[string]*terraform.OutputState{},
+						Resources:    map[string]*terraform.ResourceState{},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "Not found: example_thing.test")
+			},
+		},
+		{
+			Description:       "resource not found",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values:            map[string]*regexp.Regexp{},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_other_thing.test": {
+								Type:     "example_other_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "Not found: example_thing.test")
+			},
+		},
+		{
+			Description:       "no primary instance",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values:            map[string]*regexp.Regexp{},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Deposed: []*terraform.InstanceState{
+									{
+										ID: "11111",
+										Meta: map[string]interface{}{
+											"schema_version": 0,
+										},
+										Attributes: map[string]string{
+											"%":  "1",
+											"id": "11111",
+										},
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "No primary instance: example_thing.test")
+			},
+		},
+		{
+			Description:       "value map has no non-empty values",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values:            map[string]*regexp.Regexp{"key": nil},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "has no non-empty values")
+			},
+		},
+		{
+			Description:       "attribute path does not end with sentinel value",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test",
+			Values:            map[string]*regexp.Regexp{},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "does not end with the special value")
+			},
+		},
+		{
+			Description:       "attribute not found",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values:            map[string]*regexp.Regexp{"key": regexp.MustCompile("value")},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.*\"")
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute single value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("value"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":               "3",
+										"id":              "11111",
+										"test.%":          "1",
+										"test.12345.key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute single value mismatch",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("2"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":               "3",
+										"id":              "11111",
+										"test.%":          "1",
+										"test.12345.key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.*\"")
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute single nested value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1.0.nested_key1": regexp.MustCompile("value"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                             "3",
+										"id":                            "11111",
+										"test.%":                        "1",
+										"test.12345.key1.0.nested_key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute single nested value mismatch",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1.0.nested_key1": regexp.MustCompile("2"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                             "3",
+										"id":                            "11111",
+										"test.%":                        "1",
+										"test.12345.key1.0.nested_key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.*\"")
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute multiple value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("value"),
+				"key2": regexp.MustCompile("value"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":               "4",
+										"id":              "11111",
+										"test.%":          "1",
+										"test.12345.key1": "value1",
+										"test.12345.key2": "value2",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute unset/empty value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("value"),
+				"key2": nil,
+				"key3": nil,
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":               "4",
+										"id":              "11111",
+										"test.%":          "1",
+										"test.12345.key1": "value1",
+										"test.12345.key2": "",
+										// key3 is unset
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute multiple value mismatch",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("1"),
+				"key2": regexp.MustCompile("3"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":               "4",
+										"id":              "11111",
+										"test.%":          "1",
+										"test.12345.key1": "value1",
+										"test.12345.key2": "value2",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.*\"")
+			},
+		},
+		{
+			Description:       "multiple root TypeSet attribute single value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("value1"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":               "4",
+										"id":              "11111",
+										"test.%":          "2",
+										"test.12345.key1": "value2",
+										"test.67890.key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "multiple root TypeSet attribute multiple value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("1"),
+				"key2": regexp.MustCompile("2"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":               "6",
+										"id":              "11111",
+										"test.%":          "2",
+										"test.12345.key1": "value2",
+										"test.12345.key2": "value3",
+										"test.67890.key1": "value1",
+										"test.67890.key2": "value2",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single nested TypeSet attribute single value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.0.nested_test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("value"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                             "4",
+										"id":                            "11111",
+										"test.%":                        "1",
+										"test.0.nested_test.%":          "1",
+										"test.0.nested_test.12345.key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single nested TypeSet attribute single value mismatch",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.0.nested_test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1": regexp.MustCompile("2"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                             "4",
+										"id":                            "11111",
+										"test.%":                        "1",
+										"test.0.nested_test.%":          "1",
+										"test.0.nested_test.12345.key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.0.nested_test.*\"")
+			},
+		},
+		{
+			Description:       "single nested TypeSet attribute single nested value match",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.0.nested_test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1.0.nested_key1": regexp.MustCompile("value"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                               "5",
+										"id":                              "11111",
+										"test.%":                          "1",
+										"test.0.nested_test.%":            "1",
+										"test.0.nested_test.12345.key1.%": "1",
+										"test.0.nested_test.12345.key1.0.nested_key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single nested TypeSet attribute single nested value mismatch",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "test.0.nested_test.*",
+			Values: map[string]*regexp.Regexp{
+				"key1.0.nested_key1": regexp.MustCompile("2"),
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                               "5",
+										"id":                              "11111",
+										"test.%":                          "1",
+										"test.0.nested_test.%":            "1",
+										"test.0.nested_test.12345.key1.%": "1",
+										"test.0.nested_test.12345.key1.0.nested_key1": "value1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"test.0.nested_test.*\"")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			err := TestMatchTypeSetElemNestedAttrs(testCase.ResourceAddress, testCase.ResourceAttribute, testCase.Values)(testCase.TerraformState)
 
 			if err != nil {
 				if testCase.ExpectedError == nil {

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -937,9 +937,6 @@ func TestAccAWSAutoScalingGroup_initialLifecycleHook(t *testing.T) {
 						"default_result": "CONTINUE",
 						"name":           "launching",
 					}),
-					// TODO: TypeSet check rewrite check to avoid hash reference
-					testAccCheckAWSAutoScalingGroupInitialLifecycleHookExists(
-						"aws_autoscaling_group.bar", "initial_lifecycle_hook.391359060.name"),
 				),
 			},
 			{
@@ -1120,26 +1117,6 @@ func testAccCheckAWSAutoScalingGroupExists(n string, group *autoscaling.Group) r
 		*group = *describeGroups.AutoScalingGroups[0]
 
 		return nil
-	}
-}
-
-func testAccCheckAWSAutoScalingGroupInitialLifecycleHookExists(asg, hookAttr string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		asgResource, ok := s.RootModule().Resources[asg]
-		if !ok {
-			return fmt.Errorf("Not found: %s", asg)
-		}
-
-		if asgResource.Primary.ID == "" {
-			return fmt.Errorf("No AutoScaling Group ID is set")
-		}
-
-		hookName := asgResource.Primary.Attributes[hookAttr]
-		if hookName == "" {
-			return fmt.Errorf("ASG %s has no hook name %s", asg, hookAttr)
-		}
-
-		return checkLifecycleHookExistsByName(asgResource.Primary.ID, hookName)
 	}
 }
 

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -534,23 +534,26 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 						"volume_size": "9",
 						"volume_type": "gp2",
 					}),
-					// TODO: TypeSet check develop regex support
-					resource.TestMatchResourceAttr(resourceName, "ebs_block_device.2576023345.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
+					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]*regexp.Regexp{
+						"volume_id": regexp.MustCompile("vol-[a-z0-9]+"),
+					}),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
 						"device_name": "/dev/sdc",
 						"volume_size": "10",
 						"volume_type": "io1",
 						"iops":        "100",
 					}),
-					// TODO: TypeSet check develop regex support
-					resource.TestMatchResourceAttr(resourceName, "ebs_block_device.2554893574.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
+					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]*regexp.Regexp{
+						"volume_id": regexp.MustCompile("vol-[a-z0-9]+"),
+					}),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]string{
 						"device_name": "/dev/sdd",
 						"encrypted":   "true",
 						"volume_size": "12",
 					}),
-					// TODO: TypeSet check develop regex support
-					resource.TestMatchResourceAttr(resourceName, "ebs_block_device.2634515331.volume_id", regexp.MustCompile("vol-[a-z0-9]+")),
+					tfawsresource.TestMatchTypeSetElemNestedAttrs(resourceName, "ebs_block_device.*", map[string]*regexp.Regexp{
+						"volume_id": regexp.MustCompile("vol-[a-z0-9]+"),
+					}),
 					resource.TestCheckResourceAttr(resourceName, "ephemeral_block_device.#", "1"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ephemeral_block_device.*", map[string]string{
 						"device_name":  "/dev/sde",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14686 
Relates #14383 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: add tfawsresource method for regex matching in typesets
tech-debt: replace TODO items related to regex matching in typset attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSInstance_blockDevices (115.20s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (194.08s)
--- PASS: TestAccAwsWafv2RuleGroup_IpSetReferenceStatement (28.85s)
--- PASS: TestAccAwsWafv2RuleGroup_RegexPatternSetReferenceStatement (29.60s)
--- PASS: TestAccAwsWafv2WebACL_RuleGroupReferenceStatement (458.32s)
```
