### PR TITLE
r/eks_node_group: Add support for ami_type AL2_ARM_64 to eks_node_group

### DIFF
--- a/aws/resource_aws_eks_node_group.go
+++ b/aws/resource_aws_eks_node_group.go
@@ -40,6 +40,7 @@ func resourceAwsEksNodeGroup() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					eks.AMITypesAl2X8664,
 					eks.AMITypesAl2X8664Gpu,
+					eks.AMITypesAl2Arm64,
 				}, false),
 			},
 			"arn": {

--- a/aws/resource_aws_eks_node_group_test.go
+++ b/aws/resource_aws_eks_node_group_test.go
@@ -147,7 +147,7 @@ func TestAccAWSEksNodeGroup_disappears(t *testing.T) {
 }
 
 func TestAccAWSEksNodeGroup_AmiType(t *testing.T) {
-	var nodeGroup1 eks.Nodegroup
+	var nodeGroup1, nodeGroup2 eks.Nodegroup
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_eks_node_group.test"
 
@@ -167,6 +167,13 @@ func TestAccAWSEksNodeGroup_AmiType(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksNodeGroupConfigAmiType(rName, eks.AMITypesAl2Arm64),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksNodeGroupExists(resourceName, &nodeGroup2),
+					resource.TestCheckResourceAttr(resourceName, "ami_type", eks.AMITypesAl2Arm64),
+				),
 			},
 		},
 	})

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -123,7 +123,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `ami_type` - (Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided.
+* `ami_type` - (Optional) Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`, `AL2_ARM_64`. Terraform will only perform drift detection if a configuration value is provided.
 * `disk_size` - (Optional) Disk size in GiB for worker nodes. Defaults to `20`. Terraform will only perform drift detection if a configuration value is provided.
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
 * `instance_types` - (Optional) Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided. Currently, the EKS API only accepts a single value in the set.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/eks_node_group: Add support for ami_type AL2_ARM_64 
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEksNodeGroup_AmiType'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEksNodeGroup_AmiType -timeout 120m
=== RUN   TestAccAWSEksNodeGroup_AmiType
=== PAUSE TestAccAWSEksNodeGroup_AmiType
=== CONT  TestAccAWSEksNodeGroup_AmiType
--- PASS: TestAccAWSEksNodeGroup_AmiType (1609.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1609.543s
```
