### PR TITLE
tests/provider: Update resource testing to 0.12 syntax (Sec/Ser Resources)

### DIFF
--- a/aws/resource_aws_secretsmanager_secret_rotation_test.go
+++ b/aws/resource_aws_secretsmanager_secret_rotation_test.go
@@ -124,15 +124,15 @@ resource "aws_lambda_function" "test1" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s-1"
   handler       = "exports.example"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test1" {
-  action         = "lambda:InvokeFunction"
-  function_name  = "${aws_lambda_function.test1.function_name}"
-  principal      = "secretsmanager.amazonaws.com"
-  statement_id   = "AllowExecutionFromSecretsManager1"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test1.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager1"
 }
 
 # Not a real rotation function
@@ -140,15 +140,15 @@ resource "aws_lambda_function" "test2" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s-2"
   handler       = "exports.example"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test2" {
-  action         = "lambda:InvokeFunction"
-  function_name  = "${aws_lambda_function.test2.function_name}"
-  principal      = "secretsmanager.amazonaws.com"
-  statement_id   = "AllowExecutionFromSecretsManager2"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test2.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager2"
 }
 
 resource "aws_secretsmanager_secret" "test" {
@@ -156,14 +156,14 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_rotation" "test" {
-	secret_id 					= "${aws_secretsmanager_secret.test.id}"
-	rotation_lambda_arn = "${aws_lambda_function.test1.arn}"
+  secret_id           = aws_secretsmanager_secret.test.id
+  rotation_lambda_arn = aws_lambda_function.test1.arn
 
-	rotation_rules {
+  rotation_rules {
     automatically_after_days = %[2]d
-	}
+  }
 
-	depends_on = [aws_lambda_permission.test1]
+  depends_on = [aws_lambda_permission.test1]
 }
 `, rName, automaticallyAfterDays)
 }

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -555,7 +555,7 @@ resource "aws_kms_key" "test2" {
 }
 
 resource "aws_secretsmanager_secret" "test" {
-  kms_key_id = "${aws_kms_key.test1.id}"
+  kms_key_id = aws_kms_key.test1.id
   name       = "%s"
 }
 `, rName)
@@ -572,7 +572,7 @@ resource "aws_kms_key" "test2" {
 }
 
 resource "aws_secretsmanager_secret" "test" {
-  kms_key_id = "${aws_kms_key.test2.id}"
+  kms_key_id = aws_kms_key.test2.id
   name       = "%s"
 }
 `, rName)
@@ -591,7 +591,7 @@ func testAccAwsSecretsManagerSecretConfig_RotationLambdaARN(rName string) string
 	return baseAccAWSLambdaConfig(rName, rName, rName) + fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
   name                = "%[1]s"
-  rotation_lambda_arn = "${aws_lambda_function.test1.arn}"
+  rotation_lambda_arn = aws_lambda_function.test1.arn
 
   depends_on = [aws_lambda_permission.test1]
 }
@@ -601,15 +601,15 @@ resource "aws_lambda_function" "test1" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s-1"
   handler       = "exports.example"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test1" {
-  action         = "lambda:InvokeFunction"
-  function_name  = "${aws_lambda_function.test1.function_name}"
-  principal      = "secretsmanager.amazonaws.com"
-  statement_id   = "AllowExecutionFromSecretsManager1"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test1.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager1"
 }
 
 # Not a real rotation function
@@ -617,15 +617,15 @@ resource "aws_lambda_function" "test2" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s-2"
   handler       = "exports.example"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test2" {
-  action         = "lambda:InvokeFunction"
-  function_name  = "${aws_lambda_function.test2.function_name}"
-  principal      = "secretsmanager.amazonaws.com"
-  statement_id   = "AllowExecutionFromSecretsManager2"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test2.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager2"
 }
 `, rName)
 }
@@ -637,20 +637,20 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s"
   handler       = "exports.example"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
+  role          = aws_iam_role.iam_for_lambda.arn
   runtime       = "nodejs12.x"
 }
 
 resource "aws_lambda_permission" "test" {
-  action         = "lambda:InvokeFunction"
-  function_name  = "${aws_lambda_function.test.function_name}"
-  principal      = "secretsmanager.amazonaws.com"
-  statement_id   = "AllowExecutionFromSecretsManager1"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager1"
 }
 
 resource "aws_secretsmanager_secret" "test" {
   name                = "%[1]s"
-  rotation_lambda_arn = "${aws_lambda_function.test.arn}"
+  rotation_lambda_arn = aws_lambda_function.test.arn
 
   rotation_rules {
     automatically_after_days = %[2]d
@@ -701,9 +701,9 @@ resource "aws_secretsmanager_secret" "test" {
 func testAccAwsSecretsManagerSecretConfig_Policy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = %[1]q 
+  name = %[1]q
 
-  assume_role_policy   = <<EOF
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -718,6 +718,7 @@ resource "aws_iam_role" "test" {
   ]
 }
 EOF
+
 }
 
 resource "aws_secretsmanager_secret" "test" {
@@ -727,18 +728,19 @@ resource "aws_secretsmanager_secret" "test" {
 {
   "Version": "2012-10-17",
   "Statement": [
-	{
-	  "Sid": "EnableAllPermissions",
-	  "Effect": "Allow",
-	  "Principal": {
-		"AWS": "${aws_iam_role.test.arn}"
-	  },
-	  "Action": "secretsmanager:GetSecretValue",
-	  "Resource": "*"
-	}
+    {
+      "Sid": "EnableAllPermissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.test.arn}"
+      },
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "*"
+    }
   ]
 }
 POLICY
+
 }
 `, rName)
 }

--- a/aws/resource_aws_secretsmanager_secret_version_test.go
+++ b/aws/resource_aws_secretsmanager_secret_version_test.go
@@ -215,7 +215,7 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.test.id}"
+  secret_id     = aws_secretsmanager_secret.test.id
   secret_string = "test-string"
 }
 `, rName)
@@ -228,8 +228,8 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.test.id}"
-  secret_binary = "${base64encode("test-binary")}"
+  secret_id     = aws_secretsmanager_secret.test.id
+  secret_binary = base64encode("test-binary")
 }
 `, rName)
 }
@@ -241,7 +241,7 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.test.id}"
+  secret_id     = aws_secretsmanager_secret.test.id
   secret_string = "test-string"
 
   version_stages = ["one", "AWSCURRENT"]
@@ -256,7 +256,7 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.test.id}"
+  secret_id     = aws_secretsmanager_secret.test.id
   secret_string = "test-string"
 
   version_stages = ["two", "AWSCURRENT"]
@@ -271,7 +271,7 @@ resource "aws_secretsmanager_secret" "test" {
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.test.id}"
+  secret_id     = aws_secretsmanager_secret.test.id
   secret_string = "test-string"
 
   version_stages = ["one", "two", "AWSCURRENT"]

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -1422,7 +1422,7 @@ resource "aws_security_group_rule" "ingress_1" {
   to_port     = 8000
   cidr_blocks = ["10.0.0.0/8"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
@@ -1437,7 +1437,7 @@ resource "aws_vpc" "tftest" {
 }
 
 resource "aws_security_group" "web" {
-  vpc_id = "${aws_vpc.tftest.id}"
+  vpc_id = aws_vpc.tftest.id
 
   tags = {
     Name = "tf-acc-test"
@@ -1445,13 +1445,13 @@ resource "aws_security_group" "web" {
 }
 
 resource "aws_security_group_rule" "ingress_1" {
-  type        = "ingress"
-  protocol    = "6"
-  from_port   = 80
-  to_port     = 8000
+  type             = "ingress"
+  protocol         = "6"
+  from_port        = 80
+  to_port          = 8000
   ipv6_cidr_blocks = ["::/0"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `
 
@@ -1465,7 +1465,7 @@ resource "aws_vpc" "tftest" {
 }
 
 resource "aws_security_group" "web" {
-  vpc_id = "${aws_vpc.tftest.id}"
+  vpc_id = aws_vpc.tftest.id
 
   tags = {
     Name = "tf-acc-test"
@@ -1479,24 +1479,23 @@ resource "aws_security_group_rule" "ingress_1" {
   to_port     = 8000
   cidr_blocks = ["10.0.0.0/8"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
-
 `
 
 const testAccAWSSecurityGroupRuleIssue5310 = `
 resource "aws_security_group" "issue_5310" {
-    name = "terraform-test-issue_5310"
-    description = "SG for test of issue 5310"
+  name        = "terraform-test-issue_5310"
+  description = "SG for test of issue 5310"
 }
 
 resource "aws_security_group_rule" "issue_5310" {
-    type = "ingress"
-    from_port = 0
-    to_port = 65535
-    protocol = "tcp"
-    security_group_id = "${aws_security_group.issue_5310.id}"
-    self = true
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  security_group_id = aws_security_group.issue_5310.id
+  self              = true
 }
 `
 
@@ -1518,7 +1517,7 @@ resource "aws_security_group_rule" "ingress_1" {
   to_port     = 8000
   cidr_blocks = ["10.0.0.0/8"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
@@ -1541,41 +1540,40 @@ resource "aws_security_group_rule" "egress_1" {
   to_port     = 8000
   cidr_blocks = ["10.0.0.0/8"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
 
 const testAccAWSSecurityGroupRuleConfigMultiIngress = `
 resource "aws_security_group" "web" {
-  name = "terraform_acceptance_test_example_2"
+  name        = "terraform_acceptance_test_example_2"
   description = "Used in the terraform acceptance tests"
 }
 
 resource "aws_security_group" "worker" {
-  name = "terraform_acceptance_test_example_worker"
+  name        = "terraform_acceptance_test_example_worker"
   description = "Used in the terraform acceptance tests"
 }
 
-
 resource "aws_security_group_rule" "ingress_1" {
-  type = "ingress"
-  protocol = "tcp"
-  from_port = 22
-  to_port = 22
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = 22
+  to_port     = 22
   cidr_blocks = ["10.0.0.0/8"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 
 resource "aws_security_group_rule" "ingress_2" {
-  type = "ingress"
-  protocol = "tcp"
+  type      = "ingress"
+  protocol  = "tcp"
   from_port = 80
-  to_port = 8000
-        self = true
+  to_port   = 8000
+  self      = true
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `
 
@@ -1583,74 +1581,77 @@ func testAccAWSSecurityGroupRuleMultiDescription(rInt int, rType string) string 
 	var b bytes.Buffer
 	b.WriteString(fmt.Sprintf(`
 resource "aws_vpc" "tf_sgrule_description_test" {
-    cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-security-group-rule-multi-desc"
-    }
+    Name = "terraform-testacc-security-group-rule-multi-desc"
+  }
 }
 
 resource "aws_vpc_endpoint" "s3-us-west-2" {
-    vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
-    service_name = "com.amazonaws.us-west-2.s3"
-    }
+  vpc_id       = aws_vpc.tf_sgrule_description_test.id
+  service_name = "com.amazonaws.us-west-2.s3"
+}
 
 resource "aws_security_group" "worker" {
-    name = "terraform_test_%[1]d"
-    vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
-    description = "Used in the terraform acceptance tests"
+  name        = "terraform_test_%[1]d"
+  vpc_id      = aws_vpc.tf_sgrule_description_test.id
+  description = "Used in the terraform acceptance tests"
+
   tags = { Name = "tf-sg-rule-description" }
 }
 
 resource "aws_security_group" "nat" {
-    name = "terraform_test_%[1]d_nat"
-    vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
-    description = "Used in the terraform acceptance tests"
+  name        = "terraform_test_%[1]d_nat"
+  vpc_id      = aws_vpc.tf_sgrule_description_test.id
+  description = "Used in the terraform acceptance tests"
+
   tags = { Name = "tf-sg-rule-description" }
 }
 
 resource "aws_security_group_rule" "%[2]s_rule_1" {
-    security_group_id = "${aws_security_group.worker.id}"
-    description = "CIDR Description"
-    type = "%[2]s"
-    protocol = "tcp"
-    from_port = 22
-    to_port = 22
-    cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.worker.id
+  description       = "CIDR Description"
+  type              = "%[2]s"
+  protocol          = "tcp"
+  from_port         = 22
+  to_port           = 22
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "%[2]s_rule_2" {
-    security_group_id = "${aws_security_group.worker.id}"
-    description = "IPv6 CIDR Description"
-    type = "%[2]s"
-    protocol = "tcp"
-    from_port = 22
-    to_port = 22
-    ipv6_cidr_blocks = ["::/0"]
+  security_group_id = aws_security_group.worker.id
+  description       = "IPv6 CIDR Description"
+  type              = "%[2]s"
+  protocol          = "tcp"
+  from_port         = 22
+  to_port           = 22
+  ipv6_cidr_blocks  = ["::/0"]
 }
 
 resource "aws_security_group_rule" "%[2]s_rule_3" {
-    security_group_id = "${aws_security_group.worker.id}"
-    description = "NAT SG Description"
-    type = "%[2]s"
-    protocol = "tcp"
-    from_port = 22
-    to_port = 22
-    source_security_group_id = "${aws_security_group.nat.id}"
+  security_group_id        = aws_security_group.worker.id
+  description              = "NAT SG Description"
+  type                     = "%[2]s"
+  protocol                 = "tcp"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = aws_security_group.nat.id
 }
 `, rInt, rType))
 
 	if rType == "egress" {
 		b.WriteString(`
 resource "aws_security_group_rule" "egress_rule_4" {
-    security_group_id = "${aws_security_group.worker.id}"
-    description = "Prefix List Description"
-    type = "egress"
-    protocol = "tcp"
-    from_port = 22
-    to_port = 22
-    prefix_list_ids = ["${aws_vpc_endpoint.s3-us-west-2.prefix_list_id}"]
+  security_group_id = aws_security_group.worker.id
+  description       = "Prefix List Description"
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 22
+  to_port           = 22
+  prefix_list_ids   = [aws_vpc_endpoint.s3-us-west-2.prefix_list_id]
 }
-        `)
+`)
 	}
 
 	return b.String()
@@ -1660,26 +1661,28 @@ resource "aws_security_group_rule" "egress_rule_4" {
 const testAccAWSSecurityGroupRuleConfigSelfReference = `
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-rule-self-ref"
   }
 }
 
 resource "aws_security_group" "web" {
-  name = "main"
-  vpc_id = "${aws_vpc.main.id}"
+  name   = "main"
+  vpc_id = aws_vpc.main.id
+
   tags = {
     Name = "sg-self-test"
   }
 }
 
 resource "aws_security_group_rule" "self" {
-  type = "ingress"
-  protocol = "-1"
-  from_port = 0
-  to_port = 0
-  self = true
-  security_group_id = "${aws_security_group.web.id}"
+  type              = "ingress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  self              = true
+  security_group_id = aws_security_group.web.id
 }
 `
 
@@ -1695,7 +1698,7 @@ resource "aws_vpc" "default" {
 
 resource "aws_security_group" "web" {
   name   = "tf-other-%d"
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
   tags = {
     Name = "tf-other-sg"
@@ -1704,7 +1707,7 @@ resource "aws_security_group" "web" {
 
 resource "aws_security_group" "nat" {
   name   = "tf-nat-%d"
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
   tags = {
     Name = "tf-nat-sg"
@@ -1718,7 +1721,7 @@ resource "aws_security_group_rule" "ingress" {
   protocol    = "tcp"
   cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 
 resource "aws_security_group_rule" "other" {
@@ -1728,7 +1731,7 @@ resource "aws_security_group_rule" "other" {
   protocol    = "tcp"
   cidr_blocks = ["10.0.5.0/24"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 
 // same a above, but different group, to guard against bad hashing
@@ -1739,7 +1742,7 @@ resource "aws_security_group_rule" "nat_ingress" {
   protocol    = "tcp"
   cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
 
-  security_group_id = "${aws_security_group.nat.id}"
+  security_group_id = aws_security_group.nat.id
 }
 `, rInt, rInt)
 }
@@ -1756,7 +1759,7 @@ resource "aws_vpc" "default" {
 
 resource "aws_security_group" "web" {
   name   = "tf-other-%d"
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
   tags = {
     Name = "tf-other-sg"
@@ -1765,7 +1768,7 @@ resource "aws_security_group" "web" {
 
 resource "aws_security_group" "nat" {
   name   = "tf-nat-%d"
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
   tags = {
     Name = "tf-nat-sg"
@@ -1778,8 +1781,8 @@ resource "aws_security_group_rule" "source_ingress" {
   to_port   = 80
   protocol  = "tcp"
 
-  source_security_group_id = "${aws_security_group.nat.id}"
-  security_group_id        = "${aws_security_group.web.id}"
+  source_security_group_id = aws_security_group.nat.id
+  security_group_id        = aws_security_group.web.id
 }
 
 resource "aws_security_group_rule" "other_ingress" {
@@ -1789,7 +1792,7 @@ resource "aws_security_group_rule" "other_ingress" {
   protocol    = "tcp"
   cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `, rInt, rInt)
 }
@@ -1797,49 +1800,52 @@ resource "aws_security_group_rule" "other_ingress" {
 const testAccAWSSecurityGroupRulePrefixListEgressConfig = `
 
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
-    cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-security-group-rule-prefix-list-egress"
-    }
+    Name = "terraform-testacc-security-group-rule-prefix-list-egress"
+  }
 }
 
 resource "aws_route_table" "default" {
-    vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
+  vpc_id = aws_vpc.tf_sg_prefix_list_egress_test.id
 }
 
 resource "aws_vpc_endpoint" "s3-us-west-2" {
-      vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
-      service_name = "com.amazonaws.us-west-2.s3"
-      route_table_ids = ["${aws_route_table.default.id}"]
-      policy = <<POLICY
+  vpc_id          = aws_vpc.tf_sg_prefix_list_egress_test.id
+  service_name    = "com.amazonaws.us-west-2.s3"
+  route_table_ids = [aws_route_table.default.id]
+
+  policy = <<POLICY
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid":"AllowAll",
-            "Effect":"Allow",
-            "Principal":"*",
-            "Action":"*",
-            "Resource":"*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAll",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
 }
 POLICY
+
 }
 
 resource "aws_security_group" "egress" {
-    name = "terraform_acceptance_test_prefix_list_egress"
-    description = "Used in the terraform acceptance tests"
-    vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
+  name        = "terraform_acceptance_test_prefix_list_egress"
+  description = "Used in the terraform acceptance tests"
+  vpc_id      = aws_vpc.tf_sg_prefix_list_egress_test.id
 }
 
 resource "aws_security_group_rule" "egress_1" {
-  type = "egress"
-  protocol = "-1"
-  from_port = 0
-  to_port = 0
-  prefix_list_ids = ["${aws_vpc_endpoint.s3-us-west-2.prefix_list_id}"]
-    security_group_id = "${aws_security_group.egress.id}"
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  prefix_list_ids   = [aws_vpc_endpoint.s3-us-west-2.prefix_list_id]
+  security_group_id = aws_security_group.egress.id
 }
 `
 
@@ -1862,7 +1868,7 @@ resource "aws_security_group_rule" "ingress_1" {
   cidr_blocks = ["10.0.0.0/8"]
   description = "TF acceptance test ingress rule"
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
@@ -1886,7 +1892,7 @@ resource "aws_security_group_rule" "ingress_1" {
   cidr_blocks = ["10.0.0.0/8"]
   description = "TF acceptance test ingress rule updated"
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
@@ -1910,7 +1916,7 @@ resource "aws_security_group_rule" "egress_1" {
   cidr_blocks = ["10.0.0.0/8"]
   description = "TF acceptance test egress rule"
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
@@ -1934,7 +1940,7 @@ resource "aws_security_group_rule" "egress_1" {
   cidr_blocks = ["10.0.0.0/8"]
   description = "TF acceptance test egress rule updated"
 
-  security_group_id = "${aws_security_group.web.id}"
+  security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
@@ -1954,7 +1960,7 @@ resource "aws_security_group_rule" "test" {
   description       = %q
   from_port         = 0
   protocol          = -1
-  security_group_id = "${aws_security_group.test.id}"
+  security_group_id = aws_security_group.test.id
   to_port           = 0
   type              = "ingress"
 }
@@ -1976,7 +1982,7 @@ resource "aws_security_group_rule" "test" {
   description       = %q
   from_port         = -1
   protocol          = -1
-  security_group_id = "${aws_security_group.test.id}"
+  security_group_id = aws_security_group.test.id
   to_port           = -1
   type              = "ingress"
 }
@@ -1997,7 +2003,7 @@ resource "aws_security_group_rule" "test1" {
   cidr_blocks       = ["10.0.0.0/8"]
   from_port         = 0
   protocol          = -1
-  security_group_id = "${aws_security_group.test.id}"
+  security_group_id = aws_security_group.test.id
   to_port           = 65535
   type              = "ingress"
 }
@@ -2006,7 +2012,7 @@ resource "aws_security_group_rule" "test2" {
   cidr_blocks       = ["172.168.0.0/16"]
   from_port         = 443
   protocol          = "tcp"
-  security_group_id = "${aws_security_group.test.id}"
+  security_group_id = aws_security_group.test.id
   to_port           = 443
   type              = "ingress"
 }
@@ -2018,35 +2024,36 @@ var testAccAWSSecurityGroupRuleRace = func() string {
 	iterations := 50
 	b.WriteString(fmt.Sprintf(`
 resource "aws_vpc" "default" {
-    cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-security-group-rule-race"
-    }
+    Name = "terraform-testacc-security-group-rule-race"
+  }
 }
 
 resource "aws_security_group" "race" {
-    name   = "tf-sg-rule-race-group-%d"
-    vpc_id = "${aws_vpc.default.id}"
+  name   = "tf-sg-rule-race-group-%d"
+  vpc_id = aws_vpc.default.id
 }
 `, acctest.RandInt()))
 	for i := 1; i < iterations; i++ {
 		b.WriteString(fmt.Sprintf(`
 resource "aws_security_group_rule" "ingress%d" {
-    security_group_id = "${aws_security_group.race.id}"
-    type              = "ingress"
-    from_port         = %d
-    to_port           = %d
-    protocol          = "tcp"
-    cidr_blocks       = ["10.0.0.%d/32"]
+  security_group_id = aws_security_group.race.id
+  type              = "ingress"
+  from_port         = %d
+  to_port           = %d
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.%d/32"]
 }
 
 resource "aws_security_group_rule" "egress%d" {
-    security_group_id = "${aws_security_group.race.id}"
-    type              = "egress"
-    from_port         = %d
-    to_port           = %d
-    protocol          = "tcp"
-    cidr_blocks       = ["10.0.0.%d/32"]
+  security_group_id = aws_security_group.race.id
+  type              = "egress"
+  from_port         = %d
+  to_port           = %d
+  protocol          = "tcp"
+  cidr_blocks       = ["10.0.0.%d/32"]
 }
 `, i, i, i, i, i, i, i, i))
 	}
@@ -2066,7 +2073,7 @@ resource "aws_vpc" "foo" {
 resource "aws_security_group" "web" {
   name        = "allow_all-%d"
   description = "Allow all inbound traffic"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 }
 
 resource "aws_security_group_rule" "allow_self" {
@@ -2074,8 +2081,8 @@ resource "aws_security_group_rule" "allow_self" {
   from_port                = 0
   to_port                  = 0
   protocol                 = "-1"
-  security_group_id        = "${aws_security_group.web.id}"
-  source_security_group_id = "${aws_security_group.web.id}"
+  security_group_id        = aws_security_group.web.id
+  source_security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
@@ -2095,7 +2102,7 @@ resource "aws_vpc" "foo" {
 resource "aws_security_group" "web" {
   name        = "allow_all-%d"
   description = "Allow all inbound traffic"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 }
 
 resource "aws_security_group_rule" "allow_self" {
@@ -2104,7 +2111,7 @@ resource "aws_security_group_rule" "allow_self" {
   to_port                  = 0
   protocol                 = "-1"
   description              = "some description"
-  security_group_id        = "${aws_security_group.web.id}"
+  security_group_id        = aws_security_group.web.id
   source_security_group_id = "${data.aws_caller_identity.current.account_id}/${aws_security_group.web.id}"
 }
 `, rInt)
@@ -2123,7 +2130,7 @@ resource "aws_vpc" "foo" {
 resource "aws_security_group" "web" {
   name        = "allow_all-%d"
   description = "Allow all inbound traffic"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 }
 
 resource "aws_security_group_rule" "allow_self" {
@@ -2131,8 +2138,8 @@ resource "aws_security_group_rule" "allow_self" {
   from_port                = 0
   to_port                  = 0
   protocol                 = "-1"
-  security_group_id        = "${aws_security_group.web.id}"
-  source_security_group_id = "${aws_security_group.web.id}"
+  security_group_id        = aws_security_group.web.id
+  source_security_group_id = aws_security_group.web.id
 }
 `, rInt)
 }
@@ -2149,7 +2156,7 @@ resource "aws_security_group_rule" "ing" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["1.2.3.4/33"]
-  security_group_id = "${aws_security_group.foo.id}"
+  security_group_id = aws_security_group.foo.id
 }
 `, rInt)
 }
@@ -2166,7 +2173,7 @@ resource "aws_security_group_rule" "ing" {
   to_port           = 0
   protocol          = "-1"
   ipv6_cidr_blocks  = ["::/244"]
-  security_group_id = "${aws_security_group.foo.id}"
+  security_group_id = aws_security_group.foo.id
 }
 `, rInt)
 }

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -551,7 +551,6 @@ func TestResourceAwsSecurityGroupIPPermGather(t *testing.T) {
 		// loop and match rules, because the ordering is not guarneteed
 		for _, l := range local {
 			if i["from_port"] == l["from_port"] {
-
 				if i["to_port"] != l["to_port"] {
 					t.Fatalf("to_port does not match")
 				}
@@ -2685,31 +2684,32 @@ func testAccAWSSecurityGroupConfigRuleLimit(egressStartIndex, egressRulesCount i
 	c := `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-rule-limit"
   }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_rule_limit"
+  name        = "terraform_acceptance_test_rule_limit"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 
-	tags = {
+  tags = {
     Name = "tf-acc-test"
   }
 
-	// egress rules to exhaust the limit
+  # egress rules to exhaust the limit
 `
 
 	for i := egressStartIndex; i < egressRulesCount+egressStartIndex; i++ {
 		c += fmt.Sprintf(`
   egress {
-		protocol = "tcp"
-		from_port = "${80 + %[1]d}"
-		to_port = "${80 + %[1]d}"
-		cidr_blocks = ["${cidrhost("10.1.0.0/16", %[1]d)}/32"]
-	}
+    protocol    = "tcp"
+    from_port   = "${80 + %[1]d}"
+    to_port     = "${80 + %[1]d}"
+    cidr_blocks = ["${cidrhost("10.1.0.0/16", %[1]d)}/32"]
+  }
 `, i)
 	}
 
@@ -2722,26 +2722,27 @@ func testAccAWSSecurityGroupConfigCidrBlockRuleLimit(egressStartIndex, egressRul
 	c := `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-rule-limit"
   }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_rule_limit"
+  name        = "terraform_acceptance_test_rule_limit"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 
-	tags = {
+  tags = {
     Name = "tf-acc-test"
   }
 
-	// egress rules to exhaust the limit
-	egress {
-		protocol = "tcp"
-		from_port = "80"
-		to_port = "80"
-		cidr_blocks = [
+  # egress rules to exhaust the limit
+  egress {
+    protocol = "tcp"
+    from_port = "80"
+    to_port = "80"
+    cidr_blocks = [
 `
 
 	for i := egressStartIndex; i < egressRulesCount+egressStartIndex; i++ {
@@ -2758,28 +2759,29 @@ resource "aws_security_group" "test" {
 const testAccAWSSecurityGroupConfigEmptyRuleDescription = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-empty-rule-description"
   }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_desc_example"
+  name        = "terraform_acceptance_test_desc_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
-    protocol = "6"
-    from_port = 80
-    to_port = 8000
+    protocol    = "6"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
     description = ""
   }
 
   egress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
     description = ""
   }
@@ -2787,132 +2789,139 @@ resource "aws_security_group" "test" {
   tags = {
     Name = "tf-acc-test"
   }
-}`
+}
+`
 
 const testAccAWSSecurityGroupConfigIpv6 = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-ipv6"
   }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example"
+  name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
-    protocol = "6"
-    from_port = 80
-    to_port = 8000
+    protocol         = "6"
+    from_port        = 80
+    to_port          = 8000
     ipv6_cidr_blocks = ["::/0"]
   }
 
   egress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol         = "tcp"
+    from_port        = 80
+    to_port          = 8000
     ipv6_cidr_blocks = ["::/0"]
   }
 
-	tags = {
-		Name = "tf-acc-test"
-	}
+  tags = {
+    Name = "tf-acc-test"
+  }
 }
 `
 
 const testAccAWSSecurityGroupConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group"
-	}
+
+  tags = {
+    Name = "terraform-testacc-security-group"
+  }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example"
+  name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
-    protocol = "6"
-    from_port = 80
-    to_port = 8000
+    protocol    = "6"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
   }
 
-	tags = {
-		Name = "tf-acc-revoke-test"
-	}
+  tags = {
+    Name = "tf-acc-revoke-test"
+  }
 }
 `
 
 const testAccAWSSecurityGroupConfig_revoke_base_removed = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-revoke"
-	}
+
+  tags = {
+    Name = "terraform-testacc-security-group-revoke"
+  }
 }
 `
+
 const testAccAWSSecurityGroupConfig_revoke_base = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-revoke"
-	}
+
+  tags = {
+    Name = "terraform-testacc-security-group-revoke"
+  }
 }
 
 resource "aws_security_group" "primary" {
-  name = "tf-acc-sg-race-revoke-primary"
+  name        = "tf-acc-sg-race-revoke-primary"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.sg-race-revoke.id}"
+  vpc_id      = aws_vpc.sg-race-revoke.id
 
-	tags = {
-		Name = "tf-acc-revoke-test-primary"
-	}
+  tags = {
+    Name = "tf-acc-revoke-test-primary"
+  }
 }
 
 resource "aws_security_group" "secondary" {
-  name = "tf-acc-sg-race-revoke-secondary"
+  name        = "tf-acc-sg-race-revoke-secondary"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.sg-race-revoke.id}"
+  vpc_id      = aws_vpc.sg-race-revoke.id
 
-	tags = {
-		Name = "tf-acc-revoke-test-secondary"
-	}
+  tags = {
+    Name = "tf-acc-revoke-test-secondary"
+  }
 }
 `
 
 const testAccAWSSecurityGroupConfig_revoke_false = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-revoke"
-	}
+
+  tags = {
+    Name = "terraform-testacc-security-group-revoke"
+  }
 }
 
 resource "aws_security_group" "primary" {
-  name = "tf-acc-sg-race-revoke-primary"
+  name        = "tf-acc-sg-race-revoke-primary"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.sg-race-revoke.id}"
+  vpc_id      = aws_vpc.sg-race-revoke.id
 
-	tags = {
-		Name = "tf-acc-revoke-test-primary"
-	}
+  tags = {
+    Name = "tf-acc-revoke-test-primary"
+  }
 
   revoke_rules_on_delete = false
 }
 
 resource "aws_security_group" "secondary" {
-  name = "tf-acc-sg-race-revoke-secondary"
+  name        = "tf-acc-sg-race-revoke-secondary"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.sg-race-revoke.id}"
+  vpc_id      = aws_vpc.sg-race-revoke.id
 
-	tags = {
-		Name = "tf-acc-revoke-test-secondary"
-	}
+  tags = {
+    Name = "tf-acc-revoke-test-secondary"
+  }
 
   revoke_rules_on_delete = false
 }
@@ -2921,31 +2930,32 @@ resource "aws_security_group" "secondary" {
 const testAccAWSSecurityGroupConfig_revoke_true = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-revoke"
-	}
+
+  tags = {
+    Name = "terraform-testacc-security-group-revoke"
+  }
 }
 
 resource "aws_security_group" "primary" {
-  name = "tf-acc-sg-race-revoke-primary"
+  name        = "tf-acc-sg-race-revoke-primary"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.sg-race-revoke.id}"
+  vpc_id      = aws_vpc.sg-race-revoke.id
 
-	tags = {
-		Name = "tf-acc-revoke-test-primary"
-	}
+  tags = {
+    Name = "tf-acc-revoke-test-primary"
+  }
 
   revoke_rules_on_delete = true
 }
 
 resource "aws_security_group" "secondary" {
-  name = "tf-acc-sg-race-revoke-secondary"
+  name        = "tf-acc-sg-race-revoke-secondary"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.sg-race-revoke.id}"
+  vpc_id      = aws_vpc.sg-race-revoke.id
 
-	tags = {
-		Name = "tf-acc-revoke-test-secondary"
-	}
+  tags = {
+    Name = "tf-acc-revoke-test-secondary"
+  }
 
   revoke_rules_on_delete = true
 }
@@ -2954,34 +2964,35 @@ resource "aws_security_group" "secondary" {
 const testAccAWSSecurityGroupConfigChange = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-change"
   }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example"
+  name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 9000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 9000
     cidr_blocks = ["10.0.0.0/8"]
   }
 
   ingress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["0.0.0.0/0", "10.0.0.0/8"]
   }
 
   egress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
   }
 }
@@ -3000,7 +3011,7 @@ resource "aws_vpc" "foo" {
 resource "aws_security_group" "test" {
   name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
     protocol    = "6"
@@ -3028,27 +3039,28 @@ resource "aws_security_group" "test" {
 const testAccAWSSecurityGroupConfigSelf = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-self"
   }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example"
+  name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
-    protocol = "tcp"
+    protocol  = "tcp"
     from_port = 80
-    to_port = 8000
-    self = true
+    to_port   = 8000
+    self      = true
   }
 
   egress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
   }
 }
@@ -3057,134 +3069,138 @@ resource "aws_security_group" "test" {
 const testAccAWSSecurityGroupConfigVpc = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-vpc"
   }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example"
+  name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
   }
 
-	egress {
-		protocol = "tcp"
-		from_port = 80
-		to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
-	}
+  egress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+  }
 }
 `
 
 const testAccAWSSecurityGroupConfigVpcNegOneIngress = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-vpc-neg-one-ingress"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-security-group-vpc-neg-one-ingress"
+  }
 }
 
 resource "aws_security_group" "test" {
-	name = "terraform_acceptance_test_example"
-	description = "Used in the terraform acceptance tests"
-	vpc_id = "${aws_vpc.foo.id}"
+  name        = "terraform_acceptance_test_example"
+  description = "Used in the terraform acceptance tests"
+  vpc_id      = aws_vpc.foo.id
 
-	ingress {
-		protocol = "-1"
-		from_port = 0
-		to_port = 0
-		cidr_blocks = ["10.0.0.0/8"]
-	}
+  ingress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["10.0.0.0/8"]
+  }
 }
 `
 
 const testAccAWSSecurityGroupConfigVpcProtoNumIngress = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-vpc-proto-num-ingress"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-security-group-vpc-proto-num-ingress"
+  }
 }
 
 resource "aws_security_group" "test" {
-	name = "terraform_acceptance_test_example"
-	description = "Used in the terraform acceptance tests"
-	vpc_id = "${aws_vpc.foo.id}"
+  name        = "terraform_acceptance_test_example"
+  description = "Used in the terraform acceptance tests"
+  vpc_id      = aws_vpc.foo.id
 
-	ingress {
-		protocol = "50"
-		from_port = 0
-		to_port = 0
-		cidr_blocks = ["10.0.0.0/8"]
-	}
+  ingress {
+    protocol    = "50"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["10.0.0.0/8"]
+  }
 }
 `
 
 const testAccAWSSecurityGroupConfigMultiIngress = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-multi-ingress"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-security-group-multi-ingress"
+  }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example_1"
+  name        = "terraform_acceptance_test_example_1"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
   }
 
   egress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
   }
 }
 
 resource "aws_security_group" "test2" {
-  name = "terraform_acceptance_test_example_2"
+  name        = "terraform_acceptance_test_example_2"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
-    protocol = "tcp"
-    from_port = 22
-    to_port = 22
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
     cidr_blocks = ["10.0.0.0/8"]
   }
 
   ingress {
-    protocol = "tcp"
-    from_port = 800
-    to_port = 800
+    protocol    = "tcp"
+    from_port   = 800
+    to_port     = 800
     cidr_blocks = ["10.0.0.0/8"]
   }
 
   ingress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
-    security_groups = ["${aws_security_group.test.id}"]
+    protocol        = "tcp"
+    from_port       = 80
+    to_port         = 8000
+    security_groups = [aws_security_group.test.id]
   }
 
   egress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
   }
 }
@@ -3192,16 +3208,17 @@ resource "aws_security_group" "test2" {
 
 const testAccAWSSecurityGroupConfigTags = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-tags"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-security-group-tags"
+  }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example"
+  name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   tags = {
     foo = "bar"
@@ -3211,16 +3228,17 @@ resource "aws_security_group" "test" {
 
 const testAccAWSSecurityGroupConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-tags"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-security-group-tags"
+  }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example"
+  name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   tags = {
     bar = "baz"
@@ -3231,38 +3249,40 @@ resource "aws_security_group" "test" {
 
 const testAccAWSSecurityGroupConfig_generatedName = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-generated-name"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-security-group-generated-name"
+  }
 }
 
 resource "aws_security_group" "test" {
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id = aws_vpc.foo.id
 
-	tags = {
-		Name = "tf-acc-test"
-	}
+  tags = {
+    Name = "tf-acc-test"
+  }
 }
 `
 
 const testAccAWSSecurityGroupConfigDefaultEgress = `
 resource "aws_vpc" "tf_sg_egress_test" {
-    cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-security-group-default-egress"
-    }
+    Name = "terraform-testacc-security-group-default-egress"
+  }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example_1"
+  name        = "terraform_acceptance_test_example_1"
   description = "Used in the terraform acceptance tests"
-        vpc_id = "${aws_vpc.tf_sg_egress_test.id}"
+  vpc_id      = aws_vpc.tf_sg_egress_test.id
 
   egress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 8000
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 8000
     cidr_blocks = ["10.0.0.0/8"]
   }
 }
@@ -3270,7 +3290,7 @@ resource "aws_security_group" "test" {
 
 const testAccAWSSecurityGroupConfigClassic = `
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example_1"
+  name        = "terraform_acceptance_test_example_1"
   description = "Used in the terraform acceptance tests"
 }
 `
@@ -3332,13 +3352,13 @@ resource "aws_vpc" "foo" {
 resource "aws_security_group" "test2" {
   name        = "tf_acc_%d"
   description = "Used in the terraform acceptance tests"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 }
 
 resource "aws_security_group" "test" {
   name        = "tf_acc_%d"
   description = "Used in the terraform acceptance tests"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
     protocol    = "tcp"
@@ -3358,7 +3378,7 @@ resource "aws_security_group" "test" {
     protocol        = "tcp"
     from_port       = 22
     to_port         = 22
-    security_groups = ["${aws_security_group.test2.id}"]
+    security_groups = [aws_security_group.test2.id]
   }
 
   egress {
@@ -3379,7 +3399,7 @@ resource "aws_security_group" "test" {
     protocol        = "tcp"
     from_port       = 22
     to_port         = 22
-    security_groups = ["${aws_security_group.test2.id}"]
+    security_groups = [aws_security_group.test2.id]
   }
 
   tags = {
@@ -3391,87 +3411,99 @@ resource "aws_security_group" "test" {
 
 const testAccAWSSecurityGroupInvalidIngressCidr = `
 resource "aws_security_group" "test" {
-  name = "testing-foo"
+  name        = "testing-foo"
   description = "foo-testing"
+
   ingress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["1.2.3.4/33"]
   }
-}`
+}
+`
 
 const testAccAWSSecurityGroupInvalidEgressCidr = `
 resource "aws_security_group" "test" {
-  name = "testing-foo"
+  name        = "testing-foo"
   description = "foo-testing"
+
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["1.2.3.4/33"]
   }
-}`
+}
+`
 
 const testAccAWSSecurityGroupInvalidIPv6IngressCidr = `
 resource "aws_security_group" "test" {
-  name = "testing-foo"
+  name        = "testing-foo"
   description = "foo-testing"
+
   ingress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
     ipv6_cidr_blocks = ["::/244"]
   }
-}`
+}
+`
 
 const testAccAWSSecurityGroupInvalidIPv6EgressCidr = `
 resource "aws_security_group" "test" {
-  name = "testing-foo"
+  name        = "testing-foo"
   description = "foo-testing"
+
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
     ipv6_cidr_blocks = ["::/244"]
   }
-}`
+}
+`
 
 const testAccAWSSecurityGroupCombindCIDRandGroups = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-combine-rand-groups"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-security-group-combine-rand-groups"
+  }
 }
 
 resource "aws_security_group" "two" {
-	name = "tf-test-1"
-	vpc_id = "${aws_vpc.foo.id}"
-	tags = {
-		Name = "tf-test-1"
-	}
+  name   = "tf-test-1"
+  vpc_id = aws_vpc.foo.id
+
+  tags = {
+    Name = "tf-test-1"
+  }
 }
 
 resource "aws_security_group" "one" {
-	name = "tf-test-2"
-	vpc_id = "${aws_vpc.foo.id}"
-	tags = {
-		Name = "tf-test-w"
-	}
+  name   = "tf-test-2"
+  vpc_id = aws_vpc.foo.id
+
+  tags = {
+    Name = "tf-test-w"
+  }
 }
 
 resource "aws_security_group" "three" {
-	name = "tf-test-3"
-	vpc_id = "${aws_vpc.foo.id}"
-	tags = {
-		Name = "tf-test-3"
-	}
+  name   = "tf-test-3"
+  vpc_id = aws_vpc.foo.id
+
+  tags = {
+    Name = "tf-test-3"
+  }
 }
 
 resource "aws_security_group" "test" {
-  name = "tf-mix-test"
-  vpc_id = "${aws_vpc.foo.id}"
+  name   = "tf-mix-test"
+  vpc_id = aws_vpc.foo.id
 
   ingress {
     from_port   = 80
@@ -3480,9 +3512,9 @@ resource "aws_security_group" "test" {
     cidr_blocks = ["10.0.0.0/16", "10.1.0.0/16", "10.7.0.0/16"]
 
     security_groups = [
-      "${aws_security_group.one.id}",
-      "${aws_security_group.two.id}",
-      "${aws_security_group.three.id}",
+      aws_security_group.one.id,
+      aws_security_group.two.id,
+      aws_security_group.three.id,
     ]
   }
 
@@ -3494,16 +3526,17 @@ resource "aws_security_group" "test" {
 
 const testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-security-group-ingress-w-cidr-and-sg"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-security-group-ingress-w-cidr-and-sg"
+  }
 }
 
 resource "aws_security_group" "test2" {
   name        = "tf_other_acc_tests"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   tags = {
     Name = "tf-acc-test"
@@ -3513,7 +3546,7 @@ resource "aws_security_group" "test2" {
 resource "aws_security_group" "test" {
   name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 
   ingress {
     protocol  = "tcp"
@@ -3530,7 +3563,7 @@ resource "aws_security_group" "test" {
     from_port       = 80
     to_port         = 8000
     cidr_blocks     = ["10.0.0.0/8"]
-    security_groups = ["${aws_security_group.test2.id}"]
+    security_groups = [aws_security_group.test2.id]
   }
 
   egress {
@@ -3575,7 +3608,7 @@ resource "aws_security_group" "test" {
     from_port       = 80
     to_port         = 8000
     cidr_blocks     = ["10.0.0.0/8"]
-    security_groups = ["${aws_security_group.test2.name}"]
+    security_groups = [aws_security_group.test2.name]
   }
 
   tags = {
@@ -3597,21 +3630,21 @@ resource "aws_vpc" "main" {
 
 resource "aws_security_group" "ssh_base" {
   name   = "test-ssh-base"
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_security_group" "jump" {
   name   = "test-jump"
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_security_group" "provision" {
   name   = "test-provision"
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_security_group" "nat" {
-  vpc_id      = "${aws_vpc.main.id}"
+  vpc_id      = aws_vpc.main.id
   name        = "nat"
   description = "For nat servers "
 
@@ -3619,17 +3652,18 @@ resource "aws_security_group" "nat" {
     from_port       = 22
     to_port         = 22
     protocol        = "tcp"
-    security_groups = ["${aws_security_group.jump.id}"]
+    security_groups = [aws_security_group.jump.id]
   }
 
   ingress {
     from_port       = 22
     to_port         = 22
     protocol        = "tcp"
-    security_groups = ["${aws_security_group.provision.id}"]
+    security_groups = [aws_security_group.provision.id]
   }
 }
 `
+
 const testAccAWSSecurityGroupConfig_allowAll = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
@@ -3642,7 +3676,7 @@ resource "aws_vpc" "foo" {
 resource "aws_security_group" "test" {
   name        = "allow_all"
   description = "Allow all inbound traffic"
-  vpc_id      = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
 }
 
 resource "aws_security_group_rule" "allow_all" {
@@ -3652,7 +3686,7 @@ resource "aws_security_group_rule" "allow_all" {
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.test.id}"
+  security_group_id = aws_security_group.test.id
 }
 
 resource "aws_security_group_rule" "allow_all-1" {
@@ -3662,7 +3696,7 @@ resource "aws_security_group_rule" "allow_all-1" {
   protocol  = "tcp"
 
   self              = true
-  security_group_id = "${aws_security_group.test.id}"
+  security_group_id = aws_security_group.test.id
 }
 `
 
@@ -3676,18 +3710,18 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_security_group" "test" {
-  name        = "test group 1"
-  vpc_id      = "${aws_vpc.foo.id}"
+  name   = "test group 1"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_security_group" "test2" {
-  name        = "test group 2"
-  vpc_id      = "${aws_vpc.foo.id}"
+  name   = "test group 2"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_security_group" "test3" {
-  name        = "test group 3"
-  vpc_id      = "${aws_vpc.foo.id}"
+  name   = "test group 3"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_security_group_rule" "allow_test2" {
@@ -3696,8 +3730,8 @@ resource "aws_security_group_rule" "allow_test2" {
   to_port   = 0
   protocol  = "tcp"
 
-  source_security_group_id = "${aws_security_group.test.id}"
-  security_group_id = "${aws_security_group.test2.id}"
+  source_security_group_id = aws_security_group.test.id
+  security_group_id        = aws_security_group.test2.id
 }
 
 resource "aws_security_group_rule" "allow_test3" {
@@ -3706,8 +3740,8 @@ resource "aws_security_group_rule" "allow_test3" {
   to_port   = 0
   protocol  = "tcp"
 
-  source_security_group_id = "${aws_security_group.test.id}"
-  security_group_id = "${aws_security_group.test3.id}"
+  source_security_group_id = aws_security_group.test.id
+  security_group_id        = aws_security_group.test3.id
 }
 `
 
@@ -3721,13 +3755,13 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_security_group" "test" {
-  name        = "test group 1"
-  vpc_id      = "${aws_vpc.foo.id}"
+  name   = "test group 1"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_security_group" "test2" {
-  name        = "test group 2"
-  vpc_id      = "${aws_vpc.foo.id}"
+  name   = "test group 2"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_security_group_rule" "allow_security_group" {
@@ -3736,8 +3770,8 @@ resource "aws_security_group_rule" "allow_security_group" {
   to_port   = 0
   protocol  = "tcp"
 
-  source_security_group_id = "${aws_security_group.test2.id}"
-  security_group_id = "${aws_security_group.test.id}"
+  source_security_group_id = aws_security_group.test2.id
+  security_group_id        = aws_security_group.test.id
 }
 
 resource "aws_security_group_rule" "allow_cidr_block" {
@@ -3746,8 +3780,8 @@ resource "aws_security_group_rule" "allow_cidr_block" {
   to_port   = 0
   protocol  = "tcp"
 
-  cidr_blocks = ["10.0.0.0/32"]
-  security_group_id = "${aws_security_group.test.id}"
+  cidr_blocks       = ["10.0.0.0/32"]
+  security_group_id = aws_security_group.test.id
 }
 
 resource "aws_security_group_rule" "allow_ipv6_cidr_block" {
@@ -3756,8 +3790,8 @@ resource "aws_security_group_rule" "allow_ipv6_cidr_block" {
   to_port   = 0
   protocol  = "tcp"
 
-  ipv6_cidr_blocks = ["::/0"]
-  security_group_id = "${aws_security_group.test.id}"
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = aws_security_group.test.id
 }
 `
 
@@ -3771,8 +3805,8 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_security_group" "test" {
-  name        = "test group 1"
-  vpc_id      = "${aws_vpc.foo.id}"
+  name   = "test group 1"
+  vpc_id = aws_vpc.foo.id
 }
 
 resource "aws_security_group_rule" "allow_cidr_block" {
@@ -3781,8 +3815,8 @@ resource "aws_security_group_rule" "allow_cidr_block" {
   to_port   = 0
   protocol  = "tcp"
 
-  cidr_blocks = ["10.0.0.0/32"]
-  security_group_id = "${aws_security_group.test.id}"
+  cidr_blocks       = ["10.0.0.0/32"]
+  security_group_id = aws_security_group.test.id
 }
 
 resource "aws_security_group_rule" "allow_ipv6_cidr_block" {
@@ -3791,35 +3825,38 @@ resource "aws_security_group_rule" "allow_ipv6_cidr_block" {
   to_port   = 0
   protocol  = "tcp"
 
-  ipv6_cidr_blocks = ["::/0"]
-  security_group_id = "${aws_security_group.test.id}"
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = aws_security_group.test.id
 }
 `
 
 const testAccAWSSecurityGroupConfigIpv4andIpv6Egress = `
 resource "aws_vpc" "foo" {
-  cidr_block = "10.1.0.0/16"
+  cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
+
   tags = {
-      Name = "terraform-testacc-security-group-ipv4-and-ipv6-egress"
+    Name = "terraform-testacc-security-group-ipv4-and-ipv6-egress"
   }
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_example"
+  name        = "terraform_acceptance_test_example"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.foo.id}"
+  vpc_id      = aws_vpc.foo.id
+
   egress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    cidr_blocks  = ["0.0.0.0/0"]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
+
   egress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    ipv6_cidr_blocks  = ["::/0"]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 `
@@ -3828,47 +3865,50 @@ const testAccAWSSecurityGroupConfigPrefixListEgress = `
 data "aws_region" "current" {}
 
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
-    cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-security-group-prefix-list-egress"
-    }
+    Name = "terraform-testacc-security-group-prefix-list-egress"
+  }
 }
 
 resource "aws_route_table" "default" {
-    vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
+  vpc_id = aws_vpc.tf_sg_prefix_list_egress_test.id
 }
 
 resource "aws_vpc_endpoint" "test" {
-  	vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
-  	service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
-  	route_table_ids = ["${aws_route_table.default.id}"]
-  	policy = <<POLICY
+  vpc_id          = aws_vpc.tf_sg_prefix_list_egress_test.id
+  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  route_table_ids = [aws_route_table.default.id]
+
+  policy = <<POLICY
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid":"AllowAll",
-			"Effect":"Allow",
-			"Principal":"*",
-			"Action":"*",
-			"Resource":"*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAll",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
 }
 POLICY
+
 }
 
 resource "aws_security_group" "test" {
-    name = "terraform_acceptance_test_prefix_list_egress"
-    description = "Used in the terraform acceptance tests"
-    vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
+  name        = "terraform_acceptance_test_prefix_list_egress"
+  description = "Used in the terraform acceptance tests"
+  vpc_id      = aws_vpc.tf_sg_prefix_list_egress_test.id
 
-    egress {
-      protocol = "-1"
-      from_port = 0
-      to_port = 0
-      prefix_list_ids = ["${aws_vpc_endpoint.test.prefix_list_id}"]
-    }
+  egress {
+    protocol        = "-1"
+    from_port       = 0
+    to_port         = 0
+    prefix_list_ids = [aws_vpc_endpoint.test.prefix_list_id]
+  }
 }
 `
 
@@ -3876,47 +3916,50 @@ const testAccAWSSecurityGroupConfigPrefixListIngress = `
 data "aws_region" "current" {}
 
 resource "aws_vpc" "tf_sg_prefix_list_ingress_test" {
-    cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
+
   tags = {
-        Name = "terraform-testacc-security-group-prefix-list-ingress"
-    }
+    Name = "terraform-testacc-security-group-prefix-list-ingress"
+  }
 }
 
 resource "aws_route_table" "default" {
-    vpc_id = "${aws_vpc.tf_sg_prefix_list_ingress_test.id}"
+  vpc_id = aws_vpc.tf_sg_prefix_list_ingress_test.id
 }
 
 resource "aws_vpc_endpoint" "test" {
-    vpc_id = "${aws_vpc.tf_sg_prefix_list_ingress_test.id}"
-    service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
-    route_table_ids = ["${aws_route_table.default.id}"]
-    policy = <<POLICY
+  vpc_id          = aws_vpc.tf_sg_prefix_list_ingress_test.id
+  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  route_table_ids = [aws_route_table.default.id]
+
+  policy = <<POLICY
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid":"AllowAll",
-            "Effect":"Allow",
-            "Principal":"*",
-            "Action":"*",
-            "Resource":"*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAll",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
 }
 POLICY
+
 }
 
 resource "aws_security_group" "test" {
-    name = "terraform_acceptance_test_prefix_list_ingress"
-    description = "Used in the terraform acceptance tests"
-    vpc_id = "${aws_vpc.tf_sg_prefix_list_ingress_test.id}"
+  name        = "terraform_acceptance_test_prefix_list_ingress"
+  description = "Used in the terraform acceptance tests"
+  vpc_id      = aws_vpc.tf_sg_prefix_list_ingress_test.id
 
-    ingress {
-      protocol = "-1"
-      from_port = 0
-      to_port = 0
-      prefix_list_ids = ["${aws_vpc_endpoint.test.prefix_list_id}"]
-    }
+  ingress {
+    protocol        = "-1"
+    from_port       = 0
+    to_port         = 0
+    prefix_list_ids = [aws_vpc_endpoint.test.prefix_list_id]
+  }
 }
 `
 
@@ -3932,51 +3975,52 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "${var.name}"
+    Name = var.name
   }
 }
 
 resource "aws_route_table" "default" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_vpc_endpoint" "test" {
-  vpc_id          = "${aws_vpc.test.id}"
+  vpc_id          = aws_vpc.test.id
   service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
-  route_table_ids = ["${aws_route_table.default.id}"]
+  route_table_ids = [aws_route_table.default.id]
 
   policy = <<POLICY
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid":"AllowAll",
-			"Effect":"Allow",
-			"Principal":"*",
-			"Action":"*",
-			"Resource":"*"
-		}
-	]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAll",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
 }
 POLICY
+
 }
 
 resource "aws_security_group" "source1" {
   name        = "${var.name}-source1"
   description = "terraform acceptance test for security group as source1"
-  vpc_id      = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 }
 
 resource "aws_security_group" "source2" {
   name        = "${var.name}-source2"
   description = "terraform acceptance test for security group as source2"
-  vpc_id      = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 }
 
 resource "aws_security_group" "test" {
-  name        = "${var.name}"
+  name        = var.name
   description = "terraform acceptance test for security group"
-  vpc_id      = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 
   ingress {
     protocol    = "tcp"
@@ -4014,7 +4058,7 @@ resource "aws_security_group" "test" {
     protocol        = "tcp"
     from_port       = 80
     to_port         = 80
-    security_groups = ["${aws_security_group.source1.id}", "${aws_security_group.source2.id}"]
+    security_groups = [aws_security_group.source1.id, aws_security_group.source2.id]
     description     = "ingress from other security groups"
   }
 
@@ -4038,7 +4082,7 @@ resource "aws_security_group" "test" {
     from_port       = 0
     to_port         = 0
     protocol        = "-1"
-    prefix_list_ids = ["${aws_vpc_endpoint.test.prefix_list_id}"]
+    prefix_list_ids = [aws_vpc_endpoint.test.prefix_list_id]
     description     = "egress for vpc endpoints"
   }
 }
@@ -4048,37 +4092,38 @@ resource "aws_security_group" "test" {
 const testAccAWSSecurityGroupConfig_rulesDropOnError_Init = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-drop-rules-test"
   }
 }
 
 resource "aws_security_group" "test_ref0" {
-  name = "terraform_acceptance_test_drop_rules_ref0"
-  vpc_id = "${aws_vpc.test.id}"
+  name   = "terraform_acceptance_test_drop_rules_ref0"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_security_group" "test_ref1" {
-  name = "terraform_acceptance_test_drop_rules_ref1"
-  vpc_id = "${aws_vpc.test.id}"
+  name   = "terraform_acceptance_test_drop_rules_ref1"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_drop_rules"
+  name        = "terraform_acceptance_test_drop_rules"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test"
   }
 
   ingress {
-    protocol = "tcp"
+    protocol  = "tcp"
     from_port = "80"
-    to_port = "80"
+    to_port   = "80"
     security_groups = [
-      "${aws_security_group.test_ref0.id}",
-      "${aws_security_group.test_ref1.id}",
+      aws_security_group.test_ref0.id,
+      aws_security_group.test_ref1.id,
     ]
   }
 }
@@ -4087,37 +4132,38 @@ resource "aws_security_group" "test" {
 const testAccAWSSecurityGroupConfig_rulesDropOnError_AddBadRule = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-security-group-drop-rules-test"
   }
 }
 
 resource "aws_security_group" "test_ref0" {
-  name = "terraform_acceptance_test_drop_rules_ref0"
-  vpc_id = "${aws_vpc.test.id}"
+  name   = "terraform_acceptance_test_drop_rules_ref0"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_security_group" "test_ref1" {
-  name = "terraform_acceptance_test_drop_rules_ref1"
-  vpc_id = "${aws_vpc.test.id}"
+  name   = "terraform_acceptance_test_drop_rules_ref1"
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_security_group" "test" {
-  name = "terraform_acceptance_test_drop_rules"
+  name        = "terraform_acceptance_test_drop_rules"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id      = aws_vpc.test.id
 
   tags = {
     Name = "tf-acc-test"
   }
 
   ingress {
-    protocol = "tcp"
+    protocol  = "tcp"
     from_port = "80"
-    to_port = "80"
+    to_port   = "80"
     security_groups = [
-      "${aws_security_group.test_ref0.id}",
-      "${aws_security_group.test_ref1.id}",
+      aws_security_group.test_ref0.id,
+      aws_security_group.test_ref1.id,
       "sg-malformed", # non-existent rule to trigger API error
     ]
   }
@@ -4139,17 +4185,17 @@ resource "aws_security_group" "test" {
     Name = "terraform-testacc-security-group-egress-config-mode"
   }
 
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   egress {
-    cidr_blocks = ["${aws_vpc.test.cidr_block}"]
+    cidr_blocks = [aws_vpc.test.cidr_block]
     from_port   = 0
     protocol    = "tcp"
     to_port     = 0
   }
 
   egress {
-    cidr_blocks = ["${aws_vpc.test.cidr_block}"]
+    cidr_blocks = [aws_vpc.test.cidr_block]
     from_port   = 0
     protocol    = "udp"
     to_port     = 0
@@ -4173,7 +4219,7 @@ resource "aws_security_group" "test" {
     Name = "terraform-testacc-security-group-egress-config-mode"
   }
 
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 `
 }
@@ -4195,7 +4241,7 @@ resource "aws_security_group" "test" {
     Name = "terraform-testacc-security-group-egress-config-mode"
   }
 
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 `
 }
@@ -4215,17 +4261,17 @@ resource "aws_security_group" "test" {
     Name = "terraform-testacc-security-group-ingress-config-mode"
   }
 
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 
   ingress {
-    cidr_blocks = ["${aws_vpc.test.cidr_block}"]
+    cidr_blocks = [aws_vpc.test.cidr_block]
     from_port   = 0
     protocol    = "tcp"
     to_port     = 0
   }
 
   ingress {
-    cidr_blocks = ["${aws_vpc.test.cidr_block}"]
+    cidr_blocks = [aws_vpc.test.cidr_block]
     from_port   = 0
     protocol    = "udp"
     to_port     = 0
@@ -4249,7 +4295,7 @@ resource "aws_security_group" "test" {
     Name = "terraform-testacc-security-group-ingress-config-mode"
   }
 
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 `
 }
@@ -4271,7 +4317,7 @@ resource "aws_security_group" "test" {
     Name = "terraform-testacc-security-group-ingress-config-mode"
   }
 
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id = aws_vpc.test.id
 }
 `
 }

--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -288,7 +288,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
   name = "%[1]s.tf"
-  vpc  = "${aws_vpc.test.id}"
+  vpc  = aws_vpc.test.id
 }
 `, rName)
 }
@@ -306,7 +306,7 @@ resource "aws_vpc" "test" {
 resource "aws_service_discovery_private_dns_namespace" "test" {
   description = %[1]q
   name        = "%[2]s.tf"
-  vpc         = "${aws_vpc.test.id}"
+  vpc         = aws_vpc.test.id
 }
 `, description, rName)
 }
@@ -323,13 +323,13 @@ resource "aws_vpc" "test" {
 
 resource "aws_service_discovery_private_dns_namespace" "top" {
   name = "%[1]s.tf"
-  vpc  = "${aws_vpc.test.id}"
+  vpc  = aws_vpc.test.id
 }
 
 # Ensure ordering after first namespace
 resource "aws_service_discovery_private_dns_namespace" "subdomain" {
-  name = "${aws_service_discovery_private_dns_namespace.top.name}"
-  vpc  = "${aws_service_discovery_private_dns_namespace.top.vpc}"
+  name = aws_service_discovery_private_dns_namespace.top.name
+  vpc  = aws_service_discovery_private_dns_namespace.top.vpc
 }
 `, rName)
 }
@@ -346,7 +346,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
   name = "%[1]s.tf"
-  vpc  = "${aws_vpc.test.id}"
+  vpc  = aws_vpc.test.id
 
   tags = {
     %[2]q = %[3]q
@@ -367,7 +367,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
   name = "%[1]s.tf"
-  vpc  = "${aws_vpc.test.id}"
+  vpc  = aws_vpc.test.id
 
   tags = {
     %[2]q = %[3]q

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -356,14 +356,14 @@ resource "aws_vpc" "test" {
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
   name = "%[1]s.tf"
-  vpc  = "${aws_vpc.test.id}"
+  vpc  = aws_vpc.test.id
 }
 
 resource "aws_service_discovery_service" "test" {
   name = %[1]q
 
   dns_config {
-    namespace_id = "${aws_service_discovery_private_dns_namespace.test.id}"
+    namespace_id = aws_service_discovery_private_dns_namespace.test.id
 
     dns_records {
       ttl  = 5
@@ -389,8 +389,8 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "test" {
-  name        = "%[1]s.tf"
-  vpc         = "${aws_vpc.test.id}"
+  name = "%[1]s.tf"
+  vpc  = aws_vpc.test.id
 }
 
 resource "aws_service_discovery_service" "test" {
@@ -399,7 +399,7 @@ resource "aws_service_discovery_service" "test" {
   description = "test"
 
   dns_config {
-    namespace_id = "${aws_service_discovery_private_dns_namespace.test.id}"
+    namespace_id = aws_service_discovery_private_dns_namespace.test.id
 
     dns_records {
       ttl  = 10
@@ -433,7 +433,7 @@ resource "aws_service_discovery_service" "test" {
   description = "test"
 
   dns_config {
-    namespace_id = "${aws_service_discovery_public_dns_namespace.test.id}"
+    namespace_id = aws_service_discovery_public_dns_namespace.test.id
 
     dns_records {
       ttl  = 5
@@ -462,7 +462,7 @@ resource "aws_service_discovery_service" "test" {
   name = %[1]q
 
   dns_config {
-    namespace_id = "${aws_service_discovery_public_dns_namespace.test.id}"
+    namespace_id = aws_service_discovery_public_dns_namespace.test.id
 
     dns_records {
       ttl  = 5
@@ -483,7 +483,7 @@ resource "aws_service_discovery_http_namespace" "test" {
 
 resource "aws_service_discovery_service" "test" {
   name         = %[1]q
-  namespace_id = "${aws_service_discovery_http_namespace.test.id}"
+  namespace_id = aws_service_discovery_http_namespace.test.id
 }
 `, rName)
 }
@@ -496,7 +496,7 @@ resource "aws_service_discovery_http_namespace" "test" {
 
 resource "aws_service_discovery_service" "test" {
   name         = %[1]q
-  namespace_id = "${aws_service_discovery_http_namespace.test.id}"
+  namespace_id = aws_service_discovery_http_namespace.test.id
 
   tags = {
     %[2]q = %[3]q
@@ -513,7 +513,7 @@ resource "aws_service_discovery_http_namespace" "test" {
 
 resource "aws_service_discovery_service" "test" {
   name         = %[1]q
-  namespace_id = "${aws_service_discovery_http_namespace.test.id}"
+  namespace_id = aws_service_discovery_http_namespace.test.id
 
   tags = {
     %[2]q = %[3]q

--- a/aws/resource_aws_servicequotas_service_quota_test.go
+++ b/aws/resource_aws_servicequotas_service_quota_test.go
@@ -159,9 +159,9 @@ data "aws_servicequotas_service_quota" "test" {
 }
 
 resource "aws_servicequotas_service_quota" "test" {
-  quota_code   = "${data.aws_servicequotas_service_quota.test.quota_code}"
-  service_code = "${data.aws_servicequotas_service_quota.test.service_code}"
-  value        = "${data.aws_servicequotas_service_quota.test.value}"
+  quota_code   = data.aws_servicequotas_service_quota.test.quota_code
+  service_code = data.aws_servicequotas_service_quota.test.service_code
+  value        = data.aws_servicequotas_service_quota.test.value
 }
 `, quotaCode, serviceCode)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Related: #8950, #14417

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing: Handled via daily acceptance testing