### PR TITLE
Fix CI `go test` failures: Check for null regexp in 'testCheckTypeSetElemNestedAttrsInState'

### DIFF
--- a/aws/internal/tfawsresource/testing.go
+++ b/aws/internal/tfawsresource/testing.go
@@ -71,7 +71,7 @@ func TestCheckTypeSetElemNestedAttrs(name, attr string, values map[string]string
 //
 //   map[string]*regexp.Regexp{
 //	     "key1": regexp.MustCompile("value"),
-//       "key2": regexp,.MustCompile(""),
+//       "key2": regexp.MustCompile(""),
 //   }
 //
 func TestMatchTypeSetElemNestedAttrs(name, attr string, values map[string]*regexp.Regexp) resource.TestCheckFunc {
@@ -233,7 +233,7 @@ func testCheckTypeSetElemNestedAttrsInState(is *terraform.InstanceState, attrPar
 				match = true
 			}
 		case map[string]*regexp.Regexp:
-			if v, keyExists := t[nestedAttr]; keyExists && v.MatchString(stateValue) {
+			if v, keyExists := t[nestedAttr]; keyExists && v != nil && v.MatchString(stateValue) {
 				match = true
 			}
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes occasional CI `go test` failures, for example:

* https://github.com/terraform-providers/terraform-provider-aws/pull/12303/checks?check_run_id=1004981487
* https://github.com/terraform-providers/terraform-provider-aws/runs/1000545643

This crash can be reproduced locally by tweaking the test case and running

```console
$ go test ./aws/internal/tfawsresource -v -run TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_unset/empty_value_match
=== RUN   TestTestMatchTypeSetElemNestedAttrs
=== RUN   TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_unset/empty_value_match
--- FAIL: TestTestMatchTypeSetElemNestedAttrs (0.00s)
    --- FAIL: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_unset/empty_value_match (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x90 pc=0x5333a2]

goroutine 7 [running]:
testing.tRunner.func1.1(0xeb3c80, 0x19c5130)
	/usr/local/go/src/testing/testing.go:988 +0x30d
testing.tRunner.func1(0xc0000dcd80)
	/usr/local/go/src/testing/testing.go:991 +0x3f9
panic(0xeb3c80, 0x19c5130)
	/usr/local/go/src/runtime/panic.go:969 +0x166
regexp.(*Regexp).doExecute(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/usr/local/go/src/regexp/exec.go:527 +0x562
regexp.(*Regexp).doMatch(...)
	/usr/local/go/src/regexp/exec.go:514
regexp.(*Regexp).MatchString(...)
	/usr/local/go/src/regexp/regexp.go:507
github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource.testCheckTypeSetElemNestedAttrsInState(0xc0000da230, 0xc0002d37c0, 0x2, 0x2, 0x1, 0xea7980, 0xc000088ff0, 0x2)
	/home/kit/wrk/src/github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource/testing.go:236 +0x514
github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource.TestMatchTypeSetElemNestedAttrs.func1(0xc0000db110, 0x12, 0xffa838)
	/home/kit/wrk/src/github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource/testing.go:101 +0x21f
github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource.TestTestMatchTypeSetElemNestedAttrs.func12(0xc0000dcd80)
	/home/kit/wrk/src/github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource/testing_test.go:1691 +0x72
testing.tRunner(0xc0000dcd80, 0xc000046b00)
	/usr/local/go/src/testing/testing.go:1039 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1090 +0x372
FAIL	github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource	0.017s
FAIL
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ go test ./aws/internal/tfawsresource -v -run TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_unset/empty_value_match
=== RUN   TestTestMatchTypeSetElemNestedAttrs
=== RUN   TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_unset/empty_value_match
--- PASS: TestTestMatchTypeSetElemNestedAttrs (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_unset/empty_value_match (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource	0.012s
```
