### PR TITLE
r/aws_service_discovery_http_namespace: Correct name validation

### DIFF
--- a/aws/resource_aws_service_discovery_http_namespace.go
+++ b/aws/resource_aws_service_discovery_http_namespace.go
@@ -27,7 +27,7 @@ func resourceAwsServiceDiscoveryHttpNamespace() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateServiceDiscoveryHttpNamespaceName,
+				ValidateFunc: validateServiceDiscoveryNamespaceName,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_service_discovery_private_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace.go
@@ -32,9 +32,10 @@ func resourceAwsServiceDiscoveryPrivateDnsNamespace() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateServiceDiscoveryNamespaceName,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_service_discovery_public_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace.go
@@ -24,9 +24,10 @@ func resourceAwsServiceDiscoveryPublicDnsNamespace() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateServiceDiscoveryNamespaceName,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2354,27 +2354,6 @@ func validateCloudFrontPublicKeyNamePrefix(v interface{}, k string) (ws []string
 	return
 }
 
-func validateServiceDiscoveryHttpNamespaceName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z_-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, underscores and hyphens allowed in %q", k))
-	}
-	if !regexp.MustCompile(`^[a-zA-Z]`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"first character of %q must be a letter", k))
-	}
-	if !regexp.MustCompile(`[a-zA-Z]$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"last character of %q must be a letter", k))
-	}
-	if len(value) > 1024 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be greater than 1024 characters", k))
-	}
-	return
-}
-
 func validateLbTargetGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 32 {
@@ -2478,3 +2457,8 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 
 	return
 }
+
+var validateServiceDiscoveryNamespaceName = validation.All(
+	validation.StringLenBetween(1, 1024),
+	validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z._-]+$`), ""),
+)

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3146,3 +3146,36 @@ func TestValidateRoute53ResolverName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateServiceDiscoveryNamespaceName(t *testing.T) {
+	validNames := []string{
+		"ValidName",
+		"V_-.dN01e",
+		"0",
+		".",
+		"-",
+		"_",
+		strings.Repeat("x", 1024),
+	}
+	for _, v := range validNames {
+		_, errors := validateServiceDiscoveryNamespaceName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid namespace name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"Inval:dName",
+		"Invalid Name",
+		"*",
+		"",
+		// length > 512
+		strings.Repeat("x", 1025),
+	}
+	for _, v := range invalidNames {
+		_, errors := validateServiceDiscoveryNamespaceName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid namespace name", v)
+		}
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14741.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_service_discovery_http_namespace: Correct validation of `name` attribute to allow `.`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSServiceDiscoveryHttpNamespace_basic\|TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic\|TestAccAWSServiceDiscoveryPublicDnsNamespace_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSServiceDiscoveryHttpNamespace_basic\|TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic\|TestAccAWSServiceDiscoveryPublicDnsNamespace_basic -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryHttpNamespace_basic
=== PAUSE TestAccAWSServiceDiscoveryHttpNamespace_basic
=== RUN   TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
=== PAUSE TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
=== RUN   TestAccAWSServiceDiscoveryPublicDnsNamespace_basic
=== PAUSE TestAccAWSServiceDiscoveryPublicDnsNamespace_basic
=== CONT  TestAccAWSServiceDiscoveryHttpNamespace_basic
=== CONT  TestAccAWSServiceDiscoveryPublicDnsNamespace_basic
=== CONT  TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_basic (89.35s)
--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_basic (110.16s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (119.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	119.223s
```
