### PR TITLE
tests/provider: Update hardcoded AZs (Data subnet ids)

### DIFF
--- a/aws/data_source_aws_subnet_ids_test.go
+++ b/aws/data_source_aws_subnet_ids_test.go
@@ -49,9 +49,9 @@ func TestAccDataSourceAwsSubnetIDs_filter(t *testing.T) {
 }
 
 func testAccDataSourceAwsSubnetIDsConfigWithDataSource(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "172.%d.0.0/16"
+  cidr_block = "172.%[1]d.0.0/16"
 
   tags = {
     Name = "terraform-testacc-subnet-ids-data-source"
@@ -60,8 +60,8 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test_public_a" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.123.0/24"
-  availability_zone = "us-west-2a"
+  cidr_block        = "172.%[1]d.123.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-subnet-ids-data-source-public-a"
@@ -71,8 +71,8 @@ resource "aws_subnet" "test_public_a" {
 
 resource "aws_subnet" "test_private_a" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.125.0/24"
-  availability_zone = "us-west-2a"
+  cidr_block        = "172.%[1]d.125.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-subnet-ids-data-source-private-a"
@@ -82,8 +82,8 @@ resource "aws_subnet" "test_private_a" {
 
 resource "aws_subnet" "test_private_b" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.126.0/24"
-  availability_zone = "us-west-2b"
+  cidr_block        = "172.%[1]d.126.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-subnet-ids-data-source-private-b"
@@ -102,13 +102,13 @@ data "aws_subnet_ids" "private" {
     Tier = "Private"
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt))
 }
 
 func testAccDataSourceAwsSubnetIDsConfig(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "172.%d.0.0/16"
+  cidr_block = "172.%[1]d.0.0/16"
 
   tags = {
     Name = "terraform-testacc-subnet-ids-data-source"
@@ -117,8 +117,8 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test_public_a" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.123.0/24"
-  availability_zone = "us-west-2a"
+  cidr_block        = "172.%[1]d.123.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-subnet-ids-data-source-public-a"
@@ -128,8 +128,8 @@ resource "aws_subnet" "test_public_a" {
 
 resource "aws_subnet" "test_private_a" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.125.0/24"
-  availability_zone = "us-west-2a"
+  cidr_block        = "172.%[1]d.125.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-subnet-ids-data-source-private-a"
@@ -139,21 +139,21 @@ resource "aws_subnet" "test_private_a" {
 
 resource "aws_subnet" "test_private_b" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.126.0/24"
-  availability_zone = "us-west-2b"
+  cidr_block        = "172.%[1]d.126.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-subnet-ids-data-source-private-b"
     Tier = "Private"
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt))
 }
 
 func testAccDataSourceAwsSubnetIDs_filter(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "172.%d.0.0/16"
+  cidr_block = "172.%[1]d.0.0/16"
 
   tags = {
     Name = "terraform-testacc-subnet-ids-data-source"
@@ -162,20 +162,20 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test_a_one" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.1.0/24"
-  availability_zone = "us-west-2a"
+  cidr_block        = "172.%[1]d.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 }
 
 resource "aws_subnet" "test_a_two" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.2.0/24"
-  availability_zone = "us-west-2a"
+  cidr_block        = "172.%[1]d.2.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 }
 
 resource "aws_subnet" "test_b" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.3.0/24"
-  availability_zone = "us-west-2b"
+  cidr_block        = "172.%[1]d.3.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
 }
 
 data "aws_subnet_ids" "test" {
@@ -186,5 +186,5 @@ data "aws_subnet_ids" "test" {
     values = [aws_subnet.test_a_one.availability_zone]
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing (GovCloud partition):

```
--- PASS: TestAccDataSourceAwsSubnetIDs_filter (29.38s)
--- PASS: TestAccDataSourceAwsSubnetIDs_basic (48.85s)
```

Output from acceptance testing (commercial/standard partition):

```
--- PASS: TestAccDataSourceAwsSubnetIDs_filter (24.43s)
--- PASS: TestAccDataSourceAwsSubnetIDs_basic (42.13s)
```