### PR TITLE
tech-debt: IAM Role and Service Linked Role Acceptance Tests

### DIFF
--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -74,9 +74,13 @@ func resourceAwsIamRole() *schema.Resource {
 			},
 
 			"description": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateIamRoleDescription,
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 1000),
+					validation.StringDoesNotMatch(regexp.MustCompile("[“‘]"), "cannot contain specially formatted single or double quotes: [“‘]"),
+					validation.StringMatch(regexp.MustCompile(`[\p{L}\p{M}\p{Z}\p{S}\p{N}\p{P}]*`), `must satisfy regular expression pattern: [\p{L}\p{M}\p{Z}\p{S}\p{N}\p{P}]*)`),
+				),
 			},
 
 			"assume_role_policy": {

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -724,7 +724,7 @@ func testAccAWSIAMRoleConfigWithDescription(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name        = "test-role-%s"
-  description = "This 1s a D3scr!pti0n with weird content: &@90ë“‘{«¡Çø}"
+  description = "This 1s a D3scr!pti0n with weird content: &@90ë\"'{«¡Çø}"
   path        = "/"
 
   assume_role_policy = <<EOF

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -191,7 +191,7 @@ func TestAccAWSIAMRole_basicWithDescription(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "path", "/"),
-					resource.TestCheckResourceAttr(resourceName, "description", "This 1s a D3scr!pti0n with weird content: &@90ë“‘{«¡Çø}"),
+					resource.TestCheckResourceAttr(resourceName, "description", "This 1s a D3scr!pti0n with weird content: &@90ë\"'{«¡Çø}"),
 				),
 			},
 			{
@@ -204,7 +204,7 @@ func TestAccAWSIAMRole_basicWithDescription(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "path", "/"),
-					resource.TestCheckResourceAttr(resourceName, "description", "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë“‘{«¡Çø}"),
+					resource.TestCheckResourceAttr(resourceName, "description", "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë\"'{«¡Çø}"),
 				),
 			},
 			{
@@ -753,7 +753,7 @@ func testAccAWSIAMRoleConfigWithUpdatedDescription(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name        = "test-role-%s"
-  description = "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë“‘{«¡Çø}"
+  description = "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë\"'{«¡Çø}"
   path        = "/"
 
   assume_role_policy = <<EOF

--- a/aws/resource_aws_iam_service_linked_role_test.go
+++ b/aws/resource_aws_iam_service_linked_role_test.go
@@ -30,7 +30,11 @@ func testSweepIamServiceLinkedRoles(region string) error {
 	input := &iam.ListRolesInput{
 		PathPrefix: aws.String("/aws-service-role/"),
 	}
-	customSuffixRegex := regexp.MustCompile(`_tf-acc-test-\d+$`)
+
+	// include generic service role names created by:
+	// TestAccAWSIAMServiceLinkedRole_basic
+	// TestAccAWSIAMServiceLinkedRole_CustomSuffix_DiffSuppressFunc
+	customSuffixRegex := regexp.MustCompile(`_?(tf-acc-test-\d+|ServiceRoleFor(ApplicationAutoScaling_CustomResource|ElasticBeanstalk))$`)
 	err = conn.ListRolesPages(input, func(page *iam.ListRolesOutput, lastPage bool) bool {
 		if len(page.Roles) == 0 {
 			log.Printf("[INFO] No IAM Service Roles to sweep")

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1854,21 +1854,6 @@ func validateWafPredicatesType() schema.SchemaValidateFunc {
 	}, false)
 }
 
-func validateIamRoleDescription(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if len(value) > 1000 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 1000 characters", k))
-	}
-
-	if !regexp.MustCompile(`[\p{L}\p{M}\p{Z}\p{S}\p{N}\p{P}]*`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			`Only alphanumeric & accented characters allowed in %q: %q (Must satisfy regular expression pattern: [\p{L}\p{M}\p{Z}\p{S}\p{N}\p{P}]*)`,
-			k, value))
-	}
-	return
-}
-
 func validateAwsSSMName(v interface{}, k string) (ws []string, errors []error) {
 	// http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateDocument.html#EC2-CreateDocument-request-Name
 	value := v.(string)

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2289,29 +2289,6 @@ func TestValidateWafMetricName(t *testing.T) {
 	}
 }
 
-func TestValidateIamRoleDescription(t *testing.T) {
-	validNames := []string{
-		"This 1s a D3scr!pti0n with weird content: @ #^ù£ê®æ ø]ŒîÏî~ÈÙ£÷=,ë",
-		strings.Repeat("W", 1000),
-	}
-	for _, v := range validNames {
-		_, errors := validateIamRoleDescription(v, "description")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid IAM Role Description: %q", v, errors)
-		}
-	}
-
-	invalidNames := []string{
-		strings.Repeat("W", 1001), // > 1000
-	}
-	for _, v := range invalidNames {
-		_, errors := validateIamRoleDescription(v, "description")
-		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid IAM Role Description", v)
-		}
-	}
-}
-
 func TestValidateAwsSSMName(t *testing.T) {
 	validNames := []string{
 		".foo-bar_123",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14386

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt/iam_role: update plan-time validation to check for specially formatted single and double quotes, not allowed by API
tech-debt/iam_service_linked_role: update test sweeper to catch lingering service roles without tf-acc-test suffix
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSIAMRole_basicWithDescription (31.32s)
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix_DiffSuppressFunc (22.87s)
```
