### PR TITLE
r/user_pool_domain - remove from state when deleted + move waiters to their own package

### DIFF
--- a/aws/internal/service/cognitoidentityprovider/waiter/status.go
+++ b/aws/internal/service/cognitoidentityprovider/waiter/status.go
@@ -6,6 +6,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+const (
+	userPoolDomainStatusNotFound = "NotFound"
+	userPoolDomainStatusUnknown  = "Unknown"
+)
+
 // UserPoolDomainStatus fetches the Operation and its Status
 func UserPoolDomainStatus(conn *cognitoidentityprovider.CognitoIdentityProvider, domain string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
@@ -16,11 +21,11 @@ func UserPoolDomainStatus(conn *cognitoidentityprovider.CognitoIdentityProvider,
 		output, err := conn.DescribeUserPoolDomain(input)
 
 		if err != nil {
-			return nil, "", err
+			return nil, userPoolDomainStatusUnknown, err
 		}
 
 		if output == nil {
-			return nil, "", nil
+			return nil, userPoolDomainStatusNotFound, nil
 		}
 
 		return output, aws.StringValue(output.DomainDescription.Status), nil

--- a/aws/internal/service/cognitoidentityprovider/waiter/status.go
+++ b/aws/internal/service/cognitoidentityprovider/waiter/status.go
@@ -1,0 +1,28 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// UserPoolDomainStatus fetches the Operation and its Status
+func UserPoolDomainStatus(conn *cognitoidentityprovider.CognitoIdentityProvider, domain string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &cognitoidentityprovider.DescribeUserPoolDomainInput{
+			Domain: aws.String(domain),
+		}
+
+		output, err := conn.DescribeUserPoolDomain(input)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if output == nil {
+			return nil, "", nil
+		}
+
+		return output, aws.StringValue(output.DomainDescription.Status), nil
+	}
+}

--- a/aws/internal/service/cognitoidentityprovider/waiter/waiter.go
+++ b/aws/internal/service/cognitoidentityprovider/waiter/waiter.go
@@ -1,0 +1,58 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for an Operation to return Success
+	UserPoolDomainDeleteTimeout = 1 * time.Minute
+	UserPoolDomainCreateTimeout = 1 * time.Minute
+)
+
+// UserPoolDomainDeleted waits for an Operation to return Success
+func UserPoolDomainDeleted(conn *cognitoidentityprovider.CognitoIdentityProvider, domain string) (*cognitoidentityprovider.DescribeUserPoolDomainOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			cognitoidentityprovider.DomainStatusTypeUpdating,
+			cognitoidentityprovider.DomainStatusTypeDeleting,
+		},
+		Target:  []string{""},
+		Refresh: UserPoolDomainStatus(conn, domain),
+		Timeout: UserPoolDomainDeleteTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*cognitoidentityprovider.DescribeUserPoolDomainOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func UserPoolDomainCreated(conn *cognitoidentityprovider.CognitoIdentityProvider, domain string, timeout time.Duration) (*cognitoidentityprovider.DescribeUserPoolDomainOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			cognitoidentityprovider.DomainStatusTypeCreating,
+			cognitoidentityprovider.DomainStatusTypeUpdating,
+		},
+		Target: []string{
+			cognitoidentityprovider.DomainStatusTypeActive,
+		},
+		Refresh:    UserPoolDomainStatus(conn, domain),
+		MinTimeout: UserPoolDomainCreateTimeout,
+		Timeout:    timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*cognitoidentityprovider.DescribeUserPoolDomainOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/internal/service/cognitoidentityprovider/waiter/waiter.go
+++ b/aws/internal/service/cognitoidentityprovider/waiter/waiter.go
@@ -10,7 +10,6 @@ import (
 const (
 	// Maximum amount of time to wait for an Operation to return Success
 	UserPoolDomainDeleteTimeout = 1 * time.Minute
-	UserPoolDomainCreateTimeout = 1 * time.Minute
 )
 
 // UserPoolDomainDeleted waits for an Operation to return Success
@@ -43,9 +42,8 @@ func UserPoolDomainCreated(conn *cognitoidentityprovider.CognitoIdentityProvider
 		Target: []string{
 			cognitoidentityprovider.DomainStatusTypeActive,
 		},
-		Refresh:    UserPoolDomainStatus(conn, domain),
-		MinTimeout: UserPoolDomainCreateTimeout,
-		Timeout:    timeout,
+		Refresh: UserPoolDomainStatus(conn, domain),
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()

--- a/aws/internal/service/cognitoidentityprovider/waiter/waiter.go
+++ b/aws/internal/service/cognitoidentityprovider/waiter/waiter.go
@@ -1,9 +1,9 @@
 package waiter
 
 import (
-	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 

--- a/aws/resource_aws_cognito_user_pool_domain.go
+++ b/aws/resource_aws_cognito_user_pool_domain.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cognitoidentityprovider/waiter"
 )
 
 func resourceAwsCognitoUserPoolDomain() *schema.Resource {
@@ -83,37 +83,13 @@ func resourceAwsCognitoUserPoolDomainCreate(d *schema.ResourceData, meta interfa
 
 	_, err := conn.CreateUserPoolDomain(params)
 	if err != nil {
-		return fmt.Errorf("Error creating Cognito User Pool Domain: %s", err)
+		return fmt.Errorf("Error creating Cognito User Pool Domain: %w", err)
 	}
 
 	d.SetId(domain)
 
-	stateConf := resource.StateChangeConf{
-		Pending: []string{
-			cognitoidentityprovider.DomainStatusTypeCreating,
-			cognitoidentityprovider.DomainStatusTypeUpdating,
-		},
-		Target: []string{
-			cognitoidentityprovider.DomainStatusTypeActive,
-		},
-		MinTimeout: 1 * time.Minute,
-		Timeout:    timeout,
-		Refresh: func() (interface{}, string, error) {
-			domain, err := conn.DescribeUserPoolDomain(&cognitoidentityprovider.DescribeUserPoolDomainInput{
-				Domain: aws.String(d.Get("domain").(string)),
-			})
-			if err != nil {
-				return 42, "", err
-			}
-
-			desc := domain.DomainDescription
-
-			return domain, *desc.Status, nil
-		},
-	}
-	_, err = stateConf.WaitForState()
-	if err != nil {
-		return err
+	if _, err := waiter.UserPoolDomainCreated(conn, d.Id(), timeout); err != nil {
+		return fmt.Errorf("error waiting for User Pool Domain (%s) creation: %w", d.Id(), err)
 	}
 
 	return resourceAwsCognitoUserPoolDomainRead(d, meta)
@@ -127,7 +103,7 @@ func resourceAwsCognitoUserPoolDomainRead(d *schema.ResourceData, meta interface
 		Domain: aws.String(d.Id()),
 	})
 	if err != nil {
-		if isAWSErr(err, "ResourceNotFoundException", "") {
+		if isAWSErr(err, cognitoidentityprovider.ErrCodeResourceNotFoundException, "") {
 			log.Printf("[WARN] Cognito User Pool Domain %q not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -136,6 +112,12 @@ func resourceAwsCognitoUserPoolDomainRead(d *schema.ResourceData, meta interface
 	}
 
 	desc := domain.DomainDescription
+
+	if desc.Status == nil {
+		log.Printf("[WARN] Cognito User Pool Domain %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	d.Set("domain", d.Id())
 	d.Set("certificate_arn", "")
@@ -160,35 +142,16 @@ func resourceAwsCognitoUserPoolDomainDelete(d *schema.ResourceData, meta interfa
 		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("Error deleting User Pool Domain: %w", err)
 	}
 
-	stateConf := resource.StateChangeConf{
-		Pending: []string{
-			cognitoidentityprovider.DomainStatusTypeUpdating,
-			cognitoidentityprovider.DomainStatusTypeDeleting,
-		},
-		Target:  []string{""},
-		Timeout: 1 * time.Minute,
-		Refresh: func() (interface{}, string, error) {
-			domain, err := conn.DescribeUserPoolDomain(&cognitoidentityprovider.DescribeUserPoolDomainInput{
-				Domain: aws.String(d.Id()),
-			})
-			if err != nil {
-				if isAWSErr(err, "ResourceNotFoundException", "") {
-					return 42, "", nil
-				}
-				return 42, "", err
-			}
-
-			desc := domain.DomainDescription
-			if desc.Status == nil {
-				return 42, "", nil
-			}
-
-			return domain, *desc.Status, nil
-		},
+	if _, err := waiter.UserPoolDomainDeleted(conn, d.Id()); err != nil {
+		if isAWSErr(err, cognitoidentityprovider.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error waiting for User Pool Domain (%s) deletion: %w", d.Id(), err)
 	}
-	_, err = stateConf.WaitForState()
-	return err
+
+	return nil
+
 }


### PR DESCRIPTION
improve check for disappears + test

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #5313

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_user_pool_domain - remove from state when deleted
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolDomain_'
--- PASS: TestAccAWSCognitoUserPoolDomain_basic (54.56s)
--- SKIP: TestAccAWSCognitoUserPoolDomain_custom (0.00s)
--- PASS: TestAccAWSCognitoUserPoolDomain_disappears (46.92s)
```
