### PR TITLE
r/storagegateway_smb_file_share - support cache attributes + case sensitivity + fix docs

### DIFF
--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -186,7 +186,7 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 		input.CacheAttributes = expandStorageGatewayNfsFileShareCacheAttributes(v.([]interface{}))
 	}
 
-	log.Printf("[DEBUG] Creating Storage Gateway SMB File Share: %s", input)
+	log.Printf("[DEBUG] Creating Storage Gateway SMB File Share: %#v", input)
 	output, err := conn.CreateSMBFileShare(input)
 	if err != nil {
 		return fmt.Errorf("error creating Storage Gateway SMB File Share: %w", err)
@@ -218,7 +218,7 @@ func resourceAwsStorageGatewaySmbFileShareRead(d *schema.ResourceData, meta inte
 		FileShareARNList: []*string{aws.String(d.Id())},
 	}
 
-	log.Printf("[DEBUG] Reading Storage Gateway SMB File Share: %s", input)
+	log.Printf("[DEBUG] Reading Storage Gateway SMB File Share: %#v", input)
 	output, err := conn.DescribeSMBFileShares(input)
 	if err != nil {
 		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
@@ -313,7 +313,7 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 			input.CacheAttributes = expandStorageGatewayNfsFileShareCacheAttributes(v.([]interface{}))
 		}
 
-		log.Printf("[DEBUG] Updating Storage Gateway SMB File Share: %s", input)
+		log.Printf("[DEBUG] Updating Storage Gateway SMB File Share: %#v", input)
 		_, err := conn.UpdateSMBFileShare(input)
 		if err != nil {
 			return fmt.Errorf("error updating Storage Gateway SMB File Share: %w", err)
@@ -343,7 +343,7 @@ func resourceAwsStorageGatewaySmbFileShareDelete(d *schema.ResourceData, meta in
 		FileShareARN: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Deleting Storage Gateway SMB File Share: %s", input)
+	log.Printf("[DEBUG] Deleting Storage Gateway SMB File Share: %#v", input)
 	_, err := conn.DeleteFileShare(input)
 	if err != nil {
 		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
@@ -378,7 +378,7 @@ func storageGatewaySmbFileShareRefreshFunc(fileShareArn string, conn *storagegat
 			FileShareARNList: []*string{aws.String(fileShareArn)},
 		}
 
-		log.Printf("[DEBUG] Reading Storage Gateway SMB File Share: %s", input)
+		log.Printf("[DEBUG] Reading Storage Gateway SMB File Share: %#v", input)
 		output, err := conn.DescribeSMBFileShares(input)
 		if err != nil {
 			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {

--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -56,6 +56,7 @@ func resourceAwsStorageGatewaySmbFileShare() *schema.Resource {
 					"S3_ONEZONE_IA",
 					"S3_STANDARD_IA",
 					"S3_STANDARD",
+					"S3_INTELLIGENT_TIERING",
 				}, false),
 			},
 			"fileshare_id": {
@@ -87,6 +88,7 @@ func resourceAwsStorageGatewaySmbFileShare() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateArn,
+				RequiredWith: []string{"kms_encrypted"},
 			},
 			"location_arn": {
 				Type:         schema.TypeString,
@@ -95,18 +97,10 @@ func resourceAwsStorageGatewaySmbFileShare() *schema.Resource {
 				ValidateFunc: validateArn,
 			},
 			"object_acl": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  storagegateway.ObjectACLPrivate,
-				ValidateFunc: validation.StringInSlice([]string{
-					storagegateway.ObjectACLAuthenticatedRead,
-					storagegateway.ObjectACLAwsExecRead,
-					storagegateway.ObjectACLBucketOwnerFullControl,
-					storagegateway.ObjectACLBucketOwnerRead,
-					storagegateway.ObjectACLPrivate,
-					storagegateway.ObjectACLPublicRead,
-					storagegateway.ObjectACLPublicReadWrite,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      storagegateway.ObjectACLPrivate,
+				ValidateFunc: validation.StringInSlice(storagegateway.ObjectACL_Values(), false),
 			},
 			"path": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -189,7 +189,7 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 	log.Printf("[DEBUG] Creating Storage Gateway SMB File Share: %s", input)
 	output, err := conn.CreateSMBFileShare(input)
 	if err != nil {
-		return fmt.Errorf("error creating Storage Gateway SMB File Share: %s", err)
+		return fmt.Errorf("error creating Storage Gateway SMB File Share: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.FileShareARN))
@@ -204,7 +204,7 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 	}
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("error waiting for Storage Gateway SMB File Share creation: %s", err)
+		return fmt.Errorf("error waiting for Storage Gateway SMB File Share creation: %w", err)
 	}
 
 	return resourceAwsStorageGatewaySmbFileShareRead(d, meta)
@@ -226,7 +226,7 @@ func resourceAwsStorageGatewaySmbFileShareRead(d *schema.ResourceData, meta inte
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading Storage Gateway SMB File Share: %s", err)
+		return fmt.Errorf("error reading Storage Gateway SMB File Share: %w", err)
 	}
 
 	if output == nil || len(output.SMBFileShareInfoList) == 0 || output.SMBFileShareInfoList[0] == nil {
@@ -246,7 +246,7 @@ func resourceAwsStorageGatewaySmbFileShareRead(d *schema.ResourceData, meta inte
 	d.Set("guess_mime_type_enabled", fileshare.GuessMIMETypeEnabled)
 
 	if err := d.Set("invalid_user_list", flattenStringSet(fileshare.InvalidUserList)); err != nil {
-		return fmt.Errorf("error setting invalid_user_list: %s", err)
+		return fmt.Errorf("error setting invalid_user_list: %w", err)
 	}
 
 	if err := d.Set("cache_attributes", flattenStorageGatewayNfsFileShareCacheAttributes(fileshare.CacheAttributes)); err != nil {
@@ -265,11 +265,11 @@ func resourceAwsStorageGatewaySmbFileShareRead(d *schema.ResourceData, meta inte
 	d.Set("smb_acl_enabled", fileshare.SMBACLEnabled)
 
 	if err := d.Set("valid_user_list", flattenStringSet(fileshare.ValidUserList)); err != nil {
-		return fmt.Errorf("error setting valid_user_list: %s", err)
+		return fmt.Errorf("error setting valid_user_list: %w", err)
 	}
 
 	if err := d.Set("tags", keyvaluetags.StoragegatewayKeyValueTags(fileshare.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil
@@ -281,7 +281,7 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.StoragegatewayUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating tags: %s", err)
+			return fmt.Errorf("error updating tags: %w", err)
 		}
 	}
 
@@ -316,7 +316,7 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 		log.Printf("[DEBUG] Updating Storage Gateway SMB File Share: %s", input)
 		_, err := conn.UpdateSMBFileShare(input)
 		if err != nil {
-			return fmt.Errorf("error updating Storage Gateway SMB File Share: %s", err)
+			return fmt.Errorf("error updating Storage Gateway SMB File Share: %w", err)
 		}
 
 		stateConf := &resource.StateChangeConf{
@@ -329,7 +329,7 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 		}
 		_, err = stateConf.WaitForState()
 		if err != nil {
-			return fmt.Errorf("error waiting for Storage Gateway SMB File Share update: %s", err)
+			return fmt.Errorf("error waiting for Storage Gateway SMB File Share update: %w", err)
 		}
 	}
 
@@ -349,7 +349,7 @@ func resourceAwsStorageGatewaySmbFileShareDelete(d *schema.ResourceData, meta in
 		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
 			return nil
 		}
-		return fmt.Errorf("error deleting Storage Gateway SMB File Share: %s", err)
+		return fmt.Errorf("error deleting Storage Gateway SMB File Share: %w", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -366,7 +366,7 @@ func resourceAwsStorageGatewaySmbFileShareDelete(d *schema.ResourceData, meta in
 		if isResourceNotFoundError(err) {
 			return nil
 		}
-		return fmt.Errorf("error waiting for Storage Gateway SMB File Share deletion: %s", err)
+		return fmt.Errorf("error waiting for Storage Gateway SMB File Share deletion: %w", err)
 	}
 
 	return nil
@@ -384,7 +384,7 @@ func storageGatewaySmbFileShareRefreshFunc(fileShareArn string, conn *storagegat
 			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
 				return nil, "MISSING", nil
 			}
-			return nil, "ERROR", fmt.Errorf("error reading Storage Gateway SMB File Share: %s", err)
+			return nil, "ERROR", fmt.Errorf("error reading Storage Gateway SMB File Share: %w", err)
 		}
 
 		if output == nil || len(output.SMBFileShareInfoList) == 0 || output.SMBFileShareInfoList[0] == nil {

--- a/aws/resource_aws_storagegateway_smb_file_share_test.go
+++ b/aws/resource_aws_storagegateway_smb_file_share_test.go
@@ -88,6 +88,7 @@ func TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", iamResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "valid_user_list.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "0"),
 				),
 			},
 			{
@@ -537,6 +538,49 @@ func TestAccAWSStorageGatewaySmbFileShare_audit(t *testing.T) {
 	})
 }
 
+func TestAccAWSStorageGatewaySmbFileShare_cacheAttributes(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareCacheAttributesConfig(rName, 300),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareCacheAttributesConfig(rName, 500),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "500"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareCacheAttributesConfig(rName, 300),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_attributes.0.cache_stale_timeout_in_seconds", "300"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSStorageGatewaySmbFileShareDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
 
@@ -932,9 +976,9 @@ func testAccAWSStorageGatewaySmbFileShareSMBACLConfig(rName string, enabled bool
 	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName) + fmt.Sprintf(`
 resource "aws_storagegateway_smb_file_share" "test" {
   authentication  = "ActiveDirectory"
-  gateway_arn     = "${aws_storagegateway_gateway.test.arn}"
-  location_arn    = "${aws_s3_bucket.test.arn}"
-  role_arn        = "${aws_iam_role.test.arn}"
+  gateway_arn     = aws_storagegateway_gateway.test.arn
+  location_arn    = aws_s3_bucket.test.arn
+  role_arn        = aws_iam_role.test.arn
   smb_acl_enabled = %[1]t
 }
 `, enabled)
@@ -949,10 +993,10 @@ resource "aws_cloudwatch_log_group" "test" {
 resource "aws_storagegateway_smb_file_share" "test" {
   # Use GuestAccess to simplify testing
   authentication        = "GuestAccess"
-  gateway_arn           = "${aws_storagegateway_gateway.test.arn}"
-  location_arn          = "${aws_s3_bucket.test.arn}"
-  role_arn              = "${aws_iam_role.test.arn}"
-  audit_destination_arn = "${aws_cloudwatch_log_group.test.arn}"
+  gateway_arn           = aws_storagegateway_gateway.test.arn
+  location_arn          = aws_s3_bucket.test.arn
+  role_arn              = aws_iam_role.test.arn
+  audit_destination_arn = aws_cloudwatch_log_group.test.arn
 }
 `, rName)
 }
@@ -976,4 +1020,20 @@ resource "aws_storagegateway_smb_file_share" "test" {
   audit_destination_arn = "${aws_cloudwatch_log_group.test2.arn}"
 }
 `, rName)
+}
+
+func testAccAWSStorageGatewaySmbFileShareCacheAttributesConfig(rName string, timeout int) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication        = "GuestAccess"
+  gateway_arn           = aws_storagegateway_gateway.test.arn
+  location_arn          = aws_s3_bucket.test.arn
+  role_arn              = aws_iam_role.test.arn
+
+  cache_attributes {
+    cache_stale_timeout_in_seconds = %[1]d
+  }
+}
+`, timeout)
 }

--- a/aws/resource_aws_storagegateway_smb_file_share_test.go
+++ b/aws/resource_aws_storagegateway_smb_file_share_test.go
@@ -581,6 +581,28 @@ func TestAccAWSStorageGatewaySmbFileShare_cacheAttributes(t *testing.T) {
 	})
 }
 
+func TestAccAWSStorageGatewaySmbFileShare_disappears(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_Authentication_GuestAccess(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsStorageGatewaySmbFileShare(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSStorageGatewaySmbFileShareDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
 

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -53,11 +53,19 @@ The following arguments are supported:
 * `kms_encrypted` - (Optional) Boolean value if `true` to use Amazon S3 server side encryption with your own AWS KMS key, or `false` to use a key managed by Amazon S3. Defaults to `false`.
 * `kms_key_arn` - (Optional) Amazon Resource Name (ARN) for KMS key used for Amazon S3 server side encryption. This value can only be set when `kms_encrypted` is true.
 * `object_acl` - (Optional) Access Control List permission for S3 bucket objects. Defaults to `private`.
+* `cache_attributes` - (Optional) Refresh cache information. see [Cache Attributes](#cache_attributes) for more details.
 * `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
 * `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.
 * `smb_acl_enabled` - (Optional) Set this value to `true` to enable ACL (access control list) on the SMB fileshare. Set it to `false` to map file and directory permissions to the POSIX permissions. This setting applies only to `ActiveDirectory` authentication type.
 * `valid_user_list` - (Optional) A list of users in the Active Directory that are allowed to access the file share. Only valid if `authentication` is set to `ActiveDirectory`.
 * `tags` - (Optional) Key-value map of resource tags
+
+### cache_attributes
+
+* `cache_stale_timeout_in_seconds` - (Optional) Refreshes a file share's cache by using Time To Live (TTL).
+ TTL is the length of time since the last refresh after which access to the directory would cause the file gateway
+  to first refresh that directory's contents from the Amazon S3 bucket. Valid Values: 300 to 2,592,000 seconds (5 minutes to 30 days)
+
 
 ## Attribute Reference
 

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -52,22 +52,12 @@ The following arguments are supported:
 * `invalid_user_list` - (Optional) A list of users in the Active Directory that are not allowed to access the file share. Only valid if `authentication` is set to `ActiveDirectory`.
 * `kms_encrypted` - (Optional) Boolean value if `true` to use Amazon S3 server side encryption with your own AWS KMS key, or `false` to use a key managed by Amazon S3. Defaults to `false`.
 * `kms_key_arn` - (Optional) Amazon Resource Name (ARN) for KMS key used for Amazon S3 server side encryption. This value can only be set when `kms_encrypted` is true.
-* `smb_file_share_defaults` - (Optional) Nested argument with file share default values. More information below.
 * `object_acl` - (Optional) Access Control List permission for S3 bucket objects. Defaults to `private`.
 * `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
 * `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.
 * `smb_acl_enabled` - (Optional) Set this value to `true` to enable ACL (access control list) on the SMB fileshare. Set it to `false` to map file and directory permissions to the POSIX permissions. This setting applies only to `ActiveDirectory` authentication type.
 * `valid_user_list` - (Optional) A list of users in the Active Directory that are allowed to access the file share. Only valid if `authentication` is set to `ActiveDirectory`.
 * `tags` - (Optional) Key-value map of resource tags
-
-### smb_file_share_defaults
-
-Files and folders stored as Amazon S3 objects in S3 buckets don't, by default, have Unix file permissions assigned to them. Upon discovery in an S3 bucket by Storage Gateway, the S3 objects that represent files and folders are assigned these default Unix permissions.
-
-* `directory_mode` - (Optional) The Unix directory mode in the string form "nnnn". Defaults to `"0777"`.
-* `file_mode` - (Optional) The Unix file mode in the string form "nnnn". Defaults to `"0666"`.
-* `group_id` - (Optional) The default group ID for the file share (unless the files have another group ID specified). Defaults to `0`. Valid values: `0` through `4294967294`.
-* `owner_id` - (Optional) The default owner ID for the file share (unless the files have another owner ID specified). Defaults to `0`. Valid values: `0` through `4294967294`.
 
 ## Attribute Reference
 

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -57,6 +57,7 @@ The following arguments are supported:
 * `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
 * `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.
 * `smb_acl_enabled` - (Optional) Set this value to `true` to enable ACL (access control list) on the SMB fileshare. Set it to `false` to map file and directory permissions to the POSIX permissions. This setting applies only to `ActiveDirectory` authentication type.
+* `case_sensitivity` - (Optional) The case of an object name in an Amazon S3 bucket. For `ClientSpecified`, the client determines the case sensitivity. For `CaseSensitive`, the gateway determines the case sensitivity. The default value is `ClientSpecified`.
 * `valid_user_list` - (Optional) A list of users in the Active Directory that are allowed to access the file share. Only valid if `authentication` is set to `ActiveDirectory`.
 * `tags` - (Optional) Key-value map of resource tags
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8503

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_storagegateway_nfs_file_share - support cache attributes
resource_aws_storagegateway_nfs_file_share - support case sensitivity
resource_aws_storagegateway_nfs_file_share  - add intelligent tiering to storage_class
resource_aws_storagegateway_nfs_file_share - remove `smb_file_share_defaults` from docs
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess (320.69s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_cacheAttributes (724.33s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_disappears (391.73s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_caseSensitivity (517.89s)
...
```
