### PR TITLE
tests/provider: Update resource testing to 0.12 syntax (S3/Sa Resources)

### DIFF
--- a/aws/resource_aws_s3_access_point_test.go
+++ b/aws/resource_aws_s3_access_point_test.go
@@ -171,32 +171,43 @@ func TestAccAWSS3AccessPoint_Policy(t *testing.T) {
 	resourceName := "aws_s3_access_point.test"
 
 	expectedPolicyText1 := func() string {
-		return fmt.Sprintf(`
-		{
-		  "Version": "2012-10-17",
-		  "Statement": [{
-			"Sid": "",
-			"Effect": "Allow",
-			"Principal": {"AWS":"*"},
-			"Action": "s3:GetObjectTagging",
-			"Resource": ["arn:%s:s3:%s:%s:accesspoint/%s/object/*"]
-		  }]
-		}
-		`, testAccGetPartition(), testAccGetRegion(), testAccGetAccountID(), rName)
+		return fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:GetObjectTagging",
+      "Resource": [
+        "arn:%s:s3:%s:%s:accesspoint/%s/object/*"
+      ]
+    }
+  ]
+}`, testAccGetPartition(), testAccGetRegion(), testAccGetAccountID(), rName)
 	}
 	expectedPolicyText2 := func() string {
-		return fmt.Sprintf(`
-		{
-		  "Version": "2012-10-17",
-		  "Statement": [{
-			"Sid": "",
-			"Effect": "Allow",
-			"Principal": {"AWS":"*"},
-			"Action": ["s3:GetObjectLegalHold","s3:GetObjectRetention"],
-			"Resource": ["arn:%s:s3:%s:%s:accesspoint/%s/object/*"]
-		  }]
-		}
-		`, testAccGetPartition(), testAccGetRegion(), testAccGetAccountID(), rName)
+		return fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "s3:GetObjectLegalHold",
+        "s3:GetObjectRetention"
+      ],
+      "Resource": [
+        "arn:%s:s3:%s:%s:accesspoint/%s/object/*"
+      ]
+    }
+  ]
+}`, testAccGetPartition(), testAccGetRegion(), testAccGetAccountID(), rName)
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -460,7 +471,7 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
   name   = %[2]q
 }
 `, bucketName, accessPointName)
@@ -473,9 +484,9 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
-  policy = "${data.aws_iam_policy_document.test.json}"
+  policy = data.aws_iam_policy_document.test.json
 
   public_access_block_configuration {
     block_public_acls       = true
@@ -517,9 +528,9 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
-  policy = "${data.aws_iam_policy_document.test.json}"
+  policy = data.aws_iam_policy_document.test.json
 
   public_access_block_configuration {
     block_public_acls       = true
@@ -562,7 +573,7 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 
   public_access_block_configuration {
@@ -582,7 +593,7 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 
   public_access_block_configuration {
@@ -610,11 +621,11 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 
   vpc_configuration {
-    vpc_id = "${aws_vpc.test.id}"
+    vpc_id = aws_vpc.test.id
   }
 }
 `, rName)

--- a/aws/resource_aws_s3_account_public_access_block_test.go
+++ b/aws/resource_aws_s3_account_public_access_block_test.go
@@ -400,7 +400,7 @@ func testAccAWSS3AccountPublicAccessBlockConfigAccountId() string {
 data "aws_caller_identity" "test" {}
 
 resource "aws_s3_account_public_access_block" "test" {
-  account_id = "${data.aws_caller_identity.test.account_id}"
+  account_id = data.aws_caller_identity.test.account_id
 }
 `
 }

--- a/aws/resource_aws_s3_bucket_analytics_configuration_test.go
+++ b/aws/resource_aws_s3_bucket_analytics_configuration_test.go
@@ -677,6 +677,7 @@ resource "aws_s3_bucket_analytics_configuration" "test" {
   storage_class_analysis {
     data_export {
       output_schema_version = "V_1"
+
       destination {
         s3_bucket_destination {
           format     = "CSV"
@@ -1167,7 +1168,6 @@ func TestFlattenS3StorageClassAnalysis(t *testing.T) {
 								map[string]interface{}{
 									"s3_bucket_destination": []interface{}{
 										map[string]interface{}{
-
 											"bucket_arn": "arn:aws:s3",
 											"format":     s3.AnalyticsS3ExportFileFormatCsv,
 										},

--- a/aws/resource_aws_s3_bucket_inventory_test.go
+++ b/aws/resource_aws_s3_bucket_inventory_test.go
@@ -203,7 +203,7 @@ func testAccAWSS3BucketInventoryConfig(bucketName, inventoryName string) string 
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket_inventory" "test" {
-  bucket = "${aws_s3_bucket.test.id}"
+  bucket = aws_s3_bucket.test.id
   name   = %[1]q
 
   included_object_versions = "All"
@@ -224,8 +224,8 @@ resource "aws_s3_bucket_inventory" "test" {
   destination {
     bucket {
       format     = "ORC"
-      bucket_arn = "${aws_s3_bucket.test.arn}"
-      account_id = "${data.aws_caller_identity.current.account_id}"
+      bucket_arn = aws_s3_bucket.test.arn
+      account_id = data.aws_caller_identity.current.account_id
       prefix     = "inventory"
     }
   }
@@ -236,7 +236,7 @@ resource "aws_s3_bucket_inventory" "test" {
 func testAccAWSS3BucketInventoryConfigEncryptWithSSES3(bucketName, inventoryName string) string {
 	return testAccAWSS3BucketInventoryConfigBucket(bucketName) + fmt.Sprintf(`
 resource "aws_s3_bucket_inventory" "test" {
-  bucket = "${aws_s3_bucket.test.id}"
+  bucket = aws_s3_bucket.test.id
   name   = %[1]q
 
   included_object_versions = "Current"
@@ -248,7 +248,7 @@ resource "aws_s3_bucket_inventory" "test" {
   destination {
     bucket {
       format     = "CSV"
-      bucket_arn = "${aws_s3_bucket.test.arn}"
+      bucket_arn = aws_s3_bucket.test.arn
 
       encryption {
         sse_s3 {}
@@ -267,7 +267,7 @@ resource "aws_kms_key" "test" {
 }
 
 resource "aws_s3_bucket_inventory" "test" {
-  bucket = "${aws_s3_bucket.test.id}"
+  bucket = aws_s3_bucket.test.id
   name   = %[2]q
 
   included_object_versions = "Current"
@@ -279,11 +279,11 @@ resource "aws_s3_bucket_inventory" "test" {
   destination {
     bucket {
       format     = "Parquet"
-      bucket_arn = "${aws_s3_bucket.test.arn}"
+      bucket_arn = aws_s3_bucket.test.arn
 
       encryption {
         sse_kms {
-          key_id = "${aws_kms_key.test.arn}"
+          key_id = aws_kms_key.test.arn
         }
       }
     }

--- a/aws/resource_aws_s3_bucket_metric_test.go
+++ b/aws/resource_aws_s3_bucket_metric_test.go
@@ -636,8 +636,9 @@ func testAccAWSS3BucketMetricsConfigWithEmptyFilter(bucketName, metricName strin
 %s
 
 resource "aws_s3_bucket_metric" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
-  name = "%s"
+  bucket = aws_s3_bucket.bucket.id
+  name   = "%s"
+
   filter {}
 }
 `, testAccAWSS3BucketMetricsConfigBucket(bucketName), metricName)
@@ -648,7 +649,7 @@ func testAccAWSS3BucketMetricsConfigWithFilterPrefix(bucketName, metricName, pre
 %s
 
 resource "aws_s3_bucket_metric" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
   name   = "%s"
 
   filter {
@@ -663,7 +664,7 @@ func testAccAWSS3BucketMetricsConfigWithFilterPrefixAndMultipleTags(bucketName, 
 %s
 
 resource "aws_s3_bucket_metric" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
   name   = "%s"
 
   filter {
@@ -683,7 +684,7 @@ func testAccAWSS3BucketMetricsConfigWithFilterPrefixAndSingleTag(bucketName, met
 %s
 
 resource "aws_s3_bucket_metric" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
   name   = "%s"
 
   filter {
@@ -702,7 +703,7 @@ func testAccAWSS3BucketMetricsConfigWithFilterMultipleTags(bucketName, metricNam
 %s
 
 resource "aws_s3_bucket_metric" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
   name   = "%s"
 
   filter {
@@ -720,7 +721,7 @@ func testAccAWSS3BucketMetricsConfigWithFilterSingleTag(bucketName, metricName, 
 %s
 
 resource "aws_s3_bucket_metric" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
   name   = "%s"
 
   filter {
@@ -737,7 +738,7 @@ func testAccAWSS3BucketMetricsConfigWithoutFilter(bucketName, metricName string)
 %s
 
 resource "aws_s3_bucket_metric" "test" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
   name   = "%s"
 }
 `, testAccAWSS3BucketMetricsConfigBucket(bucketName), metricName)

--- a/aws/resource_aws_s3_bucket_notification_test.go
+++ b/aws/resource_aws_s3_bucket_notification_test.go
@@ -477,19 +477,26 @@ resource "aws_sns_topic" "topic" {
 
   policy = <<POLICY
 {
-	"Version":"2012-10-17",
-	"Statement":[{
-		"Sid": "",
-		"Effect": "Allow",
-		"Principal": {"AWS":"*"},
-		"Action": "SNS:Publish",
-		"Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
-		"Condition":{
-			"ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
-		}
-	}]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "${aws_s3_bucket.bucket.arn}"
+        }
+      }
+    }
+  ]
 }
 POLICY
+
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -498,11 +505,11 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   topic {
     id        = "notification-sns1"
-    topic_arn = "${aws_sns_topic.topic.arn}"
+    topic_arn = aws_sns_topic.topic.arn
 
     events = [
       "s3:ObjectCreated:*",
@@ -515,7 +522,7 @@ resource "aws_s3_bucket_notification" "notification" {
 
   topic {
     id        = "notification-sns2"
-    topic_arn = "${aws_sns_topic.topic.arn}"
+    topic_arn = aws_sns_topic.topic.arn
 
     events = [
       "s3:ObjectCreated:*",
@@ -537,20 +544,23 @@ resource "aws_sqs_queue" "queue" {
 
   policy = <<POLICY
 {
-	"Version":"2012-10-17",
-	"Statement": [{
-		"Effect":"Allow",
-		"Principal":"*",
-		"Action":"sqs:SendMessage",
-		"Resource":"arn:${data.aws_partition.current.partition}:sqs:*:*:%[1]s",
-		"Condition":{
-			"ArnEquals":{
-				"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"
-			}
-		}
-	}]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:${data.aws_partition.current.partition}:sqs:*:*:%[1]s",
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "${aws_s3_bucket.bucket.arn}"
+        }
+      }
+    }
+  ]
 }
 POLICY
+
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -559,11 +569,11 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   queue {
     id        = "notification-sqs"
-    queue_arn = "${aws_sqs_queue.queue.arn}"
+    queue_arn = aws_sqs_queue.queue.arn
 
     events = [
       "s3:ObjectCreated:*",
@@ -597,20 +607,21 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 EOF
+
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.func.arn}"
+  function_name = aws_lambda_function.func.arn
   principal     = "s3.amazonaws.com"
-  source_arn    = "${aws_s3_bucket.bucket.arn}"
+  source_arn    = aws_s3_bucket.bucket.arn
 }
 
 resource "aws_lambda_function" "func" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   runtime       = "nodejs12.x"
 }
@@ -621,11 +632,11 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   lambda_function {
     id                  = "notification-lambda"
-    lambda_function_arn = "${aws_lambda_function.func.arn}"
+    lambda_function_arn = aws_lambda_function.func.arn
 
     events = [
       "s3:ObjectCreated:*",
@@ -642,30 +653,44 @@ resource "aws_s3_bucket_notification" "notification" {
 func testAccAWSS3BucketNotificationConfigLambdaFunctionLambdaFunctionArnAlias(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
-  name               = %[1]q
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+
+  name = %[1]q
 }
 
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   handler       = "exports.example"
-  role          = "${aws_iam_role.test.arn}"
+  role          = aws_iam_role.test.arn
   runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_alias" "test" {
-  function_name    = "${aws_lambda_function.test.arn}"
+  function_name    = aws_lambda_function.test.arn
   function_version = "$LATEST"
   name             = "testalias"
 }
 
 resource "aws_lambda_permission" "test" {
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.test.arn}"
+  function_name = aws_lambda_function.test.arn
   principal     = "s3.amazonaws.com"
-  qualifier     = "${aws_lambda_alias.test.name}"
-  source_arn    = "${aws_s3_bucket.test.arn}"
+  qualifier     = aws_lambda_alias.test.name
+  source_arn    = aws_s3_bucket.test.arn
   statement_id  = "AllowExecutionFromS3Bucket"
 }
 
@@ -675,12 +700,12 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_bucket_notification" "test" {
-  bucket = "${aws_s3_bucket.test.id}"
+  bucket = aws_s3_bucket.test.id
 
   lambda_function {
     events              = ["s3:ObjectCreated:*"]
     id                  = "test"
-    lambda_function_arn = "${aws_lambda_alias.test.arn}"
+    lambda_function_arn = aws_lambda_alias.test.arn
   }
 }
 `, rName)
@@ -695,19 +720,26 @@ resource "aws_sns_topic" "topic" {
 
   policy = <<POLICY
 {
-	"Version":"2012-10-17",
-	"Statement":[{
-		"Sid": "",
-		"Effect": "Allow",
-		"Principal": {"AWS":"*"},
-		"Action": "SNS:Publish",
-		"Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
-		"Condition":{
-			"ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
-		}
-	}]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "${aws_s3_bucket.bucket.arn}"
+        }
+      }
+    }
+  ]
 }
 POLICY
+
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -716,11 +748,11 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "notification" {
-  bucket = "${aws_s3_bucket.bucket.id}"
+  bucket = aws_s3_bucket.bucket.id
 
   topic {
     id        = "notification-sns1"
-    topic_arn = "${aws_sns_topic.topic.arn}"
+    topic_arn = aws_sns_topic.topic.arn
 
     events = [
       "s3:ObjectCreated:*",

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -1158,8 +1158,8 @@ func testAccAWSS3BucketObjectCreateTempFile(t *testing.T, data string) string {
 func testAccAWSS3BucketObjectConfigBasic(bucket, key string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket_object" "object" {
-  bucket = "%s"
-  key = "%s"
+  bucket = %q
+  key    = %q
 }
 `, bucket, key)
 }
@@ -1171,8 +1171,8 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "test-key"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "test-key"
 }
 `, randInt)
 }
@@ -1184,9 +1184,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket       = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket       = aws_s3_bucket.object_bucket.bucket
   key          = "test-key"
-  source       = "%s"
+  source       = %q
   content_type = "binary/octet-stream"
 }
 `, randInt, source)
@@ -1199,9 +1199,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket           = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket           = aws_s3_bucket.object_bucket.bucket
   key              = "test-key"
-  source           = "%s"
+  source           = %q
   content_language = "en"
   content_type     = "binary/octet-stream"
   website_redirect = "http://google.com"
@@ -1216,9 +1216,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket  = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket  = aws_s3_bucket.object_bucket.bucket
   key     = "test-key"
-  content = "%s"
+  content = %q
 }
 `, randInt, content)
 }
@@ -1230,13 +1230,13 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket  = "${aws_s3_bucket.object_bucket.bucket}"
-  key     = "test-key"
-  source = "%s"
+  bucket                 = aws_s3_bucket.object_bucket.bucket
+  key                    = "test-key"
   server_side_encryption = "AES256"
-  etag = "${filemd5("%s")}"
+  source                 = %[1]q
+  etag                   = filemd5(%[1]q)
 }
-`, randInt, source, source)
+`, randInt, source)
 }
 
 func testAccAWSS3BucketObjectConfigContentBase64(randInt int, contentBase64 string) string {
@@ -1246,9 +1246,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket         = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket         = aws_s3_bucket.object_bucket.bucket
   key            = "test-key"
-  content_base64 = "%s"
+  content_base64 = %q
 }
 `, randInt, contentBase64)
 }
@@ -1264,12 +1264,12 @@ resource "aws_s3_bucket" "object_bucket_3" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket_3.bucket}"
+  bucket = aws_s3_bucket.object_bucket_3.bucket
   key    = "updateable-key"
-  source = "%s"
-  etag   = "${filemd5("%s")}"
+  source = %[3]q
+  etag   = filemd5(%[3]q)
 }
-`, randInt, bucketVersioning, source, source)
+`, randInt, bucketVersioning, source)
 }
 
 func testAccAWSS3BucketObjectConfig_updateableViaAccessPoint(rName string, bucketVersioning bool, source string) string {
@@ -1283,15 +1283,15 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_access_point" "test" {
-  bucket = "${aws_s3_bucket.test.bucket}"
+  bucket = aws_s3_bucket.test.bucket
   name   = %[1]q
 }
 
 resource "aws_s3_bucket_object" "test" {
-  bucket = "${aws_s3_access_point.test.arn}"
+  bucket = aws_s3_access_point.test.arn
   key    = "updateable-key"
   source = %[3]q
-  etag   = "${filemd5(%[3]q)}"
+  etag   = filemd5(%[3]q)
 }
 `, rName, bucketVersioning, source)
 }
@@ -1305,10 +1305,10 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket     = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket     = aws_s3_bucket.object_bucket.bucket
   key        = "test-key"
-  source     = "%s"
-  kms_key_id = "${aws_kms_key.kms_key_1.arn}"
+  source     = %q
+  kms_key_id = aws_kms_key.kms_key_1.arn
 }
 `, randInt, source)
 }
@@ -1320,9 +1320,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket                 = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket                 = aws_s3_bucket.object_bucket.bucket
   key                    = "test-key"
-  source                 = "%s"
+  source                 = %q
   server_side_encryption = "AES256"
 }
 `, randInt, source)
@@ -1339,10 +1339,10 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket  = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket  = aws_s3_bucket.object_bucket.bucket
   key     = "test-key"
-  content = "%s"
-  acl     = "%s"
+  content = %q
+  acl     = %q
 }
 `, randInt, content, acl)
 }
@@ -1354,10 +1354,10 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket        = "${aws_s3_bucket.object_bucket.bucket}"
+  bucket        = aws_s3_bucket.object_bucket.bucket
   key           = "test-key"
   content       = "some_bucket_content"
-  storage_class = "%s"
+  storage_class = %q
 }
 `, randInt, storage_class)
 }
@@ -1373,9 +1373,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket  = "${aws_s3_bucket.object_bucket.bucket}"
-  key     = "%s"
-  content = "%s"
+  bucket  = aws_s3_bucket.object_bucket.bucket
+  key     = %q
+  content = %q
 
   tags = {
     Key1 = "AAA"
@@ -1397,9 +1397,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket  = "${aws_s3_bucket.object_bucket.bucket}"
-  key     = "%s"
-  content = "%s"
+  bucket  = aws_s3_bucket.object_bucket.bucket
+  key     = %q
+  content = %q
 
   tags = {
     Key2 = "BBB"
@@ -1422,9 +1422,9 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket  = "${aws_s3_bucket.object_bucket.bucket}"
-  key     = "%s"
-  content = "%s"
+  bucket  = aws_s3_bucket.object_bucket.bucket
+  key     = %q
+  content = %q
 }
 `, randInt, key, content)
 }
@@ -1436,8 +1436,8 @@ resource "aws_s3_bucket" "object_bucket" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket  = "${aws_s3_bucket.object_bucket.bucket}"
-  key     = "test-key"
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = "test-key"
 
   metadata = {
     %[2]s = %[3]q
@@ -1451,18 +1451,20 @@ func testAccAWSS3BucketObjectConfig_noObjectLockLegalHold(randInt int, content s
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%d"
+
   versioning {
     enabled = true
   }
+
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "test-key"
-  content = "%s"
+  bucket        = aws_s3_bucket.object_bucket.bucket
+  key           = "test-key"
+  content       = %q
   force_destroy = true
 }
 `, randInt, content)
@@ -1472,20 +1474,22 @@ func testAccAWSS3BucketObjectConfig_withObjectLockLegalHold(randInt int, content
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%d"
+
   versioning {
     enabled = true
   }
+
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "test-key"
-  content = "%s"
-  object_lock_legal_hold_status = "%s"
-  force_destroy = true
+  bucket                        = aws_s3_bucket.object_bucket.bucket
+  key                           = "test-key"
+  content                       = %q
+  object_lock_legal_hold_status = %q
+  force_destroy                 = true
 }
 `, randInt, content, legalHoldStatus)
 }
@@ -1494,18 +1498,20 @@ func testAccAWSS3BucketObjectConfig_noObjectLockRetention(randInt int, content s
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%d"
+
   versioning {
     enabled = true
   }
+
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "test-key"
-  content = "%s"
+  bucket        = aws_s3_bucket.object_bucket.bucket
+  key           = "test-key"
+  content       = %q
   force_destroy = true
 }
 `, randInt, content)
@@ -1515,56 +1521,59 @@ func testAccAWSS3BucketObjectConfig_withObjectLockRetention(randInt int, content
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
   bucket = "tf-object-test-bucket-%d"
+
   versioning {
     enabled = true
   }
+
   object_lock_configuration {
     object_lock_enabled = "Enabled"
   }
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket.bucket}"
-  key = "test-key"
-  content = "%s"
-  force_destroy = true
-  object_lock_mode = "GOVERNANCE"
-  object_lock_retain_until_date = "%s"
+  bucket                        = aws_s3_bucket.object_bucket.bucket
+  key                           = "test-key"
+  content                       = %q
+  force_destroy                 = true
+  object_lock_mode              = "GOVERNANCE"
+  object_lock_retain_until_date = %q
 }
 `, randInt, content, retainUntilDate)
 }
 
 func testAccAWSS3BucketObjectConfig_NonVersioned(randInt int, source string) string {
 	policy := `{
-		"Version": "2012-10-17",
-		"Statement": [
-			{
-				"Sid": "AllowYeah",
-				"Effect": "Allow",
-				"Action": "s3:*",
-				"Resource": "*"
-			},
-			{
-				"Sid":    "DenyStm1",
-				"Effect": "Deny",
-				"Action": [
-					"s3:GetObjectVersion*",
-					"s3:ListBucketVersions"
-				],
-				"Resource": "*"
-			}
-		]
-	}`
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowYeah",
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyStm1",
+      "Effect": "Deny",
+      "Action": [
+        "s3:GetObjectVersion*",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": "*"
+    }
+  ]
+}`
+
 	return testAccProviderConfigAssumeRolePolicy(policy) + fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket_3" {
   bucket = "tf-object-test-bucket-%d"
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket = "${aws_s3_bucket.object_bucket_3.bucket}"
+  bucket = aws_s3_bucket.object_bucket_3.bucket
   key    = "updateable-key"
-  source = "%s"
-  etag   = "${filemd5("%s")}"
+  source = %[1]q
+  etag   = filemd5(%[1]q)
 }
-`, randInt, source, source)
+`, randInt, source)
 }

--- a/aws/resource_aws_s3_bucket_policy_test.go
+++ b/aws/resource_aws_s3_bucket_policy_test.go
@@ -17,16 +17,22 @@ func TestAccAWSS3BucketPolicy_basic(t *testing.T) {
 	partition := testAccGetPartition()
 
 	expectedPolicyText := fmt.Sprintf(`{
-	"Version": "2012-10-17",
-	"Statement": [{
-		"Sid": "",
-		"Effect": "Allow",
-		"Principal": {"AWS":"*"},
-		"Action": "s3:*",
-		"Resource": ["arn:%s:s3:::%s/*","arn:%s:s3:::%s"]
-	}]
-}
-`, partition, name, partition, name)
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:*",
+      "Resource": [
+        "arn:%s:s3:::%s/*",
+        "arn:%s:s3:::%s"
+      ]
+    }
+  ]
+}`, partition, name, partition, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,28 +60,44 @@ func TestAccAWSS3BucketPolicy_policyUpdate(t *testing.T) {
 	partition := testAccGetPartition()
 
 	expectedPolicyText1 := fmt.Sprintf(`{
-	"Version": "2012-10-17",
-	"Statement": [{
-		"Sid": "",
-		"Effect": "Allow",
-		"Principal": {"AWS":"*"},
-		"Action": "s3:*",
-		"Resource": ["arn:%s:s3:::%s/*","arn:%s:s3:::%s"]
-	}]
-}
-`, partition, name, partition, name)
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:*",
+      "Resource": [
+        "arn:%[1]s:s3:::%[2]s/*",
+        "arn:%[1]s:s3:::%[2]s"
+      ]
+    }
+  ]
+}`, partition, name)
 
 	expectedPolicyText2 := fmt.Sprintf(`{
-	"Version":"2012-10-17",
-	"Statement":[{
-		"Sid": "",
-		"Effect": "Allow",
-		"Principal": {"AWS":"*"},
-		"Action": ["s3:DeleteBucket", "s3:ListBucket", "s3:ListBucketVersions"],
-		"Resource": ["arn:%s:s3:::%s/*","arn:%s:s3:::%s"]
-	}]
-}
-`, partition, name, partition, name)
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "s3:DeleteBucket",
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:%[1]s:s3:::%[2]s/*",
+        "arn:%[1]s:s3:::%[2]s"
+      ]
+    }
+  ]
+}`, partition, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -153,8 +175,8 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_policy" "bucket" {
-  bucket = "${aws_s3_bucket.bucket.bucket}"
-  policy = "${data.aws_iam_policy_document.policy.json}"
+  bucket = aws_s3_bucket.bucket.bucket
+  policy = data.aws_iam_policy_document.policy.json
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -166,7 +188,7 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "${aws_s3_bucket.bucket.arn}",
+      aws_s3_bucket.bucket.arn,
       "${aws_s3_bucket.bucket.arn}/*",
     ]
 
@@ -190,8 +212,8 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_policy" "bucket" {
-  bucket = "${aws_s3_bucket.bucket.bucket}"
-  policy = "${data.aws_iam_policy_document.policy.json}"
+  bucket = aws_s3_bucket.bucket.bucket
+  policy = data.aws_iam_policy_document.policy.json
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -205,7 +227,7 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "${aws_s3_bucket.bucket.arn}",
+      aws_s3_bucket.bucket.arn,
       "${aws_s3_bucket.bucket.arn}/*",
     ]
 

--- a/aws/resource_aws_s3_bucket_public_access_block_test.go
+++ b/aws/resource_aws_s3_bucket_public_access_block_test.go
@@ -349,7 +349,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {
-  bucket = "${aws_s3_bucket.bucket.bucket}"
+  bucket = aws_s3_bucket.bucket.bucket
 
   block_public_acls       = "%s"
   block_public_policy     = "%s"

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -259,7 +259,6 @@ func TestAccAWSS3Bucket_tagsWithNoSystemTags(t *testing.T) {
 				),
 			},
 			{
-
 				Config: testAccAWSS3BucketConfig_withNoTags(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists(resourceName),
@@ -352,7 +351,6 @@ func TestAccAWSS3Bucket_tagsWithSystemTags(t *testing.T) {
 				),
 			},
 			{
-
 				Config: testAccAWSS3BucketConfig_withNoTags(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketExists(resourceName),
@@ -2508,18 +2506,16 @@ func testAccCheckAWSS3BucketCreateViaCloudFormation(n string, stackId *string) r
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).cfconn
 		stackName := acctest.RandomWithPrefix("tf-acc-test-s3tags")
-		templateBody := fmt.Sprintf(`
-        {
-            "Resources": {
-                "TfTestBucket": {
-                    "Type": "AWS::S3::Bucket",
-                    "Properties": {
-                        "BucketName": "%s",
-                    }
-                }
-            }
-        }
-        `, n)
+		templateBody := fmt.Sprintf(`{
+  "Resources": {
+    "TfTestBucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketName": "%s"
+      }
+    }
+  }
+}`, n)
 
 		req := &cloudformation.CreateStackInput{
 			StackName:    aws.String(stackName),
@@ -2972,18 +2968,19 @@ func testAccCheckS3BucketWebsiteEndpoint(resourceName string, attributeName stri
 
 func testAccAWSS3BucketPolicy(bucketName, partition string) string {
 	return fmt.Sprintf(`{
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid": "",
-			"Effect": "Allow",
-			"Principal": {"AWS": "*"},
-			"Action": "s3:GetObject",
-			"Resource": "arn:%[1]s:s3:::%[2]s/*"
-		}
-	]
-}
-`, partition, bucketName)
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:%[1]s:s3:::%[2]s/*"
+    }
+  ]
+}`, partition, bucketName)
 }
 
 func testAccAWSS3BucketConfig_Basic(bucketName string) string {
@@ -2997,8 +2994,8 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfig_withNoTags(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = %[1]q
-  acl = "private"
+  bucket        = %[1]q
+  acl           = "private"
   force_destroy = false
 }
 `, bucketName)
@@ -3007,9 +3004,10 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfig_withTags(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = %[1]q
-  acl = "private"
+  bucket        = %[1]q
+  acl           = "private"
   force_destroy = false
+
   tags = {
     Key1 = "AAA"
     Key2 = "BBB"
@@ -3022,9 +3020,10 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfig_withUpdatedTags(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = %[1]q
-  acl = "private"
+  bucket        = %[1]q
+  acl           = "private"
   force_destroy = false
+
   tags = {
     Key2 = "BBB"
     Key3 = "XXX"
@@ -3169,15 +3168,18 @@ resource "aws_s3_bucket" "bucket" {
     error_document = "error.html"
 
     routing_rules = <<EOF
-[{
-	"Condition": {
-		"KeyPrefixEquals": "docs/"
-	},
-	"Redirect": {
-		"ReplaceKeyPrefixWith": "documents/"
-	}
-}]
+[
+  {
+    "Condition": {
+      "KeyPrefixEquals": "docs/"
+    },
+    "Redirect": {
+      "ReplaceKeyPrefixWith": "documents/"
+    }
+  }
+]
 EOF
+
   }
 }
 `, bucketName)
@@ -3251,7 +3253,7 @@ resource "aws_s3_bucket" "arbitrary" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = "${aws_kms_key.arbitrary.arn}"
+        kms_master_key_id = aws_kms_key.arbitrary.arn
         sse_algorithm     = "aws:kms"
       }
     }
@@ -3369,8 +3371,8 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigWithAcl(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-	bucket = %[1]q
-	acl    = "public-read"
+  bucket = %[1]q
+  acl    = "public-read"
 }
 `, bucketName)
 }
@@ -3378,8 +3380,8 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigWithAclUpdate(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-	bucket = %[1]q
-	acl    = "private"
+  bucket = %[1]q
+  acl    = "private"
 }
 `, bucketName)
 }
@@ -3389,12 +3391,13 @@ func testAccAWSS3BucketConfigWithGrants(bucketName string) string {
 data "aws_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "bucket" {
-	bucket = %[1]q
-	grant {
-        id = "${data.aws_canonical_user_id.current.id}"
-        type = "CanonicalUser"
-        permissions = ["FULL_CONTROL", "WRITE"]
-    }
+  bucket = %[1]q
+
+  grant {
+    id          = data.aws_canonical_user_id.current.id
+    type        = "CanonicalUser"
+    permissions = ["FULL_CONTROL", "WRITE"]
+  }
 }
 `, bucketName)
 }
@@ -3404,17 +3407,19 @@ func testAccAWSS3BucketConfigWithGrantsUpdate(bucketName string) string {
 data "aws_canonical_user_id" "current" {}
 
 resource "aws_s3_bucket" "bucket" {
-	bucket = %[1]q
-	grant {
-        id = "${data.aws_canonical_user_id.current.id}"
-        type = "CanonicalUser"
-        permissions = ["READ"]
-    }
-    grant {
-        type = "Group"
-        permissions = ["READ_ACP"]
-        uri = "http://acs.amazonaws.com/groups/s3/LogDelivery"
-    }
+  bucket = %[1]q
+
+  grant {
+    id          = data.aws_canonical_user_id.current.id
+    type        = "CanonicalUser"
+    permissions = ["READ"]
+  }
+
+  grant {
+    type        = "Group"
+    permissions = ["READ_ACP"]
+    uri         = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+  }
 }
 `, bucketName)
 }
@@ -3431,7 +3436,7 @@ resource "aws_s3_bucket" "bucket" {
   acl    = "private"
 
   logging {
-    target_bucket = "${aws_s3_bucket.log_bucket.id}"
+    target_bucket = aws_s3_bucket.log_bucket.id
     target_prefix = "log/"
   }
 }
@@ -3514,33 +3519,35 @@ resource "aws_s3_bucket" "bucket" {
       date = "2016-01-12"
     }
   }
-	lifecycle_rule {
-		id = "id5"
-		enabled = true
 
-		tags = {
-			"tagKey" = "tagValue"
-			"terraform" = "hashicorp"
-		}
+  lifecycle_rule {
+    id      = "id5"
+    enabled = true
 
-		transition {
-			days = 0
-			storage_class = "GLACIER"
-		}
-	}
-	lifecycle_rule {
-		id = "id6"
-		enabled = true
+    tags = {
+      "tagKey"    = "tagValue"
+      "terraform" = "hashicorp"
+    }
 
-		tags = {
-			"tagKey" = "tagValue"
-		}
+    transition {
+      days          = 0
+      storage_class = "GLACIER"
+    }
+  }
 
-		transition {
-			days = 0
-			storage_class = "GLACIER"
-		}
-	}
+  lifecycle_rule {
+    id      = "id6"
+    enabled = true
+
+    tags = {
+      "tagKey" = "tagValue"
+    }
+
+    transition {
+      days          = 0
+      storage_class = "GLACIER"
+    }
+  }
 }
 `, bucketName)
 }
@@ -3638,7 +3645,8 @@ func testAccAWSS3BucketConfigReplicationBasic(randInt int) string {
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "role" {
-  name               = "tf-iam-role-replication-%[1]d"
+  name = "tf-iam-role-replication-%[1]d"
+
   assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -3654,6 +3662,7 @@ resource "aws_iam_role" "role" {
   ]
 }
 POLICY
+
 }
 
 resource "aws_s3_bucket" "destination" {
@@ -3670,12 +3679,12 @@ resource "aws_s3_bucket" "destination" {
 func testAccAWSS3BucketConfigReplication(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
-    }
+  versioning {
+    enabled = true
+  }
 }
 `, randInt)
 }
@@ -3683,26 +3692,27 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationWithConfiguration(randInt int, storageClass string) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = aws_iam_role.role.arn
+
+    rules {
+      id     = "foobar"
+      prefix = "foo"
+      status = "Enabled"
+
+      destination {
+        bucket        = aws_s3_bucket.destination.arn
+        storage_class = "%[2]s"
+      }
     }
-
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            prefix = "foo"
-            status = "Enabled"
-
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "%[2]s"
-            }
-        }
-    }
+  }
 }
 `, randInt, storageClass)
 }
@@ -3716,33 +3726,34 @@ resource "aws_kms_key" "replica" {
 }
 
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
-    }
+  versioning {
+    enabled = true
+  }
 
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            prefix = "foo"
-            status = "Enabled"
+  replication_configuration {
+    role = aws_iam_role.role.arn
 
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "STANDARD"
-                replica_kms_key_id = "${aws_kms_key.replica.arn}"
-            }
+    rules {
+      id     = "foobar"
+      prefix = "foo"
+      status = "Enabled"
 
-            source_selection_criteria {
-                sse_kms_encrypted_objects {
-                  enabled = true
-                }
-            }
+      destination {
+        bucket             = aws_s3_bucket.destination.arn
+        storage_class      = "STANDARD"
+        replica_kms_key_id = aws_kms_key.replica.arn
+      }
+
+      source_selection_criteria {
+        sse_kms_encrypted_objects {
+          enabled = true
         }
+      }
     }
+  }
 }
 `, randInt)
 }
@@ -3752,31 +3763,32 @@ func testAccAWSS3BucketConfigReplicationWithAccessControlTranslation(randInt int
 data "aws_caller_identity" "current" {}
 
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
-    }
+  versioning {
+    enabled = true
+  }
 
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            prefix = "foo"
-            status = "Enabled"
+  replication_configuration {
+    role = aws_iam_role.role.arn
 
-            destination {
-                account_id         = "${data.aws_caller_identity.current.account_id}"
-                bucket             = "${aws_s3_bucket.destination.arn}"
-                storage_class      = "STANDARD"
+    rules {
+      id     = "foobar"
+      prefix = "foo"
+      status = "Enabled"
 
-                access_control_translation {
-                    owner = "Destination"
-                }
-            }
+      destination {
+        account_id    = data.aws_caller_identity.current.account_id
+        bucket        = aws_s3_bucket.destination.arn
+        storage_class = "STANDARD"
+
+        access_control_translation {
+          owner = "Destination"
         }
+      }
     }
+  }
 }
 `, randInt)
 }
@@ -3823,38 +3835,39 @@ resource "aws_kms_key" "replica" {
 }
 
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
-    }
+  versioning {
+    enabled = true
+  }
 
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            prefix = "foo"
-            status = "Enabled"
+  replication_configuration {
+    role = aws_iam_role.role.arn
 
-            destination {
-                account_id         = "${data.aws_caller_identity.current.account_id}"
-                bucket             = "${aws_s3_bucket.destination.arn}"
-                storage_class      = "STANDARD"
-                replica_kms_key_id = "${aws_kms_key.replica.arn}"
+    rules {
+      id     = "foobar"
+      prefix = "foo"
+      status = "Enabled"
 
-                access_control_translation {
-                    owner = "Destination"
-                }
-            }
+      destination {
+        account_id         = data.aws_caller_identity.current.account_id
+        bucket             = aws_s3_bucket.destination.arn
+        storage_class      = "STANDARD"
+        replica_kms_key_id = aws_kms_key.replica.arn
 
-            source_selection_criteria {
-                sse_kms_encrypted_objects {
-                  enabled = true
-                }
-            }
+        access_control_translation {
+          owner = "Destination"
         }
+      }
+
+      source_selection_criteria {
+        sse_kms_encrypted_objects {
+          enabled = true
+        }
+      }
     }
+  }
 }
 `, randInt)
 }
@@ -3862,25 +3875,26 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationWithoutStorageClass(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = aws_iam_role.role.arn
+
+    rules {
+      id     = "foobar"
+      prefix = "foo"
+      status = "Enabled"
+
+      destination {
+        bucket = aws_s3_bucket.destination.arn
+      }
     }
-
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            prefix = "foo"
-            status = "Enabled"
-
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-            }
-        }
-    }
+  }
 }
 `, randInt)
 }
@@ -3888,25 +3902,26 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationWithoutPrefix(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = aws_iam_role.role.arn
+
+    rules {
+      id     = "foobar"
+      status = "Enabled"
+
+      destination {
+        bucket        = aws_s3_bucket.destination.arn
+        storage_class = "STANDARD"
+      }
     }
-
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            status = "Enabled"
-
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "STANDARD"
-            }
-        }
-    }
+  }
 }
 `, randInt)
 }
@@ -3914,22 +3929,23 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationNoVersioning(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            prefix = "foo"
-            status = "Enabled"
+  replication_configuration {
+    role = aws_iam_role.role.arn
 
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "STANDARD"
-            }
-        }
+    rules {
+      id     = "foobar"
+      prefix = "foo"
+      status = "Enabled"
+
+      destination {
+        bucket        = aws_s3_bucket.destination.arn
+        storage_class = "STANDARD"
+      }
     }
+  }
 }
 `, randInt)
 }
@@ -3945,7 +3961,8 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   replication_configuration {
-    role = "${aws_iam_role.test.arn}"
+    role = aws_iam_role.test.arn
+
     rules {
       id     = "testid"
       status = "Enabled"
@@ -3955,7 +3972,7 @@ resource "aws_s3_bucket" "bucket" {
       }
 
       destination {
-        bucket        = "${aws_s3_bucket.destination.arn}"
+        bucket        = aws_s3_bucket.destination.arn
         storage_class = "STANDARD"
       }
     }
@@ -3975,29 +3992,30 @@ resource "aws_s3_bucket" "destination" {
 func testAccAWSS3BucketConfigReplicationWithV2ConfigurationNoTags(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
+  versioning {
+    enabled = true
+  }
+
+  replication_configuration {
+    role = aws_iam_role.role.arn
+
+    rules {
+      id     = "foobar"
+      status = "Enabled"
+
+      filter {
+        prefix = "foo"
+      }
+
+      destination {
+        bucket        = aws_s3_bucket.destination.arn
+        storage_class = "STANDARD"
+      }
     }
-
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            status = "Enabled"
-
-            filter {
-                prefix = "foo"
-            }
-
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "STANDARD"
-            }
-        }
-    }
+  }
 }
 `, randInt)
 }
@@ -4005,33 +4023,34 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationWithV2ConfigurationOnlyOneTag(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
-    }
+  versioning {
+    enabled = true
+  }
 
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            status = "Enabled"
+  replication_configuration {
+    role = aws_iam_role.role.arn
 
-            priority = 42
+    rules {
+      id     = "foobar"
+      status = "Enabled"
 
-            filter {
-  tags = {
-                    ReplicateMe = "Yes"
-                }
-            }
+      priority = 42
 
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "STANDARD"
-            }
+      filter {
+        tags = {
+          ReplicateMe = "Yes"
         }
+      }
+
+      destination {
+        bucket        = aws_s3_bucket.destination.arn
+        storage_class = "STANDARD"
+      }
     }
+  }
 }
 `, randInt)
 }
@@ -4039,36 +4058,37 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationWithV2ConfigurationPrefixAndTags(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
-    }
+  versioning {
+    enabled = true
+  }
 
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            status = "Enabled"
+  replication_configuration {
+    role = aws_iam_role.role.arn
 
-            priority = 41
+    rules {
+      id     = "foobar"
+      status = "Enabled"
 
-            filter {
-                prefix = "foo"
+      priority = 41
 
-  tags = {
-                    AnotherTag  = "OK"
-                    ReplicateMe = "Yes"
-                }
-            }
+      filter {
+        prefix = "foo"
 
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "STANDARD"
-            }
+        tags = {
+          AnotherTag  = "OK"
+          ReplicateMe = "Yes"
         }
+      }
+
+      destination {
+        bucket        = aws_s3_bucket.destination.arn
+        storage_class = "STANDARD"
+      }
     }
+  }
 }
 `, randInt)
 }
@@ -4076,33 +4096,34 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfigReplicationWithV2ConfigurationMultipleTags(randInt int) string {
 	return testAccAWSS3BucketConfigReplicationBasic(randInt) + fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-    bucket   = "tf-test-bucket-%[1]d"
-    acl      = "private"
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
 
-    versioning {
-        enabled = true
-    }
+  versioning {
+    enabled = true
+  }
 
-    replication_configuration {
-        role = "${aws_iam_role.role.arn}"
-        rules {
-            id     = "foobar"
-            status = "Enabled"
+  replication_configuration {
+    role = aws_iam_role.role.arn
 
-            filter {
-  tags = {
-                    AnotherTag  = "OK"
-                    Foo         = "Bar"
-                    ReplicateMe = "Yes"
-                }
-            }
+    rules {
+      id     = "foobar"
+      status = "Enabled"
 
-            destination {
-                bucket        = "${aws_s3_bucket.destination.arn}"
-                storage_class = "STANDARD"
-            }
+      filter {
+        tags = {
+          AnotherTag  = "OK"
+          Foo         = "Bar"
+          ReplicateMe = "Yes"
         }
+      }
+
+      destination {
+        bucket        = aws_s3_bucket.destination.arn
+        storage_class = "STANDARD"
+      }
     }
+  }
 }
 `, randInt)
 }
@@ -4141,8 +4162,8 @@ resource "aws_s3_bucket" "arbitrary" {
 func testAccAWSS3BucketConfig_forceDestroy(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = "%s"
-  acl = "private"
+  bucket        = "%s"
+  acl           = "private"
   force_destroy = true
 }
 `, bucketName)
@@ -4151,8 +4172,8 @@ resource "aws_s3_bucket" "bucket" {
 func testAccAWSS3BucketConfig_forceDestroyWithObjectLockEnabled(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = "%s"
-  acl = "private"
+  bucket        = "%s"
+  acl           = "private"
   force_destroy = true
 
   versioning {
@@ -4174,16 +4195,19 @@ resource "aws_iam_role" "test" {
   assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Action": "sts:AssumeRole",
-    "Principal": {
-      "Service": "s3.amazonaws.com"
-    },
-    "Effect": "Allow",
-    "Sid": ""
-  }]
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
 }
 POLICY
+
 }
 `, rName)
 }
@@ -4196,12 +4220,12 @@ resource "aws_s3_bucket" "test" {
 
 const testAccAWSS3BucketConfig_namePrefix = `
 resource "aws_s3_bucket" "test" {
-	bucket_prefix = "tf-test-"
+  bucket_prefix = "tf-test-"
 }
 `
 
 const testAccAWSS3BucketConfig_generatedName = `
 resource "aws_s3_bucket" "test" {
-	bucket_prefix = "tf-test-"
+  bucket_prefix = "tf-test-"
 }
 `

--- a/aws/resource_aws_sagemaker_endpoint_configuration_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration_test.go
@@ -254,7 +254,7 @@ func testAccSagemakerEndpointConfigurationConfig_Base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name               = %q
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
     image = "174872318107.dkr.ecr.us-west-2.amazonaws.com/kmeans:1"
@@ -264,7 +264,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = %q
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -283,15 +283,15 @@ data "aws_iam_policy_document" "assume_role" {
 func testAccSagemakerEndpointConfigurationConfig_Basic(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = %q
+  name = %q
 
-	production_variants {
-		variant_name = "variant-1"
-		model_name = "${aws_sagemaker_model.foo.name}"
-		initial_instance_count = 2
-		instance_type = "ml.t2.medium"
-		initial_variant_weight = 1
-	}
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.foo.name
+    initial_instance_count = 2
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 1
+  }
 }
 `, rName)
 }
@@ -299,22 +299,22 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 func testAccSagemakerEndpointConfigurationConfig_ProductionVariants_InitialVariantWeight(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = %q
+  name = %q
 
-	production_variants {
-		variant_name = "variant-1"
-		model_name = "${aws_sagemaker_model.foo.name}"
-		initial_instance_count = 1
-		instance_type = "ml.t2.medium"
-	}
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.foo.name
+    initial_instance_count = 1
+    instance_type          = "ml.t2.medium"
+  }
 
-	production_variants {
-		variant_name = "variant-2"
-		model_name = "${aws_sagemaker_model.foo.name}"
-		initial_instance_count = 1
-		instance_type = "ml.t2.medium"
-		initial_variant_weight = 0.5
-	}
+  production_variants {
+    variant_name           = "variant-2"
+    model_name             = aws_sagemaker_model.foo.name
+    initial_instance_count = 1
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 0.5
+  }
 }
 `, rName)
 }
@@ -322,16 +322,16 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 func testAccSagemakerEndpointConfigurationConfig_ProductionVariant_AcceleratorType(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = %q
+  name = %q
 
-	production_variants {
-		variant_name = "variant-1"
-		model_name = "${aws_sagemaker_model.foo.name}"
-		initial_instance_count = 2
-		instance_type = "ml.t2.medium"
-		accelerator_type = "ml.eia1.medium"
-		initial_variant_weight = 1
-	}
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.foo.name
+    initial_instance_count = 2
+    instance_type          = "ml.t2.medium"
+    accelerator_type       = "ml.eia1.medium"
+    initial_variant_weight = 1
+  }
 }
 `, rName)
 }
@@ -339,16 +339,16 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 func testAccSagemakerEndpointConfiguration_Config_KmsKeyId(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = %q
-	kms_key_arn = "${aws_kms_key.foo.arn}"
+  name        = %q
+  kms_key_arn = aws_kms_key.foo.arn
 
-	production_variants {
-		variant_name = "variant-1"
-		model_name = "${aws_sagemaker_model.foo.name}"
-		initial_instance_count = 1
-		instance_type = "ml.t2.medium"
-		initial_variant_weight = 1
-	}
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.foo.name
+    initial_instance_count = 1
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 1
+  }
 }
 
 resource "aws_kms_key" "foo" {
@@ -361,19 +361,19 @@ resource "aws_kms_key" "foo" {
 func testAccSagemakerEndpointConfigurationConfig_Tags(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = %q
+  name = %q
 
-	production_variants {
-		variant_name = "variant-1"
-		model_name = "${aws_sagemaker_model.foo.name}"
-		initial_instance_count = 1
-		instance_type = "ml.t2.medium"
-		initial_variant_weight = 1
-	}
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.foo.name
+    initial_instance_count = 1
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 1
+  }
 
-	tags = {
-		foo = "bar"
-	}
+  tags = {
+    foo = "bar"
+  }
 }
 `, rName)
 }
@@ -381,19 +381,19 @@ resource "aws_sagemaker_endpoint_configuration" "foo" {
 func testAccSagemakerEndpointConfigurationConfig_Tags_Update(rName string) string {
 	return testAccSagemakerEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "foo" {
-	name = %q
+  name = %q
 
-	production_variants {
-		variant_name = "variant-1"
-		model_name = "${aws_sagemaker_model.foo.name}"
-		initial_instance_count = 1
-		instance_type = "ml.t2.medium"
-		initial_variant_weight = 1
-	}
+  production_variants {
+    variant_name           = "variant-1"
+    model_name             = aws_sagemaker_model.foo.name
+    initial_instance_count = 1
+    instance_type          = "ml.t2.medium"
+    initial_variant_weight = 1
+  }
 
-	tags = {
-		bar = "baz"
-	}
+  tags = {
+    bar = "baz"
+  }
 }
 `, rName)
 }

--- a/aws/resource_aws_sagemaker_endpoint_test.go
+++ b/aws/resource_aws_sagemaker_endpoint_test.go
@@ -239,12 +239,12 @@ data "aws_iam_policy_document" "assume_role" {
 resource "aws_iam_role" "test" {
   name               = %[1]q
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "test" {
-  role   = "${aws_iam_role.test.name}"
-  policy = "${data.aws_iam_policy_document.access.json}"
+  role   = aws_iam_role.test.name
+  policy = data.aws_iam_policy_document.access.json
 }
 
 resource "aws_s3_bucket" "test" {
@@ -253,14 +253,14 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_s3_bucket_object" "test" {
-  bucket = "${aws_s3_bucket.test.id}"
+  bucket = aws_s3_bucket.test.id
   key    = "model.tar.gz"
   source = "test-fixtures/sagemaker-tensorflow-serving-test-model.tar.gz"
 }
 
 resource "aws_sagemaker_model" "test" {
   name               = %[1]q
-  execution_role_arn = "${aws_iam_role.test.arn}"
+  execution_role_arn = aws_iam_role.test.arn
 
   primary_container {
     image          = "520713654638.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tensorflow-serving:1.12-cpu"
@@ -277,7 +277,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     initial_instance_count = 1
     initial_variant_weight = 1
     instance_type          = "ml.t2.medium"
-    model_name             = "${aws_sagemaker_model.test.name}"
+    model_name             = aws_sagemaker_model.test.name
     variant_name           = "variant-1"
   }
 }
@@ -287,7 +287,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 func testAccSagemakerEndpointConfig(rName string) string {
 	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
-  endpoint_config_name = "${aws_sagemaker_endpoint_configuration.test.name}"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
 }
 `, rName)
@@ -302,13 +302,13 @@ resource "aws_sagemaker_endpoint_configuration" "test2" {
     initial_instance_count = 1
     initial_variant_weight = 1
     instance_type          = "ml.t2.medium"
-    model_name             = "${aws_sagemaker_model.test.name}"
+    model_name             = aws_sagemaker_model.test.name
     variant_name           = "variant-1"
   }
 }
 
 resource "aws_sagemaker_endpoint" "test" {
-  endpoint_config_name = "${aws_sagemaker_endpoint_configuration.test2.name}"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test2.name
   name                 = %[1]q
 }
 `, rName)
@@ -317,7 +317,7 @@ resource "aws_sagemaker_endpoint" "test" {
 func testAccSagemakerEndpointConfigTags(rName string) string {
 	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
-  endpoint_config_name = "${aws_sagemaker_endpoint_configuration.test.name}"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
 
   tags = {
@@ -330,7 +330,7 @@ resource "aws_sagemaker_endpoint" "test" {
 func testAccSagemakerEndpointConfigTagsUpdate(rName string) string {
 	return testAccSagemakerEndpointConfig_Base(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_endpoint" "test" {
-  endpoint_config_name = "${aws_sagemaker_endpoint_configuration.test.name}"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.test.name
   name                 = %[1]q
 
   tags = {

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -336,7 +336,7 @@ func testAccSagemakerModelConfig(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
     image = "%s"
@@ -346,7 +346,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -366,7 +366,7 @@ func testAccSagemakerModelConfigTags(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
     image = "%s"
@@ -380,7 +380,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -400,7 +400,7 @@ func testAccSagemakerModelConfigTagsUpdate(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
     image = "%s"
@@ -414,7 +414,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -434,7 +434,7 @@ func testAccSagemakerPrimaryContainerModelDataUrlConfig(rName string, image stri
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
     image          = "%s"
@@ -445,7 +445,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -462,7 +462,7 @@ data "aws_iam_policy_document" "assume_role" {
 resource "aws_iam_policy" "foo" {
   name        = "terraform-testacc-sagemaker-model-%s"
   description = "Allow Sagemaker to create model"
-  policy      = "${data.aws_iam_policy_document.foo.json}"
+  policy      = data.aws_iam_policy_document.foo.json
 }
 
 data "aws_iam_policy_document" "foo" {
@@ -501,8 +501,8 @@ data "aws_iam_policy_document" "foo" {
 }
 
 resource "aws_iam_role_policy_attachment" "foo" {
-  role       = "${aws_iam_role.foo.name}"
-  policy_arn = "${aws_iam_policy.foo.arn}"
+  role       = aws_iam_role.foo.name
+  policy_arn = aws_iam_policy.foo.arn
 }
 
 resource "aws_s3_bucket" "foo" {
@@ -512,7 +512,7 @@ resource "aws_s3_bucket" "foo" {
 }
 
 resource "aws_s3_bucket_object" "object" {
-  bucket  = "${aws_s3_bucket.foo.bucket}"
+  bucket  = aws_s3_bucket.foo.bucket
   key     = "model.tar.gz"
   content = "some-data"
 }
@@ -523,7 +523,7 @@ func testAccSagemakerPrimaryContainerHostnameConfig(rName string, image string) 
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
     image              = "%s"
@@ -534,7 +534,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -554,7 +554,7 @@ func testAccSagemakerPrimaryContainerEnvironmentConfig(rName string, image strin
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
     image = "%s"
@@ -568,7 +568,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -588,7 +588,7 @@ func testAccSagemakerModelContainers(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn = "${aws_iam_role.foo.arn}"
+  execution_role_arn = aws_iam_role.foo.arn
 
   container {
     image = "%s"
@@ -602,7 +602,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -622,7 +622,7 @@ func testAccSagemakerModelNetworkIsolation(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name                     = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn       = "${aws_iam_role.foo.arn}"
+  execution_role_arn       = aws_iam_role.foo.arn
   enable_network_isolation = true
 
   primary_container {
@@ -633,7 +633,7 @@ resource "aws_sagemaker_model" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -653,7 +653,7 @@ func testAccSagemakerModelVpcConfig(rName string, image string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_model" "foo" {
   name                     = "terraform-testacc-sagemaker-model-%s"
-  execution_role_arn       = "${aws_iam_role.foo.arn}"
+  execution_role_arn       = aws_iam_role.foo.arn
   enable_network_isolation = true
 
   primary_container {
@@ -661,15 +661,15 @@ resource "aws_sagemaker_model" "foo" {
   }
 
   vpc_config {
-    subnets            = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-    security_group_ids = ["${aws_security_group.foo.id}", "${aws_security_group.bar.id}"]
+    subnets            = [aws_subnet.foo.id, aws_subnet.bar.id]
+    security_group_ids = [aws_security_group.foo.id, aws_security_group.bar.id]
   }
 }
 
 resource "aws_iam_role" "foo" {
   name               = "terraform-testacc-sagemaker-model-%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -694,7 +694,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
 
   tags = {
     Name = "terraform-testacc-sagemaker-model-foo-%s"
@@ -704,7 +704,7 @@ resource "aws_subnet" "foo" {
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2b"
-  vpc_id            = "${aws_vpc.foo.id}"
+  vpc_id            = aws_vpc.foo.id
 
   tags = {
     Name = "terraform-testacc-sagemaker-model-bar-%s"
@@ -713,12 +713,12 @@ resource "aws_subnet" "bar" {
 
 resource "aws_security_group" "foo" {
   name   = "terraform-testacc-sagemaker-model-foo-%s"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_security_group" "bar" {
   name   = "terraform-testacc-sagemaker-model-bar-%s"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = aws_vpc.foo.id
 }
 `, rName, image, rName, rName, rName, rName, rName, rName)
 }

--- a/aws/resource_aws_sagemaker_notebook_instance_lifecycle_configuration_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_lifecycle_configuration_test.go
@@ -201,8 +201,8 @@ func testAccSagemakerNotebookInstanceLifecycleConfigurationConfig_Update(rName s
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
   name      = %q
-  on_create = "${base64encode("echo bla")}"
-  on_start  = "${base64encode("echo blub")}"
+  on_create = base64encode("echo bla")
+  on_start  = base64encode("echo blub")
 }
 `, rName)
 }

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -400,14 +400,14 @@ func testAccAWSSagemakerNotebookInstanceConfig(notebookName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
   name          = "%s"
-  role_arn      = "${aws_iam_role.foo.arn}"
+  role_arn      = aws_iam_role.foo.arn
   instance_type = "ml.t2.medium"
 }
 
 resource "aws_iam_role" "foo" {
   name               = "%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -427,14 +427,14 @@ func testAccAWSSagemakerNotebookInstanceUpdateConfig(notebookName string) string
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
   name          = "%s"
-  role_arn      = "${aws_iam_role.foo.arn}"
+  role_arn      = aws_iam_role.foo.arn
   instance_type = "ml.m4.xlarge"
 }
 
 resource "aws_iam_role" "foo" {
   name               = "%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -464,7 +464,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "test" {
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
   name               = %[1]q
   path               = "/"
 }
@@ -475,9 +475,9 @@ resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
 
 resource "aws_sagemaker_notebook_instance" "test" {
   instance_type         = "ml.t2.medium"
-  lifecycle_config_name = "${aws_sagemaker_notebook_instance_lifecycle_configuration.test.name}"
+  lifecycle_config_name = aws_sagemaker_notebook_instance_lifecycle_configuration.test.name
   name                  = %[1]q
-  role_arn              = "${aws_iam_role.test.arn}"
+  role_arn              = aws_iam_role.test.arn
 }
 `, rName)
 }
@@ -486,7 +486,7 @@ func testAccAWSSagemakerNotebookInstanceTagsConfig(notebookName string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
   name          = "%s"
-  role_arn      = "${aws_iam_role.foo.arn}"
+  role_arn      = aws_iam_role.foo.arn
   instance_type = "ml.t2.medium"
 
   tags = {
@@ -497,7 +497,7 @@ resource "aws_sagemaker_notebook_instance" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -517,7 +517,7 @@ func testAccAWSSagemakerNotebookInstanceTagsUpdateConfig(notebookName string) st
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
   name          = "%s"
-  role_arn      = "${aws_iam_role.foo.arn}"
+  role_arn      = aws_iam_role.foo.arn
   instance_type = "ml.t2.medium"
 
   tags = {
@@ -528,7 +528,7 @@ resource "aws_sagemaker_notebook_instance" "foo" {
 resource "aws_iam_role" "foo" {
   name               = "%s"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -547,28 +547,29 @@ data "aws_iam_policy_document" "assume_role" {
 func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(notebookName string, directInternetAccess string) string {
 	return fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
-	name = %[1]q
-	role_arn = "${aws_iam_role.foo.arn}"
-	instance_type = "ml.t2.medium"
-	security_groups = ["${aws_security_group.test.id}"]
-	subnet_id = "${aws_subnet.sagemaker.id}"
-	direct_internet_access = %[2]q
+  name                   = %[1]q
+  role_arn               = aws_iam_role.foo.arn
+  instance_type          = "ml.t2.medium"
+  security_groups        = [aws_security_group.test.id]
+  subnet_id              = aws_subnet.sagemaker.id
+  direct_internet_access = %[2]q
 }
 
 resource "aws_iam_role" "foo" {
-	name = %[1]q
-	path = "/"
-	assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  name               = %[1]q
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 data "aws_iam_policy_document" "assume_role" {
-	statement {
-		actions = [ "sts:AssumeRole" ]
-		principals {
-			type = "Service"
-			identifiers = [ "sagemaker.amazonaws.com" ]
-		}
-	}
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_vpc" "test" {
@@ -580,11 +581,11 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_subnet" "sagemaker" {
-  vpc_id     = "${aws_vpc.test.id}"
+  vpc_id     = aws_vpc.test.id
   cidr_block = "10.0.0.0/24"
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Related: #8950, #14417

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing: Handled via daily acceptance testing

Spot check (commercial partition):
```
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (95.80s)
--- PASS: TestAccAWSS3BucketObject_tags (95.80s)
```