### PR TITLE
issue-1146 add support for instance fleet in EMR

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -600,6 +600,7 @@ func Provider() *schema.Provider {
 			"aws_elb":                                                 resourceAwsElb(),
 			"aws_elb_attachment":                                      resourceAwsElbAttachment(),
 			"aws_emr_cluster":                                         resourceAwsEMRCluster(),
+			"aws_emr_instance_fleet":                                  resourceAwsEMRInstanceFleet(),
 			"aws_emr_instance_group":                                  resourceAwsEMRInstanceGroup(),
 			"aws_emr_security_configuration":                          resourceAwsEMRSecurityConfiguration(),
 			"aws_flow_log":                                            resourceAwsFlowLog(),

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -504,35 +504,6 @@ func resourceAwsEMRCluster() *schema.Resource {
 	}
 }
 
-func ebsConfigurationSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"iops": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-			},
-			"size": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateAwsEmrEbsVolumeType(),
-			},
-			"volumes_per_instance": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  1,
-			},
-		},
-	}
-}
-
 func InstanceFleetConfigSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -550,14 +521,132 @@ func InstanceFleetConfigSchema() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				// ForceNew: true,
-				Elem: instanceTypeConfigSchema(),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bid_price": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"bid_price_as_percentage_of_on_demand_price": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+							ForceNew: true,
+						},
+						"configurations": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"classification": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"configurations": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"classification": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"properties": {
+													Type:     schema.TypeMap,
+													Optional: true,
+													Elem:     schema.TypeString,
+												},
+											},
+										},
+									},
+									"properties": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem:     schema.TypeString,
+									},
+								},
+							},
+						},
+						"ebs_config": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"iops": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+									},
+									"size": {
+										Type:     schema.TypeInt,
+										Required: true,
+										ForceNew: true,
+									},
+									"type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validateAwsEmrEbsVolumeType(),
+									},
+									"volumes_per_instance": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+										Default:  1,
+									},
+								},
+							},
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"weighted_capacity": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+							Default:  1,
+						},
+					},
+				},
 			},
 			"launch_specifications": {
 				Type:     schema.TypeList,
 				Optional: true,
 				// ForceNew: true,
 				MaxItems: 1,
-				Elem:     launchSpecificationsSchema(),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"spot_specification": {
+							Type:     schema.TypeList,
+							Required: true,
+							ForceNew: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"block_duration_minutes": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+										Default:  0,
+									},
+									"timeout_action": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(emr.SpotProvisioningTimeoutAction_Values(), false),
+									},
+									"timeout_duration_minutes": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -332,6 +332,25 @@ func resourceAwsEMRCluster() *schema.Resource {
 					},
 				},
 			},
+			"master_instance_fleet": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"core_instance_group", "master_instance_group"},
+				Elem:          InstanceFleetConfigSchema(),
+			},
+			"core_instance_fleet": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"core_instance_group", "master_instance_group"},
+				Elem:          InstanceFleetConfigSchema(),
+			},
+
 			"bootstrap_action": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -485,6 +504,80 @@ func resourceAwsEMRCluster() *schema.Resource {
 	}
 }
 
+func ebsConfigurationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"iops": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsEmrEbsVolumeType(),
+			},
+			"volumes_per_instance": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  1,
+			},
+		},
+	}
+}
+
+func InstanceFleetConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_fleet_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(emr.InstanceFleetType_Values(), false),
+			},
+			"instance_type_configs": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				// ForceNew: true,
+				Elem: instanceTypeConfigSchema(),
+			},
+			"launch_specifications": {
+				Type:     schema.TypeList,
+				Optional: true,
+				// ForceNew: true,
+				MaxItems: 1,
+				Elem:     launchSpecificationsSchema(),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"target_on_demand_capacity": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"target_spot_capacity": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+		},
+	}
+}
+
 func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).emrconn
 
@@ -560,6 +653,16 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 		expandEbsConfig(m, instanceGroup)
 
 		instanceConfig.InstanceGroups = append(instanceConfig.InstanceGroups, instanceGroup)
+	}
+
+	if l := d.Get("master_instance_fleet").([]interface{}); len(l) > 0 && l[0] != nil {
+		instanceFleetConfig := readInstanceFleetConfig(l[0].(map[string]interface{}))
+		instanceConfig.InstanceFleets = append(instanceConfig.InstanceFleets, instanceFleetConfig)
+	}
+
+	if l := d.Get("core_instance_fleet").([]interface{}); len(l) > 0 && l[0] != nil {
+		instanceFleetConfig := readInstanceFleetConfig(l[0].(map[string]interface{}))
+		instanceConfig.InstanceFleets = append(instanceConfig.InstanceFleets, instanceFleetConfig)
 	}
 
 	var instanceProfile string
@@ -796,25 +899,42 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	instanceGroups, err := fetchAllEMRInstanceGroups(emrconn, d.Id())
 
-	if err != nil {
-		return err
+	if err == nil { // find instance group
+
+		coreGroup := emrCoreInstanceGroup(instanceGroups)
+		masterGroup := findMasterGroup(instanceGroups)
+
+		flattenedCoreInstanceGroup, err := flattenEmrCoreInstanceGroup(coreGroup)
+
+		if err != nil {
+			return fmt.Errorf("error flattening core_instance_group: %s", err)
+		}
+
+		if err := d.Set("core_instance_group", flattenedCoreInstanceGroup); err != nil {
+			return fmt.Errorf("error setting core_instance_group: %s", err)
+		}
+
+		if err := d.Set("master_instance_group", flattenEmrMasterInstanceGroup(masterGroup)); err != nil {
+			return fmt.Errorf("error setting master_instance_group: %s", err)
+		}
 	}
 
-	coreGroup := emrCoreInstanceGroup(instanceGroups)
-	masterGroup := findMasterGroup(instanceGroups)
+	instanceFleets, err := fetchAllEMRInstanceFleets(emrconn, d.Id())
 
-	flattenedCoreInstanceGroup, err := flattenEmrCoreInstanceGroup(coreGroup)
+	if err == nil { // find instance fleets
 
-	if err != nil {
-		return fmt.Errorf("error flattening core_instance_group: %s", err)
-	}
+		coreFleet := findInstanceFleet(instanceFleets, emr.InstanceRoleTypeCore)
+		masterFleet := findInstanceFleet(instanceFleets, emr.InstanceRoleTypeMaster)
 
-	if err := d.Set("core_instance_group", flattenedCoreInstanceGroup); err != nil {
-		return fmt.Errorf("error setting core_instance_group: %s", err)
-	}
+		flattenedCoreInstanceFleet := flattenInstanceFleet(coreFleet)
+		if err := d.Set("core_instance_fleet", []interface{}{flattenedCoreInstanceFleet}); err != nil {
+			return fmt.Errorf("error setting core_instance_fleet: %s", err)
+		}
 
-	if err := d.Set("master_instance_group", flattenEmrMasterInstanceGroup(masterGroup)); err != nil {
-		return fmt.Errorf("error setting master_instance_group: %s", err)
+		flattenedMasterInstanceFleet := flattenInstanceFleet(masterFleet)
+		if err := d.Set("master_instance_fleet", []interface{}{flattenedMasterInstanceFleet}); err != nil {
+			return fmt.Errorf("error setting master_instance_fleet: %s", err)
+		}
 	}
 
 	if err := d.Set("tags", keyvaluetags.EmrKeyValueTags(cluster.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
@@ -1740,4 +1860,121 @@ func fetchAllEMRInstanceGroups(conn *emr.EMR, clusterID string) ([]*emr.Instance
 	})
 
 	return groups, err
+}
+
+func readInstanceFleetConfig(data map[string]interface{}) *emr.InstanceFleetConfig {
+
+	config := &emr.InstanceFleetConfig{
+		InstanceFleetType:      aws.String(data["instance_fleet_type"].(string)),
+		Name:                   aws.String(data["name"].(string)),
+		TargetOnDemandCapacity: aws.Int64(int64(data["target_on_demand_capacity"].(int))),
+		TargetSpotCapacity:     aws.Int64(int64(data["target_spot_capacity"].(int))),
+	}
+
+	if v, ok := data["instance_type_configs"].(*schema.Set); ok && v.Len() > 0 {
+		config.InstanceTypeConfigs = expandInstanceTypeConfigs(v.List())
+	}
+
+	if v, ok := data["launch_specifications"].(*schema.Set); ok && v.Len() == 1 {
+		config.LaunchSpecifications = expandLaunchSpecification(v.List()[0])
+	}
+
+	return config
+}
+
+func fetchAllEMRInstanceFleets(conn *emr.EMR, clusterID string) ([]*emr.InstanceFleet, error) {
+	input := &emr.ListInstanceFleetsInput{
+		ClusterId: aws.String(clusterID),
+	}
+	var fleets []*emr.InstanceFleet
+
+	err := conn.ListInstanceFleetsPages(input, func(page *emr.ListInstanceFleetsOutput, lastPage bool) bool {
+		fleets = append(fleets, page.InstanceFleets...)
+
+		return !lastPage
+	})
+
+	return fleets, err
+}
+
+func findInstanceFleet(instanceFleets []*emr.InstanceFleet, instanceRoleType string) *emr.InstanceFleet {
+	for _, instanceFleet := range instanceFleets {
+		if instanceFleet.InstanceFleetType != nil {
+			if *instanceFleet.InstanceFleetType == instanceRoleType {
+				return instanceFleet
+			}
+		}
+	}
+	return nil
+}
+
+func flatteninstanceTypeConfig(itc *emr.InstanceTypeSpecification) map[string]interface{} {
+	attrs := map[string]interface{}{}
+	if itc.BidPrice != nil {
+		attrs["bid_price"] = *itc.BidPrice
+	}
+	if itc.BidPriceAsPercentageOfOnDemandPrice != nil {
+		attrs["bid_price_as_percentage_of_on_demand_price"] = *itc.BidPriceAsPercentageOfOnDemandPrice
+	}
+	attrs["ebs_config"] = flattenEBSConfig(itc.EbsBlockDevices)
+	attrs["instance_type"] = *itc.InstanceType
+	attrs["weighted_capacity"] = *itc.WeightedCapacity
+	return attrs
+}
+
+func flattenInstanceFleet(ig *emr.InstanceFleet) map[string]interface{} {
+	attrs := map[string]interface{}{}
+
+	attrs["id"] = *ig.Id
+	attrs["name"] = *ig.Name
+	attrs["instance_fleet_type"] = *ig.InstanceFleetType
+	attrs["target_on_demand_capacity"] = *ig.TargetOnDemandCapacity
+	attrs["target_spot_capacity"] = *ig.TargetSpotCapacity
+	instanceTypeConfigs := []interface{}{}
+	for _, itc := range ig.InstanceTypeSpecifications {
+		flattenTypeConfig := flatteninstanceTypeConfig(itc)
+		instanceTypeConfigs = append(instanceTypeConfigs, flattenTypeConfig)
+	}
+	attrs["instance_type_configs"] = instanceTypeConfigs
+
+	if ig.LaunchSpecifications != nil {
+		spotProvisioningSpecification := make(map[string]interface{})
+		if ig.LaunchSpecifications.SpotSpecification.BlockDurationMinutes != nil {
+			spotProvisioningSpecification["block_duration_minutes"] = *ig.LaunchSpecifications.SpotSpecification.BlockDurationMinutes
+		}
+		spotProvisioningSpecification["timeout_action"] = *ig.LaunchSpecifications.SpotSpecification.TimeoutAction
+		spotProvisioningSpecification["timeout_duration_minutes"] = *ig.LaunchSpecifications.SpotSpecification.TimeoutDurationMinutes
+
+		launchSpecifications := make([]interface{}, 0)
+		launchSpecification := make(map[string]interface{})
+		spotSpecifications := make([]interface{}, 0)
+		spotSpecifications = append(spotSpecifications, spotProvisioningSpecification)
+		launchSpecification["spot_specification"] = spotSpecifications
+		launchSpecifications = append(launchSpecifications, launchSpecification)
+		attrs["launch_specifications"] = launchSpecifications
+	}
+	return attrs
+}
+
+func expandEbsConfiguration(ebsConfigurations []interface{}) *emr.EbsConfiguration {
+	ebsConfig := &emr.EbsConfiguration{}
+	ebsConfigs := make([]*emr.EbsBlockDeviceConfig, 0)
+	for _, ebsConfiguration := range ebsConfigurations {
+		cfg := ebsConfiguration.(map[string]interface{})
+		ebs := &emr.EbsBlockDeviceConfig{}
+		volumeSpec := &emr.VolumeSpecification{
+			SizeInGB:   aws.Int64(int64(cfg["size"].(int))),
+			VolumeType: aws.String(cfg["type"].(string)),
+		}
+		if v, ok := cfg["iops"].(int); ok && v != 0 {
+			volumeSpec.Iops = aws.Int64(int64(v))
+		}
+		if v, ok := cfg["volumes_per_instance"].(int); ok && v != 0 {
+			ebs.VolumesPerInstance = aws.Int64(int64(v))
+		}
+		ebs.VolumeSpecification = volumeSpec
+		ebsConfigs = append(ebsConfigs, ebs)
+	}
+	ebsConfig.EbsBlockDeviceConfigs = ebsConfigs
+	return ebsConfig
 }

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -3425,7 +3425,7 @@ provider "aws" {
 }
 resource "aws_emr_cluster" "tf-test-cluster" {
   name          = "emr-test-%d"
-  release_label = "emr-5.8.0"
+  release_label = "emr-5.30.1"
   applications  = ["Spark"]
   ec2_attributes {
     subnet_ids                        = "${aws_subnet.main.id}"

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -1327,6 +1327,26 @@ func TestAccAWSEMRCluster_custom_ami_id(t *testing.T) {
 	})
 }
 
+func TestAccAWSEMRCluster_instance_fleet(t *testing.T) {
+	var cluster emr.Cluster
+	r := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEmrDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEmrClusterConfigInstanceFleets(r),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
+					resource.TestCheckResourceAttr(
+						"aws_emr_cluster.tf-test-cluster", "instance_fleet.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEmrDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).emrconn
 
@@ -3396,4 +3416,318 @@ EOF
   acl = "public-read"
 }
 `, r)
+}
+
+func testAccAWSEmrClusterConfigInstanceFleets(r int) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-west-2"
+}
+resource "aws_emr_cluster" "tf-test-cluster" {
+  name          = "emr-test-%d"
+  release_label = "emr-5.8.0"
+  applications  = ["Spark"]
+  ec2_attributes {
+    subnet_ids                        = "${aws_subnet.main.id}"
+    emr_managed_master_security_group = "${aws_security_group.allow_all.id}"
+    emr_managed_slave_security_group  = "${aws_security_group.allow_all.id}"
+    instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
+  }
+  master_instance_fleet    {
+    instance_fleet_type = "MASTER"
+    instance_type_configs        {
+          instance_type = "m3.xlarge"
+        }
+    
+      target_on_demand_capacity = 1
+    }
+  core_instance_fleet {
+    instance_fleet_type = "CORE"
+    instance_type_configs {
+      bid_price_as_percentage_of_on_demand_price = 80
+      ebs_config {
+        size                 = 100
+        type                 = "gp2"
+        volumes_per_instance = 1
+      }
+      instance_type     = "m3.xlarge"
+      weighted_capacity = 1
+    }
+    instance_type_configs {
+      bid_price_as_percentage_of_on_demand_price = 100
+      ebs_config {
+        size                 = 100
+        type                 = "gp2"
+        volumes_per_instance = 1
+      }
+      instance_type     = "m4.xlarge"
+      weighted_capacity = 1
+    }
+    instance_type_configs {
+      bid_price_as_percentage_of_on_demand_price = 100
+      ebs_config {
+        size                 = 100
+        type                 = "gp2"
+        volumes_per_instance = 1
+      }
+      instance_type     = "m4.2xlarge"
+      weighted_capacity = 2
+    }
+    launch_specifications {
+      spot_specification {
+        block_duration_minutes   = 0
+        timeout_action           = "SWITCH_TO_ON_DEMAND"
+        timeout_duration_minutes = 10
+      }
+    }
+    name                      = "core fleet"
+    target_on_demand_capacity = 0
+    target_spot_capacity      = 2
+  }
+  tags {
+    role     = "rolename"
+    dns_zone = "env_zone"
+    env      = "env"
+    name     = "name-env"
+  }
+  keep_job_flow_alive_when_no_steps = true
+  termination_protection = false
+  bootstrap_action {
+    path = "s3://elasticmapreduce/bootstrap-actions/run-if"
+    name = "runif"
+    args = ["instance.isMaster=true", "echo running on master node"]
+  }
+  configurations = "test-fixtures/emr_configurations.json"
+  depends_on = ["aws_main_route_table_association.a"]
+  service_role = "${aws_iam_role.iam_emr_default_role.arn}"
+}
+resource "aws_security_group" "allow_all" {
+  name        = "allow_all_%d"
+  description = "Allow all inbound traffic"
+  vpc_id      = "${aws_vpc.main.id}"
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  depends_on = ["aws_subnet.main"]
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+  tags {
+    name = "emr_test"
+  }
+}
+resource "aws_vpc" "main" {
+  cidr_block           = "168.31.0.0/16"
+  enable_dns_hostnames = true
+  tags {
+    name = "emr_test_%d"
+  }
+}
+resource "aws_subnet" "main" {
+  vpc_id     = "${aws_vpc.main.id}"
+  cidr_block = "168.31.0.0/20"
+  tags {
+    name = "emr_test_%d"
+  }
+}
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.main.id}"
+}
+resource "aws_route_table" "r" {
+  vpc_id = "${aws_vpc.main.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.gw.id}"
+  }
+}
+resource "aws_main_route_table_association" "a" {
+  vpc_id         = "${aws_vpc.main.id}"
+  route_table_id = "${aws_route_table.r.id}"
+}
+###
+# IAM things
+###
+# IAM role for EMR Service
+resource "aws_iam_role" "iam_emr_default_role" {
+  name = "iam_emr_default_role_%d"
+  assume_role_policy = <<EOT
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "elasticmapreduce.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOT
+}
+resource "aws_iam_role_policy_attachment" "service-attach" {
+  role       = "${aws_iam_role.iam_emr_default_role.id}"
+  policy_arn = "${aws_iam_policy.iam_emr_default_policy.arn}"
+}
+resource "aws_iam_policy" "iam_emr_default_policy" {
+  name = "iam_emr_default_policy_%d"
+  policy = <<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Resource": "*",
+        "Action": [
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CancelSpotInstanceRequests",
+            "ec2:CreateNetworkInterface",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateTags",
+            "ec2:DeleteNetworkInterface",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DeleteTags",
+            "ec2:DescribeAvailabilityZones",
+            "ec2:DescribeAccountAttributes",
+            "ec2:DescribeDhcpOptions",
+            "ec2:DescribeInstanceStatus",
+            "ec2:DescribeInstances",
+            "ec2:DescribeKeyPairs",
+            "ec2:DescribeNetworkAcls",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribePrefixLists",
+            "ec2:DescribeRouteTables",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSpotInstanceRequests",
+            "ec2:DescribeSpotPriceHistory",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcAttribute",
+            "ec2:DescribeVpcEndpoints",
+            "ec2:DescribeVpcEndpointServices",
+            "ec2:DescribeVpcs",
+            "ec2:DetachNetworkInterface",
+            "ec2:ModifyImageAttribute",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:RequestSpotInstances",
+            "ec2:RevokeSecurityGroupEgress",
+            "ec2:RunInstances",
+            "ec2:TerminateInstances",
+            "ec2:DeleteVolume",
+            "ec2:DescribeVolumeStatus",
+            "ec2:DescribeVolumes",
+            "ec2:DetachVolume",
+            "iam:GetRole",
+            "iam:GetRolePolicy",
+            "iam:ListInstanceProfiles",
+            "iam:ListRolePolicies",
+            "iam:PassRole",
+            "s3:CreateBucket",
+            "s3:Get*",
+            "s3:List*",
+            "sdb:BatchPutAttributes",
+            "sdb:Select",
+            "sqs:CreateQueue",
+            "sqs:Delete*",
+            "sqs:GetQueue*",
+            "sqs:PurgeQueue",
+            "sqs:ReceiveMessage"
+        ]
+    }]
+}
+EOT
+}
+# IAM Role for EC2 Instance Profile
+resource "aws_iam_role" "iam_emr_profile_role" {
+  name = "iam_emr_profile_role_%d"
+  assume_role_policy = <<EOT
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOT
+}
+resource "aws_iam_instance_profile" "emr_profile" {
+  name  = "emr_profile_%d"
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
+}
+resource "aws_iam_role_policy_attachment" "profile-attach" {
+  role       = "${aws_iam_role.iam_emr_profile_role.id}"
+  policy_arn = "${aws_iam_policy.iam_emr_profile_policy.arn}"
+}
+resource "aws_iam_policy" "iam_emr_profile_policy" {
+  name = "iam_emr_profile_policy_%d"
+  policy = <<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Resource": "*",
+        "Action": [
+            "cloudwatch:*",
+            "dynamodb:*",
+            "ec2:Describe*",
+            "elasticmapreduce:Describe*",
+            "elasticmapreduce:ListBootstrapActions",
+            "elasticmapreduce:ListClusters",
+            "elasticmapreduce:ListInstanceGroups",
+            "elasticmapreduce:ListInstanceFleets",
+            "elasticmapreduce:ListInstances",
+            "elasticmapreduce:ListSteps",
+            "kinesis:CreateStream",
+            "kinesis:DeleteStream",
+            "kinesis:DescribeStream",
+            "kinesis:GetRecords",
+            "kinesis:GetShardIterator",
+            "kinesis:MergeShards",
+            "kinesis:PutRecord",
+            "kinesis:SplitShard",
+            "rds:Describe*",
+            "s3:*",
+            "sdb:*",
+            "sns:*",
+            "sqs:*"
+        ]
+    }]
+}
+EOT
+}
+# IAM Role for autoscaling
+resource "aws_iam_role" "emr-autoscaling-role" {
+  name               = "EMR_AutoScaling_DefaultRole_%d"
+  assume_role_policy = "${data.aws_iam_policy_document.emr-autoscaling-role-policy.json}"
+}
+data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals = {
+      type        = "Service"
+      identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
+    }
+  }
+}
+resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
+  role       = "${aws_iam_role.emr-autoscaling-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
+}
+`, r, r, r, r, r, r, r, r, r, r)
 }

--- a/aws/resource_aws_emr_instance_fleet.go
+++ b/aws/resource_aws_emr_instance_fleet.go
@@ -37,14 +37,132 @@ func resourceAwsEMRInstanceFleet() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
-				Elem:     instanceTypeConfigSchema(),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bid_price": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"bid_price_as_percentage_of_on_demand_price": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+							ForceNew: true,
+						},
+						"configurations": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"classification": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"configurations": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"classification": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"properties": {
+													Type:     schema.TypeMap,
+													Optional: true,
+													Elem:     schema.TypeString,
+												},
+											},
+										},
+									},
+									"properties": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem:     schema.TypeString,
+									},
+								},
+							},
+						},
+						"ebs_config": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"iops": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+									},
+									"size": {
+										Type:     schema.TypeInt,
+										Required: true,
+										ForceNew: true,
+									},
+									"type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validateAwsEmrEbsVolumeType(),
+									},
+									"volumes_per_instance": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+										Default:  1,
+									},
+								},
+							},
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"weighted_capacity": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+							Default:  1,
+						},
+					},
+				},
 			},
 			"launch_specifications": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				MaxItems: 1,
-				Elem:     launchSpecificationsSchema(),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"spot_specification": {
+							Type:     schema.TypeList,
+							Required: true,
+							ForceNew: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"block_duration_minutes": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+										Default:  0,
+									},
+									"timeout_action": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(emr.SpotProvisioningTimeoutAction_Values(), false),
+									},
+									"timeout_duration_minutes": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -72,119 +190,6 @@ func resourceAwsEMRInstanceFleet() *schema.Resource {
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-		},
-	}
-}
-
-func instanceTypeConfigSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"bid_price": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"bid_price_as_percentage_of_on_demand_price": {
-				Type:     schema.TypeFloat,
-				Optional: true,
-				ForceNew: true,
-			},
-			"configurations": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     configurationSchema(),
-			},
-			"ebs_config": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem:     ebsConfigurationSchema(),
-			},
-			"instance_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"weighted_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  1,
-			},
-		},
-	}
-}
-
-func launchSpecificationsSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"spot_specification": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MinItems: 1,
-				Elem:     spotSpecificationSchema(),
-			},
-		},
-	}
-}
-
-func spotSpecificationSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"block_duration_minutes": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  0,
-			},
-			"timeout_action": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(emr.SpotProvisioningTimeoutAction_Values(), false),
-			},
-			"timeout_duration_minutes": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-		},
-	}
-}
-
-func configurationSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"classification": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"configurations": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     additionalConfigurationSchema(),
-			},
-			"properties": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     schema.TypeString,
-			},
-		},
-	}
-}
-
-func additionalConfigurationSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"classification": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"properties": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     schema.TypeString,
 			},
 		},
 	}

--- a/aws/resource_aws_emr_instance_fleet.go
+++ b/aws/resource_aws_emr_instance_fleet.go
@@ -1,0 +1,456 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/emr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var emrInstanceFleetNotFound = errors.New("no matching EMR Instance Fleet")
+
+func resourceAwsEMRInstanceFleet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEMRInstanceFleetCreate,
+		Read:   resourceAwsEMRInstanceFleetRead,
+		Update: resourceAwsEMRInstanceFleetUpdate,
+		Delete: resourceAwsEMRInstanceFleetDelete,
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_fleet_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(emr.InstanceFleetType_Values(), false),
+			},
+			"instance_type_configs": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     instanceTypeConfigSchema(),
+			},
+			"launch_specifications": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem:     launchSpecificationsSchema(),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"target_on_demand_capacity": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"target_spot_capacity": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"provisioned_on_demand_capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"provisioned_spot_capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func instanceTypeConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bid_price": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"bid_price_as_percentage_of_on_demand_price": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+				ForceNew: true,
+			},
+			"configurations": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     configurationSchema(),
+			},
+			"ebs_config": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     ebsConfigurationSchema(),
+			},
+			"instance_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"weighted_capacity": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  1,
+			},
+		},
+	}
+}
+
+func launchSpecificationsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"spot_specification": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MinItems: 1,
+				Elem:     spotSpecificationSchema(),
+			},
+		},
+	}
+}
+
+func spotSpecificationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"block_duration_minutes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  0,
+			},
+			"timeout_action": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(emr.SpotProvisioningTimeoutAction_Values(), false),
+			},
+			"timeout_duration_minutes": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+		},
+	}
+}
+
+func configurationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"classification": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"configurations": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     additionalConfigurationSchema(),
+			},
+			"properties": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+		},
+	}
+}
+
+func additionalConfigurationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"classification": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"properties": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+		},
+	}
+}
+
+func expandInstanceFleetConfig(data *schema.ResourceData) *emr.InstanceFleetConfig {
+
+	config := &emr.InstanceFleetConfig{
+		InstanceFleetType:      aws.String(data.Get("instance_fleet_type").(string)),
+		Name:                   aws.String(data.Get("name").(string)),
+		TargetOnDemandCapacity: aws.Int64(int64(data.Get("target_on_demand_capacity").(int))),
+		TargetSpotCapacity:     aws.Int64(int64(data.Get("target_spot_capacity").(int))),
+	}
+
+	if v, ok := data.Get("instance_type_configs").(*schema.Set); ok && v.Len() > 0 {
+		config.InstanceTypeConfigs = expandInstanceTypeConfigs(v.List())
+	}
+
+	if v, ok := data.Get("launch_specifications").(*schema.Set); ok && v.Len() == 1 {
+		config.LaunchSpecifications = expandLaunchSpecification(v.List()[0])
+	}
+
+	return config
+}
+
+func expandInstanceTypeConfigs(instanceTypeConfigs []interface{}) []*emr.InstanceTypeConfig {
+	configsOut := []*emr.InstanceTypeConfig{}
+
+	for _, raw := range instanceTypeConfigs {
+		configAttributes := raw.(map[string]interface{})
+
+		config := &emr.InstanceTypeConfig{
+			InstanceType: aws.String(configAttributes["instance_type"].(string)),
+		}
+
+		if bidPrice, ok := configAttributes["bid_price"]; ok {
+			if bidPrice != "" {
+				config.BidPrice = aws.String(bidPrice.(string))
+			}
+		}
+
+		if v, ok := configAttributes["bid_price_as_percentage_of_on_demand_price"].(float64); ok && v != 0 {
+			config.BidPriceAsPercentageOfOnDemandPrice = aws.Float64(v)
+		}
+
+		if v, ok := configAttributes["weighted_capacity"].(int); ok {
+			config.WeightedCapacity = aws.Int64(int64(v))
+		}
+
+		if v, ok := configAttributes["configurations"].(*schema.Set); ok && v.Len() > 0 {
+			config.Configurations = expandConfigurations(v.List())
+		}
+
+		if v, ok := configAttributes["ebs_config"].(*schema.Set); ok && v.Len() == 1 {
+			config.EbsConfiguration = expandEbsConfiguration(v.List())
+		}
+
+		configsOut = append(configsOut, config)
+	}
+
+	return configsOut
+}
+
+func expandConfigurations(configurations []interface{}) []*emr.Configuration {
+	configsOut := []*emr.Configuration{}
+
+	for _, raw := range configurations {
+		configAttributes := raw.(map[string]interface{})
+
+		config := &emr.Configuration{}
+
+		if v, ok := configAttributes["classification"].(string); ok {
+			config.Classification = aws.String(v)
+		}
+
+		if rawConfig, ok := configAttributes["configurations"]; ok {
+			config.Configurations = expandConfigurations(rawConfig.([]interface{}))
+		}
+
+		if v, ok := configAttributes["properties"]; ok {
+			properties := make(map[string]string)
+			for k, v := range v.(map[string]interface{}) {
+				properties[k] = v.(string)
+			}
+			config.Properties = aws.StringMap(properties)
+		}
+
+		configsOut = append(configsOut, config)
+	}
+
+	return configsOut
+}
+
+func expandLaunchSpecification(launchSpecification interface{}) *emr.InstanceFleetProvisioningSpecifications {
+	configAttributes := launchSpecification.(map[string]interface{})
+
+	return &emr.InstanceFleetProvisioningSpecifications{
+		SpotSpecification: expandSpotSpecification(configAttributes["spot_specification"].(*schema.Set).List()[0]),
+	}
+}
+
+func expandSpotSpecification(spotSpecification interface{}) *emr.SpotProvisioningSpecification {
+	configAttributes := spotSpecification.(map[string]interface{})
+
+	spotProvisioning := &emr.SpotProvisioningSpecification{
+		TimeoutAction:          aws.String(configAttributes["timeout_action"].(string)),
+		TimeoutDurationMinutes: aws.Int64(int64(configAttributes["timeout_duration_minutes"].(int))),
+	}
+
+	if v, ok := configAttributes["block_duration_minutes"]; ok && v != 0 {
+		spotProvisioning.BlockDurationMinutes = aws.Int64(int64(v.(int)))
+	}
+
+	return spotProvisioning
+}
+
+func resourceAwsEMRInstanceFleetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).emrconn
+
+	clusterId := d.Get("cluster_id").(string)
+	instanceFleetConfig := expandInstanceFleetConfig(d)
+
+	addInstanceFleetInput := &emr.AddInstanceFleetInput{
+		ClusterId:     aws.String(clusterId),
+		InstanceFleet: instanceFleetConfig,
+	}
+
+	log.Printf("[DEBUG] Creating EMR instance fleet params: %s", addInstanceFleetInput)
+	resp, err := conn.AddInstanceFleet(addInstanceFleetInput)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Created EMR instance fleet finished: %#v", resp)
+	if resp == nil {
+		return fmt.Errorf("error creating instance fleet: no instance fleet returned")
+	}
+	d.SetId(*resp.InstanceFleetId)
+
+	return nil
+}
+
+func resourceAwsEMRInstanceFleetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).emrconn
+	fleet, err := fetchEMRInstanceFleet(conn, d.Get("cluster_id").(string), d.Id())
+	if err != nil {
+		switch err {
+		case emrInstanceFleetNotFound:
+			log.Printf("[DEBUG] EMR Instance Fleet (%s) not found, removing", d.Id())
+			d.SetId("")
+			return nil
+		default:
+			return err
+		}
+	}
+
+	// Guard against the chance of fetchEMRInstanceFleet returning nil fleet but
+	// not a emrInstanceFleetNotFound error
+	if fleet == nil {
+		log.Printf("[DEBUG] EMR Instance Fleet (%s) not found, removing", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", fleet.Name)
+	d.Set("provisioned_on_demand_capacity", fleet.ProvisionedOnDemandCapacity)
+	d.Set("provisioned_spot_capacity", fleet.ProvisionedSpotCapacity)
+	if fleet.Status != nil && fleet.Status.State != nil {
+		d.Set("status", fleet.Status.State)
+	}
+
+	return nil
+}
+
+func fetchEMRInstanceFleet(conn *emr.EMR, clusterId, fleetId string) (*emr.InstanceFleet, error) {
+	fleets, err := fetchAllEMRInstanceFleets(conn, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	var instanceFleet *emr.InstanceFleet
+	for _, fleet := range fleets {
+		if fleetId == *fleet.Id {
+			instanceFleet = fleet
+			break
+		}
+	}
+
+	if instanceFleet != nil {
+		return instanceFleet, nil
+	}
+
+	return nil, emrInstanceFleetNotFound
+}
+
+func resourceAwsEMRInstanceFleetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).emrconn
+
+	log.Printf("[DEBUG] Modify EMR task fleet")
+
+	modifyInstanceFleetInput := &emr.ModifyInstanceFleetInput{
+		ClusterId: aws.String(d.Get("cluster_id").(string)),
+		InstanceFleet: &emr.InstanceFleetModifyConfig{
+			InstanceFleetId:        aws.String(d.Id()),
+			TargetOnDemandCapacity: aws.Int64(int64(d.Get("target_on_demand_capacity").(int))),
+			TargetSpotCapacity:     aws.Int64(int64(d.Get("target_spot_capacity").(int))),
+		},
+	}
+
+	_, err := conn.ModifyInstanceFleet(modifyInstanceFleetInput)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{emr.InstanceFleetStateProvisioning, emr.InstanceFleetStateBootstrapping, emr.InstanceFleetStateResizing},
+		Target:     []string{emr.InstanceFleetStateRunning},
+		Refresh:    instanceFleetStateRefresh(conn, d.Get("cluster_id").(string), d.Id()),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for instance (%s) to terminate: %s", d.Id(), err)
+	}
+
+	return resourceAwsEMRInstanceFleetRead(d, meta)
+}
+
+func instanceFleetStateRefresh(conn *emr.EMR, clusterID, ifID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		fleet, err := fetchEMRInstanceFleet(conn, clusterID, ifID)
+		if err != nil {
+			return nil, "Not Found", err
+		}
+
+		if fleet.Status == nil || fleet.Status.State == nil {
+			log.Printf("[WARN] ERM Instance Fleet found, but without state")
+			return nil, "Undefined", fmt.Errorf("undefined EMR Cluster Instance Fleet state")
+		}
+
+		return fleet, *fleet.Status.State, nil
+	}
+}
+
+func resourceAwsEMRInstanceFleetDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] AWS EMR Instance Fleet does not support DELETE; resizing cluster to zero before removing from state")
+	conn := meta.(*AWSClient).emrconn
+
+	clusterId := d.Get("cluster_id").(string)
+
+	modifyInstanceFleetInput := &emr.ModifyInstanceFleetInput{
+		ClusterId: aws.String(clusterId),
+		InstanceFleet: &emr.InstanceFleetModifyConfig{
+			InstanceFleetId:        aws.String(d.Id()),
+			TargetOnDemandCapacity: aws.Int64(0),
+			TargetSpotCapacity:     aws.Int64(0),
+		},
+	}
+
+	_, err := conn.ModifyInstanceFleet(modifyInstanceFleetInput)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_emr_instance_fleet_test.go
+++ b/aws/resource_aws_emr_instance_fleet_test.go
@@ -1,0 +1,554 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/emr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSEMRInstanceFleet_basic(t *testing.T) {
+	var fleet emr.InstanceFleet
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEmrInstanceFleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEmrInstanceFleetConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckAWSEmrInstanceFleetExists("aws_emr_instance_fleet.task", &fleet),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_fleet_type", "TASK"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_type_configs.#", "1"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_on_demand_capacity", "0"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_spot_capacity", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEMRInstanceFleet_zero_count(t *testing.T) {
+	var fleet emr.InstanceFleet
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEmrInstanceFleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEmrInstanceFleetConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckAWSEmrInstanceFleetExists("aws_emr_instance_fleet.task", &fleet),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_fleet_type", "TASK"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_type_configs.#", "1"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_on_demand_capacity", "0"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_spot_capacity", "1"),
+				),
+			},
+			{
+				Config: testAccAWSEmrInstanceFleetConfigZeroCount(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckAWSEmrInstanceFleetExists("aws_emr_instance_fleet.task", &fleet),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_fleet_type", "TASK"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_type_configs.#", "1"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_on_demand_capacity", "0"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_spot_capacity", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEMRInstanceFleet_ebsBasic(t *testing.T) {
+	var fleet emr.InstanceFleet
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEmrInstanceFleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEmrInstanceFleetConfigEbsBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckAWSEmrInstanceFleetExists("aws_emr_instance_fleet.task", &fleet),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_fleet_type", "TASK"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_type_configs.#", "1"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_on_demand_capacity", "0"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_spot_capacity", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEMRInstanceFleet_full(t *testing.T) {
+	var fleet emr.InstanceFleet
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEmrInstanceFleetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEmrInstanceFleetConfigFull(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckAWSEmrInstanceFleetExists("aws_emr_instance_fleet.task", &fleet),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_fleet_type", "TASK"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "instance_type_configs.#", "1"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_on_demand_capacity", "1"),
+					resource.TestCheckResourceAttr("aws_emr_instance_fleet.task", "target_spot_capacity", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEmrInstanceFleetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).emrconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_emr_cluster" {
+			continue
+		}
+
+		params := &emr.DescribeClusterInput{
+			ClusterId: aws.String(rs.Primary.ID),
+		}
+
+		describe, err := conn.DescribeCluster(params)
+
+		if err == nil {
+			if describe.Cluster != nil &&
+				*describe.Cluster.Status.State == "WAITING" {
+				return fmt.Errorf("EMR Cluster still exists")
+			}
+		}
+
+		providerErr, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+
+		log.Printf("[ERROR] %v", providerErr)
+	}
+
+	return nil
+}
+
+func testAccCheckAWSEmrInstanceFleetExists(n string, v *emr.InstanceFleet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No task fleet id set")
+		}
+		meta := testAccProvider.Meta()
+		conn := meta.(*AWSClient).emrconn
+		f, err := fetchEMRInstanceFleet(conn, rs.Primary.Attributes["cluster_id"], rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("EMR error: %v", err)
+		}
+
+		if f == nil {
+			return fmt.Errorf("No match found for (%s)", n)
+		}
+
+		v = f
+		return nil
+	}
+}
+
+const testAccAWSEmrInstanceFleetBase = `
+provider "aws" {
+    region = "us-west-2"
+}
+resource "aws_emr_cluster" "tf-test-cluster" {
+    name          = "emr-test-%d"
+    release_label = "emr-5.10.0"
+    applications  = ["Spark"]
+    ec2_attributes {
+        subnet_id                         = "${aws_subnet.main.id}"
+        emr_managed_master_security_group = "${aws_security_group.allow_all.id}"
+        emr_managed_slave_security_group  = "${aws_security_group.allow_all.id}"
+        instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
+    }
+    instance_fleet = [
+        {
+            instance_fleet_type = "MASTER"
+            instance_type_configs = [
+                {
+                    instance_type = "m3.xlarge"
+                }
+            ]
+            target_on_demand_capacity = 1
+        },
+        {
+            instance_fleet_type = "CORE"
+            instance_type_configs = [
+                {
+                    bid_price_as_percentage_of_on_demand_price = 80
+                    ebs_optimized = true
+                    ebs_config = [
+                        {
+                            size = 100
+                            type = "gp2"
+                            volumes_per_instance = 1
+                        }
+                    ]
+                    instance_type = "m3.xlarge"
+                    weighted_capacity = 1
+                }
+            ]
+            launch_specifications {
+                spot_specification {
+                    block_duration_minutes   = 60
+                    timeout_action           = "SWITCH_TO_ON_DEMAND"
+                    timeout_duration_minutes = 10
+                }
+            }
+            name                      = "instance-fleet-test"
+            target_on_demand_capacity = 0
+            target_spot_capacity      = 1
+        }
+    ]
+    tags {
+        role     = "rolename"
+        dns_zone = "env_zone"
+        env      = "env"
+        name     = "name-env"
+    }
+    bootstrap_action {
+        path = "s3://elasticmapreduce/bootstrap-actions/run-if"
+        name = "runif"
+        args = ["instance.isMaster=true", "echo running on master node"]
+    }
+    configurations = "test-fixtures/emr_configurations.json"
+    service_role = "${aws_iam_role.iam_emr_default_role.arn}"
+    depends_on = ["aws_internet_gateway.gw"]
+}
+resource "aws_security_group" "allow_all" {
+    name        = "allow_all"
+    description = "Allow all inbound traffic"
+    vpc_id      = "${aws_vpc.main.id}"
+    ingress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    egress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    depends_on = ["aws_subnet.main"]
+    lifecycle {
+        ignore_changes = ["ingress", "egress"]
+    }
+}
+resource "aws_vpc" "main" {
+    cidr_block           = "168.31.0.0/16"
+    enable_dns_hostnames = true
+    tags {
+        Name = "tf_acc_emr_tests"
+    }
+}
+resource "aws_subnet" "main" {
+    vpc_id     = "${aws_vpc.main.id}"
+    cidr_block = "168.31.0.0/20"
+    #  map_public_ip_on_launch = true
+}
+resource "aws_internet_gateway" "gw" {
+    vpc_id = "${aws_vpc.main.id}"
+}
+resource "aws_route_table" "r" {
+    vpc_id = "${aws_vpc.main.id}"
+    route {
+        cidr_block = "0.0.0.0/0"
+        gateway_id = "${aws_internet_gateway.gw.id}"
+    }
+}
+resource "aws_main_route_table_association" "a" {
+    vpc_id         = "${aws_vpc.main.id}"
+    route_table_id = "${aws_route_table.r.id}"
+}
+###
+# IAM role for EMR Service
+resource "aws_iam_role" "iam_emr_default_role" {
+    name = "iam_emr_default_role_%d"
+    assume_role_policy = <<EOT
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "elasticmapreduce.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOT
+}
+resource "aws_iam_role_policy_attachment" "service-attach" {
+    role       = "${aws_iam_role.iam_emr_default_role.id}"
+    policy_arn = "${aws_iam_policy.iam_emr_default_policy.arn}"
+}
+resource "aws_iam_policy" "iam_emr_default_policy" {
+    name = "iam_emr_default_policy_%d"
+    policy = <<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Resource": "*",
+        "Action": [
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CancelSpotInstanceRequests",
+            "ec2:CreateNetworkInterface",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateTags",
+            "ec2:DeleteNetworkInterface",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DeleteTags",
+            "ec2:DescribeAvailabilityZones",
+            "ec2:DescribeAccountAttributes",
+            "ec2:DescribeDhcpOptions",
+            "ec2:DescribeInstanceStatus",
+            "ec2:DescribeInstances",
+            "ec2:DescribeKeyPairs",
+            "ec2:DescribeNetworkAcls",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribePrefixLists",
+            "ec2:DescribeRouteTables",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSpotInstanceRequests",
+            "ec2:DescribeSpotPriceHistory",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcAttribute",
+            "ec2:DescribeVpcEndpoints",
+            "ec2:DescribeVpcEndpointServices",
+            "ec2:DescribeVpcs",
+            "ec2:DetachNetworkInterface",
+            "ec2:ModifyImageAttribute",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:RequestSpotInstances",
+            "ec2:RevokeSecurityGroupEgress",
+            "ec2:RunInstances",
+            "ec2:TerminateInstances",
+            "ec2:DeleteVolume",
+            "ec2:DescribeVolumeStatus",
+            "ec2:DescribeVolumes",
+            "ec2:DetachVolume",
+            "iam:GetRole",
+            "iam:GetRolePolicy",
+            "iam:ListInstanceProfiles",
+            "iam:ListRolePolicies",
+            "iam:PassRole",
+            "s3:CreateBucket",
+            "s3:Get*",
+            "s3:List*",
+            "sdb:BatchPutAttributes",
+            "sdb:Select",
+            "sqs:CreateQueue",
+            "sqs:Delete*",
+            "sqs:GetQueue*",
+            "sqs:PurgeQueue",
+            "sqs:ReceiveMessage"
+        ]
+    }]
+}
+EOT
+}
+# IAM Role for EC2 Instance Profile
+resource "aws_iam_role" "iam_emr_profile_role" {
+    name = "iam_emr_profile_role_%d"
+    assume_role_policy = <<EOT
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOT
+}
+resource "aws_iam_instance_profile" "emr_profile" {
+    name = "emr_profile_%d"
+    role = "${aws_iam_role.iam_emr_profile_role.name}"
+}
+resource "aws_iam_role_policy_attachment" "profile-attach" {
+    role       = "${aws_iam_role.iam_emr_profile_role.id}"
+    policy_arn = "${aws_iam_policy.iam_emr_profile_policy.arn}"
+}
+resource "aws_iam_policy" "iam_emr_profile_policy" {
+    name = "iam_emr_profile_policy_%d"
+    policy = <<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Resource": "*",
+        "Action": [
+            "cloudwatch:*",
+            "dynamodb:*",
+            "ec2:Describe*",
+            "elasticmapreduce:Describe*",
+            "elasticmapreduce:ListBootstrapActions",
+            "elasticmapreduce:ListClusters",
+            "elasticmapreduce:ListInstanceGroups",
+            "elasticmapreduce:ListInstances",
+            "elasticmapreduce:ListSteps",
+            "kinesis:CreateStream",
+            "kinesis:DeleteStream",
+            "kinesis:DescribeStream",
+            "kinesis:GetRecords",
+            "kinesis:GetShardIterator",
+            "kinesis:MergeShards",
+            "kinesis:PutRecord",
+            "kinesis:SplitShard",
+            "rds:Describe*",
+            "s3:*",
+            "sdb:*",
+            "sns:*",
+            "sqs:*"
+        ]
+    }]
+}
+EOT
+}
+`
+
+func testAccAWSEmrInstanceFleetConfig(r int) string {
+	return fmt.Sprintf(testAccAWSEmrInstanceFleetBase+`
+    resource "aws_emr_instance_fleet" "task" {
+        cluster_id            = "${aws_emr_cluster.tf-test-cluster.id}"
+        instance_fleet_type   = "TASK"
+        instance_type_configs = [
+            {
+                instance_type = "m3.xlarge"
+            }
+        ]
+        launch_specifications {
+            spot_specification {
+                timeout_action           = "TERMINATE_CLUSTER"
+                timeout_duration_minutes = 10
+            }
+        }
+        name                      = "emr_instance_fleet_%d"
+        target_on_demand_capacity = 0
+        target_spot_capacity      = 1
+    }
+    `, r, r, r, r, r, r, r)
+}
+
+func testAccAWSEmrInstanceFleetConfigZeroCount(r int) string {
+	return fmt.Sprintf(testAccAWSEmrInstanceFleetBase+`
+    resource "aws_emr_instance_fleet" "task" {
+        cluster_id            = "${aws_emr_cluster.tf-test-cluster.id}"
+        instance_fleet_type   = "TASK"
+        instance_type_configs = [
+            {
+                instance_type = "m3.xlarge"
+            }
+        ]
+        launch_specifications {
+            spot_specification {
+                timeout_action           = "TERMINATE_CLUSTER"
+                timeout_duration_minutes = 10
+            }
+        }
+        name                      = "emr_instance_fleet_%d"
+        target_on_demand_capacity = 0
+        target_spot_capacity      = 0
+    }
+    `, r, r, r, r, r, r, r)
+}
+
+func testAccAWSEmrInstanceFleetConfigEbsBasic(r int) string {
+	return fmt.Sprintf(testAccAWSEmrInstanceFleetBase+`
+    resource "aws_emr_instance_fleet" "task" {
+        cluster_id            = "${aws_emr_cluster.tf-test-cluster.id}"
+        instance_fleet_type   = "TASK"
+        instance_type_configs = [
+            {
+                ebs_optimized = true
+                ebs_config = [
+                    {
+                        size = 10
+                        type = "gp2"
+                        volumes_per_instance = 1
+                    }
+                ]
+                instance_type = "m3.xlarge"
+            }
+        ]
+        launch_specifications {
+            spot_specification {
+                timeout_action           = "TERMINATE_CLUSTER"
+                timeout_duration_minutes = 10
+            }
+        }
+        name                      = "emr_instance_fleet_%d"
+        target_on_demand_capacity = 0
+        target_spot_capacity      = 1
+    }
+    `, r, r, r, r, r, r, r)
+}
+
+func testAccAWSEmrInstanceFleetConfigFull(r int) string {
+	return fmt.Sprintf(testAccAWSEmrInstanceFleetBase+`
+    resource "aws_emr_instance_fleet" "task" {
+        cluster_id            = "${aws_emr_cluster.tf-test-cluster.id}"
+        instance_fleet_type   = "TASK"
+        instance_type_configs = [
+            {
+                bid_price_as_percentage_of_on_demand_price = 100
+                configurations = [
+                    {
+                        classification = "core-site"
+                        properties {
+                            "hadoop.security.groups.cache.secs" = "250"
+                        }
+                    }
+                ]
+                ebs_optimized = true
+                ebs_config = [
+                    {
+                        size = 10
+                        type = "gp2"
+                        volumes_per_instance = 1
+                    }
+                ]
+                instance_type     = "m3.xlarge"
+                weighted_capacity = 8
+            }
+        ]
+        launch_specifications {
+            spot_specification {
+                block_duration_minutes   = 60
+                timeout_action           = "TERMINATE_CLUSTER"
+                timeout_duration_minutes = 10
+            }
+        }
+        name                      = "emr_instance_fleet_%d"
+        target_on_demand_capacity = 1
+        target_spot_capacity      = 1
+    }
+    `, r, r, r, r, r, r, r)
+}

--- a/aws/resource_aws_emr_instance_fleet_test.go
+++ b/aws/resource_aws_emr_instance_fleet_test.go
@@ -169,7 +169,7 @@ provider "aws" {
 }
 resource "aws_emr_cluster" "tf-test-cluster" {
     name          = "emr-test-%d"
-    release_label = "emr-5.10.0"
+    release_label = "emr-5.30.1"
     applications  = ["Spark"]
     ec2_attributes {
         subnet_id                         = "${aws_subnet.main.id}"

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -14,8 +14,6 @@ for more information.
 
 To configure [Instance Groups](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-group-configuration.html#emr-plan-instance-groups) for [task nodes](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html#emr-plan-task), see the [`aws_emr_instance_group` resource](/docs/providers/aws/r/emr_instance_group.html).
 
--> Support for [Instance Fleets](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-group-configuration.html#emr-plan-instance-fleets) will be made available in an upcoming release.
-
 ## Example Usage
 
 ```hcl
@@ -148,6 +146,98 @@ Started](https://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr
 guide for more information on these IAM roles. There is also a fully-bootable
 example Terraform configuration at the bottom of this page.
 
+## Instance Fleet
+
+```hcl
+resource "aws_emr_cluster" "example" {
+  # ... other configuration ...
+  master_instance_fleet {
+    instance_fleet_type = "MASTER"
+    instance_type_configs {
+      instance_type = "m4.xlarge"
+    }
+    target_on_demand_capacity = 1
+  }
+  core_instance_fleet {
+    instance_fleet_type = "CORE"
+    instance_type_configs {
+      bid_price_as_percentage_of_on_demand_price = 80
+      ebs_config {
+        size                 = 100
+        type                 = "gp2"
+        volumes_per_instance = 1
+      }
+      instance_type     = "m3.xlarge"
+      weighted_capacity = 1
+    }
+    instance_type_configs {
+      bid_price_as_percentage_of_on_demand_price = 100
+      ebs_config {
+        size                 = 100
+        type                 = "gp2"
+        volumes_per_instance = 1
+      }
+      instance_type     = "m4.xlarge"
+      weighted_capacity = 1
+    }
+    instance_type_configs {
+      bid_price_as_percentage_of_on_demand_price = 100
+      ebs_config {
+        size                 = 100
+        type                 = "gp2"
+        volumes_per_instance = 1
+      }
+      instance_type     = "m4.2xlarge"
+      weighted_capacity = 2
+    }
+    launch_specifications {
+      spot_specification {
+        block_duration_minutes   = 0
+        timeout_action           = "SWITCH_TO_ON_DEMAND"
+        timeout_duration_minutes = 10
+      }
+    }
+    name                      = "core fleet"
+    target_on_demand_capacity = 2
+    target_spot_capacity      = 2
+  }
+}
+resource "aws_emr_instance_fleet" "task" {
+  cluster_id          = aws_emr_cluster.example.id
+  instance_fleet_type = "TASK"
+  instance_type_configs {
+    bid_price_as_percentage_of_on_demand_price = 100
+    ebs_config {
+      size                 = 100
+      type                 = "gp2"
+      volumes_per_instance = 1
+    }
+    instance_type     = "m4.xlarge"
+    weighted_capacity = 1
+  }
+  instance_type_configs {
+    bid_price_as_percentage_of_on_demand_price = 100
+    ebs_config {
+      size                 = 100
+      type                 = "gp2"
+      volumes_per_instance = 1
+    }
+    instance_type     = "m4.2xlarge"
+    weighted_capacity = 2
+  }
+  launch_specifications {
+    spot_specification {
+      block_duration_minutes   = 0
+      timeout_action           = "TERMINATE_CLUSTER"
+      timeout_duration_minutes = 10
+    }
+  }
+  name                      = "task fleet"
+  target_on_demand_capacity = 0
+  target_spot_capacity      = 10
+}
+```
+
 ### Enable Debug Logging
 
 [Debug logging in EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-debugging.html)
@@ -228,11 +318,13 @@ The following arguments are supported:
 * `name` - (Required) The name of the job flow
 * `release_label` - (Required) The release label for the Amazon EMR release
 * `master_instance_group` - (Optional) Configuration block to use an [Instance Group](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-group-configuration.html#emr-plan-instance-groups) for the [master node type](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html#emr-plan-master).
+* `master_instance_fleet` - (Optional) Configuration block to use an [Instance Fleet](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-fleet.html) for the master node type. Cannot be specified if any `master_instance_group` configuration blocks are set. Detailed below.
 * `scale_down_behavior` - (Optional) The way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs or an `instance group` is resized.
 * `additional_info` - (Optional) A JSON string for selecting additional features such as adding proxy information. Note: Currently there is no API to retrieve the value of this argument after EMR cluster creation from provider, therefore Terraform cannot detect drift from the actual EMR cluster if its value is changed outside Terraform.
 * `service_role` - (Required) IAM role that will be assumed by the Amazon EMR service to access AWS resources
 * `security_configuration` - (Optional) The security configuration name to attach to the EMR cluster. Only valid for EMR clusters with `release_label` 4.8.0 or greater
 * `core_instance_group` - (Optional) Configuration block to use an [Instance Group](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-group-configuration.html#emr-plan-instance-groups) for the [core node type](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html#emr-plan-core).
+* `core_instance_fleet` - (Optional) Configuration block to use an [Instance Fleet](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-fleet.html) for the core node type. Cannot be specified if any `core_instance_group` configuration blocks are set. Detailed below.
 * `log_uri` - (Optional) S3 bucket to write the log files of the job flow. If a value is not provided, logs are not created
 * `applications` - (Optional) A list of applications for the cluster. Valid values are: `Flink`, `Hadoop`, `Hive`, `Mahout`, `Pig`, `Spark`, and `JupyterHub` (as of EMR 5.14.0). Case insensitive
 * `termination_protection` - (Optional) Switch on/off termination protection (default is `false`, except when using multiple master nodes). Before attempting to destroy the resource when termination protection is enabled, this configuration must be applied with its value set to `false`.
@@ -367,6 +459,37 @@ Attributes for Hadoop job step configuration
 * `jar` - (Required) Path to a JAR file run during the step.
 * `main_class` - (Optional) Name of the main class in the specified Java file. If not specified, the JAR file should specify a Main-Class in its manifest file.
 * `properties` - (Optional) Key-Value map of Java properties that are set when the step runs. You can use these properties to pass key value pairs to your main function.
+
+## master_instance_fleet Configuration Block
+
+Supported nested arguments for the `master_instance_fleet` configuration block:
+
+* `instance_fleet_type` - (Required) has to be `MASTER`.
+* `instance_type_configs` - (Optional) Configuration block for instance fleet
+* `launch_specifications` - (Optional) Configuration block for launch specification
+* `target_on_demand_capacity` - (Optional)  The target capacity of On-Demand units for the instance fleet, which determines how many On-Demand instances to provision.
+* `target_spot_capacity` - (Optional) The target capacity of Spot units for the instance fleet, which determines how many Spot instances to provision.
+* `name` - (Optional) Friendly name given to the instance fleet.
+
+## core_instance_fleet Configuration Block
+
+Supported nested arguments for the `core_instance_fleet` configuration block:
+
+* `instance_fleet_type` - (Required) has to be `CORE`.
+* `instance_type_configs` - (Optional) Configuration block for instance fleet
+* `launch_specifications` - (Optional) Configuration block for launch specification
+* `target_on_demand_capacity` - (Optional)  The target capacity of On-Demand units for the instance fleet, which determines how many On-Demand instances to provision.
+* `target_spot_capacity` - (Optional) The target capacity of Spot units for the instance fleet, which determines how many Spot instances to provision.
+* `name` - (Optional) Friendly name given to the instance fleet.
+
+## instance_type_configs Configuration Block
+
+* `bid_price` - (Optional) The bid price for each EC2 Spot instance type as defined by `instance_type`. Expressed in USD. If neither `bid_price` nor `bid_price_as_percentage_of_on_demand_price` is provided, `bid_price_as_percentage_of_on_demand_price` defaults to 100%.
+* `bid_price_as_percentage_of_on_demand_price` - (Optional) The bid price, as a percentage of On-Demand price, for each EC2 Spot instance as defined by `instance_type`. Expressed as a number (for example, 20 specifies 20%). If neither `bid_price` nor `bid_price_as_percentage_of_on_demand_price` is provided, `bid_price_as_percentage_of_on_demand_price` defaults to 100%.
+* `configurations` - (Optional) A configuration classification that applies when provisioning cluster instances, which can include configurations for applications and software that run on the cluster. List of `configuration` blocks.
+* `ebs_config` - (Optional) Configuration block(s) for EBS volumes attached to each instance in the instance group. Detailed below.
+* `instance_type` - (Required) An EC2 instance type, such as m4.xlarge.
+* `weighted_capacity` - (Optional) The number of units that a provisioned instance of this type provides toward fulfilling the target capacities defined in `aws_emr_instance_fleet`.
 
 ## Attributes Reference
 

--- a/website/docs/r/emr_instance_fleet.html.markdown
+++ b/website/docs/r/emr_instance_fleet.html.markdown
@@ -1,0 +1,157 @@
+---
+subcategory: "Elastic Map Reduce (EMR)"
+layout: "aws"
+page_title: "AWS: aws_emr_instance_fleet"
+description: |-
+  Provides an Elastic MapReduce Cluster Instance Fleet
+---
+
+# aws_emr_instance_fleet
+
+Provides an Elastic MapReduce Cluster Instance Fleet configuration.
+See [Amazon Elastic MapReduce Documentation](https://aws.amazon.com/documentation/emr/) for more information.
+
+~> **NOTE:** At this time, Instance Fleets cannot be destroyed through the API nor
+web interface. Instance Fleets are destroyed when the EMR Cluster is destroyed.
+Terraform will resize any Instance Fleet to zero when destroying the resource.
+
+## Example Usage
+
+```hcl
+resource "aws_emr_instance_fleet" "task" {
+  cluster_id          = aws_emr_cluster.cluster.id
+  instance_fleet_type = "TASK"
+  instance_type_configs {
+    bid_price_as_percentage_of_on_demand_price = 100
+    ebs_config {
+      size                 = 100
+      type                 = "gp2"
+      volumes_per_instance = 1
+    }
+    instance_type     = "m4.xlarge"
+    weighted_capacity = 1
+  }
+  instance_type_configs {
+    bid_price_as_percentage_of_on_demand_price = 100
+    ebs_config {
+      size                 = 100
+      type                 = "gp2"
+      volumes_per_instance = 1
+    }
+    instance_type     = "m4.2xlarge"
+    weighted_capacity = 2
+  }
+  launch_specifications {
+    spot_specification {
+      block_duration_minutes   = 0
+      timeout_action           = "TERMINATE_CLUSTER"
+      timeout_duration_minutes = 10
+    }
+  }
+  name                      = "task fleet"
+  target_on_demand_capacity = 1
+  target_spot_capacity      = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` - (Required) ID of the EMR Cluster to attach to. Changing this forces a new resource to be created.
+
+* `instance_fleet_type` - (Required) The node type that the instance fleet hosts. Valid values are `MASTER`, `CORE`, and `TASK`. Changing this forces a new resource to be created.
+
+* `instance_type_configs` - (Optional) The instance type configurations that define the EC2 instances in the instance fleet. List of `instance_type_config` blocks. 
+
+* `launch_specifications` - (Optional) The launch specification for the instance fleet. 
+
+    * `spot_specification` - (Required) The launch specification for Spot instances in the fleet, which determines the 
+    defined duration and provisioning timeout behavior.
+
+* `name` - (Optional) The friendly name of the instance fleet.
+
+* `target_on_demand_capacity` - (Optional) The target capacity of On-Demand units for the instance fleet, which determines how many On-Demand instances to provision.
+
+* `target_spot_capacity` - (Optional) The target capacity of Spot units for the instance fleet, which determines how many Spot instances to provision.
+
+
+
+`instance_type_config` supports the following:
+
+* `bid_price` - (Optional) The bid price for each EC2 Spot instance type as defined by `instance_type`. 
+Expressed in USD. If neither `bid_price` nor `bid_price_as_percentage_of_on_demand_price` is provided, 
+`bid_price_as_percentage_of_on_demand_price` defaults to 100%.
+
+* `bid_price_as_percentage_of_on_demand_price` - (Optional) The bid price, as a percentage of On-Demand price, 
+for each EC2 Spot instance as defined by `instance_type`. Expressed as a number (for example, 20 specifies 20%). 
+If neither `bid_price` nor `bid_price_as_percentage_of_on_demand_price` is provided, 
+`bid_price_as_percentage_of_on_demand_price` defaults to 100%.
+
+* `configurations` - (Optional) A configuration classification that applies when provisioning cluster instances, 
+which can include configurations for applications and software that run on the cluster. List of `configuration` blocks.
+
+* `ebs_config` - (Optional) The configuration of Amazon Elastic Block Storage (EBS) attached to each instance as
+defined by `instance_type`.
+
+* `instance_type` - (Required) An EC2 instance type, such as m3.xlarge.
+
+* `weighted_capacity` - (Optional) The number of units that a provisioned instance of this type provides toward 
+fulfilling the target capacities defined in `aws_emr_instance_fleet`. This value is 1 for a master instance fleet, 
+and must be 1 or greater for core and task instance fleets. Defaults to 1 if not specified.
+
+
+
+`spot_specification` supports the following:
+
+* `block_duration_minutes` - (Optional) The defined duration for Spot instances (also known as Spot blocks) in minutes. 
+When specified, the Spot instance does not terminate before the defined duration expires, and defined duration pricing 
+for Spot instances applies. Valid values are 60, 120, 180, 240, 300, or 360. The duration period starts as soon as a 
+Spot instance receives its instance ID. At the end of the duration, Amazon EC2 marks the Spot instance for termination 
+and provides a Spot instance termination notice, which gives the instance a two-minute warning before it terminates.
+
+* `timeout_action` - (Required) The action to take when `target_spot_capacity` has not been fulfilled when the 
+`timeout_duration_minutes` has expired. Spot instances are not uprovisioned within the Spot provisioining timeout.
+Valid values are `TERMINATE_CLUSTER` and `SWITCH_TO_ON_DEMAND`. `SWITCH_TO_ON_DEMAND` specifies that if no Spot 
+instances are available, On-Demand Instances should be provisioned to fulfill any remaining Spot capacity.
+
+* `timeout_duration_minutes` - (Required) The spot provisioning timeout period in minutes. If Spot instances are not 
+provisioned within this time period, the `timeout_action` is taken. Minimum value is 5 and maximum value is 1440. 
+The timeout applies only during initial provisioning, when the cluster is first created.
+
+
+
+`configuration` supports the following:
+
+* `classification` - (Optional) The classification within a configuration.
+
+* `configurations` - (Optional) A list of additional configurations to apply within a configuration object.
+
+* `properties` - (Optional) A set of properties specified within a configuration classification.
+
+
+
+`ebs_config` EBS volume specifications such as volume type, IOPS, and size (GiB) that will be requested for the EBS volume attached to an EC2 instance in the cluster.
+
+* `iops` - (Optional) The number of I/O operations per second (IOPS) that the volume supports.
+
+* `size_in_gb` - (Required) The volume size, in gibibytes (GiB). This can be a number from 1 - 1024. If the volume type is EBS-optimized, the minimum value is 10.
+
+* `volume_type` - (Required) The volume type. Volume types supported are `gp2`, `io1`, `standard`.
+
+* `volumes_per_instance` - (Optional) Number of EBS volumes with a specific volume configuration that will be associated with every instance in the instance group
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The unique identifier of the instance fleet.
+
+* `provisioned_on_demand_capacity` The number of On-Demand units that have been provisioned for the instance 
+fleet to fulfill TargetOnDemandCapacity. This provisioned capacity might be less than or greater than TargetOnDemandCapacity.
+
+* `provisioned_spot_capacity` The number of Spot units that have been provisioned for this instance fleet 
+to fulfill TargetSpotCapacity. This provisioned capacity might be less than or greater than TargetSpotCapacity.
+
+* `status` The current status of the instance fleet.

--- a/website/docs/r/spot_instance_request.html.markdown
+++ b/website/docs/r/spot_instance_request.html.markdown
@@ -67,6 +67,7 @@ Spot Instance Requests support all the same arguments as
 * `valid_until` - (Optional) The end date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request. The default end date is 7 days from the current date.
 * `valid_from` - (Optional) The start date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). The default is to start fulfilling the request immediately.
 * `tags` - (Optional) A map of tags to assign to the Spot Instance Request. These tags are not automatically applied to the launched Instance.
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1146

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_emr_cluster: Support instance fleet ([#1146](https://github.com/terraform-providers/terraform-provider-aws/issues/1146))
* **New Resource:** `aws_emr_instance_fleet`: ([#1146](https://github.com/terraform-providers/terraform-provider-aws/issues/1146))
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
