### PR TITLE
tests/provider: Update hardcoded AZs  (DB instance)

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -2537,7 +2537,6 @@ func testAccCheckAWSDBInstanceDestroy(s *terraform.State) error {
 
 func testAccCheckAWSDBInstanceAttributes(v *rds.DBInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		if *v.Engine != "mysql" {
 			return fmt.Errorf("bad engine: %#v", *v.Engine)
 		}
@@ -2556,7 +2555,6 @@ func testAccCheckAWSDBInstanceAttributes(v *rds.DBInstance) resource.TestCheckFu
 
 func testAccCheckAWSDBInstanceAttributes_MSSQL(v *rds.DBInstance, tz string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		if *v.Engine != "sqlserver-ex" {
 			return fmt.Errorf("bad engine: %#v", *v.Engine)
 		}
@@ -2605,7 +2603,6 @@ func testAccCheckAWSDBInstanceParameterApplyStatusInSync(dbInstance *rds.DBInsta
 
 func testAccCheckAWSDBInstanceReplicaAttributes(source, replica *rds.DBInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		if replica.ReadReplicaSourceDBInstanceIdentifier != nil && *replica.ReadReplicaSourceDBInstanceIdentifier != *source.DBInstanceIdentifier {
 			return fmt.Errorf("bad source identifier for replica, expected: '%s', got: '%s'", *source.DBInstanceIdentifier, *replica.ReadReplicaSourceDBInstanceIdentifier)
 		}
@@ -3052,7 +3049,8 @@ resource "aws_db_instance" "test" {
 var testAccAWSDBInstanceConfigKmsKeyId = `
 resource "aws_kms_key" "foo" {
   description = "Terraform acc test %s"
-  policy      = <<POLICY
+
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",
@@ -3103,7 +3101,8 @@ resource "aws_db_instance" "bar" {
   password            = "barbarbarbar"
   skip_final_snapshot = true
   username            = "foo"
-}`
+}
+`
 
 func testAccAWSDBInstanceConfigWithOptionGroup(rName string) string {
 	return fmt.Sprintf(`
@@ -3173,7 +3172,7 @@ resource "aws_db_instance" "snapshot" {
 }
 
 func testAccAWSDBInstanceConfig_S3Import(bucketName string, bucketPrefix string, uniqueId string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_s3_bucket" "xtrabackup" {
   bucket = "%s"
 }
@@ -3210,19 +3209,19 @@ resource "aws_iam_policy" "test" {
 
   policy = <<POLICY
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:*"
-            ],
-            "Resource": [
-                "${aws_s3_bucket.xtrabackup.arn}",
-                "${aws_s3_bucket.xtrabackup.arn}/*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.xtrabackup.arn}",
+        "${aws_s3_bucket.xtrabackup.arn}/*"
+      ]
+    }
+  ]
 }
 POLICY
 }
@@ -3248,7 +3247,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -3258,7 +3257,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -3303,7 +3302,7 @@ resource "aws_db_instance" "s3" {
     ingestion_role = aws_iam_role.rds_s3_access_role.arn
   }
 }
-`, bucketName, bucketPrefix, uniqueId, uniqueId, uniqueId, uniqueId, uniqueId, bucketPrefix)
+`, bucketName, bucketPrefix, uniqueId, uniqueId, uniqueId, uniqueId, uniqueId, bucketPrefix))
 }
 
 func testAccAWSDBInstanceConfig_FinalSnapshotIdentifier(rInt int) string {
@@ -3508,7 +3507,7 @@ resource "aws_db_instance" "bar" {
 }
 
 func testAccAWSDBInstanceConfigWithSubnetGroup(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3519,7 +3518,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -3529,7 +3528,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -3563,11 +3562,11 @@ resource "aws_db_instance" "bar" {
   backup_retention_period = 0
   apply_immediately       = true
 }
-`, rName, rName)
+`, rName, rName))
 }
 
 func testAccAWSDBInstanceConfigWithSubnetGroupUpdated(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3586,7 +3585,7 @@ resource "aws_vpc" "bar" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -3596,7 +3595,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -3606,7 +3605,7 @@ resource "aws_subnet" "bar" {
 
 resource "aws_subnet" "test" {
   cidr_block        = "10.10.3.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.bar.id
 
   tags = {
@@ -3616,7 +3615,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_subnet" "another_test" {
   cidr_block        = "10.10.4.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.bar.id
 
   tags = {
@@ -3660,11 +3659,11 @@ resource "aws_db_instance" "bar" {
 
   apply_immediately = true
 }
-`, rName, rName, rName)
+`, rName, rName, rName))
 }
 
 func testAccAWSDBMSSQL_timezone(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -3683,7 +3682,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -3693,7 +3692,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -3735,11 +3734,11 @@ resource "aws_security_group_rule" "rds-mssql-1" {
 
   security_group_id = aws_security_group.rds-mssql.id
 }
-`, rInt, rInt, rInt)
+`, rInt, rInt, rInt))
 }
 
 func testAccAWSDBMSSQL_timezone_AKST(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -3758,7 +3757,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -3768,7 +3767,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -3811,11 +3810,11 @@ resource "aws_security_group_rule" "rds-mssql-1" {
 
   security_group_id = aws_security_group.rds-mssql.id
 }
-`, rInt, rInt, rInt)
+`, rInt, rInt, rInt))
 }
 
 func testAccAWSDBMSSQLDomain(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -3834,7 +3833,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -3844,7 +3843,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -3936,11 +3935,11 @@ resource "aws_iam_role_policy_attachment" "attatch-policy" {
   role       = aws_iam_role.role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt))
 }
 
 func testAccAWSDBMSSQLUpdateDomain(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -3959,7 +3958,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -3969,7 +3968,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -4062,11 +4061,11 @@ resource "aws_iam_role_policy_attachment" "attatch-policy" {
   role       = aws_iam_role.role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt))
 }
 
 func testAccAWSDBMSSQLDomainSnapshotRestore(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4085,7 +4084,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -4095,7 +4094,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -4192,11 +4191,11 @@ resource "aws_iam_role_policy_attachment" "attatch-policy" {
   role       = aws_iam_role.role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
 }
-`, rInt)
+`, rInt))
 }
 
 func testAccAWSDBMySQLSnapshotRestoreWithEngineVersion(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4215,7 +4214,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -4225,7 +4224,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -4284,7 +4283,7 @@ resource "aws_security_group_rule" "rds-mysql-1" {
 
   security_group_id = aws_security_group.rds-mysql.id
 }
-`, rInt)
+`, rInt))
 }
 
 func testAccAWSDBInstanceConfigAllowMajorVersionUpgrade(rName string, allowMajorVersionUpgrade bool) string {
@@ -4319,7 +4318,7 @@ resource "aws_db_instance" "bar" {
 `, acctest.RandInt())
 
 func testAccAWSDBInstanceConfigCloudwatchLogsExportConfiguration(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4338,7 +4337,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -4348,7 +4347,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -4374,11 +4373,11 @@ resource "aws_db_instance" "bar" {
     "error",
   ]
 }
-`, rInt, rInt)
+`, rInt, rInt))
 }
 
 func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationAdd(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4397,7 +4396,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -4407,7 +4406,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -4436,11 +4435,11 @@ resource "aws_db_instance" "bar" {
     "general",
   ]
 }
-`, rInt, rInt)
+`, rInt, rInt))
 }
 
 func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationModify(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4459,7 +4458,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -4469,7 +4468,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -4498,11 +4497,11 @@ resource "aws_db_instance" "bar" {
     "slowquery",
   ]
 }
-`, rInt, rInt)
+`, rInt, rInt))
 }
 
 func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationDelete(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4521,7 +4520,7 @@ resource "aws_db_subnet_group" "rds_one" {
 
 resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   cidr_block        = "10.1.1.0/24"
 
   tags = {
@@ -4531,7 +4530,7 @@ resource "aws_subnet" "main" {
 
 resource "aws_subnet" "other" {
   vpc_id            = aws_vpc.foo.id
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   cidr_block        = "10.1.2.0/24"
 
   tags = {
@@ -4554,7 +4553,7 @@ resource "aws_db_instance" "bar" {
 
   apply_immediately = true
 }
-`, rInt, rInt)
+`, rInt, rInt))
 }
 
 func testAccAWSDBInstanceConfigEc2Classic(rInt int) string {
@@ -4597,16 +4596,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_DbSubnetGroupName(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -4642,7 +4632,7 @@ resource "aws_db_instance" "test" {
   username             = "tfacctest"
   skip_final_snapshot  = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_DbSubnetGroupName_RamShared(rName string) string {
@@ -4733,16 +4723,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -4784,7 +4765,7 @@ resource "aws_db_instance" "test" {
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.test.id]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_DeletionProtection(rName string, deletionProtection bool) string {
@@ -4969,16 +4950,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_AvailabilityZone(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
@@ -4997,7 +4969,7 @@ resource "aws_db_instance" "test" {
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, rName)
+`, rName, rName))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_BackupRetentionPeriod(rName string, backupRetentionPeriod int) string {
@@ -5050,19 +5022,10 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName(rName string) string {
-	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+	return testAccAlternateRegionProviderConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
   provider = "awsalternate"
 
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-data "aws_availability_zones" "available" {
   state = "available"
 
   filter {
@@ -5093,7 +5056,7 @@ resource "aws_subnet" "alternate" {
   count    = 2
   provider = "awsalternate"
 
-  availability_zone = data.aws_availability_zones.alternate.names[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
   vpc_id            = aws_vpc.alternate.id
 
@@ -5200,7 +5163,7 @@ resource "aws_subnet" "sameaccountalternateregion" {
   count    = 2
   provider = "awssameaccountalternateregion"
 
-  availability_zone = data.aws_availability_zones.sameaccountalternateregion.names[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
   vpc_id            = aws_vpc.sameaccountalternateregion.id
 
@@ -5213,7 +5176,7 @@ resource "aws_subnet" "alternateaccountsameregion" {
   count    = 2
   provider = "awsalternateaccountsameregion"
 
-  availability_zone = data.aws_availability_zones.alternateaccountsameregion.names[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = aws_vpc.alternateaccountsameregion.id
 
@@ -5290,19 +5253,10 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+	return testAccAlternateRegionProviderConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
   provider = "awsalternate"
 
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-data "aws_availability_zones" "available" {
   state = "available"
 
   filter {
@@ -5338,7 +5292,7 @@ resource "aws_subnet" "alternate" {
   count    = 2
   provider = "awsalternate"
 
-  availability_zone = data.aws_availability_zones.alternate.names[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
   vpc_id            = aws_vpc.alternate.id
 
@@ -5820,16 +5774,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_AvailabilityZone(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
   engine              = "mariadb"
@@ -5852,7 +5797,7 @@ resource "aws_db_instance" "test" {
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 }
-`, rName, rName, rName)
+`, rName, rName, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_BackupRetentionPeriod(rName string, backupRetentionPeriod int) string {
@@ -5941,16 +5886,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -5998,7 +5934,7 @@ resource "aws_db_instance" "test" {
   snapshot_identifier  = aws_db_snapshot.test.id
   skip_final_snapshot  = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName_RamShared(rName string) string {
@@ -6101,16 +6037,7 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -6164,7 +6091,7 @@ resource "aws_db_instance" "test" {
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.test.id]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DeletionProtection(rName string, deletionProtection bool) string {

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -74,7 +74,7 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfig,
+				Config: testAccAWSDBInstanceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance1),
 					testAccCheckAWSDBInstanceAttributes(&dbInstance1),
@@ -95,7 +95,7 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone_id"),
 					resource.TestCheckResourceAttr(resourceName, "iam_database_authentication_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "instance_class", "db.t2.micro"),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_class", "data.aws_rds_orderable_db_instance.test", "instance_class"),
 					resource.TestCheckResourceAttr(resourceName, "license_model", "general-public-license"),
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window"),
 					resource.TestCheckResourceAttr(resourceName, "max_allocated_storage", "0"),
@@ -136,7 +136,7 @@ func TestAccAWSDBInstance_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfig_namePrefix,
+				Config: testAccAWSDBInstanceConfig_namePrefix(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.test", &v),
 					testAccCheckAWSDBInstanceAttributes(&v),
@@ -157,7 +157,7 @@ func TestAccAWSDBInstance_generatedName(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfig_generatedName,
+				Config: testAccAWSDBInstanceConfig_generatedName(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.test", &v),
 					testAccCheckAWSDBInstanceAttributes(&v),
@@ -172,16 +172,13 @@ func TestAccAWSDBInstance_kmsKey(t *testing.T) {
 	kmsKeyResourceName := "aws_kms_key.foo"
 	resourceName := "aws_db_instance.bar"
 
-	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAWSDBInstanceConfigKmsKeyId, ri)
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccAWSDBInstanceConfig_KmsKeyId(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &v),
 					testAccCheckAWSDBInstanceAttributes(&v),
@@ -214,7 +211,7 @@ func TestAccAWSDBInstance_subnetGroup(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfigWithSubnetGroup(rName),
+				Config: testAccAWSDBInstanceConfig_WithSubnetGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -222,7 +219,7 @@ func TestAccAWSDBInstance_subnetGroup(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSDBInstanceConfigWithSubnetGroupUpdated(rName),
+				Config: testAccAWSDBInstanceConfig_WithSubnetGroupUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -244,7 +241,7 @@ func TestAccAWSDBInstance_optionGroup(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfigWithOptionGroup(rName),
+				Config: testAccAWSDBInstanceConfig_WithOptionGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					testAccCheckAWSDBInstanceAttributes(&v),
@@ -265,7 +262,7 @@ func TestAccAWSDBInstance_iamAuth(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAWSDBIAMAuth(acctest.RandInt()),
+				Config: testAccAWSDBInstanceConfig_IAMAuth(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					testAccCheckAWSDBInstanceAttributes(&v),
@@ -289,7 +286,7 @@ func TestAccAWSDBInstance_AllowMajorVersionUpgrade(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfigAllowMajorVersionUpgrade(rName, true),
+				Config: testAccAWSDBInstanceConfig_AllowMajorVersionUpgrade(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance1),
 					resource.TestCheckResourceAttr(resourceName, "allow_major_version_upgrade", "true"),
@@ -308,7 +305,7 @@ func TestAccAWSDBInstance_AllowMajorVersionUpgrade(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAWSDBInstanceConfigAllowMajorVersionUpgrade(rName, false),
+				Config: testAccAWSDBInstanceConfig_AllowMajorVersionUpgrade(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance1),
 					resource.TestCheckResourceAttr(resourceName, "allow_major_version_upgrade", "false"),
@@ -1875,7 +1872,7 @@ func TestAccAWSDBInstance_MonitoringInterval(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbInstanceConfigMonitoringInterval(rName, 30),
+				Config: testAccAWSDbInstanceConfig_MonitoringInterval(rName, 30),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "30"),
@@ -1893,21 +1890,21 @@ func TestAccAWSDBInstance_MonitoringInterval(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccDbInstanceConfigMonitoringInterval(rName, 60),
+				Config: testAccAWSDbInstanceConfig_MonitoringInterval(rName, 60),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "60"),
 				),
 			},
 			{
-				Config: testAccDbInstanceConfigMonitoringInterval(rName, 0),
+				Config: testAccAWSDbInstanceConfig_MonitoringInterval(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "0"),
 				),
 			},
 			{
-				Config: testAccDbInstanceConfigMonitoringInterval(rName, 30),
+				Config: testAccAWSDbInstanceConfig_MonitoringInterval(rName, 30),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "30"),
@@ -1929,7 +1926,7 @@ func TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbInstanceConfigMonitoringRoleArn(rName),
+				Config: testAccAWSDbInstanceConfig_MonitoringRoleArn(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttrPair(resourceName, "monitoring_role_arn", iamRoleResourceName, "arn"),
@@ -1947,7 +1944,7 @@ func TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccDbInstanceConfigMonitoringInterval(rName, 0),
+				Config: testAccAWSDbInstanceConfig_MonitoringInterval(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "0"),
@@ -1969,7 +1966,7 @@ func TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbInstanceConfigMonitoringRoleArn(rName),
+				Config: testAccAWSDbInstanceConfig_MonitoringRoleArn(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttrPair(resourceName, "monitoring_role_arn", iamRoleResourceName, "arn"),
@@ -1987,7 +1984,7 @@ func TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccDbInstanceConfigMonitoringRoleArnRemoved(rName),
+				Config: testAccAWSDbInstanceConfig_MonitoringRoleArnRemoved(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 				),
@@ -2008,7 +2005,7 @@ func TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDbInstanceConfigMonitoringRoleArnRemoved(rName),
+				Config: testAccAWSDbInstanceConfig_MonitoringRoleArnRemoved(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 				),
@@ -2025,7 +2022,7 @@ func TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccDbInstanceConfigMonitoringRoleArn(rName),
+				Config: testAccAWSDbInstanceConfig_MonitoringRoleArn(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttrPair(resourceName, "monitoring_role_arn", iamRoleResourceName, "arn"),
@@ -2038,7 +2035,7 @@ func TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled(t *testing.T) {
 // Regression test for https://github.com/hashicorp/terraform/issues/3760 .
 // We apply a plan, then change just the iops. If the apply succeeds, we
 // consider this a pass, as before in 3760 the request would fail
-func TestAccAWSDBInstance_separate_iops_update(t *testing.T) {
+func TestAccAWSDBInstance_separateIopsUpdate(t *testing.T) {
 	var v rds.DBInstance
 
 	rName := acctest.RandString(5)
@@ -2049,7 +2046,7 @@ func TestAccAWSDBInstance_separate_iops_update(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotInstanceConfig_iopsUpdate(rName, 1000),
+				Config: testAccAWSDBInstanceConfig_SnapshotInstanceConfig_iopsUpdate(rName, 1000),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					testAccCheckAWSDBInstanceAttributes(&v),
@@ -2057,7 +2054,7 @@ func TestAccAWSDBInstance_separate_iops_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccSnapshotInstanceConfig_iopsUpdate(rName, 2000),
+				Config: testAccAWSDBInstanceConfig_SnapshotInstanceConfig_iopsUpdate(rName, 2000),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					testAccCheckAWSDBInstanceAttributes(&v),
@@ -2078,7 +2075,7 @@ func TestAccAWSDBInstance_portUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotInstanceConfig_mysqlPort(rName),
+				Config: testAccAWSDBInstanceConfig_SnapshotInstanceConfig_mysqlPort(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -2087,7 +2084,7 @@ func TestAccAWSDBInstance_portUpdate(t *testing.T) {
 			},
 
 			{
-				Config: testAccSnapshotInstanceConfig_updateMysqlPort(rName),
+				Config: testAccAWSDBInstanceConfig_SnapshotInstanceConfig_updateMysqlPort(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -2108,7 +2105,7 @@ func TestAccAWSDBInstance_MSSQL_TZ(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBMSSQL_timezone(rInt),
+				Config: testAccAWSDBInstanceConfig_MSSQL_timezone(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql", &v),
 					testAccCheckAWSDBInstanceAttributes_MSSQL(&v, ""),
@@ -2120,7 +2117,7 @@ func TestAccAWSDBInstance_MSSQL_TZ(t *testing.T) {
 			},
 
 			{
-				Config: testAccAWSDBMSSQL_timezone_AKST(rInt),
+				Config: testAccAWSDBInstanceConfig_MSSQL_timezone_AKST(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql", &v),
 					testAccCheckAWSDBInstanceAttributes_MSSQL(&v, "Alaskan Standard Time"),
@@ -2144,7 +2141,7 @@ func TestAccAWSDBInstance_MSSQL_Domain(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBMSSQLDomain(rInt),
+				Config: testAccAWSDBInstanceConfig_MSSQLDomain(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql", &vBefore),
 					testAccCheckAWSDBInstanceDomainAttributes("terraformtesting.com", &vBefore),
@@ -2155,7 +2152,7 @@ func TestAccAWSDBInstance_MSSQL_Domain(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSDBMSSQLUpdateDomain(rInt),
+				Config: testAccAWSDBInstanceConfig_MSSQLUpdateDomain(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql", &vAfter),
 					testAccCheckAWSDBInstanceDomainAttributes("corp.notexample.com", &vAfter),
@@ -2179,7 +2176,7 @@ func TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBMSSQLDomainSnapshotRestore(rInt),
+				Config: testAccAWSDBInstanceConfig_MSSQLDomainSnapshotRestore(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql_restore", &vRestoredInstance),
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql", &v),
@@ -2204,7 +2201,7 @@ func TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBMySQLSnapshotRestoreWithEngineVersion(rInt),
+				Config: testAccAWSDBInstanceConfig_MySQLSnapshotRestoreWithEngineVersion(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mysql_restore", &vRestoredInstance),
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mysql", &v),
@@ -2227,7 +2224,7 @@ func TestAccAWSDBInstance_MinorVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfigAutoMinorVersion,
+				Config: testAccAWSDBInstanceConfig_AutoMinorVersion(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 				),
@@ -2251,7 +2248,7 @@ func TestAccAWSDBInstance_ec2Classic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfigEc2Classic(rInt),
+				Config: testAccAWSDBInstanceConfig_Ec2Classic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 				),
@@ -2271,7 +2268,7 @@ func TestAccAWSDBInstance_cloudwatchLogsExportConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfigCloudwatchLogsExportConfiguration(rInt),
+				Config: testAccAWSDBInstanceConfig_CloudwatchLogsExportConfiguration(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 				),
@@ -2303,7 +2300,7 @@ func TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate(t *testing.T) 
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfigCloudwatchLogsExportConfiguration(rInt),
+				Config: testAccAWSDBInstanceConfig_CloudwatchLogsExportConfiguration(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -2313,7 +2310,7 @@ func TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationAdd(rInt),
+				Config: testAccAWSDBInstanceConfig_CloudwatchLogsExportConfigurationAdd(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -2325,7 +2322,7 @@ func TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationModify(rInt),
+				Config: testAccAWSDBInstanceConfig_CloudwatchLogsExportConfigurationModify(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -2337,7 +2334,7 @@ func TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationDelete(rInt),
+				Config: testAccAWSDBInstanceConfig_CloudwatchLogsExportConfigurationDelete(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -2757,18 +2754,18 @@ func testAccCheckAWSDBInstanceExists(n string, v *rds.DBInstance) resource.TestC
 }
 
 // Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8792
-func TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled(t *testing.T) {
+func TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled(t *testing.T) {
 	var dbInstance rds.DBInstance
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, "mysql") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsDisabled(rName),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsDisabled(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "false"),
@@ -2785,7 +2782,7 @@ func TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled(t *tes
 				},
 			},
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsEnabled(rName),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsEnabled(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -2795,18 +2792,18 @@ func TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled(t *tes
 	})
 }
 
-func TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled(t *testing.T) {
+func TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled(t *testing.T) {
 	var dbInstance rds.DBInstance
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, "mysql") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsEnabled(rName),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsEnabled(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -2823,7 +2820,7 @@ func TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled(t *tes
 				},
 			},
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsDisabled(rName),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsDisabled(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "false"),
@@ -2833,19 +2830,19 @@ func TestAccAWSRDSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled(t *tes
 	})
 }
 
-func TestAccAWSRDSDBInstance_PerformanceInsightsKmsKeyId(t *testing.T) {
+func TestAccAWSDBInstance_PerformanceInsightsKmsKeyId(t *testing.T) {
 	var dbInstance rds.DBInstance
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, "mysql") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsKmsKeyId(rName),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsKmsKeyId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -2863,7 +2860,7 @@ func TestAccAWSRDSDBInstance_PerformanceInsightsKmsKeyId(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsKmsKeyIdDisabled(rName),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsKmsKeyIdDisabled(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "false"),
@@ -2871,7 +2868,7 @@ func TestAccAWSRDSDBInstance_PerformanceInsightsKmsKeyId(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsKmsKeyId(rName),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsKmsKeyId(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -2882,18 +2879,18 @@ func TestAccAWSRDSDBInstance_PerformanceInsightsKmsKeyId(t *testing.T) {
 	})
 }
 
-func TestAccAWSRDSDBInstance_PerformanceInsightsRetentionPeriod(t *testing.T) {
+func TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod(t *testing.T) {
 	var dbInstance rds.DBInstance
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, "mysql") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsRetentionPeriod(rName, 731),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsRetentionPeriod(rName, 731),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -2911,7 +2908,7 @@ func TestAccAWSRDSDBInstance_PerformanceInsightsRetentionPeriod(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAWSDBInstancePerformanceInsightsRetentionPeriod(rName, 7),
+				Config: testAccAWSDBInstanceConfig_PerformanceInsightsRetentionPeriod(rName, 7),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -2931,7 +2928,7 @@ func TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled(t *testin
 	resourceName := "aws_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, "mysql") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -2961,7 +2958,7 @@ func TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled(t *testi
 	resourceName := "aws_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, "mysql") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -2984,6 +2981,7 @@ func TestAccAWSDBInstance_CACertificateIdentifier(t *testing.T) {
 	var dbInstance rds.DBInstance
 
 	resourceName := "aws_db_instance.bar"
+	cacID := "rds-ca-2019"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2991,23 +2989,49 @@ func TestAccAWSDBInstance_CACertificateIdentifier(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccAWSDBInstanceConfigWithCACertificateIdentifier, "rds-ca-2019"),
+				Config: testAccAWSDBInstanceConfig_WithCACertificateIdentifier(cacID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
-					resource.TestCheckResourceAttr(resourceName, "ca_cert_identifier", "rds-ca-2019"),
+					resource.TestCheckResourceAttr(resourceName, "ca_cert_identifier", cacID),
 				),
 			},
 		},
 	})
 }
 
-var testAccAWSDBInstanceConfig = `
+func testAccAWSDBInstanceConfig_orderableClass(engine, version, license string) string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = %q
+  engine_version = %q
+  license_model  = %q
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
+}
+`, engine, version, license)
+}
+
+func testAccAWSDBInstanceConfig_orderableClassMysql() string {
+	return testAccAWSDBInstanceConfig_orderableClass("mysql", "5.6.35", "general-public-license")
+}
+
+func testAccAWSDBInstanceConfig_orderableClassMariadb() string {
+	return testAccAWSDBInstanceConfig_orderableClass("mariadb", "10.2.15", "general-public-license")
+}
+
+func testAccAWSDBInstanceConfig_orderableClassSQLServerEx() string {
+	return testAccAWSDBInstanceConfig_orderableClass("sqlserver-ex", "14.00.1000.169.v1", "license-included")
+}
+
+func testAccAWSDBInstanceConfig_basic() string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "bar" {
   allocated_storage       = 10
   backup_retention_period = 0
-  engine                  = "MySQL"
-  engine_version          = "5.6.35"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   name                    = "baz"
   parameter_group_name    = "default.mysql5.6"
   password                = "barbarbarbar"
@@ -3019,36 +3043,42 @@ resource "aws_db_instance" "bar" {
   # validation error).
   maintenance_window = "Fri:09:00-Fri:09:30"
 }
-`
+`))
+}
 
-const testAccAWSDBInstanceConfig_namePrefix = `
+func testAccAWSDBInstanceConfig_namePrefix() string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage   = 10
-  engine              = "MySQL"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier_prefix   = "tf-test-"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "password"
   publicly_accessible = true
   skip_final_snapshot = true
   username            = "root"
 }
-`
+`))
+}
 
-const testAccAWSDBInstanceConfig_generatedName = `
+func testAccAWSDBInstanceConfig_generatedName() string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage   = 10
-  engine              = "MySQL"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "password"
   publicly_accessible = true
   skip_final_snapshot = true
   username            = "root"
 }
-`
+`))
+}
 
-var testAccAWSDBInstanceConfigKmsKeyId = `
+func testAccAWSDBInstanceConfig_KmsKeyId(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_kms_key" "foo" {
-  description = "Terraform acc test %s"
+  description = "Terraform acc test %d"
 
   policy = <<POLICY
 {
@@ -3069,15 +3099,29 @@ resource "aws_kms_key" "foo" {
 POLICY
 }
 
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.default.engine
+  engine_version             = data.aws_rds_engine_version.default.version
+  license_model              = "general-public-license"
+  storage_type               = "standard"
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t2.medium"]
+
+  supports_storage_encryption = true
+}
+
 resource "aws_db_instance" "bar" {
   allocated_storage       = 10
   backup_retention_period = 0
-  engine                  = "MySQL"
-  engine_version          = "5.6.35"
-  instance_class          = "db.t2.small"
+  engine                  = data.aws_rds_engine_version.default.engine
+  engine_version          = data.aws_rds_engine_version.default.version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   kms_key_id              = aws_kms_key.foo.arn
   name                    = "baz"
-  parameter_group_name    = "default.mysql5.6"
+  parameter_group_name    = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
   password                = "barbarbarbar"
   skip_final_snapshot     = true
   storage_encrypted       = true
@@ -3088,26 +3132,29 @@ resource "aws_db_instance" "bar" {
   # validation error).
   maintenance_window = "Fri:09:00-Fri:09:30"
 }
-`
+`, rInt)
+}
 
-const testAccAWSDBInstanceConfigWithCACertificateIdentifier = `
+func testAccAWSDBInstanceConfig_WithCACertificateIdentifier(cacID string) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "bar" {
   allocated_storage   = 10
   apply_immediately   = true
-  ca_cert_identifier  = "%s"
-  engine              = "MySQL"
-  instance_class      = "db.t2.micro"
+  ca_cert_identifier  = %q
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   name                = "baz"
   password            = "barbarbarbar"
   skip_final_snapshot = true
   username            = "foo"
 }
-`
+`, cacID))
+}
 
-func testAccAWSDBInstanceConfigWithOptionGroup(rName string) string {
-	return fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_WithOptionGroup(rName string) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_option_group" "test" {
-  engine_name              = "mysql"
+  engine_name              = data.aws_rds_orderable_db_instance.test.engine
   major_engine_version     = "5.6"
   name                     = %[1]q
   option_group_description = "Test option group for terraform"
@@ -3118,44 +3165,58 @@ resource "aws_db_instance" "bar" {
   engine              = aws_db_option_group.test.engine_name
   engine_version      = aws_db_option_group.test.major_engine_version
   identifier          = %[1]q
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   name                = "baz"
   option_group_name   = aws_db_option_group.test.name
   password            = "barbarbarbar"
   skip_final_snapshot = true
   username            = "foo"
 }
-`, rName)
+`, rName))
 }
 
-func testAccCheckAWSDBIAMAuth(n int) string {
+func testAccAWSDBInstanceConfig_IAMAuth(n int) string {
 	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.default.engine
+  engine_version             = data.aws_rds_engine_version.default.version
+  license_model              = "general-public-license"
+  storage_type               = "standard"
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t2.medium"]
+
+  supports_iam_database_authentication = true
+}
+
 resource "aws_db_instance" "bar" {
   identifier                          = "foobarbaz-test-terraform-%d"
   allocated_storage                   = 10
-  engine                              = "mysql"
-  engine_version                      = "5.6.34"
-  instance_class                      = "db.t2.micro"
+  engine                              = data.aws_rds_engine_version.default.engine
+  engine_version                      = data.aws_rds_engine_version.default.version
+  instance_class                      = data.aws_rds_orderable_db_instance.test.instance_class
   name                                = "baz"
   password                            = "barbarbarbar"
   username                            = "foo"
   backup_retention_period             = 0
   skip_final_snapshot                 = true
-  parameter_group_name                = "default.mysql5.6"
+  parameter_group_name                = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
   iam_database_authentication_enabled = true
 }
 `, n)
 }
 
 func testAccAWSDBInstanceConfig_FinalSnapshotIdentifier_SkipFinalSnapshot() string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "snapshot" {
   identifier = "tf-acc-test-%[1]d"
 
   allocated_storage       = 5
-  engine                  = "mysql"
-  engine_version          = "5.6.35"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   name                    = "baz"
   password                = "barbarbarbar"
   username                = "foo"
@@ -3168,24 +3229,24 @@ resource "aws_db_instance" "snapshot" {
   skip_final_snapshot       = true
   final_snapshot_identifier = "tf-acc-test-%[1]d"
 }
-`, acctest.RandInt())
+`, acctest.RandInt()))
 }
 
 func testAccAWSDBInstanceConfig_S3Import(bucketName string, bucketPrefix string, uniqueId string) string {
 	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_s3_bucket" "xtrabackup" {
-  bucket = "%s"
+  bucket = %[1]q
 }
 
 resource "aws_s3_bucket_object" "xtrabackup_db" {
   bucket = aws_s3_bucket.xtrabackup.id
-  key    = "%s/mysql-5-6-xtrabackup.tar.gz"
+  key    = "%[2]s/mysql-5-6-xtrabackup.tar.gz"
   source = "./testdata/mysql-5-6-xtrabackup.tar.gz"
   etag   = filemd5("./testdata/mysql-5-6-xtrabackup.tar.gz")
 }
 
 resource "aws_iam_role" "rds_s3_access_role" {
-  name = "%s-role"
+  name = "%[3]s-role"
 
   assume_role_policy = <<EOF
 {
@@ -3205,7 +3266,7 @@ EOF
 }
 
 resource "aws_iam_policy" "test" {
-  name = "%s-policy"
+  name = "%[3]s-policy"
 
   policy = <<POLICY
 {
@@ -3227,7 +3288,7 @@ POLICY
 }
 
 resource "aws_iam_policy_attachment" "test-attach" {
-  name = "%s-policy-attachment"
+  name = "%[3]s-policy-attachment"
 
   roles = [
     aws_iam_role.rds_s3_access_role.name,
@@ -3266,7 +3327,7 @@ resource "aws_subnet" "bar" {
 }
 
 resource "aws_db_subnet_group" "foo" {
-  name       = "%s-subnet-group"
+  name       = "%[3]s-subnet-group"
   subnet_ids = [aws_subnet.foo.id, aws_subnet.bar.id]
 
   tags = {
@@ -3274,14 +3335,24 @@ resource "aws_db_subnet_group" "foo" {
   }
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = "mysql"
+  engine_version = "5.6.41"
+  license_model  = "general-public-license"
+  storage_type   = "standard"
+
+  # instance class db.t2.micro is not supported for restoring from S3
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t2.medium"]
+}
+
 resource "aws_db_instance" "s3" {
-  identifier = "%s-db"
+  identifier = "%[3]s-db"
 
   allocated_storage          = 5
-  engine                     = "mysql"
+  engine                     = data.aws_rds_orderable_db_instance.test.engine
   engine_version             = "5.6"
   auto_minor_version_upgrade = true
-  instance_class             = "db.t2.small"
+  instance_class             = data.aws_rds_orderable_db_instance.test.instance_class
   name                       = "baz"
   password                   = "barbarbarbar"
   publicly_accessible        = false
@@ -3294,26 +3365,26 @@ resource "aws_db_instance" "s3" {
   db_subnet_group_name = aws_db_subnet_group.foo.id
 
   s3_import {
-    source_engine         = "mysql"
+    source_engine         = data.aws_rds_orderable_db_instance.test.engine
     source_engine_version = "5.6"
 
     bucket_name    = aws_s3_bucket.xtrabackup.bucket
-    bucket_prefix  = "%s"
+    bucket_prefix  = %[2]q
     ingestion_role = aws_iam_role.rds_s3_access_role.arn
   }
 }
-`, bucketName, bucketPrefix, uniqueId, uniqueId, uniqueId, uniqueId, uniqueId, bucketPrefix))
+`, bucketName, bucketPrefix, uniqueId))
 }
 
 func testAccAWSDBInstanceConfig_FinalSnapshotIdentifier(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "snapshot" {
-  identifier = "tf-snapshot-%d"
+  identifier = "tf-snapshot-%[1]d"
 
   allocated_storage       = 5
-  engine                  = "mysql"
-  engine_version          = "5.6.35"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   name                    = "baz"
   password                = "barbarbarbar"
   publicly_accessible     = true
@@ -3323,16 +3394,16 @@ resource "aws_db_instance" "snapshot" {
   parameter_group_name = "default.mysql5.6"
 
   copy_tags_to_snapshot     = true
-  final_snapshot_identifier = "foobarbaz-test-terraform-final-snapshot-%d"
+  final_snapshot_identifier = "foobarbaz-test-terraform-final-snapshot-%[1]d"
 
   tags = {
     Name = "tf-tags-db"
   }
 }
-`, rInt, rInt)
+`, rInt))
 }
 
-func testAccDbInstanceConfigMonitoringInterval(rName string, monitoringInterval int) string {
+func testAccAWSDbInstanceConfig_MonitoringInterval(rName string, monitoringInterval int) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {
 }
@@ -3362,14 +3433,28 @@ resource "aws_iam_role_policy_attachment" "test" {
   role       = aws_iam_role.test.name
 }
 
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.default.engine
+  engine_version             = data.aws_rds_engine_version.default.version
+  license_model              = "general-public-license"
+  storage_type               = "standard"
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t2.medium"]
+
+  supports_enhanced_monitoring = true
+}
+
 resource "aws_db_instance" "test" {
   depends_on = [aws_iam_role_policy_attachment.test]
 
   allocated_storage   = 5
-  engine              = "mysql"
-  engine_version      = "5.6.35"
+  engine              = data.aws_rds_engine_version.default.engine
+  engine_version      = data.aws_rds_engine_version.default.version
   identifier          = %[1]q
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   monitoring_interval = %[2]d
   monitoring_role_arn = aws_iam_role.test.arn
   name                = "baz"
@@ -3380,14 +3465,28 @@ resource "aws_db_instance" "test" {
 `, rName, monitoringInterval)
 }
 
-func testAccDbInstanceConfigMonitoringRoleArnRemoved(rName string) string {
+func testAccAWSDbInstanceConfig_MonitoringRoleArnRemoved(rName string) string {
 	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.default.engine
+  engine_version             = data.aws_rds_engine_version.default.version
+  license_model              = "general-public-license"
+  storage_type               = "standard"
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t2.medium"]
+
+  supports_enhanced_monitoring = true
+}
+
 resource "aws_db_instance" "test" {
   allocated_storage   = 5
-  engine              = "mysql"
-  engine_version      = "5.6.35"
-  identifier          = %[1]q
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_engine_version.default.engine
+  engine_version      = data.aws_rds_engine_version.default.version
+  identifier          = %q
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   name                = "baz"
   password            = "barbarbarbar"
   skip_final_snapshot = true
@@ -3396,7 +3495,7 @@ resource "aws_db_instance" "test" {
 `, rName)
 }
 
-func testAccDbInstanceConfigMonitoringRoleArn(rName string) string {
+func testAccAWSDbInstanceConfig_MonitoringRoleArn(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {
 }
@@ -3426,14 +3525,28 @@ resource "aws_iam_role_policy_attachment" "test" {
   role       = aws_iam_role.test.name
 }
 
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.default.engine
+  engine_version             = data.aws_rds_engine_version.default.version
+  license_model              = "general-public-license"
+  storage_type               = "standard"
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t2.medium"]
+
+  supports_enhanced_monitoring = true
+}
+
 resource "aws_db_instance" "test" {
   depends_on = [aws_iam_role_policy_attachment.test]
 
   allocated_storage   = 5
-  engine              = "mysql"
-  engine_version      = "5.6.35"
+  engine              = data.aws_rds_engine_version.default.engine
+  engine_version      = data.aws_rds_engine_version.default.version
   identifier          = %[1]q
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   monitoring_interval = 5
   monitoring_role_arn = aws_iam_role.test.arn
   name                = "baz"
@@ -3444,35 +3557,49 @@ resource "aws_db_instance" "test" {
 `, rName)
 }
 
-func testAccSnapshotInstanceConfig_iopsUpdate(rName string, iops int) string {
+func testAccAWSDBInstanceConfig_SnapshotInstanceConfig_iopsUpdate(rName string, iops int) string {
 	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = data.aws_rds_engine_version.default.engine
+  engine_version             = data.aws_rds_engine_version.default.version
+  license_model              = "general-public-license"
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
+
+  storage_type  = "io1"
+  supports_iops = true
+}
+
 resource "aws_db_instance" "bar" {
   identifier           = "mydb-rds-%s"
-  engine               = "mysql"
-  engine_version       = "5.6.35"
-  instance_class       = "db.t2.micro"
+  engine               = data.aws_rds_engine_version.default.engine
+  engine_version       = data.aws_rds_engine_version.default.version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "mydb"
   username             = "foo"
   password             = "barbarbar"
-  parameter_group_name = "default.mysql5.6"
+  parameter_group_name = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
   skip_final_snapshot  = true
 
   apply_immediately = true
 
-  storage_type      = "io1"
+  storage_type      = data.aws_rds_orderable_db_instance.test.storage_type
   allocated_storage = 200
   iops              = %d
 }
 `, rName, iops)
 }
 
-func testAccSnapshotInstanceConfig_mysqlPort(rName string) string {
-	return fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_SnapshotInstanceConfig_mysqlPort(rName string) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "bar" {
   identifier           = "mydb-rds-%s"
-  engine               = "mysql"
-  engine_version       = "5.6.35"
-  instance_class       = "db.t2.micro"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "mydb"
   username             = "foo"
   password             = "barbarbar"
@@ -3483,16 +3610,16 @@ resource "aws_db_instance" "bar" {
 
   apply_immediately = true
 }
-`, rName)
+`, rName))
 }
 
-func testAccSnapshotInstanceConfig_updateMysqlPort(rName string) string {
-	return fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_SnapshotInstanceConfig_updateMysqlPort(rName string) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "bar" {
   identifier           = "mydb-rds-%s"
-  engine               = "mysql"
-  engine_version       = "5.6.35"
-  instance_class       = "db.t2.micro"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "mydb"
   username             = "foo"
   password             = "barbarbar"
@@ -3503,11 +3630,14 @@ resource "aws_db_instance" "bar" {
 
   apply_immediately = true
 }
-`, rName)
+`, rName))
 }
 
-func testAccAWSDBInstanceConfigWithSubnetGroup(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_WithSubnetGroup(rName string) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3537,7 +3667,7 @@ resource "aws_subnet" "bar" {
 }
 
 resource "aws_db_subnet_group" "foo" {
-  name       = "foo-%s"
+  name       = "foo-%[1]s"
   subnet_ids = [aws_subnet.foo.id, aws_subnet.bar.id]
 
   tags = {
@@ -3546,10 +3676,10 @@ resource "aws_db_subnet_group" "foo" {
 }
 
 resource "aws_db_instance" "bar" {
-  identifier           = "mydb-rds-%s"
-  engine               = "mysql"
-  engine_version       = "5.6.35"
-  instance_class       = "db.t2.micro"
+  identifier           = "mydb-rds-%[1]s"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "mydb"
   username             = "foo"
   password             = "barbarbar"
@@ -3562,11 +3692,14 @@ resource "aws_db_instance" "bar" {
   backup_retention_period = 0
   apply_immediately       = true
 }
-`, rName, rName))
+`, rName))
 }
 
-func testAccAWSDBInstanceConfigWithSubnetGroupUpdated(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_WithSubnetGroupUpdated(rName string) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -3624,7 +3757,7 @@ resource "aws_subnet" "another_test" {
 }
 
 resource "aws_db_subnet_group" "foo" {
-  name       = "foo-%s"
+  name       = "foo-%[1]s"
   subnet_ids = [aws_subnet.foo.id, aws_subnet.bar.id]
 
   tags = {
@@ -3633,7 +3766,7 @@ resource "aws_db_subnet_group" "foo" {
 }
 
 resource "aws_db_subnet_group" "bar" {
-  name       = "bar-%s"
+  name       = "bar-%[1]s"
   subnet_ids = [aws_subnet.test.id, aws_subnet.another_test.id]
 
   tags = {
@@ -3642,10 +3775,10 @@ resource "aws_db_subnet_group" "bar" {
 }
 
 resource "aws_db_instance" "bar" {
-  identifier           = "mydb-rds-%s"
-  engine               = "mysql"
-  engine_version       = "5.6.35"
-  instance_class       = "db.t2.micro"
+  identifier           = "mydb-rds-%[1]s"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "mydb"
   username             = "foo"
   password             = "barbarbar"
@@ -3659,11 +3792,14 @@ resource "aws_db_instance" "bar" {
 
   apply_immediately = true
 }
-`, rName, rName, rName))
+`, rName))
 }
 
-func testAccAWSDBMSSQL_timezone(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_MSSQL_timezone(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassSQLServerEx(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -3674,7 +3810,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_db_subnet_group" "rds_one" {
-  name        = "tf_acc_test_%d"
+  name        = "tf_acc_test_%[1]d"
   description = "db subnets for rds_one"
 
   subnet_ids = [aws_subnet.main.id, aws_subnet.other.id]
@@ -3701,15 +3837,15 @@ resource "aws_subnet" "other" {
 }
 
 resource "aws_db_instance" "mssql" {
-  identifier = "tf-test-mssql-%d"
+  identifier = "tf-test-mssql-%[1]d"
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
 
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   allocated_storage       = 20
   username                = "somecrazyusername"
   password                = "somecrazypassword"
-  engine                  = "sqlserver-ex"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   backup_retention_period = 0
   skip_final_snapshot     = true
 
@@ -3719,7 +3855,7 @@ resource "aws_db_instance" "mssql" {
 }
 
 resource "aws_security_group" "rds-mssql" {
-  name = "tf-rds-mssql-test-%d"
+  name = "tf-rds-mssql-test-%[1]d"
 
   description = "TF Testing"
   vpc_id      = aws_vpc.foo.id
@@ -3734,11 +3870,14 @@ resource "aws_security_group_rule" "rds-mssql-1" {
 
   security_group_id = aws_security_group.rds-mssql.id
 }
-`, rInt, rInt, rInt))
+`, rInt))
 }
 
-func testAccAWSDBMSSQL_timezone_AKST(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_MSSQL_timezone_AKST(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassSQLServerEx(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -3749,7 +3888,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_db_subnet_group" "rds_one" {
-  name        = "tf_acc_test_%d"
+  name        = "tf_acc_test_%[1]d"
   description = "db subnets for rds_one"
 
   subnet_ids = [aws_subnet.main.id, aws_subnet.other.id]
@@ -3776,15 +3915,15 @@ resource "aws_subnet" "other" {
 }
 
 resource "aws_db_instance" "mssql" {
-  identifier = "tf-test-mssql-%d"
+  identifier = "tf-test-mssql-%[1]d"
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
 
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   allocated_storage       = 20
   username                = "somecrazyusername"
   password                = "somecrazypassword"
-  engine                  = "sqlserver-ex"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   backup_retention_period = 0
   skip_final_snapshot     = true
 
@@ -3795,7 +3934,7 @@ resource "aws_db_instance" "mssql" {
 }
 
 resource "aws_security_group" "rds-mssql" {
-  name = "tf-rds-mssql-test-%d"
+  name = "tf-rds-mssql-test-%[1]d"
 
   description = "TF Testing"
   vpc_id      = aws_vpc.foo.id
@@ -3810,11 +3949,14 @@ resource "aws_security_group_rule" "rds-mssql-1" {
 
   security_group_id = aws_security_group.rds-mssql.id
 }
-`, rInt, rInt, rInt))
+`, rInt))
 }
 
-func testAccAWSDBMSSQLDomain(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_MSSQLDomain(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassSQLServerEx(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -3825,7 +3967,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_db_subnet_group" "rds_one" {
-  name        = "tf_acc_test_%d"
+  name        = "tf_acc_test_%[1]d"
   description = "db subnets for rds_one"
 
   subnet_ids = [aws_subnet.main.id, aws_subnet.other.id]
@@ -3852,15 +3994,15 @@ resource "aws_subnet" "other" {
 }
 
 resource "aws_db_instance" "mssql" {
-  identifier = "tf-test-mssql-%d"
+  identifier = "tf-test-mssql-%[1]d"
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
 
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   allocated_storage       = 20
   username                = "somecrazyusername"
   password                = "somecrazypassword"
-  engine                  = "sqlserver-ex"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   backup_retention_period = 0
   skip_final_snapshot     = true
 
@@ -3871,7 +4013,7 @@ resource "aws_db_instance" "mssql" {
 }
 
 resource "aws_security_group" "rds-mssql" {
-  name = "tf-rds-mssql-test-%d"
+  name = "tf-rds-mssql-test-%[1]d"
 
   description = "TF Testing"
   vpc_id      = aws_vpc.foo.id
@@ -3912,7 +4054,7 @@ resource "aws_directory_service_directory" "bar" {
 }
 
 resource "aws_iam_role" "role" {
-  name = "tf-acc-db-instance-mssql-domain-role-%d"
+  name = "tf-acc-db-instance-mssql-domain-role-%[1]d"
 
   assume_role_policy = <<EOF
 {
@@ -3935,11 +4077,14 @@ resource "aws_iam_role_policy_attachment" "attatch-policy" {
   role       = aws_iam_role.role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
 }
-`, rInt, rInt, rInt, rInt))
+`, rInt))
 }
 
-func testAccAWSDBMSSQLUpdateDomain(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_MSSQLUpdateDomain(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassSQLServerEx(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -3950,7 +4095,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_db_subnet_group" "rds_one" {
-  name        = "tf_acc_test_%d"
+  name        = "tf_acc_test_%[1]d"
   description = "db subnets for rds_one"
 
   subnet_ids = [aws_subnet.main.id, aws_subnet.other.id]
@@ -3977,15 +4122,15 @@ resource "aws_subnet" "other" {
 }
 
 resource "aws_db_instance" "mssql" {
-  identifier = "tf-test-mssql-%d"
+  identifier = "tf-test-mssql-%[1]d"
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
 
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   allocated_storage       = 20
   username                = "somecrazyusername"
   password                = "somecrazypassword"
-  engine                  = "sqlserver-ex"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   backup_retention_period = 0
   skip_final_snapshot     = true
   apply_immediately       = true
@@ -3997,7 +4142,7 @@ resource "aws_db_instance" "mssql" {
 }
 
 resource "aws_security_group" "rds-mssql" {
-  name = "tf-rds-mssql-test-%d"
+  name = "tf-rds-mssql-test-%[1]d"
 
   description = "TF Testing"
   vpc_id      = aws_vpc.foo.id
@@ -4038,7 +4183,7 @@ resource "aws_directory_service_directory" "bar" {
 }
 
 resource "aws_iam_role" "role" {
-  name = "tf-acc-db-instance-mssql-domain-role-%d"
+  name = "tf-acc-db-instance-mssql-domain-role-%[1]d"
 
   assume_role_policy = <<EOF
 {
@@ -4061,11 +4206,14 @@ resource "aws_iam_role_policy_attachment" "attatch-policy" {
   role       = aws_iam_role.role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
 }
-`, rInt, rInt, rInt, rInt))
+`, rInt))
 }
 
-func testAccAWSDBMSSQLDomainSnapshotRestore(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_MSSQLDomainSnapshotRestore(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassSQLServerEx(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4104,9 +4252,9 @@ resource "aws_subnet" "other" {
 
 resource "aws_db_instance" "mssql" {
   allocated_storage   = 20
-  engine              = "sqlserver-ex"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = "tf-test-mssql-%[1]d"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "somecrazypassword"
   skip_final_snapshot = true
   username            = "somecrazyusername"
@@ -4122,11 +4270,11 @@ resource "aws_db_instance" "mssql_restore" {
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
 
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   allocated_storage       = 20
   username                = "somecrazyusername"
   password                = "somecrazypassword"
-  engine                  = "sqlserver-ex"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   backup_retention_period = 0
   skip_final_snapshot     = true
   snapshot_identifier     = aws_db_snapshot.mssql-snap.id
@@ -4194,8 +4342,11 @@ resource "aws_iam_role_policy_attachment" "attatch-policy" {
 `, rInt))
 }
 
-func testAccAWSDBMySQLSnapshotRestoreWithEngineVersion(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_MySQLSnapshotRestoreWithEngineVersion(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4234,10 +4385,10 @@ resource "aws_subnet" "other" {
 
 resource "aws_db_instance" "mysql" {
   allocated_storage   = 20
-  engine              = "MySQL"
-  engine_version      = "5.6.35"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  engine_version      = data.aws_rds_orderable_db_instance.test.engine_version
   identifier          = "tf-test-mysql-%[1]d"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "password"
   skip_final_snapshot = true
   username            = "root"
@@ -4253,11 +4404,11 @@ resource "aws_db_instance" "mysql_restore" {
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
 
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   allocated_storage       = 20
   username                = "root"
   password                = "password"
-  engine                  = "MySQL"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   engine_version          = "5.6.41"
   backup_retention_period = 0
   skip_final_snapshot     = true
@@ -4286,39 +4437,44 @@ resource "aws_security_group_rule" "rds-mysql-1" {
 `, rInt))
 }
 
-func testAccAWSDBInstanceConfigAllowMajorVersionUpgrade(rName string, allowMajorVersionUpgrade bool) string {
-	return fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_AllowMajorVersionUpgrade(rName string, allowMajorVersionUpgrade bool) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage           = 10
-  allow_major_version_upgrade = %[2]t
-  engine                      = "MySQL"
-  engine_version              = "5.6"
-  identifier                  = %[1]q
-  instance_class              = "db.t2.micro"
+  allow_major_version_upgrade = %t
+  engine                      = data.aws_rds_orderable_db_instance.test.engine
+  engine_version              = data.aws_rds_orderable_db_instance.test.engine_version
+  identifier                  = %q
+  instance_class              = data.aws_rds_orderable_db_instance.test.instance_class
   name                        = "baz"
   password                    = "barbarbarbar"
   skip_final_snapshot         = true
   username                    = "foo"
 }
-`, rName, allowMajorVersionUpgrade)
+`, allowMajorVersionUpgrade, rName))
 }
 
-var testAccAWSDBInstanceConfigAutoMinorVersion = fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_AutoMinorVersion() string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "bar" {
   identifier          = "foobarbaz-test-terraform-%d"
   allocated_storage   = 10
-  engine              = "MySQL"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   engine_version      = "5.6"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   name                = "baz"
   password            = "barbarbarbar"
   username            = "foo"
   skip_final_snapshot = true
 }
-`, acctest.RandInt())
+`, acctest.RandInt()))
+}
 
-func testAccAWSDBInstanceConfigCloudwatchLogsExportConfiguration(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_CloudwatchLogsExportConfiguration(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4329,7 +4485,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_db_subnet_group" "rds_one" {
-  name        = "tf_acc_test_%d"
+  name        = "tf_acc_test_%[1]d"
   description = "db subnets for rds_one"
 
   subnet_ids = [aws_subnet.main.id, aws_subnet.other.id]
@@ -4356,13 +4512,13 @@ resource "aws_subnet" "other" {
 }
 
 resource "aws_db_instance" "bar" {
-  identifier = "foobarbaz-test-terraform-%d"
+  identifier = "foobarbaz-test-terraform-%[1]d"
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
   allocated_storage    = 10
-  engine               = "MySQL"
-  engine_version       = "5.6"
-  instance_class       = "db.t2.micro"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "baz"
   password             = "barbarbarbar"
   username             = "foo"
@@ -4373,11 +4529,14 @@ resource "aws_db_instance" "bar" {
     "error",
   ]
 }
-`, rInt, rInt))
+`, rInt))
 }
 
-func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationAdd(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_CloudwatchLogsExportConfigurationAdd(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4388,7 +4547,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_db_subnet_group" "rds_one" {
-  name        = "tf_acc_test_%d"
+  name        = "tf_acc_test_%[1]d"
   description = "db subnets for rds_one"
 
   subnet_ids = [aws_subnet.main.id, aws_subnet.other.id]
@@ -4415,13 +4574,13 @@ resource "aws_subnet" "other" {
 }
 
 resource "aws_db_instance" "bar" {
-  identifier = "foobarbaz-test-terraform-%d"
+  identifier = "foobarbaz-test-terraform-%[1]d"
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
   allocated_storage    = 10
-  engine               = "MySQL"
-  engine_version       = "5.6"
-  instance_class       = "db.t2.micro"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "baz"
   password             = "barbarbarbar"
   username             = "foo"
@@ -4435,11 +4594,14 @@ resource "aws_db_instance" "bar" {
     "general",
   ]
 }
-`, rInt, rInt))
+`, rInt))
 }
 
-func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationModify(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_CloudwatchLogsExportConfigurationModify(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4450,7 +4612,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_db_subnet_group" "rds_one" {
-  name        = "tf_acc_test_%d"
+  name        = "tf_acc_test_%[1]d"
   description = "db subnets for rds_one"
 
   subnet_ids = [aws_subnet.main.id, aws_subnet.other.id]
@@ -4477,13 +4639,13 @@ resource "aws_subnet" "other" {
 }
 
 resource "aws_db_instance" "bar" {
-  identifier = "foobarbaz-test-terraform-%d"
+  identifier = "foobarbaz-test-terraform-%[1]d"
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
   allocated_storage    = 10
-  engine               = "MySQL"
-  engine_version       = "5.6"
-  instance_class       = "db.t2.micro"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "baz"
   password             = "barbarbarbar"
   username             = "foo"
@@ -4497,11 +4659,14 @@ resource "aws_db_instance" "bar" {
     "slowquery",
   ]
 }
-`, rInt, rInt))
+`, rInt))
 }
 
-func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationDelete(rInt int) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+func testAccAWSDBInstanceConfig_CloudwatchLogsExportConfigurationDelete(rInt int) string {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -4512,7 +4677,7 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_db_subnet_group" "rds_one" {
-  name        = "tf_acc_test_%d"
+  name        = "tf_acc_test_%[1]d"
   description = "db subnets for rds_one"
 
   subnet_ids = [aws_subnet.main.id, aws_subnet.other.id]
@@ -4539,13 +4704,13 @@ resource "aws_subnet" "other" {
 }
 
 resource "aws_db_instance" "bar" {
-  identifier = "foobarbaz-test-terraform-%d"
+  identifier = "foobarbaz-test-terraform-%[1]d"
 
   db_subnet_group_name = aws_db_subnet_group.rds_one.name
   allocated_storage    = 10
-  engine               = "MySQL"
-  engine_version       = "5.6"
-  instance_class       = "db.t2.micro"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "baz"
   password             = "barbarbarbar"
   username             = "foo"
@@ -4553,23 +4718,18 @@ resource "aws_db_instance" "bar" {
 
   apply_immediately = true
 }
-`, rInt, rInt))
+`, rInt))
 }
 
-func testAccAWSDBInstanceConfigEc2Classic(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_rds_orderable_db_instance" "test" {
-  engine                     = "mysql"
-  engine_version             = "5.6.41"
-  preferred_instance_classes = ["db.m3.medium", "db.m3.large", "db.r3.large"]
-}
-
+func testAccAWSDBInstanceConfig_Ec2Classic(rInt int) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "bar" {
   identifier           = "foobarbaz-test-terraform-%[1]d"
   allocated_storage    = 10
   engine               = data.aws_rds_orderable_db_instance.test.engine
   engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
   instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
+  storage_type         = data.aws_rds_orderable_db_instance.test.storage_type
   name                 = "baz"
   password             = "barbarbarbar"
   username             = "foo"
@@ -4578,25 +4738,28 @@ resource "aws_db_instance" "bar" {
   parameter_group_name = "default.mysql5.6"
   skip_final_snapshot  = true
 }
-`, rInt)
+`, rInt))
 }
 
 func testAccAWSDBInstanceConfig_MariaDB(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage   = 5
-  engine              = "mariadb"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = %q
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_DbSubnetGroupName(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -4625,9 +4788,9 @@ resource "aws_db_subnet_group" "test" {
 resource "aws_db_instance" "test" {
   allocated_storage    = 5
   db_subnet_group_name = aws_db_subnet_group.test.name
-  engine               = "mysql"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
   identifier           = %[1]q
-  instance_class       = "db.t2.micro"
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   password             = "avoid-plaintext-passwords"
   username             = "tfacctest"
   skip_final_snapshot  = true
@@ -4636,8 +4799,11 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_DbSubnetGroupName_RamShared(rName string) string {
-	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAlternateAccountProviderConfig(),
+		fmt.Sprintf(`
+data "aws_availability_zones" "alternate" {
   provider = "awsalternate"
 
   state = "available"
@@ -4664,7 +4830,7 @@ resource "aws_subnet" "test" {
   count    = 2
   provider = "awsalternate"
 
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  availability_zone = data.aws_availability_zones.alternate.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = aws_vpc.test.id
 
@@ -4711,19 +4877,22 @@ resource "aws_security_group" "test" {
 resource "aws_db_instance" "test" {
   allocated_storage      = 5
   db_subnet_group_name   = aws_db_subnet_group.test.name
-  engine                 = "mysql"
+  engine                 = data.aws_rds_orderable_db_instance.test.engine
   identifier             = %[1]q
-  instance_class         = "db.t2.micro"
+  instance_class         = data.aws_rds_orderable_db_instance.test.instance_class
   password               = "avoid-plaintext-passwords"
   username               = "tfacctest"
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.test.id]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -4757,9 +4926,9 @@ resource "aws_db_subnet_group" "test" {
 resource "aws_db_instance" "test" {
   allocated_storage      = 5
   db_subnet_group_name   = aws_db_subnet_group.test.name
-  engine                 = "mysql"
+  engine                 = data.aws_rds_orderable_db_instance.test.engine
   identifier             = %[1]q
-  instance_class         = "db.t2.micro"
+  instance_class         = data.aws_rds_orderable_db_instance.test.instance_class
   password               = "avoid-plaintext-passwords"
   username               = "tfacctest"
   skip_final_snapshot    = true
@@ -4769,28 +4938,37 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_DeletionProtection(rName string, deletionProtection bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage   = 5
   deletion_protection = %t
-  engine              = "mysql"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = %q
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
 }
-`, deletionProtection, rName)
+`, deletionProtection, rName))
 }
 
 func testAccAWSDBInstanceConfig_EnabledCloudwatchLogsExports_Oracle(rName string) string {
 	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = "oracle-se"
+  engine_version = "11.2.0.4.v25"
+  license_model  = "bring-your-own-license"
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.m5.large", "db.m4.large", "db.r4.large"]
+}
+
 resource "aws_db_instance" "test" {
   allocated_storage               = 10
   enabled_cloudwatch_logs_exports = ["alert", "listener", "trace"]
-  engine                          = "oracle-se"
+  engine                          = data.aws_rds_orderable_db_instance.test.engine
   identifier                      = %q
-  instance_class                  = "db.t3.micro"
+  instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true
@@ -4800,13 +4978,22 @@ resource "aws_db_instance" "test" {
 
 func testAccAWSDBInstanceConfig_EnabledCloudwatchLogsExports_MSSQL(rName string) string {
 	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = "sqlserver-se"
+  engine_version = "14.00.1000.169.v1"
+  license_model  = "license-included"
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.m5.large", "db.m4.large", "db.r4.large"]
+}
+
 resource "aws_db_instance" "test" {
   allocated_storage               = 20
   enabled_cloudwatch_logs_exports = ["agent", "error"]
-  engine                          = "sqlserver-se"
+  engine                          = data.aws_rds_orderable_db_instance.test.engine
   identifier                      = %q
-  instance_class                  = "db.m4.large"
-  license_model                   = "license-included"
+  instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
+  license_model                   = data.aws_rds_orderable_db_instance.test.license_model
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true
@@ -4815,102 +5002,104 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_EnabledCloudwatchLogsExports_Postgresql(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClass("postgres", "12.2", "postgresql-license"),
+		fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage               = 10
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
-  engine                          = "postgres"
+  engine                          = data.aws_rds_orderable_db_instance.test.engine
   identifier                      = %q
-  instance_class                  = "db.t2.micro"
+  instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_MaxAllocatedStorage(rName string, maxAllocatedStorage int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage     = 5
-  engine                = "mysql"
-  identifier            = %[1]q
-  instance_class        = "db.t2.micro"
-  max_allocated_storage = %[2]d
+  engine                = data.aws_rds_orderable_db_instance.test.engine
+  identifier            = %q
+  instance_class        = data.aws_rds_orderable_db_instance.test.instance_class
+  max_allocated_storage = %d
   password              = "avoid-plaintext-passwords"
   username              = "tfacctest"
   skip_final_snapshot   = true
 }
-`, rName, maxAllocatedStorage)
+`, rName, maxAllocatedStorage))
 }
 
 func testAccAWSDBInstanceConfig_Password(rName, password string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage   = 5
-  engine              = "mysql"
-  identifier          = %[1]q
-  instance_class      = "db.t2.micro"
-  password            = %[2]q
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = %q
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  password            = %q
   username            = "tfacctest"
   skip_final_snapshot = true
 }
-`, rName, password)
+`, rName, password))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_AllocatedStorage(rName string, allocatedStorage int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  allocated_storage   = %d
-  identifier          = %q
+  allocated_storage   = %[2]d
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, allocatedStorage, rName)
+`, rName, allocatedStorage))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_AllowMajorVersionUpgrade(rName string, allowMajorVersionUpgrade bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   identifier              = "%[1]s-source"
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -4923,40 +5112,43 @@ resource "aws_db_instance" "test" {
   replicate_source_db         = aws_db_instance.source.id
   skip_final_snapshot         = true
 }
-`, rName, allowMajorVersionUpgrade)
+`, rName, allowMajorVersionUpgrade))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_AutoMinorVersionUpgrade(rName string, autoMinorVersionUpgrade bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  auto_minor_version_upgrade = %t
-  identifier                 = %q
+  auto_minor_version_upgrade = %[2]t
+  identifier                 = %[1]q
   instance_class             = aws_db_instance.source.instance_class
   replicate_source_db        = aws_db_instance.source.id
   skip_final_snapshot        = true
 }
-`, rName, autoMinorVersionUpgrade, rName)
+`, rName, autoMinorVersionUpgrade))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_AvailabilityZone(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMysql(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -4964,65 +5156,68 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_instance" "test" {
   availability_zone   = data.aws_availability_zones.available.names[0]
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, rName))
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_BackupRetentionPeriod(rName string, backupRetentionPeriod int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  backup_retention_period = %d
-  identifier              = %q
+  backup_retention_period = %[2]d
+  identifier              = %[1]q
   instance_class          = aws_db_instance.source.instance_class
   replicate_source_db     = aws_db_instance.source.id
   skip_final_snapshot     = true
 }
-`, rName, backupRetentionPeriod, rName)
+`, rName, backupRetentionPeriod))
 }
 
 // We provide maintenance_window to prevent the following error from a randomly selected window:
 // InvalidParameterValue: The backup window and maintenance window must not overlap.
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_BackupWindow(rName, backupWindow, maintenanceWindow string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  backup_window       = %q
-  identifier          = %q
+  backup_window       = %[2]q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  maintenance_window  = %q
+  maintenance_window  = %[3]q
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, backupWindow, rName, maintenanceWindow)
+`, rName, backupWindow, maintenanceWindow))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName(rName string) string {
-	return testAccAlternateRegionProviderConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+	return composeConfig(
+		testAccAlternateRegionProviderConfig(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
   provider = "awsalternate"
 
@@ -5056,7 +5251,7 @@ resource "aws_subnet" "alternate" {
   count    = 2
   provider = "awsalternate"
 
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  availability_zone = data.aws_availability_zones.alternate.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
   vpc_id            = aws_vpc.alternate.id
 
@@ -5089,15 +5284,26 @@ resource "aws_db_subnet_group" "test" {
   subnet_ids = aws_subnet.test[*].id
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  provider = "awsalternate"
+
+  engine         = "mysql"
+  engine_version = "5.6.35"
+  license_model  = "general-public-license"
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
+}
+
 resource "aws_db_instance" "source" {
   provider = "awsalternate"
 
   allocated_storage       = 5
   backup_retention_period = 1
   db_subnet_group_name    = aws_db_subnet_group.alternate.name
-  engine                  = "mysql"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   identifier              = "%[1]s-source"
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -5110,11 +5316,11 @@ resource "aws_db_instance" "test" {
   replicate_source_db  = aws_db_instance.source.arn
   skip_final_snapshot  = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName_RamShared(rName string) string {
-	return testAccAlternateAccountAndAlternateRegionProviderConfig() + fmt.Sprintf(`
+	return composeConfig(testAccAlternateAccountAndAlternateRegionProviderConfig() + fmt.Sprintf(`
 data "aws_availability_zones" "alternateaccountsameregion" {
   provider = "awsalternateaccountsameregion"
 
@@ -5163,7 +5369,7 @@ resource "aws_subnet" "sameaccountalternateregion" {
   count    = 2
   provider = "awssameaccountalternateregion"
 
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  availability_zone = data.aws_availability_zones.sameaccountalternateregion.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
   vpc_id            = aws_vpc.sameaccountalternateregion.id
 
@@ -5176,7 +5382,7 @@ resource "aws_subnet" "alternateaccountsameregion" {
   count    = 2
   provider = "awsalternateaccountsameregion"
 
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  availability_zone = data.aws_availability_zones.alternateaccountsameregion.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = aws_vpc.alternateaccountsameregion.id
 
@@ -5227,15 +5433,26 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.alternateaccountsameregion.id
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  provider = "awssameaccountalternateregion"
+
+  engine         = "mysql"
+  engine_version = "5.6.35"
+  license_model  = "general-public-license"
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
+}
+
 resource "aws_db_instance" "source" {
   provider = "awssameaccountalternateregion"
 
   allocated_storage       = 5
   backup_retention_period = 1
   db_subnet_group_name    = aws_db_subnet_group.sameaccountalternateregion.name
-  engine                  = "mysql"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   identifier              = "%[1]s-source"
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -5249,11 +5466,14 @@ resource "aws_db_instance" "test" {
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.test.id]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return testAccAlternateRegionProviderConfig() + testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+	return composeConfig(
+		testAccAlternateRegionProviderConfig(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 data "aws_availability_zones" "alternate" {
   provider = "awsalternate"
 
@@ -5292,7 +5512,7 @@ resource "aws_subnet" "alternate" {
   count    = 2
   provider = "awsalternate"
 
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  availability_zone = data.aws_availability_zones.alternate.names[count.index]
   cidr_block        = "10.1.${count.index}.0/24"
   vpc_id            = aws_vpc.alternate.id
 
@@ -5325,15 +5545,26 @@ resource "aws_db_subnet_group" "test" {
   subnet_ids = aws_subnet.test[*].id
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  provider = "awsalternate"
+
+  engine         = "mysql"
+  engine_version = "5.6.35"
+  license_model  = "general-public-license"
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
+}
+
 resource "aws_db_instance" "source" {
   provider = "awsalternate"
 
   allocated_storage       = 5
   backup_retention_period = 1
   db_subnet_group_name    = aws_db_subnet_group.alternate.name
-  engine                  = "mysql"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   identifier              = "%[1]s-source"
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -5347,89 +5578,89 @@ resource "aws_db_instance" "test" {
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.test.id]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_DeletionProtection(rName string, deletionProtection bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  deletion_protection = %t
-  identifier          = %q
+  deletion_protection = %[2]t
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, deletionProtection, rName)
+`, rName, deletionProtection))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_IamDatabaseAuthenticationEnabled(rName string, iamDatabaseAuthenticationEnabled bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  iam_database_authentication_enabled = %t
-  identifier                          = %q
+  iam_database_authentication_enabled = %[2]t
+  identifier                          = %[1]q
   instance_class                      = aws_db_instance.source.instance_class
   replicate_source_db                 = aws_db_instance.source.id
   skip_final_snapshot                 = true
 }
-`, rName, iamDatabaseAuthenticationEnabled, rName)
+`, rName, iamDatabaseAuthenticationEnabled))
 }
 
 // We provide backup_window to prevent the following error from a randomly selected window:
 // InvalidParameterValue: The backup window and maintenance window must not overlap.
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_MaintenanceWindow(rName, backupWindow, maintenanceWindow string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  backup_window       = %q
-  identifier          = %q
+  backup_window       = %[2]q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  maintenance_window  = %q
+  maintenance_window  = %[3]q
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, backupWindow, rName, maintenanceWindow)
+`, rName, backupWindow, maintenanceWindow))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_MaxAllocatedStorage(rName string, maxAllocatedStorage int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
   identifier              = "%[1]s-source"
-  instance_class          = "db.t2.micro"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -5443,16 +5674,16 @@ resource "aws_db_instance" "test" {
   replicate_source_db   = aws_db_instance.source.id
   skip_final_snapshot   = true
 }
-`, rName, maxAllocatedStorage)
+`, rName, maxAllocatedStorage))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_Monitoring(rName string, monitoringInterval int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 data "aws_partition" "current" {
 }
 
 resource "aws_iam_role" "test" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -5479,53 +5710,53 @@ resource "aws_iam_role_policy_attachment" "test" {
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  monitoring_interval = %d
+  monitoring_interval = %[2]d
   monitoring_role_arn = aws_iam_role.test.arn
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, rName, rName, monitoringInterval)
+`, rName, monitoringInterval))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_MultiAZ(rName string, multiAz bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  multi_az            = %t
+  multi_az            = %[2]t
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, rName, multiAz)
+`, rName, multiAz))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_ParameterGroupName(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_parameter_group" "test" {
-  family = "mysql5.7"
-  name   = %q
+  family = "mysql5.6"
+  name   = %[1]q
 
   parameter {
     name  = "sync_binlog"
@@ -5536,194 +5767,111 @@ resource "aws_db_parameter_group" "test" {
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  engine_version          = "5.7.22"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  identifier           = %q
+  identifier           = %[1]q
   instance_class       = aws_db_instance.source.instance_class
   parameter_group_name = aws_db_parameter_group.test.id
   replicate_source_db  = aws_db_instance.source.id
   skip_final_snapshot  = true
 }
-`, rName, rName, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_Port(rName string, port int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  port                = %d
+  port                = %[2]d
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, rName, rName, port)
+`, rName, port))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_VpcSecurityGroupIds(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 data "aws_vpc" "default" {
   default = true
 }
 
 resource "aws_security_group" "test" {
-  name   = %q
+  name   = %[1]q
   vpc_id = data.aws_vpc.default.id
 }
 
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  identifier             = %q
+  identifier             = %[1]q
   instance_class         = aws_db_instance.source.instance_class
   replicate_source_db    = aws_db_instance.source.id
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.test.id]
 }
-`, rName, rName, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_CACertificateIdentifier(rName string, caName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
-  ca_cert_identifier      = %q
+  ca_cert_identifier      = %[2]q
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   replicate_source_db = aws_db_instance.source.id
-  ca_cert_identifier  = %q
+  ca_cert_identifier  = %[2]q
   skip_final_snapshot = true
 }
-`, rName, caName, rName, caName)
+`, rName, caName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
-  password            = "avoid-plaintext-passwords"
-  username            = "tfacctest"
-  skip_final_snapshot = true
-}
-
-resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
-}
-
-resource "aws_db_instance" "test" {
-  identifier          = %q
-  instance_class      = aws_db_instance.source.instance_class
-  snapshot_identifier = aws_db_snapshot.test.id
-  skip_final_snapshot = true
-}
-`, rName, rName, rName)
-}
-
-func testAccAWSDBInstanceConfig_SnapshotIdentifier_AllocatedStorage(rName string, allocatedStorage int) string {
-	return fmt.Sprintf(`
-resource "aws_db_instance" "source" {
-  allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
-  password            = "avoid-plaintext-passwords"
-  username            = "tfacctest"
-  skip_final_snapshot = true
-}
-
-resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
-}
-
-resource "aws_db_instance" "test" {
-  allocated_storage   = %d
-  identifier          = %q
-  instance_class      = aws_db_instance.source.instance_class
-  snapshot_identifier = aws_db_snapshot.test.id
-  skip_final_snapshot = true
-}
-`, rName, rName, allocatedStorage, rName)
-}
-
-func testAccAWSDBInstanceConfig_SnapshotIdentifier_Io1Storage(rName string, iops int) string {
-	return fmt.Sprintf(`
-resource "aws_db_instance" "source" {
-  allocated_storage   = 200
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
-  password            = "avoid-plaintext-passwords"
-  username            = "tfacctest"
-  skip_final_snapshot = true
-}
-
-resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
-}
-
-resource "aws_db_instance" "test" {
-  identifier          = %q
-  instance_class      = aws_db_instance.source.instance_class
-  snapshot_identifier = aws_db_snapshot.test.id
-  skip_final_snapshot = true
-  allocated_storage   = 200
-  iops                = %d
-  storage_type        = "io1"
-}
-`, rName, rName, rName, iops)
-}
-
-func testAccAWSDBInstanceConfig_SnapshotIdentifier_AllowMajorVersionUpgrade(rName string, allowMajorVersionUpgrade bool) string {
-	return fmt.Sprintf(`
-resource "aws_db_instance" "source" {
-  allocated_storage   = 5
-  engine              = "postgres"
-  engine_version      = "10.1"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = "%[1]s-source"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -5735,9 +5883,119 @@ resource "aws_db_snapshot" "test" {
 }
 
 resource "aws_db_instance" "test" {
+  identifier          = %[1]q
+  instance_class      = aws_db_instance.source.instance_class
+  snapshot_identifier = aws_db_snapshot.test.id
+  skip_final_snapshot = true
+}
+`, rName))
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_AllocatedStorage(rName string, allocatedStorage int) string {
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = aws_db_instance.source.id
+  db_snapshot_identifier = %[1]q
+}
+
+resource "aws_db_instance" "test" {
+  allocated_storage   = %[2]d
+  identifier          = %[1]q
+  instance_class      = aws_db_instance.source.instance_class
+  snapshot_identifier = aws_db_snapshot.test.id
+  skip_final_snapshot = true
+}
+`, rName, allocatedStorage))
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_Io1Storage(rName string, iops int) string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = "mariadb"
+  engine_version = "10.2.15"
+  license_model  = "general-public-license"
+  storage_type   = "io1"
+
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
+}
+
+resource "aws_db_instance" "source" {
+  allocated_storage   = 200
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = aws_db_instance.source.id
+  db_snapshot_identifier = %[1]q
+}
+
+resource "aws_db_instance" "test" {
+  identifier          = %[1]q
+  instance_class      = aws_db_instance.source.instance_class
+  snapshot_identifier = aws_db_snapshot.test.id
+  skip_final_snapshot = true
+  allocated_storage   = 200
+  iops                = %[2]d
+  storage_type        = data.aws_rds_orderable_db_instance.test.storage_type
+}
+`, rName, iops)
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_AllowMajorVersionUpgrade(rName string, allowMajorVersionUpgrade bool) string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "postgres10" {
+  engine         = "postgres"
+  engine_version = "10.1"
+  license_model  = "postgresql-license"
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
+}
+
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = data.aws_rds_orderable_db_instance.postgres10.engine
+  engine_version      = data.aws_rds_orderable_db_instance.postgres10.engine_version
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.postgres10.instance_class
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = aws_db_instance.source.id
+  db_snapshot_identifier = %[1]q
+}
+
+data "aws_rds_orderable_db_instance" "postgres11" {
+  engine         = "postgres"
+  engine_version = "11.1"
+  license_model  = "postgresql-license"
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t2.medium"]
+}
+
+resource "aws_db_instance" "test" {
   allow_major_version_upgrade = %[2]t
-  engine                      = "postgres"
-  engine_version              = "11.1"
+  engine                      = data.aws_rds_orderable_db_instance.postgres11.engine
+  engine_version              = data.aws_rds_orderable_db_instance.postgres11.engine_version
   identifier                  = %[1]q
   instance_class              = aws_db_instance.source.instance_class
   snapshot_identifier         = aws_db_snapshot.test.id
@@ -5747,12 +6005,12 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_AutoMinorVersionUpgrade(rName string, autoMinorVersionUpgrade bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -5760,26 +6018,29 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  auto_minor_version_upgrade = %t
-  identifier                 = %q
+  auto_minor_version_upgrade = %[2]t
+  identifier                 = %[1]q
   instance_class             = aws_db_instance.source.instance_class
   snapshot_identifier        = aws_db_snapshot.test.id
   skip_final_snapshot        = true
 }
-`, rName, rName, autoMinorVersionUpgrade, rName)
+`, rName, autoMinorVersionUpgrade))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_AvailabilityZone(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMariadb(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -5787,26 +6048,26 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
   availability_zone   = data.aws_availability_zones.available.names[0]
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 }
-`, rName, rName, rName))
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_BackupRetentionPeriod(rName string, backupRetentionPeriod int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -5814,27 +6075,27 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  backup_retention_period = %d
-  identifier              = %q
+  backup_retention_period = %[2]d
+  identifier              = %[1]q
   instance_class          = aws_db_instance.source.instance_class
   snapshot_identifier     = aws_db_snapshot.test.id
   skip_final_snapshot     = true
 }
-`, rName, rName, backupRetentionPeriod, rName)
+`, rName, backupRetentionPeriod))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_BackupRetentionPeriod_Unset(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mariadb"
-  identifier              = "%s-source"
-  instance_class          = "db.t2.micro"
+  engine                  = data.aws_rds_orderable_db_instance.test.engine
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   skip_final_snapshot     = true
@@ -5842,28 +6103,28 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
   backup_retention_period = 0
-  identifier              = %q
+  identifier              = %[1]q
   instance_class          = aws_db_instance.source.instance_class
   snapshot_identifier     = aws_db_snapshot.test.id
   skip_final_snapshot     = true
 }
-`, rName, rName, rName)
+`, rName))
 }
 
 // We provide maintenance_window to prevent the following error from a randomly selected window:
 // InvalidParameterValue: The backup window and maintenance window must not overlap.
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_BackupWindow(rName, backupWindow, maintenanceWindow string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -5871,22 +6132,25 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  backup_window       = %q
-  identifier          = %q
+  backup_window       = %[2]q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  maintenance_window  = %q
+  maintenance_window  = %[3]q
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 }
-`, rName, rName, backupWindow, rName, maintenanceWindow)
+`, rName, backupWindow, maintenanceWindow))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMariadb(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -5914,9 +6178,9 @@ resource "aws_db_subnet_group" "test" {
 
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = "%[1]s-source"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -5938,8 +6202,11 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName_RamShared(rName string) string {
-	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMariadb(),
+		testAccAlternateAccountProviderConfig(),
+		fmt.Sprintf(`
+data "aws_availability_zones" "alternate" {
   provider = "awsalternate"
 
   state = "available"
@@ -5966,7 +6233,7 @@ resource "aws_subnet" "test" {
   count    = 2
   provider = "awsalternate"
 
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  availability_zone = data.aws_availability_zones.alternate.names[count.index]
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = aws_vpc.test.id
 
@@ -6012,9 +6279,9 @@ resource "aws_security_group" "test" {
 
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = "%[1]s-source"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6033,11 +6300,14 @@ resource "aws_db_instance" "test" {
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.test.id]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds(rName string) string {
-	return composeConfig(testAccAvailableAZsNoOptInConfig(), testAccAvailableAZsNoOptInConfig()+fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMariadb(),
+		testAccAvailableAZsNoOptInConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -6070,9 +6340,9 @@ resource "aws_db_subnet_group" "test" {
 
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = "%[1]s-source"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6095,12 +6365,12 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_DeletionProtection(rName string, deletionProtection bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mysql"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6108,26 +6378,26 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  deletion_protection = %t
-  identifier          = %q
+  deletion_protection = %[2]t
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 }
-`, rName, rName, deletionProtection, rName)
+`, rName, deletionProtection))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_IamDatabaseAuthenticationEnabled(rName string, iamDatabaseAuthenticationEnabled bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mysql"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6135,28 +6405,28 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  iam_database_authentication_enabled = %t
-  identifier                          = %q
+  iam_database_authentication_enabled = %[2]t
+  identifier                          = %[1]q
   instance_class                      = aws_db_instance.source.instance_class
   snapshot_identifier                 = aws_db_snapshot.test.id
   skip_final_snapshot                 = true
 }
-`, rName, rName, iamDatabaseAuthenticationEnabled, rName)
+`, rName, iamDatabaseAuthenticationEnabled))
 }
 
 // We provide backup_window to prevent the following error from a randomly selected window:
 // InvalidParameterValue: The backup window and maintenance window must not overlap.
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_MaintenanceWindow(rName, backupWindow, maintenanceWindow string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6164,27 +6434,27 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  backup_window       = %q
-  identifier          = %q
+  backup_window       = %[2]q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  maintenance_window  = %q
+  maintenance_window  = %[3]q
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 }
-`, rName, rName, backupWindow, rName, maintenanceWindow)
+`, rName, backupWindow, maintenanceWindow))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_MaxAllocatedStorage(rName string, maxAllocatedStorage int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
   identifier          = "%[1]s-source"
-  instance_class      = "db.t2.micro"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6203,16 +6473,16 @@ resource "aws_db_instance" "test" {
   snapshot_identifier   = aws_db_snapshot.test.id
   skip_final_snapshot   = true
 }
-`, rName, maxAllocatedStorage)
+`, rName, maxAllocatedStorage))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_Monitoring(rName string, monitoringInterval int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 data "aws_partition" "current" {
 }
 
 resource "aws_iam_role" "test" {
-  name = %q
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -6238,9 +6508,9 @@ resource "aws_iam_role_policy_attachment" "test" {
 
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6248,27 +6518,27 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  monitoring_interval = %d
+  monitoring_interval = %[2]d
   monitoring_role_arn = aws_iam_role.test.arn
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 }
-`, rName, rName, rName, rName, monitoringInterval)
+`, rName, monitoringInterval))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_MultiAZ(rName string, multiAz bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6276,27 +6546,36 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  multi_az            = %t
+  multi_az            = %[2]t
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 }
-`, rName, rName, rName, multiAz)
+`, rName, multiAz))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_MultiAZ_SQLServer(rName string, multiAz bool) string {
 	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = "sqlserver-se"
+  engine_version = "14.00.1000.169.v1"
+  license_model  = "license-included"
+  storage_type   = "standard"
+
+  preferred_instance_classes = ["db.m5.large", "db.m4.large", "db.r4.large"]
+}
+
 resource "aws_db_instance" "source" {
   allocated_storage   = 20
-  engine              = "sqlserver-se"
-  identifier          = "%s-source"
-  instance_class      = "db.m4.large"
-  license_model       = "license-included"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  license_model       = data.aws_rds_orderable_db_instance.test.license_model
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6304,26 +6583,28 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
   # InvalidParameterValue: Mirroring cannot be applied to instances with backup retention set to zero.
   backup_retention_period = 1
-  identifier              = %q
+  identifier              = %[1]q
   instance_class          = aws_db_instance.source.instance_class
-  multi_az                = %t
+  multi_az                = %[2]t
   snapshot_identifier     = aws_db_snapshot.test.id
   skip_final_snapshot     = true
 }
-`, rName, rName, rName, multiAz)
+`, rName, multiAz)
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_ParameterGroupName(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMariadb(),
+		fmt.Sprintf(`
 resource "aws_db_parameter_group" "test" {
   family = "mariadb10.2"
-  name   = %q
+  name   = %[1]q
 
   parameter {
     name  = "sync_binlog"
@@ -6333,10 +6614,10 @@ resource "aws_db_parameter_group" "test" {
 
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  engine_version      = "10.2.15"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  engine_version      = data.aws_rds_orderable_db_instance.test.engine_version
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6344,26 +6625,28 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier           = %q
+  identifier           = %[1]q
   instance_class       = aws_db_instance.source.instance_class
   parameter_group_name = aws_db_parameter_group.test.id
   snapshot_identifier  = aws_db_snapshot.test.id
   skip_final_snapshot  = true
 }
-`, rName, rName, rName, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_Port(rName string, port int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMariadb(),
+		fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6371,26 +6654,28 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
-  port                = %d
+  port                = %[2]d
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 }
-`, rName, rName, rName, port)
+`, rName, port))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_Tags(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSDBInstanceConfig_orderableClassMariadb(),
+		fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6398,11 +6683,11 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
@@ -6411,16 +6696,16 @@ resource "aws_db_instance" "test" {
     key1 = "value1"
   }
 }
-`, rName, rName, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_Tags_Unset(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6432,36 +6717,36 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier          = %q
+  identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   snapshot_identifier = aws_db_snapshot.test.id
   skip_final_snapshot = true
 
   tags = {}
 }
-`, rName, rName, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_VpcSecurityGroupIds(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 data "aws_vpc" "default" {
   default = true
 }
 
 resource "aws_security_group" "test" {
-  name   = %q
+  name   = %[1]q
   vpc_id = data.aws_vpc.default.id
 }
 
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6469,35 +6754,35 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier             = %q
+  identifier             = %[1]q
   instance_class         = aws_db_instance.source.instance_class
   snapshot_identifier    = aws_db_snapshot.test.id
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.test.id]
 }
-`, rName, rName, rName, rName)
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_VpcSecurityGroupIds_Tags(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 data "aws_vpc" "default" {
   default = true
 }
 
 resource "aws_security_group" "test" {
-  name   = %q
+  name   = %[1]q
   vpc_id = data.aws_vpc.default.id
 }
 
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mariadb"
-  identifier          = "%s-source"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6505,11 +6790,11 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier             = %q
+  identifier             = %[1]q
   instance_class         = aws_db_instance.source.instance_class
   snapshot_identifier    = aws_db_snapshot.test.id
   skip_final_snapshot    = true
@@ -6519,18 +6804,31 @@ resource "aws_db_instance" "test" {
     key1 = "value1"
   }
 }
-`, rName, rName, rName, rName)
+`, rName))
 }
 
-func testAccAWSDBInstancePerformanceInsightsDisabled(rName string) string {
+func testAccAWSDBInstanceConfig_PerformanceInsightsDisabled(rName string) string {
 	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = data.aws_rds_engine_version.default.engine
+  engine_version                = data.aws_rds_engine_version.default.version
+  license_model                 = "general-public-license"
+  storage_type                  = "standard"
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.m3.medium", "db.m3.large", "db.m4.large"]
+}
+
 resource "aws_db_instance" "test" {
   allocated_storage       = 5
   backup_retention_period = 0
-  engine                  = "mysql"
-  engine_version          = "5.6.41"
-  identifier              = %[1]q
-  instance_class          = "db.m5.large"
+  engine                  = data.aws_rds_engine_version.default.engine
+  engine_version          = data.aws_rds_engine_version.default.version
+  identifier              = %q
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   name                    = "mydb"
   password                = "mustbeeightcharaters"
   skip_final_snapshot     = true
@@ -6539,15 +6837,28 @@ resource "aws_db_instance" "test" {
 `, rName)
 }
 
-func testAccAWSDBInstancePerformanceInsightsEnabled(rName string) string {
+func testAccAWSDBInstanceConfig_PerformanceInsightsEnabled(rName string) string {
 	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = data.aws_rds_engine_version.default.engine
+  engine_version                = data.aws_rds_engine_version.default.version
+  license_model                 = "general-public-license"
+  storage_type                  = "standard"
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.m3.medium", "db.m3.large", "db.m4.large"]
+}
+
 resource "aws_db_instance" "test" {
   allocated_storage                     = 5
   backup_retention_period               = 0
-  engine                                = "mysql"
-  engine_version                        = "5.6.41"
-  identifier                            = %[1]q
-  instance_class                        = "db.m5.large"
+  engine                                = data.aws_rds_engine_version.default.engine
+  engine_version                        = data.aws_rds_engine_version.default.version
+  identifier                            = %q
+  instance_class                        = data.aws_rds_orderable_db_instance.test.instance_class
   name                                  = "mydb"
   password                              = "mustbeeightcharaters"
   performance_insights_enabled          = true
@@ -6558,16 +6869,29 @@ resource "aws_db_instance" "test" {
 `, rName)
 }
 
-func testAccAWSDBInstancePerformanceInsightsKmsKeyIdDisabled(rName string) string {
+func testAccAWSDBInstanceConfig_PerformanceInsightsKmsKeyIdDisabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 }
 
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = data.aws_rds_engine_version.default.engine
+  engine_version                = data.aws_rds_engine_version.default.version
+  license_model                 = "general-public-license"
+  storage_type                  = "standard"
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.m3.medium", "db.m3.large", "db.m4.large"]
+}
+
 resource "aws_db_instance" "test" {
-  engine                  = "mysql"
-  identifier              = %[1]q
-  instance_class          = "db.m5.large"
+  engine                  = data.aws_rds_engine_version.default.engine
+  identifier              = %q
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   allocated_storage       = 5
   backup_retention_period = 0
   name                    = "mydb"
@@ -6578,19 +6902,32 @@ resource "aws_db_instance" "test" {
 `, rName)
 }
 
-func testAccAWSDBInstancePerformanceInsightsKmsKeyId(rName string) string {
+func testAccAWSDBInstanceConfig_PerformanceInsightsKmsKeyId(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 }
 
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = data.aws_rds_engine_version.default.engine
+  engine_version                = data.aws_rds_engine_version.default.version
+  license_model                 = "general-public-license"
+  storage_type                  = "standard"
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.m3.medium", "db.m3.large", "db.m4.large"]
+}
+
 resource "aws_db_instance" "test" {
   allocated_storage                     = 5
   backup_retention_period               = 0
-  engine                                = "mysql"
-  engine_version                        = "5.6.41"
-  identifier                            = %[1]q
-  instance_class                        = "db.m5.large"
+  engine                                = data.aws_rds_engine_version.default.engine
+  engine_version                        = data.aws_rds_engine_version.default.version
+  identifier                            = %q
+  instance_class                        = data.aws_rds_orderable_db_instance.test.instance_class
   name                                  = "mydb"
   password                              = "mustbeeightcharaters"
   performance_insights_enabled          = true
@@ -6602,19 +6939,32 @@ resource "aws_db_instance" "test" {
 `, rName)
 }
 
-func testAccAWSDBInstancePerformanceInsightsRetentionPeriod(rName string, performanceInsightsRetentionPeriod int) string {
+func testAccAWSDBInstanceConfig_PerformanceInsightsRetentionPeriod(rName string, performanceInsightsRetentionPeriod int) string {
 	return fmt.Sprintf(`
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = data.aws_rds_engine_version.default.engine
+  engine_version                = data.aws_rds_engine_version.default.version
+  license_model                 = "general-public-license"
+  storage_type                  = "standard"
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.m3.medium", "db.m3.large", "db.m4.large"]
+}
+
 resource "aws_db_instance" "test" {
   allocated_storage                     = 5
   backup_retention_period               = 0
-  engine                                = "mysql"
-  engine_version                        = "5.6.41"
-  identifier                            = %[1]q
-  instance_class                        = "db.m5.large"
+  engine                                = data.aws_rds_engine_version.default.engine
+  engine_version                        = data.aws_rds_engine_version.default.version
+  identifier                            = %q
+  instance_class                        = data.aws_rds_orderable_db_instance.test.instance_class
   name                                  = "mydb"
   password                              = "mustbeeightcharaters"
   performance_insights_enabled          = true
-  performance_insights_retention_period = %[2]d
+  performance_insights_retention_period = %d
   skip_final_snapshot                   = true
   username                              = "foo"
 }
@@ -6645,20 +6995,33 @@ resource "aws_kms_key" "test" {
 POLICY
 }
 
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = data.aws_rds_engine_version.default.engine
+  engine_version                = data.aws_rds_engine_version.default.version
+  license_model                 = "general-public-license"
+  storage_type                  = "standard"
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.m3.medium", "db.m3.large", "db.m4.large"]
+}
+
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
-  engine                  = "mysql"
-  engine_version          = "5.6.41"
-  identifier              = "%s-source"
-  instance_class          = "db.m5.large"
+  engine                  = data.aws_rds_engine_version.default.engine
+  engine_version          = data.aws_rds_engine_version.default.version
+  identifier              = "%[1]s-source"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "mustbeeightcharaters"
   username                = "tfacctest"
   skip_final_snapshot     = true
 }
 
 resource "aws_db_instance" "test" {
-  identifier                            = %q
+  identifier                            = %[1]q
   instance_class                        = aws_db_instance.source.instance_class
   performance_insights_enabled          = true
   performance_insights_kms_key_id       = aws_kms_key.test.arn
@@ -6666,7 +7029,7 @@ resource "aws_db_instance" "test" {
   replicate_source_db                   = aws_db_instance.source.id
   skip_final_snapshot                   = true
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_PerformanceInsightsEnabled(rName string) string {
@@ -6693,12 +7056,25 @@ resource "aws_kms_key" "test" {
 POLICY
 }
 
+data "aws_rds_engine_version" "default" {
+  engine = "mysql"
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = data.aws_rds_engine_version.default.engine
+  engine_version                = data.aws_rds_engine_version.default.version
+  license_model                 = "general-public-license"
+  storage_type                  = "standard"
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.m3.medium", "db.m3.large", "db.m4.large"]
+}
+
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
-  engine              = "mysql"
-  engine_version      = "5.6.41"
-  identifier          = "%s-source"
-  instance_class      = "db.m5.large"
+  engine              = data.aws_rds_engine_version.default.engine
+  engine_version      = data.aws_rds_engine_version.default.version
+  identifier          = "%[1]s-source"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6706,11 +7082,11 @@ resource "aws_db_instance" "source" {
 
 resource "aws_db_snapshot" "test" {
   db_instance_identifier = aws_db_instance.source.id
-  db_snapshot_identifier = %q
+  db_snapshot_identifier = %[1]q
 }
 
 resource "aws_db_instance" "test" {
-  identifier                            = %q
+  identifier                            = %[1]q
   instance_class                        = aws_db_instance.source.instance_class
   performance_insights_enabled          = true
   performance_insights_kms_key_id       = aws_kms_key.test.arn
@@ -6718,16 +7094,16 @@ resource "aws_db_instance" "test" {
   snapshot_identifier                   = aws_db_snapshot.test.id
   skip_final_snapshot                   = true
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccAWSDBInstanceConfig_NoDeleteAutomatedBackups(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage   = 10
-  engine              = "mariadb"
-  identifier          = "%s"
-  instance_class      = "db.t2.micro"
+  engine              = data.aws_rds_orderable_db_instance.test.engine
+  identifier          = %q
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
   skip_final_snapshot = true
@@ -6735,5 +7111,5 @@ resource "aws_db_instance" "test" {
   backup_retention_period  = 1
   delete_automated_backups = false
 }
-`, rName)
+`, rName))
 }

--- a/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -157,7 +157,7 @@ resource "aws_opsworks_rds_db_instance" "tf-acc-opsworks-db" {
 }
 %s
 %s
-`, userName, password, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAWSDBInstanceConfig)
+`, userName, password, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAWSDBInstanceConfig_basic())
 }
 
 func testAccAwsOpsworksRdsDbInstanceForceNew(name string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 
Depends on #15228 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing (GovCloud partition):

```
--- FAIL: TestAccAWSDbInstanceDataSource_ec2Classic (1.38s)
--- FAIL: TestAccAWSDBInstance_DbSubnetGroupName_RamShared (1.90s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName (0.58s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared (0.41s)
--- FAIL: TestAccAWSDBInstance_S3Import (0.42s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1480.70s)
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared (0.33s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier (751.38s)
--- FAIL: TestAccAWSDBInstance_separate_iops_update (0.49s) (fixed, waiting on testing)
--- PASS: TestAccAWSDBInstance_MinorVersion (437.91s) **
--- FAIL: TestAccAWSDBInstance_ec2Classic (0.41s)
--- FAIL: TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled (3.64s) (fixed, waiting on testing)
--- FAIL: TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod (4.85s) (fixed, waiting on testing)
--- FAIL: TestAccAWSDBInstance_PerformanceInsightsKmsKeyId (5.41s) (fixed, waiting on testing)
--- FAIL: TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled (405.64s) (fixed, waiting on testing)
--- FAIL: TestAccAWSDBInstance_CACertificateIdentifier (428.80s)
--- FAIL: TestAccAWSOpsworksRdsDbInstance_basic (418.61s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (743.03s) (fixed, waiting on testing)
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1338.80s) **
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1267.70s) (fixed, waiting on testing)
--- FAIL: TestAccAWSDBInstance_MSSQL_Domain (2965.58s) (fixed, waiting on testing) (fixed, waiting on testing)
--- PASS: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (3067.96s) **
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (0.00s)
--- PASS: TestAccAWSDBInstance_kmsKey (456.21s)
--- PASS: TestAccAWSDBInstance_basic (468.92s)
--- PASS: TestAccAWSDBInstance_iamAuth (489.18s)
--- PASS: TestAccAWSDBInstance_namePrefix (489.44s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (487.70s)
--- PASS: TestAccAWSDBInstance_DeletionProtection (509.36s)
--- PASS: TestAccAWSDbInstanceDataSource_basic (509.64s)
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (511.05s)
--- PASS: TestAccAWSDBInstance_generatedName (536.79s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName (558.42s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds (559.36s)
--- PASS: TestAccAWSDBInstance_optionGroup (574.92s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (779.54s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (778.32s)
--- PASS: TestAccAWSDBInstance_subnetGroup (904.64s)
--- PASS: TestAccAWSDBInstance_Password (477.09s)
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (572.28s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1385.43s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1405.95s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1444.80s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1384.71s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1485.64s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1525.73s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1676.99s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1717.96s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1484.84s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1778.76s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1586.28s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1382.50s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds (2297.76s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2029.48s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1118.06s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1007.65s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1442.58s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1188.73s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1089.18s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1562.82s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName (1198.94s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds (1199.07s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1704.26s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1503.50s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1227.15s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1704.82s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1079.45s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (1968.55s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1240.71s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1250.00s)
--- PASS: TestAccAWSDBInstance_portUpdate (528.95s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1351.77s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (588.91s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (772.92s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1039.17s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1180.58s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (771.22s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1290.87s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1160.76s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1280.58s)
--- PASS: TestAccAWSDBInstance_MonitoringInterval (1126.42s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (466.22s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (373.26s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1877.62s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (748.88s)
--- PASS: TestAccAWSDBInstance_NoDeleteAutomatedBackups (655.23s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (746.82s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL (837.84s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (2062.29s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (4302.23s)
```

Output from acceptance testing (commercial/standard partition):

```
--- FAIL: TestAccAWSDBInstance_DbSubnetGroupName_RamShared (11.33s)
--- FAIL: TestAccAWSDbInstanceDataSource_ec2Classic (25.60s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName (1.32s)
--- FAIL: TestAccAWSDBInstance_S3Import (1.29s)
--- FAIL: TestAccAWSDBInstance_separate_iops_update (1.00s)
--- FAIL: TestAccAWSDBInstance_MinorVersion (1.60s)
--- FAIL: TestAccAWSDBInstance_ec2Classic (9.69s)
--- FAIL: TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled (7.67s)
--- FAIL: TestAccAWSDBInstance_PerformanceInsightsKmsKeyId (8.14s)
--- FAIL: TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod (7.56s)
--- FAIL: TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled (497.26s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (665.73s)
--- FAIL: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1101.79s)
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1180.47s)
--- FAIL: TestAccAWSDBInstance_MSSQL_Domain (2969.55s)
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (0.00s)
--- PASS: TestAccAWSDBInstance_generatedName (376.58s)
--- PASS: TestAccAWSDBInstance_DeletionProtection (411.38s)
--- PASS: TestAccAWSDBInstance_Password (477.99s)
--- PASS: TestAccAWSDBInstance_basic (482.03s)
--- PASS: TestAccAWSDBInstance_iamAuth (486.41s)
--- PASS: TestAccAWSDBInstance_namePrefix (506.15s)
--- PASS: TestAccAWSDBInstance_kmsKey (508.38s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName (509.21s)
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (541.00s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds (542.91s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (561.26s)
--- PASS: TestAccAWSDBInstance_optionGroup (632.05s)
--- PASS: TestAccAWSDbInstanceDataSource_basic (669.20s)
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (672.55s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (691.03s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (1036.45s)
--- PASS: TestAccAWSDBInstance_subnetGroup (1069.98s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1345.67s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1358.08s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1080.01s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1312.78s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1714.27s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1279.90s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1362.09s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1347.15s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1424.69s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1299.80s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1299.24s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1567.05s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1652.83s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1157.64s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier (1524.89s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1621.07s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1374.80s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (1904.69s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared (2089.56s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1178.23s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds (2186.02s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName (1017.86s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1277.87s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1661.11s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds (1039.39s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1058.47s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1183.09s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (985.16s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared (1311.19s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1069.46s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1508.03s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1190.96s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1642.09s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1199.81s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (2046.24s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (987.86s)
--- PASS: TestAccAWSDBInstance_portUpdate (569.62s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (634.16s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (656.35s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1106.56s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1217.91s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1097.54s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (784.05s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (518.62s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1723.47s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (382.18s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1131.79s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (671.40s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL (675.63s)
--- PASS: TestAccAWSDBInstance_MonitoringInterval (1125.34s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (755.01s)
--- PASS: TestAccAWSDBInstance_NoDeleteAutomatedBackups (580.20s)
--- PASS: TestAccAWSDBInstance_CACertificateIdentifier (518.97s)
--- PASS: TestAccAWSOpsworksRdsDbInstance_basic (702.31s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1952.91s)
--- PASS: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (3189.37s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (4009.65s)
```