### PR TITLE
Update CloudWatch Log group argument reference in CloudTrail documentation

### DIFF
--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -133,6 +133,20 @@ resource "aws_cloudtrail" "example" {
 }
 ```
 
+#### Sending Events to CloudWatch Logs
+
+```hcl
+resource "aws_cloudwatch_log_group" "example" {
+  name = "Example"
+}
+
+resource "aws_cloudtrail" "example" {
+  # ... other configuration ...
+
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.example.arn}:*" # CloudTrail requires the Log Stream wildcard
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -144,7 +158,7 @@ The following arguments are supported:
 * `cloud_watch_logs_role_arn` - (Optional) Specifies the role for the CloudWatch Logs
     endpoint to assume to write to a user’s log group.
 * `cloud_watch_logs_group_arn` - (Optional) Specifies a log group name using an Amazon Resource Name (ARN),
-    that represents the log group to which CloudTrail logs will be delivered.
+    that represents the log group to which CloudTrail logs will be delivered. Note that CloudTrail requires the Log Stream wildcard.
 * `enable_logging` - (Optional) Enables logging for the trail. Defaults to `true`.
     Setting this to `false` will pause logging.
 * `include_global_service_events` - (Optional) Specifies whether the trail is publishing events


### PR DESCRIPTION
Add an example explain how to send Events to CloudWatch Logs and update `cloud_watch_logs_group_arn` argument reference documentation.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates  #14557

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

