### PR TITLE
tech-debt: update data_source and resources skipped by AWSV001 check

### DIFF
--- a/aws/data_source_aws_ssm_patch_baseline.go
+++ b/aws/data_source_aws_ssm_patch_baseline.go
@@ -31,7 +31,7 @@ func dataSourceAwsSsmPatchBaseline() *schema.Resource {
 			"operating_system": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice(ssmPatchOSs, false),
+				ValidateFunc: validation.StringInSlice(ssm.OperatingSystem_Values(), false),
 			},
 			// Computed values
 			"description": {

--- a/aws/resource_aws_appsync_graphql_api.go
+++ b/aws/resource_aws_appsync_graphql_api.go
@@ -13,13 +13,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
-var validAppsyncAuthTypes = []string{
-	appsync.AuthenticationTypeApiKey,
-	appsync.AuthenticationTypeAwsIam,
-	appsync.AuthenticationTypeAmazonCognitoUserPools,
-	appsync.AuthenticationTypeOpenidConnect,
-}
-
 func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsAppsyncGraphqlApiCreate,
@@ -40,7 +33,7 @@ func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 						"authentication_type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice(validAppsyncAuthTypes, false),
+							ValidateFunc: validation.StringInSlice(appsync.AuthenticationType_Values(), false),
 						},
 						"openid_connect_config": {
 							Type:     schema.TypeList,
@@ -95,7 +88,7 @@ func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 			"authentication_type": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice(validAppsyncAuthTypes, false),
+				ValidateFunc: validation.StringInSlice(appsync.AuthenticationType_Values(), false),
 			},
 			"schema": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -14,14 +14,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
-var eksLogTypes = []string{
-	eks.LogTypeApi,
-	eks.LogTypeAudit,
-	eks.LogTypeAuthenticator,
-	eks.LogTypeControllerManager,
-	eks.LogTypeScheduler,
-}
-
 func resourceAwsEksCluster() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsEksClusterCreate,
@@ -202,7 +194,7 @@ func resourceAwsEksCluster() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice(eksLogTypes, true),
+					ValidateFunc: validation.StringInSlice(eks.LogType_Values(), true),
 				},
 				Set: schema.HashString,
 			},
@@ -558,7 +550,7 @@ func expandEksVpcConfigUpdateRequest(l []interface{}) *eks.VpcConfigRequest {
 
 func expandEksLoggingTypes(vEnabledLogTypes *schema.Set) *eks.Logging {
 	vEksLogTypes := []interface{}{}
-	for _, eksLogType := range eksLogTypes {
+	for _, eksLogType := range eks.LogType_Values() {
 		vEksLogTypes = append(vEksLogTypes, eksLogType)
 	}
 	vAllLogTypes := schema.NewSet(schema.HashString, vEksLogTypes)

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -11,25 +11,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
-var ssmPatchComplianceLevels = []string{
-	ssm.PatchComplianceLevelCritical,
-	ssm.PatchComplianceLevelHigh,
-	ssm.PatchComplianceLevelMedium,
-	ssm.PatchComplianceLevelLow,
-	ssm.PatchComplianceLevelInformational,
-	ssm.PatchComplianceLevelUnspecified,
-}
-
-var ssmPatchOSs = []string{
-	ssm.OperatingSystemWindows,
-	ssm.OperatingSystemAmazonLinux,
-	ssm.OperatingSystemUbuntu,
-	ssm.OperatingSystemRedhatEnterpriseLinux,
-	ssm.OperatingSystemCentos,
-	ssm.OperatingSystemAmazonLinux2,
-	ssm.OperatingSystemSuse,
-}
-
 func resourceAwsSsmPatchBaseline() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsSsmPatchBaselineCreate,
@@ -84,7 +65,7 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      ssm.PatchComplianceLevelUnspecified,
-							ValidateFunc: validation.StringInSlice(ssmPatchComplianceLevels, false),
+							ValidateFunc: validation.StringInSlice(ssm.PatchComplianceLevel_Values(), false),
 						},
 
 						"enable_non_security": {
@@ -134,14 +115,14 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      ssm.OperatingSystemWindows,
-				ValidateFunc: validation.StringInSlice(ssmPatchOSs, false),
+				ValidateFunc: validation.StringInSlice(ssm.OperatingSystem_Values(), false),
 			},
 
 			"approved_patches_compliance_level": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      ssm.PatchComplianceLevelUnspecified,
-				ValidateFunc: validation.StringInSlice(ssmPatchComplianceLevels, false),
+				ValidateFunc: validation.StringInSlice(ssm.PatchComplianceLevel_Values(), false),
 			},
 			"tags": tagsSchema(),
 		},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14601

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: update data_source aws_ssm_patch_baseline operating_system validation values
tech-debt: update resource aws_appsync_graphql_api authentication_type validation values
tech-debt: update resource aws_eks_cluster enabled_cluster_log_types validation values
tech-debt: update resource aws_ssm_patch_baseline operating_system validation values
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_APIKey (61.40s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_AWSIAM (62.70s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_CognitoUserPools (64.49s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_Multiple (62.00s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_OpenIDConnect (62.57s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType (113.40s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey (76.24s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM (77.21s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools (66.55s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect (68.57s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig (71.03s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig_ExcludeVerboseContent (127.98s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel (150.00s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Name (98.67s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL (110.22s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID (107.75s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL (127.38s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer (124.43s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Schema (114.59s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Tags (97.71s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion (101.01s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction (98.69s)
--- PASS: TestAccAWSAppsyncGraphqlApi_XrayEnabled (77.03s)
--- PASS: TestAccAWSAppsyncGraphqlApi_basic (60.99s)
--- PASS: TestAccAWSAppsyncGraphqlApi_disappears (45.10s)
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (50.81s)
--- PASS: TestAccAWSEksClusterDataSource_basic (795.12s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig (765.20s)
--- PASS: TestAccAWSEksCluster_Logging (968.25s)
--- PASS: TestAccAWSEksCluster_Tags (848.09s)
--- PASS: TestAccAWSEksCluster_Version (1467.21s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2396.64s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1721.13s)
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (1311.03s)
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (747.26s)
--- PASS: TestAccAWSEksCluster_basic (827.58s)
--- PASS: TestAccAWSSSMPatchBaseline_OperatingSystem (34.19s)
--- PASS: TestAccAWSSSMPatchBaseline_basic (38.55s)
--- PASS: TestAccAWSSSMPatchBaseline_disappears (20.50s)
--- PASS: TestAccAWSSSMPatchBaseline_tags (46.51s)
--- PASS: TestAccAWSSsmPatchBaselineDataSource_existingBaseline (51.48s)
--- PASS: TestAccAWSSsmPatchBaselineDataSource_newBaseline (67.78s)
```
