### PR TITLE
Make the documentation about aws_s3_bucket_inventory less confusing

### DIFF
--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -81,7 +81,7 @@ resource "aws_s3_bucket_inventory" "test-prefix" {
 
 The following arguments are supported:
 
-* `bucket` - (Required) The name of the bucket where the inventory configuration will be stored.
+* `bucket` - (Required) The name of the source bucket that inventory lists the objects for.
 * `name` - (Required) Unique identifier of the inventory configuration for the bucket.
 * `included_object_versions` - (Required) Object versions to include in the inventory list. Valid values: `All`, `Current`.
 * `schedule` - (Required) Specifies the schedule for generating inventory results (documented below).


### PR DESCRIPTION
As described in this issue: https://github.com/terraform-providers/terraform-provider-aws/issues/14708, the documentation about `aws_s3_bucket_inventory` can be a little bit confusing. This PR adjust the documentation to give a better description about the `bucket` argument.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14708  

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

