### PR TITLE
r/glue_crawler - allow removing schedule

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -81,23 +81,16 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"delete_behavior": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  glue.DeleteBehaviorDeprecateInDatabase,
-							ValidateFunc: validation.StringInSlice([]string{
-								glue.DeleteBehaviorDeleteFromDatabase,
-								glue.DeleteBehaviorDeprecateInDatabase,
-								glue.DeleteBehaviorLog,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      glue.DeleteBehaviorDeprecateInDatabase,
+							ValidateFunc: validation.StringInSlice(glue.DeleteBehavior_Values(), false),
 						},
 						"update_behavior": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  glue.UpdateBehaviorUpdateInDatabase,
-							ValidateFunc: validation.StringInSlice([]string{
-								glue.UpdateBehaviorLog,
-								glue.UpdateBehaviorUpdateInDatabase,
-							}, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      glue.UpdateBehaviorUpdateInDatabase,
+							ValidateFunc: validation.StringInSlice(glue.UpdateBehavior_Values(), false),
 						},
 					},
 				},
@@ -291,9 +284,13 @@ func updateCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.Updat
 	if description, ok := d.GetOk("description"); ok {
 		crawlerInput.Description = aws.String(description.(string))
 	}
+
 	if schedule, ok := d.GetOk("schedule"); ok {
 		crawlerInput.Schedule = aws.String(schedule.(string))
+	} else {
+		crawlerInput.Schedule = aws.String("")
 	}
+
 	if classifiers, ok := d.GetOk("classifiers"); ok {
 		crawlerInput.Classifiers = expandStringList(classifiers.([]interface{}))
 	}

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -834,6 +834,13 @@ func TestAccAWSGlueCrawler_Schedule(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccGlueCrawlerBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
+				),
+			},
 		},
 	})
 }
@@ -1671,6 +1678,26 @@ resource "aws_glue_crawler" "test" {
   }
 }
 EOF
+}
+`, rName)
+}
+
+func testAccGlueCrawlerBasicConfig(rName string) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
+
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
+
+  s3_target {
+    path = "s3://bucket-name"
+  }
 }
 `, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #8401

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_resource_glue_crawler - allow removing schedule
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSGlueCrawler_Schedule (185.74s)
--- PASS: TestAccAWSGlueCrawler_disappears (64.97s)
...
```
