### PR TITLE
r/glue_job - add `non_overridable_arguments` argument

### DIFF
--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -347,11 +347,7 @@ func resourceAwsGlueJobUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if kv, ok := d.GetOk("non_overridable_arguments"); ok {
-			nonOverArgs := make(map[string]string)
-			for k, v := range kv.(map[string]interface{}) {
-				nonOverArgs[k] = v.(string)
-			}
-			jobUpdate.NonOverridableArguments = aws.StringMap(nonOverArgs)
+			jobUpdate.NonOverridableArguments = stringMapToPointers(kv)
 		}
 
 		if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -137,17 +137,18 @@ func resourceAwsGlueJob() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"max_capacity"},
-				ValidateFunc: validation.StringInSlice([]string{
-					glue.WorkerTypeG1x,
-					glue.WorkerTypeG2x,
-					glue.WorkerTypeStandard,
-				}, false),
+				ValidateFunc:  validation.StringInSlice(glue.WorkerType_Values(), false),
 			},
 			"number_of_workers": {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ConflictsWith: []string{"max_capacity"},
 				ValidateFunc:  validation.IntAtLeast(2),
+			},
+			"non_overridable_arguments": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
@@ -181,6 +182,14 @@ func resourceAwsGlueJobCreate(d *schema.ResourceData, meta interface{}) error {
 			defaultArgumentsMap[k] = v.(string)
 		}
 		input.DefaultArguments = aws.StringMap(defaultArgumentsMap)
+	}
+
+	if kv, ok := d.GetOk("non_overridable_arguments"); ok {
+		nonOverArgs := make(map[string]string)
+		for k, v := range kv.(map[string]interface{}) {
+			nonOverArgs[k] = v.(string)
+		}
+		input.NonOverridableArguments = aws.StringMap(nonOverArgs)
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -270,6 +279,9 @@ func resourceAwsGlueJobRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("default_arguments", aws.StringValueMap(job.DefaultArguments)); err != nil {
 		return fmt.Errorf("error setting default_arguments: %s", err)
 	}
+	if err := d.Set("non_overridable_arguments", aws.StringValueMap(job.NonOverridableArguments)); err != nil {
+		return fmt.Errorf("error setting non_overridable_arguments: %w", err)
+	}
 	d.Set("description", job.Description)
 	d.Set("glue_version", job.GlueVersion)
 	if err := d.Set("execution_property", flattenGlueExecutionProperty(job.ExecutionProperty)); err != nil {
@@ -309,7 +321,7 @@ func resourceAwsGlueJobUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChanges("command", "connections", "default_arguments", "description",
 		"execution_property", "glue_version", "max_capacity", "max_retries", "notification_property", "number_of_workers",
-		"role_arn", "security_configuration", "timeout", "worker_type") {
+		"role_arn", "security_configuration", "timeout", "worker_type", "non_overridable_arguments") {
 		jobUpdate := &glue.JobUpdate{
 			Command: expandGlueJobCommand(d.Get("command").([]interface{})),
 			Role:    aws.String(d.Get("role_arn").(string)),
@@ -336,6 +348,14 @@ func resourceAwsGlueJobUpdate(d *schema.ResourceData, meta interface{}) error {
 				defaultArgumentsMap[k] = v.(string)
 			}
 			jobUpdate.DefaultArguments = aws.StringMap(defaultArgumentsMap)
+		}
+
+		if kv, ok := d.GetOk("non_overridable_arguments"); ok {
+			nonOverArgs := make(map[string]string)
+			for k, v := range kv.(map[string]interface{}) {
+				nonOverArgs[k] = v.(string)
+			}
+			jobUpdate.NonOverridableArguments = aws.StringMap(nonOverArgs)
 		}
 
 		if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -185,11 +185,7 @@ func resourceAwsGlueJobCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if kv, ok := d.GetOk("non_overridable_arguments"); ok {
-		nonOverArgs := make(map[string]string)
-		for k, v := range kv.(map[string]interface{}) {
-			nonOverArgs[k] = v.(string)
-		}
-		input.NonOverridableArguments = aws.StringMap(nonOverArgs)
+		input.NonOverridableArguments = stringMapToPointers(kv)
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -177,15 +177,11 @@ func resourceAwsGlueJobCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if kv, ok := d.GetOk("default_arguments"); ok {
-		defaultArgumentsMap := make(map[string]string)
-		for k, v := range kv.(map[string]interface{}) {
-			defaultArgumentsMap[k] = v.(string)
-		}
-		input.DefaultArguments = aws.StringMap(defaultArgumentsMap)
+		input.DefaultArguments = stringMapToPointers(kv.(map[string]interface{}))
 	}
 
 	if kv, ok := d.GetOk("non_overridable_arguments"); ok {
-		input.NonOverridableArguments = stringMapToPointers(kv)
+		input.NonOverridableArguments = stringMapToPointers(kv.(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -339,15 +335,11 @@ func resourceAwsGlueJobUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if kv, ok := d.GetOk("default_arguments"); ok {
-			defaultArgumentsMap := make(map[string]string)
-			for k, v := range kv.(map[string]interface{}) {
-				defaultArgumentsMap[k] = v.(string)
-			}
-			jobUpdate.DefaultArguments = aws.StringMap(defaultArgumentsMap)
+			jobUpdate.DefaultArguments = stringMapToPointers(kv.(map[string]interface{}))
 		}
 
 		if kv, ok := d.GetOk("non_overridable_arguments"); ok {
-			jobUpdate.NonOverridableArguments = stringMapToPointers(kv)
+			jobUpdate.NonOverridableArguments = stringMapToPointers(kv.(map[string]interface{}))
 		}
 
 		if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -75,6 +75,7 @@ func TestAccAWSGlueJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "command.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "command.0.script_location", "testscriptlocation"),
 					resource.TestCheckResourceAttr(resourceName, "default_arguments.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", roleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -153,6 +154,44 @@ func TestAccAWSGlueJob_DefaultArguments(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_arguments.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "default_arguments.--job-bookmark-option", "job-bookmark-enable"),
 					resource.TestCheckResourceAttr(resourceName, "default_arguments.--job-language", "scala"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueJob_nonOverridableArguments(t *testing.T) {
+	var job glue.Job
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_job.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueJobnonOverridableArgumentsConfig(rName, "job-bookmark-disable", "python"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueJobExists(resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.--job-bookmark-option", "job-bookmark-disable"),
+					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.--job-language", "python"),
+				),
+			},
+			{
+				Config: testAccAWSGlueJobnonOverridableArgumentsConfig(rName, "job-bookmark-enable", "scala"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueJobExists(resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.--job-bookmark-option", "job-bookmark-enable"),
+					resource.TestCheckResourceAttr(resourceName, "non_overridable_arguments.--job-language", "scala"),
 				),
 			},
 			{
@@ -724,6 +763,29 @@ resource "aws_glue_job" "test" {
   }
 
   default_arguments = {
+    "--job-bookmark-option" = "%s"
+    "--job-language"        = "%s"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, testAccAWSGlueJobConfig_Base(rName), rName, jobBookmarkOption, jobLanguage)
+}
+
+func testAccAWSGlueJobnonOverridableArgumentsConfig(rName, jobBookmarkOption, jobLanguage string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_glue_job" "test" {
+  max_capacity = 10
+  name         = "%s"
+  role_arn     = aws_iam_role.test.arn
+
+  command {
+    script_location = "testscriptlocation"
+  }
+
+  non_overridable_arguments = {
     "--job-bookmark-option" = "%s"
     "--job-language"        = "%s"
   }

--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -635,6 +635,29 @@ func TestAccAWSGlueJob_MaxCapacity(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueJob_disappears(t *testing.T) {
+	var job glue.Job
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_job.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueJobConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueJobExists(resourceName, &job),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsGlueJob(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSGlueJobExists(resourceName string, job *glue.Job) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -72,6 +72,7 @@ The following arguments are supported:
 * `command` – (Required) The command of the job. Defined below.
 * `connections` – (Optional) The list of connections used for this job.
 * `default_arguments` – (Optional) The map of default arguments for this job. You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes. For information about how to specify and consume your own Job arguments, see the [Calling AWS Glue APIs in Python](http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html) topic in the developer guide. For information about the key-value pairs that AWS Glue consumes to set up your job, see the [Special Parameters Used by AWS Glue](http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html) topic in the developer guide.
+* `non_overridable_arguments` – (Optional) Non-overridable arguments for this job, specified as name-value pairs.
 * `description` – (Optional) Description of the job.
 * `execution_property` – (Optional) Execution property of the job. Defined below.
 * `glue_version` - (Optional) The version of glue to use, for example "1.0". For information about available versions, see the [AWS Glue Release Notes](https://docs.aws.amazon.com/glue/latest/dg/release-notes.html).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13117
Relates #13826

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_job - add `non_overridable_arguments` argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSGlueJob_basic (98.84s)
--- PASS: TestAccAWSGlueJob_nonOverridableArguments (116.92s)
--- PASS: TestAccAWSGlueJob_disappears (84.33s)
```
