### PR TITLE
resource/aws_acm_certificate: Provide additional plan-time validation for subject_alternative_names values

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -78,8 +78,11 @@ func resourceAwsAcmCertificate() *schema.Resource {
 					// AWS Provider 3.0.0 aws_route53_zone references no longer contain a
 					// trailing period, no longer requiring a custom StateFunc
 					// to prevent ACM API error
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringDoesNotMatch(regexp.MustCompile(`\.$`), "cannot end with a period"),
+					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 253),
+						validation.StringDoesNotMatch(regexp.MustCompile(`\.$`), "cannot end with a period"),
+					),
 				},
 				Set:           schema.HashString,
 				ConflictsWith: []string{"private_key", "certificate_body", "certificate_chain"},

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -308,6 +308,23 @@ func TestAccAWSAcmCertificate_rootAndWildcardSan(t *testing.T) {
 	})
 }
 
+func TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+	domain := testAccAwsAcmCertificateRandomSubDomain(rootDomain)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAcmCertificateConfig_subjectAlternativeNames(domain, strconv.Quote(""), acm.ValidationMethodDns),
+				ExpectError: regexp.MustCompile(`expected length`),
+			},
+		},
+	})
+}
+
 func TestAccAWSAcmCertificate_san_single(t *testing.T) {
 	resourceName := "aws_acm_certificate.cert"
 	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_acm_certificate: Provide additional plan-time validation for `subject_alternative_names` argument values
```

Previously:

```
    TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString: resource_aws_acm_certificate_test.go:315: Step 1/1, expected an error with pattern, no match on: terraform failed: exit status 1

        stderr:

        Error: Error requesting certificate: ValidationException: 1 validation error detected: Value '[]' at 'subjectAlternativeNames' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 253, Member must have length greater than or equal to 1, Member must satisfy regular expression pattern: ^(\*\.)?(((?!-)[A-Za-z0-9-]{0,62}[A-Za-z0-9])\.)+((?!-)[A-Za-z0-9-]{1,62}[A-Za-z0-9])$]
        	status code: 400, request id: c82c20fc-931d-4e04-b79f-d9795db14fa9
```

The intention of this change was test and prevent against panic in Terraform 0.11, however since the provider no longer supports 0.11 and earlier, this is now merely an enhancement. We could also attempt the same regular expression validation, however that seems more likely to change in the future, should ACM support additional characters in domain naming so its omitted for now.

Output from acceptance testing (unrelated failures due to testing account quota issues):

```
--- PASS: TestAccAWSAcmCertificate_root_TrailingPeriod (2.66s)
--- PASS: TestAccAWSAcmCertificate_SubjectAlternativeNames_EmptyString (2.94s)
--- FAIL: TestAccAWSAcmCertificate_imported_DomainName (6.59s)
--- FAIL: TestAccAWSAcmCertificate_imported_IpAddress (6.22s)
--- PASS: TestAccAWSAcmCertificate_root (19.80s)
--- PASS: TestAccAWSAcmCertificate_emailValidation (20.68s)
--- PASS: TestAccAWSAcmCertificate_dnsValidation (21.38s)
--- PASS: TestAccAWSAcmCertificate_san_TrailingPeriod (21.73s)
--- PASS: TestAccAWSAcmCertificate_disableCTLogging (21.82s)
--- PASS: TestAccAWSAcmCertificate_wildcardAndRootSan (22.66s)
--- PASS: TestAccAWSAcmCertificate_san_multiple (23.00s)
--- PASS: TestAccAWSAcmCertificate_wildcard (23.41s)
--- PASS: TestAccAWSAcmCertificate_privateCert (23.68s)
--- PASS: TestAccAWSAcmCertificate_san_single (24.92s)
--- PASS: TestAccAWSAcmCertificate_rootAndWildcardSan (35.64s)
--- PASS: TestAccAWSAcmCertificate_tags (54.65s)
```
