### PR TITLE
Update AppMesh resource acceptance tests to 0.12 syntax

### DIFF
--- a/aws/resource_aws_appmesh_mesh_test.go
+++ b/aws/resource_aws_appmesh_mesh_test.go
@@ -67,7 +67,7 @@ func testSweepAppmeshMeshes(region string) error {
 
 func testAccAwsAppmeshMesh_basic(t *testing.T) {
 	var mesh appmesh.MeshData
-	resourceName := "aws_appmesh_mesh.foo"
+	resourceName := "aws_appmesh_mesh.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
@@ -96,7 +96,7 @@ func testAccAwsAppmeshMesh_basic(t *testing.T) {
 
 func testAccAwsAppmeshMesh_egressFilter(t *testing.T) {
 	var mesh appmesh.MeshData
-	resourceName := "aws_appmesh_mesh.foo"
+	resourceName := "aws_appmesh_mesh.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
@@ -135,7 +135,7 @@ func testAccAwsAppmeshMesh_egressFilter(t *testing.T) {
 
 func testAccAwsAppmeshMesh_tags(t *testing.T) {
 	var mesh appmesh.MeshData
-	resourceName := "aws_appmesh_mesh.foo"
+	resourceName := "aws_appmesh_mesh.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
@@ -225,17 +225,17 @@ func testAccCheckAppmeshMeshExists(name string, v *appmesh.MeshData) resource.Te
 	}
 }
 
-func testAccAppmeshMeshConfig_basic(name string) string {
+func testAccAppmeshMeshConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_appmesh_mesh" "foo" {
+resource "aws_appmesh_mesh" "test" {
   name = %[1]q
 }
-`, name)
+`, rName)
 }
 
-func testAccAppmeshMeshConfig_egressFilter(name, egressFilterType string) string {
+func testAccAppmeshMeshConfig_egressFilter(rName, egressFilterType string) string {
 	return fmt.Sprintf(`
-resource "aws_appmesh_mesh" "foo" {
+resource "aws_appmesh_mesh" "test" {
   name = %[1]q
 
   spec {
@@ -244,44 +244,44 @@ resource "aws_appmesh_mesh" "foo" {
     }
   }
 }
-`, name, egressFilterType)
+`, rName, egressFilterType)
 }
 
-func testAccAppmeshMeshConfigWithTags(name string) string {
+func testAccAppmeshMeshConfigWithTags(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_appmesh_mesh" "foo" {
-  name = "%s"
+resource "aws_appmesh_mesh" "test" {
+  name = %[1]q
 
   tags = {
-	foo = "bar"
-	good = "bad"
+    foo  = "bar"
+    good = "bad"
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccAppmeshMeshConfigWithUpdateTags(name string) string {
+func testAccAppmeshMeshConfigWithUpdateTags(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_appmesh_mesh" "foo" {
-  name = "%s"
+resource "aws_appmesh_mesh" "test" {
+  name = %[1]q
 
   tags = {
-	foo = "bar"
-	good = "bad2"
-	fizz = "buzz"
+    foo  = "bar"
+    good = "bad2"
+    fizz = "buzz"
   }
 }
-`, name)
+`, rName)
 }
 
-func testAccAppmeshMeshConfigWithRemoveTags(name string) string {
+func testAccAppmeshMeshConfigWithRemoveTags(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_appmesh_mesh" "foo" {
-  name = "%s"
+resource "aws_appmesh_mesh" "test" {
+  name = %[1]q
 
   tags = {
-	foo = "bar"
+    foo = "bar"
   }
 }
-`, name)
+`, rName)
 }

--- a/aws/resource_aws_appmesh_route_test.go
+++ b/aws/resource_aws_appmesh_route_test.go
@@ -289,32 +289,25 @@ func testAccAwsAppmeshRoute_tags(t *testing.T) {
 				Config: testAccAppmeshRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, "foo", "bar", "good", "bad"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppmeshRouteExists(resourceName, &r),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.good", "bad"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad"),
 				),
 			},
 			{
 				Config: testAccAppmeshRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName, "foo2", "bar", "good", "bad2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppmeshRouteExists(resourceName, &r),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.foo2", "bar"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.good", "bad2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo2", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad2"),
 				),
 			},
 			{
 				Config: testAccAppmeshRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppmeshRouteExists(resourceName, &r),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -560,7 +553,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "test" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -574,14 +567,14 @@ resource "aws_appmesh_virtual_router" "test" {
 
 resource "aws_appmesh_virtual_node" "foo" {
   name      = %[3]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_node" "bar" {
   name      = %[4]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
@@ -592,8 +585,8 @@ func testAccAppmeshRouteConfig_httpRoute(meshName, vrName, vn1Name, vn2Name, rNa
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -603,7 +596,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -617,8 +610,8 @@ func testAccAppmeshRouteConfig_httpRouteUpdated(meshName, vrName, vn1Name, vn2Na
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -628,12 +621,12 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 90
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          virtual_node = aws_appmesh_virtual_node.bar.name
           weight       = 10
         }
       }
@@ -647,8 +640,8 @@ func testAccAppmeshRouteConfig_httpRouteUpdatedWithZeroWeight(meshName, vrName, 
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -658,12 +651,12 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 99
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          virtual_node = aws_appmesh_virtual_node.bar.name
           weight       = 0
         }
       }
@@ -677,14 +670,14 @@ func testAccAppmeshRouteConfig_tcpRoute(meshName, vrName, vn1Name, vn2Name, rNam
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     tcp_route {
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -698,19 +691,19 @@ func testAccAppmeshRouteConfig_tcpRouteUpdated(meshName, vrName, vn1Name, vn2Nam
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     tcp_route {
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 90
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          virtual_node = aws_appmesh_virtual_node.bar.name
           weight       = 10
         }
       }
@@ -724,19 +717,19 @@ func testAccAppmeshRouteConfig_tcpRouteUpdatedWithZeroWeight(meshName, vrName, v
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     tcp_route {
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 99
         }
 
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.bar.name}"
+          virtual_node = aws_appmesh_virtual_node.bar.name
           weight       = 0
         }
       }
@@ -750,8 +743,8 @@ func testAccAppmeshRouteConfigWithTags(meshName, vrName, vn1Name, vn2Name, rName
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -761,7 +754,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -780,8 +773,8 @@ func testAccAwsAppmeshRouteConfig_httpHeader(meshName, vrName, vn1Name, vn2Name,
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -797,7 +790,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -811,8 +804,8 @@ func testAccAwsAppmeshRouteConfig_httpHeaderUpdated(meshName, vrName, vn1Name, v
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -841,7 +834,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }
@@ -855,8 +848,8 @@ func testAccAwsAppmeshRouteConfig_routePriority(meshName, vrName, vn1Name, vn2Na
 	return testAccAppmeshRouteConfigBase(meshName, vrName, vn1Name, vn2Name) + fmt.Sprintf(`
 resource "aws_appmesh_route" "test" {
   name                = %[1]q
-  mesh_name           = "${aws_appmesh_mesh.test.id}"
-  virtual_router_name = "${aws_appmesh_virtual_router.test.name}"
+  mesh_name           = aws_appmesh_mesh.test.id
+  virtual_router_name = aws_appmesh_virtual_router.test.name
 
   spec {
     http_route {
@@ -866,7 +859,7 @@ resource "aws_appmesh_route" "test" {
 
       action {
         weighted_target {
-          virtual_node = "${aws_appmesh_virtual_node.foo.name}"
+          virtual_node = aws_appmesh_virtual_node.foo.name
           weight       = 100
         }
       }

--- a/aws/resource_aws_appmesh_virtual_node_test.go
+++ b/aws/resource_aws_appmesh_virtual_node_test.go
@@ -414,7 +414,7 @@ func testAccAppmeshVirtualNodeConfig_basic(meshName, vnName string) string {
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
@@ -429,7 +429,7 @@ resource "aws_service_discovery_http_namespace" "test" {
 
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     backend {
@@ -452,7 +452,7 @@ resource "aws_appmesh_virtual_node" "test" {
         }
 
         service_name   = %[2]q
-        namespace_name = "${aws_service_discovery_http_namespace.test.name}"
+        namespace_name = aws_service_discovery_http_namespace.test.name
       }
     }
   }
@@ -464,7 +464,7 @@ func testAccAppmeshVirtualNodeConfig_listenerHealthChecks(meshName, vnName strin
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     backend {
@@ -503,7 +503,7 @@ func testAccAppmeshVirtualNodeConfig_listenerHealthChecksUpdated(meshName, vnNam
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     backend {
@@ -548,7 +548,7 @@ func testAccAppmeshVirtualNodeConfig_logging(meshName, vnName, path string) stri
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     backend {
@@ -586,7 +586,7 @@ func testAccAppmeshVirtualNodeConfig_tags(meshName, vnName, tagKey1, tagValue1, 
 	return testAccAppmeshVirtualNodeConfig_mesh(meshName) + fmt.Sprintf(`
 resource "aws_appmesh_virtual_node" "test" {
   name      = %[1]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 

--- a/aws/resource_aws_appmesh_virtual_router_test.go
+++ b/aws/resource_aws_appmesh_virtual_router_test.go
@@ -264,7 +264,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "test" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -286,7 +286,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "test" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -308,7 +308,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "test" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -320,8 +320,8 @@ resource "aws_appmesh_virtual_router" "test" {
   }
 
   tags = {
-	%[3]s = %[4]q
-	%[5]s = %[6]q
+    %[3]s = %[4]q
+    %[5]s = %[6]q
   }
 }
 `, meshName, vrName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_appmesh_virtual_service_test.go
+++ b/aws/resource_aws_appmesh_virtual_service_test.go
@@ -284,26 +284,26 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_node" "foo" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_node" "bar" {
   name      = %[3]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_service" "test" {
   name      = %[4]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     provider {
       virtual_node {
-        virtual_node_name = "${%[5]s.name}"
+        virtual_node_name = %[5]s.name
       }
     }
   }
@@ -319,7 +319,7 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_router" "foo" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -333,7 +333,7 @@ resource "aws_appmesh_virtual_router" "foo" {
 
 resource "aws_appmesh_virtual_router" "bar" {
   name      = %[3]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     listener {
@@ -347,12 +347,12 @@ resource "aws_appmesh_virtual_router" "bar" {
 
 resource "aws_appmesh_virtual_service" "test" {
   name      = %[4]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     provider {
       virtual_router {
-        virtual_router_name = "${%[5]s.name}"
+        virtual_router_name = %[5]s.name
       }
     }
   }
@@ -368,33 +368,33 @@ resource "aws_appmesh_mesh" "test" {
 
 resource "aws_appmesh_virtual_node" "foo" {
   name      = %[2]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_node" "bar" {
   name      = %[3]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {}
 }
 
 resource "aws_appmesh_virtual_service" "test" {
   name      = %[4]q
-  mesh_name = "${aws_appmesh_mesh.test.id}"
+  mesh_name = aws_appmesh_mesh.test.id
 
   spec {
     provider {
       virtual_node {
-        virtual_node_name = "${%[5]s.name}"
+        virtual_node_name = %[5]s.name
       }
     }
   }
 
   tags = {
-	%[6]s = %[7]q
-	%[8]s = %[9]q
+    %[6]s = %[7]q
+    %[8]s = %[9]q
   }
 }
 `, meshName, vnName1, vnName2, vsName, rName, tagKey1, tagValue1, tagKey2, tagValue2)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8950.
Relates #14417.

Update AppMesh resource acceptance tests to 0.12 syntax to help with rebase of open AppMesh PRs:

* https://github.com/terraform-providers/terraform-provider-aws/pull/11660
* https://github.com/terraform-providers/terraform-provider-aws/pull/11669
* https://github.com/terraform-providers/terraform-provider-aws/pull/12541
* https://github.com/terraform-providers/terraform-provider-aws/pull/14349
* https://github.com/terraform-providers/terraform-provider-aws/pull/14361

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppmesh'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAppmesh -timeout 120m
=== RUN   TestAccAWSAppmesh_serial
=== RUN   TestAccAWSAppmesh_serial/VirtualRouter
=== RUN   TestAccAWSAppmesh_serial/VirtualRouter/tags
=== RUN   TestAccAWSAppmesh_serial/VirtualRouter/basic
=== RUN   TestAccAWSAppmesh_serial/VirtualService
=== RUN   TestAccAWSAppmesh_serial/VirtualService/virtualNode
=== RUN   TestAccAWSAppmesh_serial/VirtualService/virtualRouter
=== RUN   TestAccAWSAppmesh_serial/VirtualService/tags
=== RUN   TestAccAWSAppmesh_serial/Mesh
=== RUN   TestAccAWSAppmesh_serial/Mesh/basic
=== RUN   TestAccAWSAppmesh_serial/Mesh/egressFilter
=== RUN   TestAccAWSAppmesh_serial/Mesh/tags
=== RUN   TestAccAWSAppmesh_serial/Route
=== RUN   TestAccAWSAppmesh_serial/Route/httpHeader
=== RUN   TestAccAWSAppmesh_serial/Route/httpRoute
=== RUN   TestAccAWSAppmesh_serial/Route/tcpRoute
=== RUN   TestAccAWSAppmesh_serial/Route/routePriority
=== RUN   TestAccAWSAppmesh_serial/Route/tags
=== RUN   TestAccAWSAppmesh_serial/VirtualNode
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/basic
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/cloudMapServiceDiscovery
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/listenerHealthChecks
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/logging
=== RUN   TestAccAWSAppmesh_serial/VirtualNode/tags
--- PASS: TestAccAWSAppmesh_serial (768.40s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualRouter (79.69s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualRouter/tags (47.28s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualRouter/basic (32.41s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualService (122.64s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/virtualNode (36.40s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/virtualRouter (33.74s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualService/tags (52.50s)
    --- PASS: TestAccAWSAppmesh_serial/Mesh (94.03s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/basic (16.03s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/egressFilter (37.25s)
        --- PASS: TestAccAWSAppmesh_serial/Mesh/tags (40.75s)
    --- PASS: TestAccAWSAppmesh_serial/Route (233.15s)
        --- PASS: TestAccAWSAppmesh_serial/Route/httpHeader (36.94s)
        --- PASS: TestAccAWSAppmesh_serial/Route/httpRoute (52.50s)
        --- PASS: TestAccAWSAppmesh_serial/Route/tcpRoute (53.10s)
        --- PASS: TestAccAWSAppmesh_serial/Route/routePriority (37.12s)
        --- PASS: TestAccAWSAppmesh_serial/Route/tags (53.49s)
    --- PASS: TestAccAWSAppmesh_serial/VirtualNode (238.89s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/basic (18.52s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/cloudMapServiceDiscovery (105.51s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/listenerHealthChecks (33.32s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/logging (33.25s)
        --- PASS: TestAccAWSAppmesh_serial/VirtualNode/tags (48.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	768.437s
```
