### PR TITLE
[WIP] r/aws_route: Correctly handle update of route target

### DIFF
--- a/aws/data_source_aws_route.go
+++ b/aws/data_source_aws_route.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 )
 
 func dataSourceAwsRoute() *schema.Resource {
@@ -189,4 +190,14 @@ func getRoutes(table *ec2.RouteTable, d *schema.ResourceData) []*ec2.Route {
 		routes = append(routes, r)
 	}
 	return routes
+}
+
+// Helper: Create an ID for a route
+func resourceAwsRouteID(d *schema.ResourceData, r *ec2.Route) string {
+
+	if r.DestinationIpv6CidrBlock != nil && *r.DestinationIpv6CidrBlock != "" {
+		return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*r.DestinationIpv6CidrBlock))
+	}
+
+	return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*r.DestinationCidrBlock))
 }

--- a/aws/internal/net/cidr.go
+++ b/aws/internal/net/cidr.go
@@ -1,0 +1,23 @@
+package net
+
+import (
+	"net"
+)
+
+// CIDRBlocksEqual returns whether or not two CIDR blocks are equal:
+// - Both CIDR blocks parse to an IP address and network
+// - The string representation of the IP addresses are equal
+// - The string representation of the networks are equal
+// This function is especially useful for IPv6 CIDR blocks which have multiple valid representations.
+func CIDRBlocksEqual(cidr1, cidr2 string) bool {
+	ip1, ipnet1, err := net.ParseCIDR(cidr1)
+	if err != nil {
+		return false
+	}
+	ip2, ipnet2, err := net.ParseCIDR(cidr2)
+	if err != nil {
+		return false
+	}
+
+	return ip2.String() == ip1.String() && ipnet2.String() == ipnet1.String()
+}

--- a/aws/internal/net/cidr_test.go
+++ b/aws/internal/net/cidr_test.go
@@ -1,0 +1,26 @@
+package net
+
+import (
+	"testing"
+)
+
+func Test_CIDRBlocksEqual(t *testing.T) {
+	for _, ts := range []struct {
+		cidr1 string
+		cidr2 string
+		equal bool
+	}{
+		{"10.2.2.0/24", "10.2.2.0/24", true},
+		{"10.2.2.0/1234", "10.2.2.0/24", false},
+		{"10.2.2.0/24", "10.2.2.0/1234", false},
+		{"2001::/15", "2001::/15", true},
+		{"::/0", "2001::/15", false},
+		{"::/0", "::0/0", true},
+		{"", "", false},
+	} {
+		equal := CIDRBlocksEqual(ts.cidr1, ts.cidr2)
+		if ts.equal != equal {
+			t.Fatalf("CIDRBlocksEqual(%q, %q) should be: %t", ts.cidr1, ts.cidr2, ts.equal)
+		}
+	}
+}

--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -28,3 +28,11 @@ const (
 	InvalidSecurityGroupIDNotFound = "InvalidSecurityGroupID.NotFound"
 	InvalidGroupNotFound           = "InvalidGroup.NotFound"
 )
+
+const (
+	ErrCodeInvalidParameterException = "InvalidParameterException"
+	ErrCodeInvalidParameterValue     = "InvalidParameterValue"
+	ErrCodeRouteNotFound             = "InvalidRoute.NotFound"
+	ErrCodeRouteTableNotFound        = "InvalidRouteTableID.NotFound"
+	ErrCodeTransitGatewayNotFound    = "InvalidTransitGatewayID.NotFound"
+)

--- a/aws/internal/service/ec2/errors.go
+++ b/aws/internal/service/ec2/errors.go
@@ -17,6 +17,13 @@ func ErrCodeEquals(err error, code string) bool {
 	return false
 }
 
+// Common.
+const (
+	InvalidParameterException = "InvalidParameterException"
+	InvalidParameterValue     = "InvalidParameterValue"
+)
+
+// Client VPN.
 const (
 	ErrCodeClientVpnEndpointIdNotFound        = "InvalidClientVpnEndpointId.NotFound"
 	ErrCodeClientVpnAuthorizationRuleNotFound = "InvalidClientVpnEndpointAuthorizationRuleNotFound"
@@ -24,15 +31,19 @@ const (
 	ErrCodeClientVpnRouteNotFound             = "InvalidClientVpnRouteNotFound"
 )
 
+// Security Group.
 const (
 	InvalidSecurityGroupIDNotFound = "InvalidSecurityGroupID.NotFound"
 	InvalidGroupNotFound           = "InvalidGroup.NotFound"
 )
 
+// Route and Route Table.
 const (
-	ErrCodeInvalidParameterException = "InvalidParameterException"
-	ErrCodeInvalidParameterValue     = "InvalidParameterValue"
-	ErrCodeRouteNotFound             = "InvalidRoute.NotFound"
-	ErrCodeRouteTableNotFound        = "InvalidRouteTableID.NotFound"
-	ErrCodeTransitGatewayNotFound    = "InvalidTransitGatewayID.NotFound"
+	InvalidRouteNotFound        = "InvalidRoute.NotFound"
+	InvalidRouteTableIDNotFound = "InvalidRouteTableID.NotFound"
+)
+
+// Transit Gateway.
+const (
+	InvalidTransitGatewayIDNotFound = "InvalidTransitGatewayID.NotFound"
 )

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -86,7 +86,7 @@ func RouteByIpv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string)
 	}
 
 	for _, route := range routeTable.Routes {
-		if aws.StringValue(route.DestinationCidrBlock) == destinationCidr {
+		if tfnet.CIDRBlocksEqual(aws.StringValue(route.DestinationCidrBlock), destinationCidr) {
 			return route, nil
 		}
 	}

--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -3,6 +3,7 @@ package finder
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	tfnet "github.com/terraform-providers/terraform-provider-aws/aws/internal/net"
 	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 )
 
@@ -53,6 +54,61 @@ func ClientVpnRouteByID(conn *ec2.EC2, routeID string) (*ec2.DescribeClientVpnRo
 	}
 
 	return ClientVpnRoute(conn, endpointID, targetSubnetID, destinationCidr)
+}
+
+// RouteTableByID returns the route table corresponding to the specified identifier.
+// Returns nil if no route table is found.
+func RouteTableByID(conn *ec2.EC2, routeTableID string) (*ec2.RouteTable, error) {
+	input := &ec2.DescribeRouteTablesInput{
+		RouteTableIds: aws.StringSlice([]string{routeTableID}),
+	}
+
+	output, err := conn.DescribeRouteTables(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.RouteTables) == 0 || output.RouteTables[0] == nil {
+		return nil, nil
+	}
+
+	return output.RouteTables[0], nil
+}
+
+type RouteFinder func(*ec2.EC2, string, string) (*ec2.Route, error)
+
+// RouteByIpv4Destination returns the route corresponding to the specified IPv4 destination.
+// Returns nil if no route is found.
+func RouteByIpv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string) (*ec2.Route, error) {
+	routeTable, err := RouteTableByID(conn, routeTableID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range routeTable.Routes {
+		if aws.StringValue(route.DestinationCidrBlock) == destinationCidr {
+			return route, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// RouteByIpv6Destination returns the route corresponding to the specified IPv6 destination.
+// Returns nil if no route is found.
+func RouteByIpv6Destination(conn *ec2.EC2, routeTableID, destinationIpv6Cidr string) (*ec2.Route, error) {
+	routeTable, err := RouteTableByID(conn, routeTableID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, route := range routeTable.Routes {
+		if tfnet.CIDRBlocksEqual(aws.StringValue(route.DestinationIpv6CidrBlock), destinationIpv6Cidr) {
+			return route, nil
+		}
+	}
+
+	return nil, nil
 }
 
 // SecurityGroupByID looks up a security group by ID. When not found, returns nil and potentially an API error.

--- a/aws/internal/service/ec2/id.go
+++ b/aws/internal/service/ec2/id.go
@@ -3,6 +3,8 @@ package ec2
 import (
 	"fmt"
 	"strings"
+
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 )
 
 const clientVpnAuthorizationRuleIDSeparator = ","
@@ -67,4 +69,9 @@ func ClientVpnRouteParseID(id string) (string, string, string, error) {
 	return "", "", "",
 		fmt.Errorf("unexpected format for ID (%q), expected endpoint-id"+clientVpnRouteIDSeparator+
 			"target-subnet-id"+clientVpnRouteIDSeparator+"destination-cidr-block", id)
+}
+
+// RouteCreateID returns a route resource ID.
+func RouteCreateID(routeTableID, destination string) string {
+	return fmt.Sprintf("r-%s%d", routeTableID, hashcode.String(destination))
 }

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -242,7 +242,7 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 	route, err := routeFinder(conn, routeTableID, destination)
 
-	if isAWSErr(err, tfec2.ErrCodeRouteTableNotFound, "") {
+	if isAWSErr(err, tfec2.InvalidRouteTableIDNotFound, "") {
 		log.Printf("[WARN] Route Table (%s) not found, removing from state", routeTableID)
 		d.SetId("")
 		return nil
@@ -355,16 +355,16 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
-		if isAWSErr(err, tfec2.ErrCodeRouteNotFound, "") {
+		if isAWSErr(err, tfec2.InvalidRouteNotFound, "") {
 			return nil
 		}
 
 		// Local routes (which may have been imported) cannot be deleted. Remove from state.
-		if isAWSErr(err, tfec2.ErrCodeInvalidParameterValue, "cannot remove local route") {
+		if isAWSErr(err, tfec2.InvalidParameterValue, "cannot remove local route") {
 			return nil
 		}
 
-		if isAWSErr(err, tfec2.ErrCodeInvalidParameterException, "") {
+		if isAWSErr(err, tfec2.InvalidParameterException, "") {
 			return resource.RetryableError(err)
 		}
 
@@ -376,7 +376,7 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 		_, err = conn.DeleteRoute(input)
 	}
 
-	if isAWSErr(err, tfec2.ErrCodeRouteNotFound, "") {
+	if isAWSErr(err, tfec2.InvalidRouteNotFound, "") {
 		return nil
 	}
 
@@ -483,11 +483,11 @@ func createRoute(conn *ec2.EC2, input *ec2.CreateRouteInput, timeout time.Durati
 	err := resource.Retry(timeout, func() *resource.RetryError {
 		_, err := conn.CreateRoute(input)
 
-		if isAWSErr(err, tfec2.ErrCodeInvalidParameterException, "") {
+		if isAWSErr(err, tfec2.InvalidParameterException, "") {
 			return resource.RetryableError(err)
 		}
 
-		if isAWSErr(err, tfec2.ErrCodeTransitGatewayNotFound, "") {
+		if isAWSErr(err, tfec2.InvalidTransitGatewayIDNotFound, "") {
 			return resource.RetryableError(err)
 		}
 

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -470,7 +470,7 @@ func getRouteDestinationAndTargetAttributeKeysFromMap(m map[string]struct {
 	}
 
 	if destinationAttributeKey == "" {
-		return "", "", fmt.Errorf("one of %q must be specified", strings.Join(routeDestinationAttributeKeys, "\", \""))
+		return "", "", fmt.Errorf("one of \"%v\" must be specified", strings.Join(routeDestinationAttributeKeys, "\", \""))
 	}
 
 	targetAttributeKey := ""
@@ -490,7 +490,7 @@ func getRouteDestinationAndTargetAttributeKeysFromMap(m map[string]struct {
 	}
 
 	if targetAttributeKey == "" {
-		return "", "", fmt.Errorf("one of %s must be specified", strings.Join(routeTargetAttributeKeys, "\", \""))
+		return "", "", fmt.Errorf("one of \"%v\" must be specified", strings.Join(routeTargetAttributeKeys, "\", \""))
 	}
 
 	return destinationAttributeKey, targetAttributeKey, nil

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -15,12 +14,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 )
 
-// How long to sleep if a limit-exceeded event happens
-var routeTargetValidationError = errors.New("Error: more than 1 target specified. Only 1 of gateway_id, " +
-	"egress_only_gateway_id, nat_gateway_id, instance_id, network_interface_id or " +
-	"vpc_peering_connection_id is allowed.")
-
-// AWS Route resource Schema declaration
 func resourceAwsRoute() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsRouteCreate,
@@ -150,46 +143,44 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	destination := d.Get(destinationAttr).(string)
 	routeTableID := d.Get("route_table_id").(string)
 	input := &ec2.CreateRouteInput{
 		RouteTableId: aws.String(routeTableID),
 	}
 
-	var pDestination **string
 	var routeReader func(*ec2.EC2, string, string) (*ec2.Route, error)
+
 	switch destinationAttr {
 	case "destination_cidr_block":
-		pDestination = &input.DestinationCidrBlock
+		input.DestinationCidrBlock = aws.String(destination)
 		routeReader = readIpv4Route
 	case "destination_ipv6_cidr_block":
-		pDestination = &input.DestinationIpv6CidrBlock
+		input.DestinationIpv6CidrBlock = aws.String(destination)
 		routeReader = readIpv6Route
 	default:
 		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
 	}
-	destination := d.Get(destinationAttr).(string)
-	*pDestination = aws.String(destination)
 
-	var pTarget **string
+	target := aws.String(d.Get(targetAttr).(string))
 	switch targetAttr {
 	case "egress_only_gateway_id":
-		pTarget = &input.EgressOnlyInternetGatewayId
+		input.EgressOnlyInternetGatewayId = target
 	case "gateway_id":
-		pTarget = &input.GatewayId
+		input.GatewayId = target
 	case "instance_id":
-		pTarget = &input.InstanceId
+		input.InstanceId = target
 	case "nat_gateway_id":
-		pTarget = &input.NatGatewayId
+		input.NatGatewayId = target
 	case "network_interface_id":
-		pTarget = &input.NetworkInterfaceId
+		input.NetworkInterfaceId = target
 	case "transit_gateway_id":
-		pTarget = &input.TransitGatewayId
+		input.TransitGatewayId = target
 	case "vpc_peering_connection_id":
-		pTarget = &input.VpcPeeringConnectionId
+		input.VpcPeeringConnectionId = target
 	default:
 		return fmt.Errorf("unexpected target attribute: `%s`", targetAttr)
 	}
-	*pTarget = aws.String(d.Get(targetAttr).(string))
 
 	log.Printf("[DEBUG] Creating Route: %s", input)
 
@@ -216,7 +207,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating route: %s", err)
+		return fmt.Errorf("error creating Route: %s", err)
 	}
 
 	var route *ec2.Route
@@ -228,7 +219,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if route == nil {
-			return resource.RetryableError(fmt.Errorf("route not found"))
+			return resource.RetryableError(fmt.Errorf("Route not found"))
 		}
 
 		return nil
@@ -239,11 +230,11 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading route for Route Table (%s) with destination (%s): %s", routeTableID, destination, err)
+		return fmt.Errorf("error reading Route for Route Table (%s) with destination (%s): %s", routeTableID, destination, err)
 	}
 
 	if route == nil {
-		return fmt.Errorf("route in Route Table (%s) with destination (%s) not found", routeTableID, destination)
+		return fmt.Errorf("Route in Route Table (%s) with destination (%s) not found", routeTableID, destination)
 	}
 
 	d.SetId(routeCreateID(routeTableID, destination))
@@ -256,9 +247,11 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 	destinationAttr := routeDestinationAttr(d)
 
+	destination := d.Get(destinationAttr).(string)
 	routeTableID := d.Get("route_table_id").(string)
 
 	var routeReader func(*ec2.EC2, string, string) (*ec2.Route, error)
+
 	switch destinationAttr {
 	case "destination_cidr_block":
 		routeReader = readIpv4Route
@@ -267,7 +260,6 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	default:
 		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
 	}
-	destination := d.Get(destinationAttr).(string)
 
 	route, err := routeReader(conn, routeTableID, destination)
 
@@ -278,7 +270,7 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading route for Route Table (%s) with destination (%s): %s", routeTableID, destination, err)
+		return fmt.Errorf("error reading Route for Route Table (%s) with destination (%s): %s", routeTableID, destination, err)
 	}
 
 	if route == nil {
@@ -306,93 +298,55 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	var numTargets int
-	var setTarget string
 
-	allowedTargets := []string{
-		"egress_only_gateway_id",
-		"gateway_id",
-		"nat_gateway_id",
-		"network_interface_id",
-		"instance_id",
-		"transit_gateway_id",
-		"vpc_peering_connection_id",
-	}
-	// Check if more than 1 target is specified
-	for _, target := range allowedTargets {
-		if len(d.Get(target).(string)) > 0 {
-			numTargets++
-			setTarget = target
-		}
+	destinationAttr, targetAttr, err := routeDestinationAndTargetAttributes(d)
+	if err != nil {
+		return err
 	}
 
-	switch setTarget {
-	//instance_id is a special case due to the fact that AWS will "discover" the network_interface_id
-	//when it creates the route and return that data.  In the case of an update, we should ignore the
-	//existing network_interface_id
-	case "instance_id":
-		if numTargets > 2 || (numTargets == 2 && len(d.Get("network_interface_id").(string)) == 0) {
-			return routeTargetValidationError
-		}
+	destination := d.Get(destinationAttr).(string)
+	routeTableID := d.Get("route_table_id").(string)
+	input := &ec2.ReplaceRouteInput{
+		RouteTableId: aws.String(routeTableID),
+	}
+
+	switch destinationAttr {
+	case "destination_cidr_block":
+		input.DestinationCidrBlock = aws.String(destination)
+	case "destination_ipv6_cidr_block":
+		input.DestinationIpv6CidrBlock = aws.String(destination)
 	default:
-		if numTargets > 1 {
-			return routeTargetValidationError
-		}
+		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
 	}
 
-	var replaceOpts *ec2.ReplaceRouteInput
-	// Formulate ReplaceRouteInput based on the target type
-	switch setTarget {
-	case "gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			GatewayId:            aws.String(d.Get("gateway_id").(string)),
-		}
+	target := aws.String(d.Get(targetAttr).(string))
+	switch targetAttr {
 	case "egress_only_gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:                aws.String(d.Get("route_table_id").(string)),
-			DestinationIpv6CidrBlock:    aws.String(d.Get("destination_ipv6_cidr_block").(string)),
-			EgressOnlyInternetGatewayId: aws.String(d.Get("egress_only_gateway_id").(string)),
-		}
-	case "nat_gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			NatGatewayId:         aws.String(d.Get("nat_gateway_id").(string)),
-		}
+		input.EgressOnlyInternetGatewayId = target
+	case "gateway_id":
+		input.GatewayId = target
 	case "instance_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			InstanceId:           aws.String(d.Get("instance_id").(string)),
-		}
+		input.InstanceId = target
+	case "nat_gateway_id":
+		input.NatGatewayId = target
 	case "network_interface_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			NetworkInterfaceId:   aws.String(d.Get("network_interface_id").(string)),
-		}
+		input.NetworkInterfaceId = target
 	case "transit_gateway_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			TransitGatewayId:     aws.String(d.Get("transit_gateway_id").(string)),
-		}
+		input.TransitGatewayId = target
 	case "vpc_peering_connection_id":
-		replaceOpts = &ec2.ReplaceRouteInput{
-			RouteTableId:           aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock:   aws.String(d.Get("destination_cidr_block").(string)),
-			VpcPeeringConnectionId: aws.String(d.Get("vpc_peering_connection_id").(string)),
-		}
+		input.VpcPeeringConnectionId = target
 	default:
-		return fmt.Errorf("An invalid target type specified: %s", setTarget)
+		return fmt.Errorf("unexpected target attribute: `%s`", targetAttr)
 	}
-	log.Printf("[DEBUG] Route replace config: %s", replaceOpts)
 
-	// Replace the route
-	_, err := conn.ReplaceRoute(replaceOpts)
-	return err
+	log.Printf("[DEBUG] Updating Route: %s", input)
+	_, err = conn.ReplaceRoute(input)
+
+	if err != nil {
+		return fmt.Errorf("error updating Route for Route Table (%s) with destination (%s): %s", routeTableID, destination, err)
+	}
+
+	return resourceAwsRouteRead(d, meta)
 }
 
 func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
@@ -400,25 +354,23 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 
 	destinationAttr := routeDestinationAttr(d)
 
+	destination := d.Get(destinationAttr).(string)
 	routeTableID := d.Get("route_table_id").(string)
 	input := &ec2.DeleteRouteInput{
 		RouteTableId: aws.String(routeTableID),
 	}
 
-	var pDestination **string
 	switch destinationAttr {
 	case "destination_cidr_block":
-		pDestination = &input.DestinationCidrBlock
+		input.DestinationCidrBlock = aws.String(destination)
 	case "destination_ipv6_cidr_block":
-		pDestination = &input.DestinationIpv6CidrBlock
+		input.DestinationIpv6CidrBlock = aws.String(destination)
 	default:
 		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
 	}
-	destination := d.Get(destinationAttr).(string)
-	*pDestination = aws.String(destination)
 
 	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		log.Printf("[DEBUG] Deleting route (%s)", d.Id())
+		log.Printf("[DEBUG] Deleting Route (%s)", d.Id())
 		_, err := conn.DeleteRoute(input)
 		if err == nil {
 			return nil
@@ -436,7 +388,7 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if isResourceTimeoutError(err) {
-		log.Printf("[DEBUG] Deleting route (%s)", d.Id())
+		log.Printf("[DEBUG] Deleting Route (%s)", d.Id())
 		_, err = conn.DeleteRoute(input)
 	}
 
@@ -445,61 +397,10 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting route for Route Table (%s) with destination (%s): %s", routeTableID, destination, err)
+		return fmt.Errorf("error deleting Route for Route Table (%s) with destination (%s): %s", routeTableID, destination, err)
 	}
 
 	return nil
-}
-
-// Helper: Create an ID for a route
-func resourceAwsRouteID(d *schema.ResourceData, r *ec2.Route) string {
-
-	if r.DestinationIpv6CidrBlock != nil && *r.DestinationIpv6CidrBlock != "" {
-		return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*r.DestinationIpv6CidrBlock))
-	}
-
-	return fmt.Sprintf("r-%s%d", d.Get("route_table_id").(string), hashcode.String(*r.DestinationCidrBlock))
-}
-
-// resourceAwsRouteFindRoute returns any route whose destination is the specified IPv4 or IPv6 CIDR block.
-// Returns nil if the route table exists but no matching destination is found.
-func resourceAwsRouteFindRoute(conn *ec2.EC2, rtbid string, cidr string, ipv6cidr string) (*ec2.Route, error) {
-	routeTableID := rtbid
-
-	findOpts := &ec2.DescribeRouteTablesInput{
-		RouteTableIds: []*string{&routeTableID},
-	}
-
-	resp, err := conn.DescribeRouteTables(findOpts)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(resp.RouteTables) < 1 || resp.RouteTables[0] == nil {
-		return nil, nil
-	}
-
-	if cidr != "" {
-		for _, route := range (*resp.RouteTables[0]).Routes {
-			if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == cidr {
-				return route, nil
-			}
-		}
-
-		return nil, nil
-	}
-
-	if ipv6cidr != "" {
-		for _, route := range (*resp.RouteTables[0]).Routes {
-			if cidrBlocksEqual(aws.StringValue(route.DestinationIpv6CidrBlock), ipv6cidr) {
-				return route, nil
-			}
-		}
-
-		return nil, nil
-	}
-
-	return nil, nil
 }
 
 // routeDestinationAttr return the route's destination attribute name.
@@ -566,7 +467,7 @@ func routeDestinationAndTargetAttributes(d *schema.ResourceData) (string, string
 
 	targetAttr := ""
 	for attr, allowed := range targetAttrs {
-		if v := d.Get(attr).(string); v != "" {
+		if v := d.Get(attr).(string); v != "" && d.HasChange(attr) {
 			if targetAttr != "" {
 				return "", "", fmt.Errorf("`%s` conflicts with `%s`", attr, targetAttr)
 			}

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -75,19 +75,16 @@ func resourceAwsRoute() *schema.Resource {
 			"gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"egress_only_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"nat_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"instance_id": {

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
 	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
@@ -36,7 +35,7 @@ func resourceAwsRoute() *schema.Resource {
 				} else {
 					d.Set("destination_cidr_block", destination)
 				}
-				d.SetId(fmt.Sprintf("r-%s%d", routeTableID, hashcode.String(destination)))
+				d.SetId(tfec2.RouteCreateID(routeTableID, destination))
 				return []*schema.ResourceData{d}, nil
 			},
 		},
@@ -217,7 +216,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Route in Route Table (%s) with destination (%s) not found", routeTableID, destination)
 	}
 
-	d.SetId(routeCreateID(routeTableID, destination))
+	d.SetId(tfec2.RouteCreateID(routeTableID, destination))
 
 	return resourceAwsRouteRead(d, meta)
 }
@@ -475,14 +474,6 @@ func routeDestinationAndTargetAttributes(d *schema.ResourceData) (string, string
 	}
 
 	return destinationAttr, targetAttr, nil
-}
-
-// TODO
-// TODO Move these to a per-service internal package and auto-generate where possible.
-// TODO
-
-func routeCreateID(routeTableID, destination string) string {
-	return fmt.Sprintf("r-%s%d", routeTableID, hashcode.String(destination))
 }
 
 // createRoute attempts to create a route.

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/hashcode"
+	tfec2 "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2"
 )
 
 func resourceAwsRoute() *schema.Resource {
@@ -149,15 +150,15 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		RouteTableId: aws.String(routeTableID),
 	}
 
-	var routeReader func(*ec2.EC2, string, string) (*ec2.Route, error)
+	var routeFinder routeFinder
 
 	switch destinationAttr {
 	case "destination_cidr_block":
 		input.DestinationCidrBlock = aws.String(destination)
-		routeReader = readIpv4Route
+		routeFinder = routeByIpv4Destination
 	case "destination_ipv6_cidr_block":
 		input.DestinationIpv6CidrBlock = aws.String(destination)
-		routeReader = readIpv6Route
+		routeFinder = routeByIpv6Destination
 	default:
 		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
 	}
@@ -187,11 +188,11 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		_, err = conn.CreateRoute(input)
 
-		if isAWSErr(err, "InvalidParameterException", "") {
+		if isAWSErr(err, tfec2.ErrCodeInvalidParameterException, "") {
 			return resource.RetryableError(err)
 		}
 
-		if isAWSErr(err, "InvalidTransitGatewayID.NotFound", "") {
+		if isAWSErr(err, tfec2.ErrCodeTransitGatewayNotFound, "") {
 			return resource.RetryableError(err)
 		}
 
@@ -212,7 +213,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var route *ec2.Route
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		route, err = routeReader(conn, routeTableID, destination)
+		route, err = routeFinder(conn, routeTableID, destination)
 
 		if err != nil {
 			return resource.RetryableError(err)
@@ -226,7 +227,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if isResourceTimeoutError(err) {
-		route, err = routeReader(conn, routeTableID, destination)
+		route, err = routeFinder(conn, routeTableID, destination)
 	}
 
 	if err != nil {
@@ -250,20 +251,20 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	destination := d.Get(destinationAttr).(string)
 	routeTableID := d.Get("route_table_id").(string)
 
-	var routeReader func(*ec2.EC2, string, string) (*ec2.Route, error)
+	var routeFinder routeFinder
 
 	switch destinationAttr {
 	case "destination_cidr_block":
-		routeReader = readIpv4Route
+		routeFinder = routeByIpv4Destination
 	case "destination_ipv6_cidr_block":
-		routeReader = readIpv6Route
+		routeFinder = routeByIpv6Destination
 	default:
 		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
 	}
 
-	route, err := routeReader(conn, routeTableID, destination)
+	route, err := routeFinder(conn, routeTableID, destination)
 
-	if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
+	if isAWSErr(err, tfec2.ErrCodeRouteTableNotFound, "") {
 		log.Printf("[WARN] Route Table (%s) not found, removing from state", routeTableID)
 		d.SetId("")
 		return nil
@@ -376,16 +377,16 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
-		if isAWSErr(err, "InvalidRoute.NotFound", "") {
+		if isAWSErr(err, tfec2.ErrCodeRouteNotFound, "") {
 			return nil
 		}
 
 		// Local routes (which may have been imported) cannot be deleted. Remove from state.
-		if isAWSErr(err, "InvalidParameterValue", "cannot remove local route") {
+		if isAWSErr(err, tfec2.ErrCodeInvalidParameterValue, "cannot remove local route") {
 			return nil
 		}
 
-		if isAWSErr(err, "InvalidParameterException", "") {
+		if isAWSErr(err, tfec2.ErrCodeInvalidParameterException, "") {
 			return resource.RetryableError(err)
 		}
 
@@ -397,7 +398,7 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 		_, err = conn.DeleteRoute(input)
 	}
 
-	if isAWSErr(err, "InvalidRoute.NotFound", "") {
+	if isAWSErr(err, tfec2.ErrCodeRouteNotFound, "") {
 		return nil
 	}
 
@@ -501,29 +502,12 @@ func routeDestinationAndTargetAttributes(d *schema.ResourceData) (string, string
 // TODO Move these to a per-service internal package and auto-generate where possible.
 // TODO
 
-// readRouteTable returns the route table corresponding to the specified identifier.
-// Returns nil if no route table is found.
-func readRouteTable(conn *ec2.EC2, identifier string) (*ec2.RouteTable, error) {
-	input := &ec2.DescribeRouteTablesInput{
-		RouteTableIds: aws.StringSlice([]string{identifier}),
-	}
+type routeFinder func(*ec2.EC2, string, string) (*ec2.Route, error)
 
-	output, err := conn.DescribeRouteTables(input)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(output.RouteTables) == 0 || output.RouteTables[0] == nil {
-		return nil, nil
-	}
-
-	return output.RouteTables[0], nil
-}
-
-// readIpv4Route returns the route corresponding to the specified destination.
+// routeByIpv4Destination returns the route corresponding to the specified IPv4 destination.
 // Returns nil if no route is found.
-func readIpv4Route(conn *ec2.EC2, routeTableID, destinationCidr string) (*ec2.Route, error) {
-	routeTable, err := readRouteTable(conn, routeTableID)
+func routeByIpv4Destination(conn *ec2.EC2, routeTableID, destinationCidr string) (*ec2.Route, error) {
+	routeTable, err := routeTableByID(conn, routeTableID)
 	if err != nil {
 		return nil, err
 	}
@@ -537,10 +521,10 @@ func readIpv4Route(conn *ec2.EC2, routeTableID, destinationCidr string) (*ec2.Ro
 	return nil, nil
 }
 
-// readIpv6Route returns the route corresponding to the specified destination.
+// routeByIpv6Destination returns the route corresponding to the specified IPv6 destination.
 // Returns nil if no route is found.
-func readIpv6Route(conn *ec2.EC2, routeTableID, destinationIpv6Cidr string) (*ec2.Route, error) {
-	routeTable, err := readRouteTable(conn, routeTableID)
+func routeByIpv6Destination(conn *ec2.EC2, routeTableID, destinationIpv6Cidr string) (*ec2.Route, error) {
+	routeTable, err := routeTableByID(conn, routeTableID)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -139,12 +139,12 @@ func resourceAwsRoute() *schema.Resource {
 func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	destinationAttr, targetAttr, err := routeDestinationAndTargetAttributes(d)
+	destinationAttributeKey, targetAttributeKey, err := getRouteDestinationAndTargetAttributeKeysFromResourceData(d)
 	if err != nil {
 		return err
 	}
 
-	destination := d.Get(destinationAttr).(string)
+	destination := d.Get(destinationAttributeKey).(string)
 	routeTableID := d.Get("route_table_id").(string)
 	input := &ec2.CreateRouteInput{
 		RouteTableId: aws.String(routeTableID),
@@ -152,7 +152,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var routeFinder finder.RouteFinder
 
-	switch destinationAttr {
+	switch destinationAttributeKey {
 	case "destination_cidr_block":
 		input.DestinationCidrBlock = aws.String(destination)
 		routeFinder = finder.RouteByIpv4Destination
@@ -160,11 +160,11 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		input.DestinationIpv6CidrBlock = aws.String(destination)
 		routeFinder = finder.RouteByIpv6Destination
 	default:
-		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
+		return fmt.Errorf("unexpected destination attribute: %q", destinationAttributeKey)
 	}
 
-	target := aws.String(d.Get(targetAttr).(string))
-	switch targetAttr {
+	target := aws.String(d.Get(targetAttributeKey).(string))
+	switch targetAttributeKey {
 	case "egress_only_gateway_id":
 		input.EgressOnlyInternetGatewayId = target
 	case "gateway_id":
@@ -180,7 +180,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	case "vpc_peering_connection_id":
 		input.VpcPeeringConnectionId = target
 	default:
-		return fmt.Errorf("unexpected target attribute: `%s`", targetAttr)
+		return fmt.Errorf("unexpected target attribute: %q", targetAttributeKey)
 	}
 
 	log.Printf("[DEBUG] Creating Route: %s", input)
@@ -224,21 +224,24 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	destinationAttr := routeDestinationAttr(d)
-
-	destination := d.Get(destinationAttr).(string)
-	routeTableID := d.Get("route_table_id").(string)
+	destinationAttributeKey := getRouteDestinationAttributeKeyFromResourceData(d)
+	if destinationAttributeKey == "" {
+		return fmt.Errorf("missing route destination attribute")
+	}
 
 	var routeFinder finder.RouteFinder
 
-	switch destinationAttr {
+	switch destinationAttributeKey {
 	case "destination_cidr_block":
 		routeFinder = finder.RouteByIpv4Destination
 	case "destination_ipv6_cidr_block":
 		routeFinder = finder.RouteByIpv6Destination
 	default:
-		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
+		return fmt.Errorf("unexpected route destination attribute: %q", destinationAttributeKey)
 	}
+
+	destination := d.Get(destinationAttributeKey).(string)
+	routeTableID := d.Get("route_table_id").(string)
 
 	route, err := routeFinder(conn, routeTableID, destination)
 
@@ -278,28 +281,28 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	destinationAttr, targetAttr, err := routeDestinationAndTargetAttributes(d)
+	destinationAttributeKey, targetAttributeKey, err := getRouteDestinationAndTargetAttributeKeysFromResourceData(d)
 	if err != nil {
 		return err
 	}
 
-	destination := d.Get(destinationAttr).(string)
+	destination := d.Get(destinationAttributeKey).(string)
 	routeTableID := d.Get("route_table_id").(string)
 	input := &ec2.ReplaceRouteInput{
 		RouteTableId: aws.String(routeTableID),
 	}
 
-	switch destinationAttr {
+	switch destinationAttributeKey {
 	case "destination_cidr_block":
 		input.DestinationCidrBlock = aws.String(destination)
 	case "destination_ipv6_cidr_block":
 		input.DestinationIpv6CidrBlock = aws.String(destination)
 	default:
-		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
+		return fmt.Errorf("unexpected destination attribute: %q", destinationAttributeKey)
 	}
 
-	target := aws.String(d.Get(targetAttr).(string))
-	switch targetAttr {
+	target := aws.String(d.Get(targetAttributeKey).(string))
+	switch targetAttributeKey {
 	case "egress_only_gateway_id":
 		input.EgressOnlyInternetGatewayId = target
 	case "gateway_id":
@@ -315,7 +318,7 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	case "vpc_peering_connection_id":
 		input.VpcPeeringConnectionId = target
 	default:
-		return fmt.Errorf("unexpected target attribute: `%s`", targetAttr)
+		return fmt.Errorf("unexpected target attribute: %q", targetAttributeKey)
 	}
 
 	log.Printf("[DEBUG] Updating Route: %s", input)
@@ -331,21 +334,24 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	destinationAttr := routeDestinationAttr(d)
+	destinationAttributeKey := getRouteDestinationAttributeKeyFromResourceData(d)
+	if destinationAttributeKey == "" {
+		return fmt.Errorf("missing route destination attribute")
+	}
 
-	destination := d.Get(destinationAttr).(string)
+	destination := d.Get(destinationAttributeKey).(string)
 	routeTableID := d.Get("route_table_id").(string)
 	input := &ec2.DeleteRouteInput{
 		RouteTableId: aws.String(routeTableID),
 	}
 
-	switch destinationAttr {
+	switch destinationAttributeKey {
 	case "destination_cidr_block":
 		input.DestinationCidrBlock = aws.String(destination)
 	case "destination_ipv6_cidr_block":
 		input.DestinationIpv6CidrBlock = aws.String(destination)
 	default:
-		return fmt.Errorf("unexpected destination attribute: `%s`", destinationAttr)
+		return fmt.Errorf("unexpected route destination attribute: %q", destinationAttributeKey)
 	}
 
 	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
@@ -387,56 +393,35 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-// routeDestinationAttr return the route's destination attribute name.
-// No validation is done.
-func routeDestinationAttr(d *schema.ResourceData) string {
-	destinationAttrs := []string{"destination_cidr_block", "destination_ipv6_cidr_block"}
-
-	for _, attr := range destinationAttrs {
-		if v := d.Get(attr).(string); v != "" {
-			return attr
-		}
-	}
-
-	return ""
+// Map of attribute key to whether or not the attribute supports IPv4 and IPv6 destinations.
+type routeAttributes map[string]struct {
+	ipv4Destination bool
+	ipv6Destination bool
 }
 
-// routeDestinationAndTargetAttributes return the route's destination and target attribute names.
-// It also validates the resource, returning any validation error.
-func routeDestinationAndTargetAttributes(d *schema.ResourceData) (string, string, error) {
-	destinationAttrs := map[string]struct {
+// Returns the attribute map's keys.
+func (m routeAttributes) keys() []string {
+	keys := []string{}
+
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+var (
+	routeDestinationAttributes = routeAttributes(map[string]struct {
 		ipv4Destination bool
 		ipv6Destination bool
 	}{
 		"destination_cidr_block":      {true, false},
 		"destination_ipv6_cidr_block": {false, true},
-	}
+	})
 
-	destinationAttr := ""
-	ipv4Destination := false
-	ipv6Destination := false
-	for attr, kind := range destinationAttrs {
-		if v := d.Get(attr).(string); v != "" {
-			if destinationAttr != "" {
-				return "", "", fmt.Errorf("`%s` conflicts with `%s`", attr, destinationAttr)
-			}
+	routeDestinationAttributeKeys = routeDestinationAttributes.keys()
 
-			destinationAttr = attr
-			ipv4Destination = kind.ipv4Destination
-			ipv6Destination = kind.ipv6Destination
-		}
-	}
-
-	if destinationAttr == "" {
-		keys := []string{}
-		for k := range destinationAttrs {
-			keys = append(keys, k)
-		}
-
-		return "", "", fmt.Errorf("one of `%s` must be specified", strings.Join(keys, "`, `"))
-	}
-
-	targetAttrs := map[string]struct {
+	routeTargetAttributes = routeAttributes(map[string]struct {
 		ipv4Destination bool
 		ipv6Destination bool
 	}{
@@ -447,33 +432,67 @@ func routeDestinationAndTargetAttributes(d *schema.ResourceData) (string, string
 		"network_interface_id":      {true, true},
 		"transit_gateway_id":        {true, false},
 		"vpc_peering_connection_id": {true, true},
+	})
+
+	routeTargetAttributeKeys = routeTargetAttributes.keys()
+
+	routeDestinationAndTargetAttributeKeys = append(append([]string{}, routeDestinationAttributeKeys...), routeTargetAttributeKeys...)
+)
+
+// getRouteDestinationAttributeKeyFromResourceData return the route's destination attribute key.
+// No validation is done.
+func getRouteDestinationAttributeKeyFromResourceData(d *schema.ResourceData) string {
+	for _, k := range routeDestinationAttributeKeys {
+		if v := d.Get(k).(string); v != "" {
+			return k
+		}
 	}
 
-	targetAttr := ""
-	for attr, allowed := range targetAttrs {
-		if v := d.Get(attr).(string); v != "" && d.HasChange(attr) {
-			if targetAttr != "" {
-				return "", "", fmt.Errorf("`%s` conflicts with `%s`", attr, targetAttr)
+	return ""
+}
+
+// getRouteDestinationAndTargetAttributeKeysFromResourceData return the route's destination and target attribute keys.
+// It also validates the resource, returning any validation error.
+func getRouteDestinationAndTargetAttributeKeysFromResourceData(d *schema.ResourceData) (string, string, error) {
+	destinationAttributeKey := ""
+	ipv4Destination := false
+	ipv6Destination := false
+	for key, kind := range routeDestinationAttributes {
+		if v := d.Get(key).(string); v != "" {
+			if destinationAttributeKey != "" {
+				return "", "", fmt.Errorf("%q conflicts with %q", key, destinationAttributeKey)
+			}
+
+			destinationAttributeKey = key
+			ipv4Destination = kind.ipv4Destination
+			ipv6Destination = kind.ipv6Destination
+		}
+	}
+
+	if destinationAttributeKey == "" {
+		return "", "", fmt.Errorf("one of %q must be specified", strings.Join(routeDestinationAttributeKeys, "\", \""))
+	}
+
+	targetAttributeKey := ""
+	for key, allowed := range routeTargetAttributes {
+		if v := d.Get(key).(string); v != "" && d.HasChange(key) {
+			if targetAttributeKey != "" {
+				return "", "", fmt.Errorf("%q conflicts with %q", key, targetAttributeKey)
 			}
 
 			if (ipv4Destination && !allowed.ipv4Destination) || (ipv6Destination && !allowed.ipv6Destination) {
-				return "", "", fmt.Errorf("`%s` not allowed for `%s` target", destinationAttr, attr)
+				return "", "", fmt.Errorf("%q not allowed for %q target", destinationAttributeKey, key)
 			}
 
-			targetAttr = attr
+			targetAttributeKey = key
 		}
 	}
 
-	if targetAttr == "" {
-		keys := []string{}
-		for k := range targetAttrs {
-			keys = append(keys, k)
-		}
-
-		return "", "", fmt.Errorf("one of `%s` must be specified", strings.Join(keys, "`, `"))
+	if targetAttributeKey == "" {
+		return "", "", fmt.Errorf("one of %s must be specified", strings.Join(routeTargetAttributeKeys, "\", \""))
 	}
 
-	return destinationAttr, targetAttr, nil
+	return destinationAttributeKey, targetAttributeKey, nil
 }
 
 // createRoute attempts to create a route.

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -185,31 +185,9 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Creating Route: %s", input)
-
-	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		_, err = conn.CreateRoute(input)
-
-		if isAWSErr(err, tfec2.ErrCodeInvalidParameterException, "") {
-			return resource.RetryableError(err)
-		}
-
-		if isAWSErr(err, tfec2.ErrCodeTransitGatewayNotFound, "") {
-			return resource.RetryableError(err)
-		}
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if isResourceTimeoutError(err) {
-		_, err = conn.CreateRoute(input)
-	}
-
+	err = createRoute(conn, input, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return fmt.Errorf("error creating Route: %s", err)
+		return err
 	}
 
 	var route *ec2.Route
@@ -505,4 +483,37 @@ func routeDestinationAndTargetAttributes(d *schema.ResourceData) (string, string
 
 func routeCreateID(routeTableID, destination string) string {
 	return fmt.Sprintf("r-%s%d", routeTableID, hashcode.String(destination))
+}
+
+// createRoute attempts to create a route.
+// The specified eventual consistency timeout is respected.
+// Any error is returned.
+func createRoute(conn *ec2.EC2, input *ec2.CreateRouteInput, timeout time.Duration) error {
+	err := resource.Retry(timeout, func() *resource.RetryError {
+		_, err := conn.CreateRoute(input)
+
+		if isAWSErr(err, tfec2.ErrCodeInvalidParameterException, "") {
+			return resource.RetryableError(err)
+		}
+
+		if isAWSErr(err, tfec2.ErrCodeTransitGatewayNotFound, "") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.CreateRoute(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error creating Route: %s", err)
+	}
+
+	return nil
 }

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -448,14 +448,17 @@ func getRouteDestinationAttributeKeyFromResourceData(d *schema.ResourceData) str
 	return ""
 }
 
-// getRouteDestinationAndTargetAttributeKeysFromResourceData return the route's destination and target attribute keys.
+// getRouteDestinationAndTargetAttributeKeysFromMap return the route's destination and target attribute keys.
 // It also validates the resource, returning any validation error.
-func getRouteDestinationAndTargetAttributeKeysFromResourceData(d *schema.ResourceData) (string, string, error) {
+func getRouteDestinationAndTargetAttributeKeysFromMap(m map[string]struct {
+	v         interface{}
+	hasChange bool
+}) (string, string, error) {
 	destinationAttributeKey := ""
 	ipv4Destination := false
 	ipv6Destination := false
 	for key, kind := range routeDestinationAttributes {
-		if v := d.Get(key).(string); v != "" {
+		if s, ok := m[key]; ok && s.v.(string) != "" {
 			if destinationAttributeKey != "" {
 				return "", "", fmt.Errorf("%q conflicts with %q", key, destinationAttributeKey)
 			}
@@ -472,7 +475,8 @@ func getRouteDestinationAndTargetAttributeKeysFromResourceData(d *schema.Resourc
 
 	targetAttributeKey := ""
 	for key, allowed := range routeTargetAttributes {
-		if v := d.Get(key).(string); v != "" && d.HasChange(key) {
+		// The HasChange check is necessary to handle Computed attributes that will be cleared once they are read back after update.
+		if s, ok := m[key]; ok && s.v.(string) != "" && s.hasChange {
 			if targetAttributeKey != "" {
 				return "", "", fmt.Errorf("%q conflicts with %q", key, targetAttributeKey)
 			}
@@ -490,6 +494,24 @@ func getRouteDestinationAndTargetAttributeKeysFromResourceData(d *schema.Resourc
 	}
 
 	return destinationAttributeKey, targetAttributeKey, nil
+}
+
+// getRouteDestinationAndTargetAttributeKeysFromResourceData return the route's destination and target attribute keys.
+// It also validates the resource, returning any validation error.
+func getRouteDestinationAndTargetAttributeKeysFromResourceData(d *schema.ResourceData) (string, string, error) {
+	m := map[string]struct {
+		v         interface{}
+		hasChange bool
+	}{}
+
+	for _, key := range routeDestinationAndTargetAttributeKeys {
+		m[key] = struct {
+			v         interface{}
+			hasChange bool
+		}{d.Get(key), d.HasChange(key)}
+	}
+
+	return getRouteDestinationAndTargetAttributeKeysFromMap(m)
 }
 
 // createRoute attempts to create a route.

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -380,6 +380,11 @@ func resourceAwsRouteDelete(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
+		// Local routes (which may have been imported) cannot be deleted. Remove from state.
+		if isAWSErr(err, "InvalidParameterValue", "cannot remove local route") {
+			return nil
+		}
+
 		if isAWSErr(err, "InvalidParameterException", "") {
 			return resource.RetryableError(err)
 		}

--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -568,3 +568,26 @@ func resourceAwsRouteTableStateRefreshFunc(conn *ec2.EC2, id string) resource.St
 		return rt, "ready", nil
 	}
 }
+
+// TODO
+// TODO Move these to a per-service internal package and auto-generate where possible.
+// TODO
+
+// routeTableByID returns the route table corresponding to the specified identifier.
+// Returns nil if no route table is found.
+func routeTableByID(conn *ec2.EC2, routeTableID string) (*ec2.RouteTable, error) {
+	input := &ec2.DescribeRouteTablesInput{
+		RouteTableIds: aws.StringSlice([]string{routeTableID}),
+	}
+
+	output, err := conn.DescribeRouteTables(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.RouteTables) == 0 || output.RouteTables[0] == nil {
+		return nil, nil
+	}
+
+	return output.RouteTables[0], nil
+}

--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -568,26 +568,3 @@ func resourceAwsRouteTableStateRefreshFunc(conn *ec2.EC2, id string) resource.St
 		return rt, "ready", nil
 	}
 }
-
-// TODO
-// TODO Move these to a per-service internal package and auto-generate where possible.
-// TODO
-
-// routeTableByID returns the route table corresponding to the specified identifier.
-// Returns nil if no route table is found.
-func routeTableByID(conn *ec2.EC2, routeTableID string) (*ec2.RouteTable, error) {
-	input := &ec2.DescribeRouteTablesInput{
-		RouteTableIds: aws.StringSlice([]string{routeTableID}),
-	}
-
-	output, err := conn.DescribeRouteTables(input)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(output.RouteTables) == 0 || output.RouteTables[0] == nil {
-		return nil, nil
-	}
-
-	return output.RouteTables[0], nil
-}

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -1020,3 +1020,21 @@ resource "aws_route_table" "test" {
 }
 `, rName, ipv6Route)
 }
+
+// testAccLatestAmazonNatInstanceAmiConfig returns the configuration for a data source that
+// describes the latest Amazon NAT instance AMI.
+// See https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html#nat-instance-ami.
+// The data source is named 'amzn-ami-nat-instance'.
+func testAccLatestAmazonNatInstanceAmiConfig() string {
+	return fmt.Sprintf(`
+data "aws_ami" "amzn-ami-nat-instance" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-vpc-nat-*"]
+  }
+}
+`)
+}

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -566,6 +566,16 @@ func TestAccAWSRouteTable_ConditionalCidrBlock(t *testing.T) {
 	})
 }
 
+func testAccCheckAWSRouteTableNumberOfRoutes(routeTable *ec2.RouteTable, n int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len := len(routeTable.Routes); len != n {
+			return fmt.Errorf("Route Table has incorrect number of routes (Expected=%d, Actual=%d)\n", n, len)
+		}
+
+		return nil
+	}
+}
+
 const testAccRouteTableConfig = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -235,7 +235,7 @@ func TestAccAWSRoute_IPv6_To_NetworkInterface(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
-					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
@@ -442,7 +442,7 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
-					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
@@ -808,8 +808,8 @@ func testAccAWSRouteConfigIpv6NetworkInterface(rName, destinationCidr string) st
 	return fmt.Sprintf(`
 data "aws_availability_zones" "current" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  blacklisted_zone_ids = ["usw2-az4"]
-  state                = "available"
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
 
   filter {
     name   = "opt-in-status"
@@ -868,8 +868,8 @@ func testAccAWSRouteConfigIpv6Instance(rName, destinationCidr string) string {
 		fmt.Sprintf(`
 data "aws_availability_zones" "current" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  blacklisted_zone_ids = ["usw2-az4"]
-  state                = "available"
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
 
   filter {
     name   = "opt-in-status"
@@ -1172,8 +1172,8 @@ func testAccAWSRouteConfigIpv4Instance(rName, destinationCidr string) string {
 		fmt.Sprintf(`
 data "aws_availability_zones" "current" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  blacklisted_zone_ids = ["usw2-az4"]
-  state                = "available"
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
 
   filter {
     name   = "opt-in-status"
@@ -1229,8 +1229,8 @@ func testAccAWSRouteConfigIpv4NetworkInterface(rName, destinationCidr string) st
 	return fmt.Sprintf(`
 data "aws_availability_zones" "current" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  blacklisted_zone_ids = ["usw2-az4"]
-  state                = "available"
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
 
   filter {
     name   = "opt-in-status"

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -989,7 +989,7 @@ resource "aws_route" "test" {
 
 func testAccAWSRouteConfigIpv6Instance(rName, destinationCidr string) string {
 	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccLatestAmazonNatInstanceAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
@@ -1024,7 +1024,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  ami           = data.aws_ami.amzn-ami-nat-instance.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id     = aws_subnet.test.id
 
@@ -1285,7 +1285,7 @@ resource "aws_route" "test" {
 
 func testAccAWSRouteConfigIpv4Instance(rName, destinationCidr string) string {
 	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccLatestAmazonNatInstanceAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
@@ -1318,7 +1318,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  ami           = data.aws_ami.amzn-ami-nat-instance.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id     = aws_subnet.test.id
 
@@ -1400,7 +1400,7 @@ resource "aws_route" "test" {
 
 func testAccAWSRouteConfigIpv4NetworkInterfaceAttached(rName, destinationCidr string) string {
 	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccLatestAmazonNatInstanceAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
@@ -1441,7 +1441,7 @@ resource "aws_network_interface" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  ami           = data.aws_ami.amzn-ami-nat-instance.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
 
   network_interface {
@@ -1476,7 +1476,7 @@ resource "aws_route" "test" {
 /*
 func testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationCidr, targetResourceName string) string {
 	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccLatestAmazonNatInstanceAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
@@ -1525,7 +1525,7 @@ resource "aws_network_interface" "test2" {
 }
 
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  ami           = data.aws_ami.amzn-ami-nat-instance.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
 
   network_interface {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -255,50 +255,6 @@ func TestAccAWSRoute_changeCidr(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute_noopdiff(t *testing.T) {
-	var route ec2.Route
-	var routeTable ec2.RouteTable
-
-	testCheck := func(s *terraform.State) error {
-		return nil
-	}
-
-	testCheckChange := func(s *terraform.State) error {
-		return nil
-	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRouteDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSRouteNoopChange,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.test", &route),
-					testCheck,
-				),
-			},
-			{
-				Config: testAccAWSRouteNoopChange,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.test", &route),
-					testAccCheckRouteTableExists("aws_route_table.test", &routeTable),
-					testCheckChange,
-				),
-			},
-			{
-				ResourceName:      "aws_route.test",
-				ImportState:       true,
-				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.test"),
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSRoute_doesNotCrashWithVPCEndpoint(t *testing.T) {
 	var route ec2.Route
 
@@ -308,7 +264,7 @@ func TestAccAWSRoute_doesNotCrashWithVPCEndpoint(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteWithVPCEndpoint(),
+				Config: testAccAWSRouteWithVPCEndpoint,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists("aws_route.bar", &route),
 				),
@@ -975,55 +931,7 @@ resource "aws_route" "bar" {
 `)
 }
 
-var testAccAWSRouteNoopChange = fmt.Sprint(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.10.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-route-noop-change"
-  }
-}
-
-resource "aws_route_table" "test" {
-  vpc_id = aws_vpc.test.id
-}
-
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  vpc_id            = aws_vpc.test.id
-  cidr_block        = "10.10.10.0/24"
-
-  tags = {
-    Name = "tf-acc-route-noop-change"
-  }
-}
-
-resource "aws_route" "test" {
-  route_table_id         = aws_route_table.test.id
-  destination_cidr_block = "0.0.0.0/0"
-  instance_id            = aws_instance.nat.id
-}
-
-resource "aws_instance" "nat" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  subnet_id     = aws_subnet.test.id
-}
-`)
-
-func testAccAWSRouteWithVPCEndpoint() string {
-	return fmt.Sprintf(`
-data "aws_region" "current" {}
-
+var testAccAWSRouteWithVPCEndpoint = fmt.Sprint(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -1059,7 +967,6 @@ resource "aws_vpc_endpoint" "baz" {
   route_table_ids = [aws_route_table.foo.id]
 }
 `)
-}
 
 func testAccAWSRouteConfigTransitGatewayIDDestinatationCidrBlock() string {
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -525,7 +525,6 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_Attached(t *testing.T) {
 	})
 }
 
-/*
 func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
@@ -589,7 +588,6 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 		},
 	})
 }
-*/
 
 func TestAccAWSRoute_IPv4_To_VpcPeeringConnection(t *testing.T) {
 	var route ec2.Route
@@ -1722,7 +1720,6 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
-/*
 func testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationCidr, targetResourceName string) string {
 	return composeConfig(
 		testAccLatestAmazonNatInstanceAmiConfig(),
@@ -1800,7 +1797,6 @@ resource "aws_route" "test" {
 }
 `, rName, destinationCidr, targetResourceName))
 }
-*/
 
 func testAccAWSRouteConfigIpv4VpcPeeringConnection(rName, destinationCidr string) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -342,6 +342,37 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_IPv4_To_VpcPeeringConnection(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.3.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4VpcPeeringConnection(rName, destinationCidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteVpcPeeringConnectionRoute(pcxResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_DoesNotCrashWithVpcEndpoint(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
@@ -1186,6 +1217,50 @@ resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = %[2]q
   network_interface_id   = aws_network_interface.test.id
+}
+`, rName, destinationCidr)
+}
+
+func testAccAWSRouteConfigIpv4VpcPeeringConnection(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "source" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "target" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id      = aws_vpc.source.id
+  peer_vpc_id = aws_vpc.target.id
+  auto_accept = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.source.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id            = aws_route_table.test.id
+  destination_cidr_block    = %[2]q
+  vpc_peering_connection_id = aws_vpc_peering_connection.test.id
 }
 `, rName, destinationCidr)
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -30,7 +30,7 @@ func TestAccAWSRoute_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
-					testAccCheckAWSRouteNumberOfRoutes(&routeTable, 2),
+					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 2),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
@@ -556,7 +556,7 @@ func TestAccAWSRoute_DoesNotCrashWithVpcEndpoint(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
-					testAccCheckAWSRouteNumberOfRoutes(&routeTable, 3),
+					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 3),
 				),
 			},
 			{
@@ -714,16 +714,6 @@ func testAccAWSRouteImportStateIdFunc(resourceName string) resource.ImportStateI
 		}
 
 		return fmt.Sprintf("%s_%s", rs.Primary.Attributes["route_table_id"], destination), nil
-	}
-}
-
-func testAccCheckAWSRouteNumberOfRoutes(routeTable *ec2.RouteTable, n int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len := len(routeTable.Routes); len != n {
-			return fmt.Errorf("Route Table has incorrect number of routes (Expected=%d, Actual=%d)\n", n, len)
-		}
-
-		return nil
 	}
 }
 

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -138,29 +138,30 @@ func TestAccAWSRoute_ipv6ToInternetGateway(t *testing.T) {
 
 func TestAccAWSRoute_ipv6ToInstance(t *testing.T) {
 	var route ec2.Route
+	resourceName := "aws_route.test"
+	instanceResourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "::/0"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteConfigIpv6Instance(),
+				Config: testAccAWSRouteConfigIpv6Instance(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.internal-default-route-ipv6", &route),
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteInstanceRoute(instanceResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 				),
 			},
 			{
-				ResourceName:      "aws_route.internal-default-route-ipv6",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.internal-default-route-ipv6"),
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
-			},
-			{
-				Config:   testAccAWSRouteConfigIpv6InstanceExpanded(),
-				PlanOnly: true,
 			},
 		},
 	})
@@ -429,6 +430,25 @@ func testAccAWSRouteImportStateIdFunc(resourceName string) resource.ImportStateI
 	}
 }
 
+func testAccCheckAWSRouteEgressOnlyInternetGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s\n", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		if gwId := aws.StringValue(route.EgressOnlyInternetGatewayId); gwId != rs.Primary.ID {
+			return fmt.Errorf("Egress Only Internet Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckAWSRouteGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -448,7 +468,7 @@ func testAccCheckAWSRouteGatewayRoute(n string, route *ec2.Route) resource.TestC
 	}
 }
 
-func testAccCheckAWSRouteEgressOnlyInternetGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
+func testAccCheckAWSRouteInstanceRoute(n string, route *ec2.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -459,8 +479,8 @@ func testAccCheckAWSRouteEgressOnlyInternetGatewayRoute(n string, route *ec2.Rou
 			return fmt.Errorf("No ID is set")
 		}
 
-		if gwId := aws.StringValue(route.EgressOnlyInternetGatewayId); gwId != rs.Primary.ID {
-			return fmt.Errorf("Egress Only Internet Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
+		if gwId := aws.StringValue(route.InstanceId); gwId != rs.Primary.ID {
+			return fmt.Errorf("Instance ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
 		}
 
 		return nil
@@ -663,22 +683,15 @@ resource "aws_route" "internal-default-route-ipv6" {
 `)
 }
 
-func testAccAWSRouteConfigIpv6Instance() string {
-	return testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.router-network.availability_zone", "t2.small", "t3.small") +
-		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
+func testAccAWSRouteConfigIpv6Instance(rName, destinationCidr string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-resource "aws_vpc" "examplevpc" {
-  cidr_block                       = "10.100.0.0/16"
-  enable_dns_hostnames             = true
-  assign_generated_ipv6_cidr_block = true
-
-  tags = {
-    Name = "terraform-testacc-route-ipv6-instance"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
 
   filter {
     name   = "opt-in-status"
@@ -686,177 +699,52 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_internet_gateway" "internet" {
-  vpc_id = aws_vpc.examplevpc.id
-
-  tags = {
-    Name = "terraform-testacc-route-ipv6-instance"
-  }
-}
-
-resource "aws_route" "igw" {
-  route_table_id         = aws_vpc.examplevpc.main_route_table_id
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.internet.id
-}
-
-resource "aws_route" "igw-ipv6" {
-  route_table_id              = aws_vpc.examplevpc.main_route_table_id
-  destination_ipv6_cidr_block = "::/0"
-  gateway_id                  = aws_internet_gateway.internet.id
-}
-
-resource "aws_subnet" "router-network" {
-  cidr_block                      = "10.100.1.0/24"
-  vpc_id                          = aws_vpc.examplevpc.id
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.examplevpc.ipv6_cidr_block, 8, 1)
-  assign_ipv6_address_on_creation = true
-  map_public_ip_on_launch         = true
-  availability_zone               = data.aws_availability_zones.available.names[0]
-
-  tags = {
-    Name = "tf-acc-route-ipv6-instance-router"
-  }
-}
-
-resource "aws_subnet" "client-network" {
-  cidr_block                      = "10.100.10.0/24"
-  vpc_id                          = aws_vpc.examplevpc.id
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.examplevpc.ipv6_cidr_block, 8, 2)
-  assign_ipv6_address_on_creation = true
-  map_public_ip_on_launch         = false
-  availability_zone               = data.aws_availability_zones.available.names[0]
-
-  tags = {
-    Name = "tf-acc-route-ipv6-instance-client"
-  }
-}
-
-resource "aws_route_table" "client-routes" {
-  vpc_id = aws_vpc.examplevpc.id
-}
-
-resource "aws_route_table_association" "client-routes" {
-  route_table_id = aws_route_table.client-routes.id
-  subnet_id      = aws_subnet.client-network.id
-}
-
-resource "aws_instance" "test-router" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  subnet_id     = aws_subnet.router-network.id
-}
-
-resource "aws_route" "internal-default-route" {
-  route_table_id         = aws_route_table.client-routes.id
-  destination_cidr_block = "0.0.0.0/0"
-  instance_id            = aws_instance.test-router.id
-}
-
-resource "aws_route" "internal-default-route-ipv6" {
-  route_table_id              = aws_route_table.client-routes.id
-  destination_ipv6_cidr_block = "::/0"
-  instance_id                 = aws_instance.test-router.id
-}
-`)
-}
-
-func testAccAWSRouteConfigIpv6InstanceExpanded() string {
-	return testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.router-network.availability_zone", "t2.small", "t3.small") +
-		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		fmt.Sprintf(`
-resource "aws_vpc" "examplevpc" {
-  cidr_block                       = "10.100.0.0/16"
-  enable_dns_hostnames             = true
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-route-ipv6-instance"
+    Name = %[1]q
   }
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_internet_gateway" "internet" {
-  vpc_id = aws_vpc.examplevpc.id
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.current.names[0]
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
-    Name = "terraform-testacc-route-ipv6-instance"
+    Name = %[1]q
   }
 }
 
-resource "aws_route" "igw" {
-  route_table_id         = aws_vpc.examplevpc.main_route_table_id
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.internet.id
-}
-
-resource "aws_route" "igw-ipv6" {
-  route_table_id              = aws_vpc.examplevpc.main_route_table_id
-  destination_ipv6_cidr_block = "::0/0"
-  gateway_id                  = aws_internet_gateway.internet.id
-}
-
-resource "aws_subnet" "router-network" {
-  cidr_block                      = "10.100.1.0/24"
-  vpc_id                          = aws_vpc.examplevpc.id
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.examplevpc.ipv6_cidr_block, 8, 1)
-  assign_ipv6_address_on_creation = true
-  map_public_ip_on_launch         = true
-  availability_zone               = data.aws_availability_zones.available.names[0]
-
-  tags = {
-    Name = "tf-acc-route-ipv6-instance-router"
-  }
-}
-
-resource "aws_subnet" "client-network" {
-  cidr_block                      = "10.100.10.0/24"
-  vpc_id                          = aws_vpc.examplevpc.id
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.examplevpc.ipv6_cidr_block, 8, 2)
-  assign_ipv6_address_on_creation = true
-  map_public_ip_on_launch         = false
-  availability_zone               = data.aws_availability_zones.available.names[0]
-
-  tags = {
-    Name = "tf-acc-route-ipv6-instance-client"
-  }
-}
-
-resource "aws_route_table" "client-routes" {
-  vpc_id = aws_vpc.examplevpc.id
-}
-
-resource "aws_route_table_association" "client-routes" {
-  route_table_id = aws_route_table.client-routes.id
-  subnet_id      = aws_subnet.client-network.id
-}
-
-resource "aws_instance" "test-router" {
+resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  subnet_id     = aws_subnet.router-network.id
+  subnet_id     = aws_subnet.test.id
+
+  ipv6_address_count = 1
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_route" "internal-default-route" {
-  route_table_id         = aws_route_table.client-routes.id
-  destination_cidr_block = "0.0.0.0/0"
-  instance_id            = aws_instance.test-router.id
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_route" "internal-default-route-ipv6" {
-  route_table_id              = aws_route_table.client-routes.id
-  destination_ipv6_cidr_block = "::0/0"
-  instance_id                 = aws_instance.test-router.id
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_ipv6_cidr_block = %[2]q
+  instance_id                 = aws_instance.test.id
 }
-`)
+`, rName, destinationCidr))
 }
 
 func testAccAWSRouteConfigIpv6PeeringConnection() string {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -169,6 +169,10 @@ func TestAccAWSRoute_ipv6ToInstance(t *testing.T) {
 
 func TestAccAWSRoute_ipv6ToNetworkInterface(t *testing.T) {
 	var route ec2.Route
+	resourceName := "aws_route.test"
+	eniResourceName := "aws_network_interface.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "::/0"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -178,15 +182,18 @@ func TestAccAWSRoute_ipv6ToNetworkInterface(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteConfigIpv6NetworkInterface(),
+				Config: testAccAWSRouteConfigIpv6NetworkInterface(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.internal-default-route-ipv6", &route),
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteNetworkInterfaceRoute(eniResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
 				),
 			},
 			{
-				ResourceName:      "aws_route.internal-default-route-ipv6",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.internal-default-route-ipv6"),
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -487,6 +494,25 @@ func testAccCheckAWSRouteInstanceRoute(n string, route *ec2.Route) resource.Test
 	}
 }
 
+func testAccCheckAWSRouteNetworkInterfaceRoute(n string, route *ec2.Route) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s\n", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		if gwId := aws.StringValue(route.NetworkInterfaceId); gwId != rs.Primary.ID {
+			return fmt.Errorf("Network Interface ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckAWSRouteNumberOfRoutes(routeTable *ec2.RouteTable, n int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len := len(routeTable.Routes); len != n {
@@ -574,22 +600,12 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-func testAccAWSRouteConfigIpv6NetworkInterface() string {
-	return testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.router-network.availability_zone", "t2.small", "t3.small") +
-		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		fmt.Sprintf(`
-resource "aws_vpc" "examplevpc" {
-  cidr_block                       = "10.100.0.0/16"
-  enable_dns_hostnames             = true
-  assign_generated_ipv6_cidr_block = true
-
-  tags = {
-    Name = "terraform-testacc-route-ipv6-network-interface"
-  }
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
+func testAccAWSRouteConfigIpv6NetworkInterface(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
 
   filter {
     name   = "opt-in-status"
@@ -597,90 +613,49 @@ data "aws_availability_zones" "available" {
   }
 }
 
-resource "aws_internet_gateway" "internet" {
-  vpc_id = aws_vpc.examplevpc.id
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-route-ipv6-network-interface"
+    Name = %[1]q
   }
 }
 
-resource "aws_route" "igw" {
-  route_table_id         = aws_vpc.examplevpc.main_route_table_id
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.internet.id
-}
-
-resource "aws_route" "igw-ipv6" {
-  route_table_id              = aws_vpc.examplevpc.main_route_table_id
-  destination_ipv6_cidr_block = "::/0"
-  gateway_id                  = aws_internet_gateway.internet.id
-}
-
-resource "aws_subnet" "router-network" {
-  cidr_block                      = "10.100.1.0/24"
-  vpc_id                          = aws_vpc.examplevpc.id
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.examplevpc.ipv6_cidr_block, 8, 1)
-  assign_ipv6_address_on_creation = true
-  map_public_ip_on_launch         = true
-  availability_zone               = data.aws_availability_zones.available.names[0]
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.current.names[0]
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
-    Name = "tf-acc-route-ipv6-network-interface-router"
+    Name = %[1]q
   }
 }
 
-resource "aws_subnet" "client-network" {
-  cidr_block                      = "10.100.10.0/24"
-  vpc_id                          = aws_vpc.examplevpc.id
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.examplevpc.ipv6_cidr_block, 8, 2)
-  assign_ipv6_address_on_creation = true
-  map_public_ip_on_launch         = false
-  availability_zone               = data.aws_availability_zones.available.names[0]
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
 
   tags = {
-    Name = "tf-acc-route-ipv6-network-interface-client"
+    Name = %[1]q
   }
 }
 
-resource "aws_route_table" "client-routes" {
-  vpc_id = aws_vpc.examplevpc.id
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_route_table_association" "client-routes" {
-  route_table_id = aws_route_table.client-routes.id
-  subnet_id      = aws_subnet.client-network.id
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_ipv6_cidr_block = %[2]q
+  network_interface_id        = aws_network_interface.test.id
 }
-
-resource "aws_instance" "test-router" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  subnet_id     = aws_subnet.router-network.id
-}
-
-resource "aws_network_interface" "router-internal" {
-  subnet_id         = aws_subnet.client-network.id
-  source_dest_check = false
-}
-
-resource "aws_network_interface_attachment" "router-internal" {
-  device_index         = 1
-  instance_id          = aws_instance.test-router.id
-  network_interface_id = aws_network_interface.router-internal.id
-}
-
-resource "aws_route" "internal-default-route" {
-  route_table_id         = aws_route_table.client-routes.id
-  destination_cidr_block = "0.0.0.0/0"
-  network_interface_id   = aws_network_interface.router-internal.id
-}
-
-resource "aws_route" "internal-default-route-ipv6" {
-  route_table_id              = aws_route_table.client-routes.id
-  destination_ipv6_cidr_block = "::/0"
-  network_interface_id        = aws_network_interface.router-internal.id
-}
-`)
+`, rName, destinationCidr)
 }
 
 func testAccAWSRouteConfigIpv6Instance(rName, destinationCidr string) string {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -278,6 +278,37 @@ func TestAccAWSRoute_IPv4_To_InternetGateway(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_IPv4_To_Instance(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	instanceResourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.3.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4Instance(rName, destinationCidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteInstanceRoute(instanceResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_DoesNotCrashWithVpcEndpoint(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
@@ -1008,4 +1039,64 @@ resource "aws_route" "test" {
   destination_ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
 }
 `, rName, ipv6Route)
+}
+
+func testAccAWSRouteConfigIpv4Instance(rName, destinationCidr string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.current.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_cidr_block      = %[2]q
+  instance_id                 = aws_instance.test.id
+}
+`, rName, destinationCidr))
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -820,6 +820,25 @@ func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
 				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
@@ -915,25 +934,6 @@ func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
-					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
-					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
-				),
-			},
-			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
@@ -973,6 +973,25 @@ func TestAccAWSRoute_IPv6_Update_Target(t *testing.T) {
 					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
 					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
@@ -1056,25 +1075,6 @@ func TestAccAWSRoute_IPv6_Update_Target(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
-					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
-					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
-				),
-			},
-			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
@@ -1096,22 +1096,24 @@ func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		r, err := resourceAwsRouteFindRoute(
-			conn,
-			rs.Primary.Attributes["route_table_id"],
-			rs.Primary.Attributes["destination_cidr_block"],
-			rs.Primary.Attributes["destination_ipv6_cidr_block"],
-		)
+
+		var route *ec2.Route
+		var err error
+		if v := rs.Primary.Attributes["destination_cidr_block"]; v != "" {
+			route, err = readIpv4Route(conn, rs.Primary.Attributes["route_table_id"], v)
+		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
+			route, err = readIpv6Route(conn, rs.Primary.Attributes["route_table_id"], v)
+		}
 
 		if err != nil {
 			return err
 		}
 
-		if r == nil {
+		if route == nil {
 			return fmt.Errorf("Route not found")
 		}
 
-		*res = *r
+		*res = *route
 
 		return nil
 	}
@@ -1124,12 +1126,14 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		route, err := resourceAwsRouteFindRoute(
-			conn,
-			rs.Primary.Attributes["route_table_id"],
-			rs.Primary.Attributes["destination_cidr_block"],
-			rs.Primary.Attributes["destination_ipv6_cidr_block"],
-		)
+
+		var route *ec2.Route
+		var err error
+		if v := rs.Primary.Attributes["destination_cidr_block"]; v != "" {
+			route, err = readIpv4Route(conn, rs.Primary.Attributes["route_table_id"], v)
+		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
+			route, err = readIpv6Route(conn, rs.Primary.Attributes["route_table_id"], v)
+		}
 
 		if route == nil && err == nil {
 			return nil

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -883,12 +883,12 @@ func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
-					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
@@ -2031,7 +2031,11 @@ resource "aws_subnet" "test" {
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  subnet_id     = aws_subnet.test.id
+
+  network_interface {
+    device_index         = 0
+    network_interface_id = aws_network_interface.test.id
+  }
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -932,7 +932,7 @@ resource "aws_route" "test" {
 
 func testAccAWSRouteConfigIpv6NetworkInterfaceUnattached(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "current" {
+data "aws_availability_zones" "available" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
   exclude_zone_ids = ["usw2-az4"]
   state            = "available"
@@ -955,7 +955,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
   ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
@@ -992,7 +992,7 @@ func testAccAWSRouteConfigIpv6Instance(rName, destinationCidr string) string {
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "current" {
+data "aws_availability_zones" "available" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
   exclude_zone_ids = ["usw2-az4"]
   state            = "available"
@@ -1015,7 +1015,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
   ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   tags = {
@@ -1288,7 +1288,7 @@ func testAccAWSRouteConfigIpv4Instance(rName, destinationCidr string) string {
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "current" {
+data "aws_availability_zones" "available" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
   exclude_zone_ids = ["usw2-az4"]
   state            = "available"
@@ -1310,7 +1310,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = %[1]q
@@ -1345,7 +1345,7 @@ resource "aws_route" "test" {
 
 func testAccAWSRouteConfigIpv4NetworkInterfaceUnattached(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "current" {
+data "aws_availability_zones" "available" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
   exclude_zone_ids = ["usw2-az4"]
   state            = "available"
@@ -1367,7 +1367,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = %[1]q
@@ -1403,7 +1403,7 @@ func testAccAWSRouteConfigIpv4NetworkInterfaceAttached(rName, destinationCidr st
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "current" {
+data "aws_availability_zones" "available" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
   exclude_zone_ids = ["usw2-az4"]
   state            = "available"
@@ -1425,7 +1425,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = %[1]q
@@ -1479,7 +1479,7 @@ func testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationC
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "current" {
+data "aws_availability_zones" "available" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
   exclude_zone_ids = ["usw2-az4"]
   state            = "available"
@@ -1501,7 +1501,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = %[1]q

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
 // IPv4 to Internet Gateway.
@@ -1138,9 +1139,9 @@ func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc
 		var route *ec2.Route
 		var err error
 		if v := rs.Primary.Attributes["destination_cidr_block"]; v != "" {
-			route, err = routeByIpv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = finder.RouteByIpv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
-			route, err = routeByIpv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = finder.RouteByIpv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		}
 
 		if err != nil {
@@ -1168,9 +1169,9 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 		var route *ec2.Route
 		var err error
 		if v := rs.Primary.Attributes["destination_cidr_block"]; v != "" {
-			route, err = routeByIpv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = finder.RouteByIpv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
-			route, err = routeByIpv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = finder.RouteByIpv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		}
 
 		if route == nil && err == nil {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -931,18 +931,9 @@ resource "aws_route" "test" {
 }
 
 func testAccAWSRouteConfigIpv6NetworkInterfaceUnattached(rName, destinationCidr string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -984,25 +975,15 @@ resource "aws_route" "test" {
   destination_ipv6_cidr_block = %[2]q
   network_interface_id        = aws_network_interface.test.id
 }
-`, rName, destinationCidr)
+`, rName, destinationCidr))
 }
 
 func testAccAWSRouteConfigIpv6Instance(rName, destinationCidr string) string {
 	return composeConfig(
 		testAccLatestAmazonNatInstanceAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -1178,18 +1159,9 @@ resource "aws_vpc_endpoint" "test" {
 }
 
 func testAccAWSRouteConfigIpv4TransitGateway(rName, destinationCidr string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -1237,7 +1209,7 @@ resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   transit_gateway_id     = aws_ec2_transit_gateway_vpc_attachment.test.transit_gateway_id
 }
-`, rName, destinationCidr)
+`, rName, destinationCidr))
 }
 
 func testAccAWSRouteConfigConditionalIpv4Ipv6(rName, destinationCidr, destinationIpv6Cidr string, ipv6Route bool) string {
@@ -1286,19 +1258,9 @@ resource "aws_route" "test" {
 func testAccAWSRouteConfigIpv4Instance(rName, destinationCidr string) string {
 	return composeConfig(
 		testAccLatestAmazonNatInstanceAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -1344,18 +1306,9 @@ resource "aws_route" "test" {
 }
 
 func testAccAWSRouteConfigIpv4NetworkInterfaceUnattached(rName, destinationCidr string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -1395,25 +1348,15 @@ resource "aws_route" "test" {
   destination_cidr_block = %[2]q
   network_interface_id   = aws_network_interface.test.id
 }
-`, rName, destinationCidr)
+`, rName, destinationCidr))
 }
 
 func testAccAWSRouteConfigIpv4NetworkInterfaceAttached(rName, destinationCidr string) string {
 	return composeConfig(
 		testAccLatestAmazonNatInstanceAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -1477,19 +1420,9 @@ resource "aws_route" "test" {
 func testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationCidr, targetResourceName string) string {
 	return composeConfig(
 		testAccLatestAmazonNatInstanceAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,6 +12,111 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
+
+func TestGetRouteDestinationAndTargetAttributeKeysFromMap(t *testing.T) {
+	testCases := []struct {
+		m map[string]struct {
+			v         interface{}
+			hasChange bool
+		}
+		destinationKey string
+		targetKey      string
+		expectedErr    *regexp.Regexp
+	}{
+		{
+			m: map[string]struct {
+				v         interface{}
+				hasChange bool
+			}{},
+			expectedErr: regexp.MustCompile(`one of .*"destination_cidr_block".* must be specified`),
+		},
+		{
+			m: map[string]struct {
+				v         interface{}
+				hasChange bool
+			}{
+				"destination_cidr_block": {"0.0.0.0/0", true},
+			},
+			expectedErr: regexp.MustCompile(`one of .*"transit_gateway_id".* must be specified`),
+		},
+		{
+			m: map[string]struct {
+				v         interface{}
+				hasChange bool
+			}{
+				"destination_cidr_block":      {"0.0.0.0/0", true},
+				"destination_ipv6_cidr_block": {"::/0", true},
+			},
+			expectedErr: regexp.MustCompile(`"destination_ipv6_cidr_block" conflicts with "destination_cidr_block"`),
+		},
+		{
+			m: map[string]struct {
+				v         interface{}
+				hasChange bool
+			}{
+				"destination_cidr_block": {"0.0.0.0/0", true},
+				"transit_gateway_id":     {"tgw-0000000000000000", true},
+			},
+			destinationKey: "destination_cidr_block",
+			targetKey:      "transit_gateway_id",
+		},
+		{
+			m: map[string]struct {
+				v         interface{}
+				hasChange bool
+			}{
+				"destination_cidr_block": {"0.0.0.0/0", true},
+				"transit_gateway_id":     {"tgw-0000000000000000", true},
+				"gateway_id":             {"vgw-0000000000000000", true},
+			},
+			expectedErr: regexp.MustCompile(`"transit_gateway_id" conflicts with "gateway_id"`),
+		},
+		{
+			m: map[string]struct {
+				v         interface{}
+				hasChange bool
+			}{
+				"destination_cidr_block": {"0.0.0.0/0", true},
+				"egress_only_gateway_id": {"eoigw-0000000000000000", true},
+			},
+			expectedErr: regexp.MustCompile(`"destination_cidr_block" not allowed for "egress_only_gateway_id" target`),
+		},
+		{
+			m: map[string]struct {
+				v         interface{}
+				hasChange bool
+			}{
+				"destination_ipv6_cidr_block": {"::/0", true},
+				"nat_gateway_id":              {"ngw-0000000000000000", true},
+			},
+			expectedErr: regexp.MustCompile(`"destination_ipv6_cidr_block" not allowed for "nat_gateway_id" target`),
+		},
+	}
+
+	for i, tc := range testCases {
+		destinationKey, targetKey, err := getRouteDestinationAndTargetAttributeKeysFromMap(tc.m)
+
+		if err != nil && tc.expectedErr == nil {
+			t.Fatalf("expected test case %d to produce no error, got: %s", i, err)
+		}
+
+		if err == nil && tc.expectedErr != nil {
+			t.Fatalf("expected test case %d to produce error, got none", i)
+		}
+
+		if err != nil && !tc.expectedErr.MatchString(err.Error()) {
+			t.Fatalf("expected test case %d to produce error matching %q, got: %s", i, tc.expectedErr, err)
+		}
+
+		if err == nil && tc.destinationKey != destinationKey {
+			t.Fatalf("expected test case %d to return destinationKey %s, got: %s", i, tc.destinationKey, destinationKey)
+		}
+
+		if err == nil && tc.targetKey != targetKey {
+			t.Fatalf("expected test case %d to return targetKey %s, got: %s", i, tc.targetKey, targetKey)
+		}
+	}
+}
 
 // IPv4 to Internet Gateway.
 func TestAccAWSRoute_basic(t *testing.T) {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -1077,6 +1078,45 @@ func TestAccAWSRoute_IPv6_Update_Target(t *testing.T) {
 				ImportState:       true,
 				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// https://github.com/terraform-providers/terraform-provider-aws/issues/11455.
+func TestAccAWSRoute_LocalRoute(t *testing.T) {
+	var routeTable ec2.RouteTable
+	var vpc ec2.Vpc
+	resourceName := "aws_route.test"
+	rtResourceName := "aws_route_table.test"
+	vpcResourceName := "aws_vpc.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4NoRoute(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists(vpcResourceName, &vpc),
+					testAccCheckRouteTableExists(rtResourceName, &routeTable),
+					testAccCheckAWSRouteTableNumberOfRoutes(&routeTable, 1),
+				),
+			},
+			{
+				Config:       testAccAWSRouteConfigIpv4LocalRoute(rName),
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(rt *ec2.RouteTable, v *ec2.Vpc) resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						return fmt.Sprintf("%s_%s", aws.StringValue(rt.RouteTableId), aws.StringValue(v.CidrBlock)), nil
+					}
+				}(&routeTable, &vpc),
+				// Don't verify the state as the local route isn't actually in the pre-import state.
+				// Just running ImportState verifies that we can import a local route.
+				ImportStateVerify: false,
 			},
 		},
 	})
@@ -2237,4 +2277,38 @@ resource "aws_route" "test" {
   %[3]s = %[4]s.id
 }
 `, rName, destinationCidr, targetAttribute, targetValue))
+}
+
+//
+
+func testAccAWSRouteConfigIpv4NoRoute(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccAWSRouteConfigIpv4LocalRoute(rName string) string {
+	return composeConfig(
+		testAccAWSRouteConfigIpv4NoRoute(rName),
+		fmt.Sprintf(`
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = aws_vpc.test.cidr_block
+  gateway_id             = "local"
+}
+`))
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -1980,7 +1980,7 @@ func testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, targetAttribut
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "current" {
+data "aws_availability_zones" "available" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
   # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
   exclude_zone_ids = ["usw2-az4"]
@@ -2019,7 +2019,7 @@ resource "aws_internet_gateway" "test" {
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   map_public_ip_on_launch = true
 
@@ -2125,7 +2125,7 @@ func testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, targetAttribut
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "current" {
+data "aws_availability_zones" "available" {
   # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
   # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
   exclude_zone_ids = ["usw2-az4"]
@@ -2165,7 +2165,7 @@ resource "aws_internet_gateway" "test" {
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
   ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
 
   map_public_ip_on_launch = true

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -782,6 +782,167 @@ func TestAccAWSRoute_ConditionalCidrBlock(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	vgwResourceName := "aws_vpn_gateway.test"
+	instanceResourceName := "aws_instance.test"
+	igwResourceName := "aws_internet_gateway.test"
+	eniResourceName := "aws_network_interface.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
+	ngwResourceName := "aws_nat_gateway.test"
+	tgwResourceName := "aws_ec2_transit_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.3.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "instance_id", instanceResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "nat_gateway_id", ngwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "nat_gateway_id", ngwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "network_interface_id", eniResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "transit_gateway_id", tgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1671,4 +1832,145 @@ resource "aws_route" "test" {
   gateway_id                  = aws_vpn_gateway.test.id
 }
 `, rName, destinationCidr)
+}
+
+func testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.current.names[0]
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
+  subnet_ids         = [aws_subnet.test.id]
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "target" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id      = aws_vpc.test.id
+  peer_vpc_id = aws_vpc.target.id
+  auto_accept = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_eip" "test" {
+  vpc = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_nat_gateway" "test" {
+  allocation_id = aws_eip.test.id
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_internet_gateway.test]
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = %[2]q
+
+  %[3]s = %[4]s.id
+}
+`, rName, destinationCidr, targetAttribute, targetValue))
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -1138,9 +1138,9 @@ func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc
 		var route *ec2.Route
 		var err error
 		if v := rs.Primary.Attributes["destination_cidr_block"]; v != "" {
-			route, err = readIpv4Route(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = routeByIpv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
-			route, err = readIpv6Route(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = routeByIpv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		}
 
 		if err != nil {
@@ -1168,9 +1168,9 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 		var route *ec2.Route
 		var err error
 		if v := rs.Primary.Attributes["destination_cidr_block"]; v != "" {
-			route, err = readIpv4Route(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = routeByIpv4Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		} else if v := rs.Primary.Attributes["destination_ipv6_cidr_block"]; v != "" {
-			route, err = readIpv6Route(conn, rs.Primary.Attributes["route_table_id"], v)
+			route, err = routeByIpv6Destination(conn, rs.Primary.Attributes["route_table_id"], v)
 		}
 
 		if route == nil && err == nil {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -13,88 +13,64 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/ec2/finder"
 )
 
-func TestGetRouteDestinationAndTargetAttributeKeysFromMap(t *testing.T) {
+func TestGetRouteDestinationAndTargetAttributeKeys(t *testing.T) {
 	testCases := []struct {
-		m map[string]struct {
-			v         interface{}
-			hasChange bool
-		}
+		m              map[string]interface{}
 		destinationKey string
 		targetKey      string
 		expectedErr    *regexp.Regexp
 	}{
 		{
-			m: map[string]struct {
-				v         interface{}
-				hasChange bool
-			}{},
+			m:           map[string]interface{}{},
 			expectedErr: regexp.MustCompile(`one of .*"destination_cidr_block".* must be specified`),
 		},
 		{
-			m: map[string]struct {
-				v         interface{}
-				hasChange bool
-			}{
-				"destination_cidr_block": {"0.0.0.0/0", true},
+			m: map[string]interface{}{
+				"destination_cidr_block": "0.0.0.0/0",
 			},
 			expectedErr: regexp.MustCompile(`one of .*"transit_gateway_id".* must be specified`),
 		},
 		{
-			m: map[string]struct {
-				v         interface{}
-				hasChange bool
-			}{
-				"destination_cidr_block":      {"0.0.0.0/0", true},
-				"destination_ipv6_cidr_block": {"::/0", true},
+			m: map[string]interface{}{
+				"destination_cidr_block":      "0.0.0.0/0",
+				"destination_ipv6_cidr_block": "::/0",
 			},
-			expectedErr: regexp.MustCompile(`"destination_ipv6_cidr_block" conflicts with "destination_cidr_block"`),
+			expectedErr: regexp.MustCompile(`("destination_ipv6_cidr_block" conflicts with "destination_cidr_block")|("destination_cidr_block" conflicts with "destination_ipv6_cidr_block")`),
 		},
 		{
-			m: map[string]struct {
-				v         interface{}
-				hasChange bool
-			}{
-				"destination_cidr_block": {"0.0.0.0/0", true},
-				"transit_gateway_id":     {"tgw-0000000000000000", true},
+			m: map[string]interface{}{
+				"destination_cidr_block": "0.0.0.0/0",
+				"transit_gateway_id":     "tgw-0000000000000000",
 			},
 			destinationKey: "destination_cidr_block",
 			targetKey:      "transit_gateway_id",
 		},
 		{
-			m: map[string]struct {
-				v         interface{}
-				hasChange bool
-			}{
-				"destination_cidr_block": {"0.0.0.0/0", true},
-				"transit_gateway_id":     {"tgw-0000000000000000", true},
-				"gateway_id":             {"vgw-0000000000000000", true},
+			m: map[string]interface{}{
+				"destination_cidr_block": "0.0.0.0/0",
+				"transit_gateway_id":     "tgw-0000000000000000",
+				"gateway_id":             "vgw-0000000000000000",
 			},
-			expectedErr: regexp.MustCompile(`"transit_gateway_id" conflicts with "gateway_id"`),
+			expectedErr: regexp.MustCompile(`("gateway_id" conflicts with "transit_gateway_id")|("transit_gateway_id" conflicts with "gateway_id")`),
 		},
 		{
-			m: map[string]struct {
-				v         interface{}
-				hasChange bool
-			}{
-				"destination_cidr_block": {"0.0.0.0/0", true},
-				"egress_only_gateway_id": {"eoigw-0000000000000000", true},
+			m: map[string]interface{}{
+				"destination_cidr_block": "0.0.0.0/0",
+				"egress_only_gateway_id": "eoigw-0000000000000000",
 			},
 			expectedErr: regexp.MustCompile(`"destination_cidr_block" not supported for "egress_only_gateway_id" target`),
 		},
 		{
-			m: map[string]struct {
-				v         interface{}
-				hasChange bool
-			}{
-				"destination_ipv6_cidr_block": {"::/0", true},
-				"nat_gateway_id":              {"ngw-0000000000000000", true},
+			m: map[string]interface{}{
+				"destination_ipv6_cidr_block": "::/0",
+				"nat_gateway_id":              "ngw-0000000000000000",
 			},
 			expectedErr: regexp.MustCompile(`"destination_ipv6_cidr_block" not supported for "nat_gateway_id" target`),
 		},
 	}
 
 	for i, tc := range testCases {
-		destinationKey, targetKey, err := getRouteDestinationAndTargetAttributeKeysFromMap(tc.m)
+		destinationKey, targetKey, err := getRouteDestinationAndTargetAttributeKeys(routeAttributeMap(tc.m))
 
 		if err != nil && tc.expectedErr == nil {
 			t.Fatalf("expected test case %d to produce no error, got: %s", i, err)

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -2019,20 +2019,9 @@ resource "aws_route" "test" {
 func testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -2164,20 +2153,9 @@ resource "aws_route" "test" {
 func testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableAZsNoOptInDefaultExcludeConfig(),
 		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
 		fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -2279,8 +2257,6 @@ resource "aws_route" "test" {
 }
 `, rName, destinationCidr, targetAttribute, targetValue))
 }
-
-//
 
 func testAccAWSRouteConfigIpv4NoRoute(rName string) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -525,6 +525,7 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_Attached(t *testing.T) {
 	})
 }
 
+/*
 func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
@@ -588,6 +589,7 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
 		},
 	})
 }
+*/
 
 func TestAccAWSRoute_IPv4_To_VpcPeeringConnection(t *testing.T) {
 	var route ec2.Route
@@ -1471,6 +1473,7 @@ resource "aws_route" "test" {
 `, rName, destinationCidr))
 }
 
+/*
 func testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationCidr, targetResourceName string) string {
 	return composeConfig(
 		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
@@ -1558,6 +1561,7 @@ resource "aws_route" "test" {
 }
 `, rName, destinationCidr, targetResourceName))
 }
+*/
 
 func testAccAWSRouteConfigIpv4VpcPeeringConnection(rName, destinationCidr string) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -27,7 +27,9 @@ func TestAccAWSRoute_basic(t *testing.T) {
 				Config: testAccAWSRouteConfigBasic(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route, cidr),
+					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", cidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 				),
 			},
 			{
@@ -63,47 +65,35 @@ func TestAccAWSRoute_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute_ipv6Support(t *testing.T) {
+func TestAccAWSRoute_ipv6ToEgressOnlyInternetGateway(t *testing.T) {
 	var route ec2.Route
-
-	//aws creates a default route
-	testCheck := func(s *terraform.State) error {
-		name := "aws_egress_only_internet_gateway.foo"
-		gwres, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", name)
-		}
-
-		if *route.EgressOnlyInternetGatewayId != gwres.Primary.ID {
-			return fmt.Errorf("Egress Only Internet Gateway Id (Expected=%s, Actual=%s)\n", gwres.Primary.ID, *route.EgressOnlyInternetGatewayId)
-		}
-
-		return nil
-	}
+	resourceName := "aws_route.test"
+	eoigwResourceName := "aws_egress_only_internet_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cidr := "::/0"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteConfigIpv6(),
+				Config: testAccAWSRouteConfigIpv6EgressOnlyInternetGateway(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.bar", &route),
-					testCheck,
-					resource.TestCheckResourceAttr("aws_route.bar", "destination_ipv6_cidr_block", "::/0"),
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteEgressOnlyInternetGatewayRoute(eoigwResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", cidr),
 				),
 			},
 			{
-				ResourceName:      "aws_route.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 			{
-				Config:   testAccAWSRouteConfigIpv6Expanded(),
+				Config:   testAccAWSRouteConfigIpv6EgressOnlyInternetGateway(rName, "::0/0"),
 				PlanOnly: true,
 			},
 		},
@@ -237,16 +227,22 @@ func TestAccAWSRoute_changeCidr(t *testing.T) {
 				Config: testAccAWSRouteConfigBasic(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route, cidr),
+					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route),
+					testAccCheckRouteTableExists(rtResourceName, &routeTable),
+					testAccCheckAWSRouteNumberOfRoutes(&routeTable, 2),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", cidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 				),
 			},
 			{
 				Config: testAccAWSRouteConfigBasic(rName, changedCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route, changedCidr),
+					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route),
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
 					testAccCheckAWSRouteNumberOfRoutes(&routeTable, 2),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", changedCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
 				),
 			},
 			{
@@ -461,12 +457,8 @@ func testAccAWSRouteImportStateIdFunc(resourceName string) resource.ImportStateI
 	}
 }
 
-func testAccCheckAWSRouteInternetGatewayRoute(n string, route *ec2.Route, cidr string) resource.TestCheckFunc {
+func testAccCheckAWSRouteInternetGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.StringValue(route.DestinationCidrBlock) != cidr {
-			return fmt.Errorf("Destination CIDR (Expected=%s, Actual=%s)\n", cidr, aws.StringValue(route.DestinationCidrBlock))
-		}
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s\n", n)
@@ -476,8 +468,27 @@ func testAccCheckAWSRouteInternetGatewayRoute(n string, route *ec2.Route, cidr s
 			return fmt.Errorf("No ID is set")
 		}
 
-		if aws.StringValue(route.GatewayId) != rs.Primary.ID {
-			return fmt.Errorf("Internet Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, aws.StringValue(route.GatewayId))
+		if gwId := aws.StringValue(route.GatewayId); gwId != rs.Primary.ID {
+			return fmt.Errorf("Internet Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSRouteEgressOnlyInternetGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s\n", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		if gwId := aws.StringValue(route.EgressOnlyInternetGatewayId); gwId != rs.Primary.ID {
+			return fmt.Errorf("Egress Only Internet Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
 		}
 
 		return nil
@@ -902,31 +913,39 @@ resource "aws_route" "pc" {
 `)
 }
 
-func testAccAWSRouteConfigIpv6() string {
+func testAccAWSRouteConfigIpv6EgressOnlyInternetGateway(rName, cidr string) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "terraform-testacc-route-ipv6"
+    Name = %[1]q
   }
 }
 
-resource "aws_egress_only_internet_gateway" "foo" {
-  vpc_id = aws_vpc.foo.id
+resource "aws_egress_only_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_route_table" "foo" {
-  vpc_id = aws_vpc.foo.id
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_route" "bar" {
-  route_table_id              = aws_route_table.foo.id
-  destination_ipv6_cidr_block = "::/0"
-  egress_only_gateway_id      = aws_egress_only_internet_gateway.foo.id
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_ipv6_cidr_block = %[2]q
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.test.id
 }
-`)
+`, rName, cidr)
 }
 
 func testAccAWSRouteConfigIpv6Expanded() string {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -12,44 +13,27 @@ import (
 
 func TestAccAWSRoute_basic(t *testing.T) {
 	var route ec2.Route
-
-	//aws creates a default route
-	testCheck := func(s *terraform.State) error {
-		if *route.DestinationCidrBlock != "10.3.0.0/16" {
-			return fmt.Errorf("Destination Cidr (Expected=%s, Actual=%s)\n", "10.3.0.0/16", *route.DestinationCidrBlock)
-		}
-
-		name := "aws_internet_gateway.foo"
-		gwres, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", name)
-		}
-
-		if *route.GatewayId != gwres.Primary.ID {
-			return fmt.Errorf("Internet Gateway Id (Expected=%s, Actual=%s)\n", gwres.Primary.ID, *route.GatewayId)
-		}
-
-		return nil
-	}
+	resourceName := "aws_route.test"
+	igwResourceName := "aws_internet_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cidr := "10.3.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteBasicConfig(),
+				Config: testAccAWSRouteConfigBasic(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.bar", &route),
-					testCheck,
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route, cidr),
 				),
 			},
 			{
-				ResourceName:      "aws_route.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -58,19 +42,20 @@ func TestAccAWSRoute_basic(t *testing.T) {
 
 func TestAccAWSRoute_disappears(t *testing.T) {
 	var route ec2.Route
+	resourceName := "aws_route.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cidr := "10.3.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteBasicConfig(),
+				Config: testAccAWSRouteConfigBasic(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.bar", &route),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute(), "aws_route.bar"),
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRoute(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -233,110 +218,41 @@ func TestAccAWSRoute_ipv6ToPeeringConnection(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute_changeRouteTable(t *testing.T) {
-	var before ec2.Route
-	var after ec2.Route
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRouteDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSRouteBasicConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.bar", &before),
-				),
-			},
-			{
-				Config: testAccAWSRouteNewRouteTable(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.bar", &after),
-				),
-			},
-			{
-				ResourceName:      "aws_route.bar",
-				ImportState:       true,
-				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSRoute_changeCidr(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
-
-	//aws creates a default route
-	testCheck := func(s *terraform.State) error {
-		if *route.DestinationCidrBlock != "10.3.0.0/16" {
-			return fmt.Errorf("Destination Cidr (Expected=%s, Actual=%s)\n", "10.3.0.0/16", *route.DestinationCidrBlock)
-		}
-
-		name := "aws_internet_gateway.foo"
-		gwres, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", name)
-		}
-
-		if *route.GatewayId != gwres.Primary.ID {
-			return fmt.Errorf("Internet Gateway Id (Expected=%s, Actual=%s)\n", gwres.Primary.ID, *route.GatewayId)
-		}
-
-		return nil
-	}
-
-	testCheckChange := func(s *terraform.State) error {
-		if *route.DestinationCidrBlock != "10.2.0.0/16" {
-			return fmt.Errorf("Destination Cidr (Expected=%s, Actual=%s)\n", "10.2.0.0/16", *route.DestinationCidrBlock)
-		}
-
-		name := "aws_internet_gateway.foo"
-		gwres, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", name)
-		}
-
-		if *route.GatewayId != gwres.Primary.ID {
-			return fmt.Errorf("Internet Gateway Id (Expected=%s, Actual=%s)\n", gwres.Primary.ID, *route.GatewayId)
-		}
-
-		if rtlen := len(routeTable.Routes); rtlen != 2 {
-			return fmt.Errorf("Route Table has too many routes (Expected=%d, Actual=%d)\n", rtlen, 2)
-		}
-
-		return nil
-	}
+	resourceName := "aws_route.test"
+	igwResourceName := "aws_internet_gateway.test"
+	rtResourceName := "aws_route_table.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cidr := "10.3.0.0/16"
+	changedCidr := "10.2.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteBasicConfig(),
+				Config: testAccAWSRouteConfigBasic(rName, cidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.bar", &route),
-					testCheck,
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route, cidr),
 				),
 			},
 			{
-				Config: testAccAWSRouteBasicConfigChangeCidr(),
+				Config: testAccAWSRouteConfigBasic(rName, changedCidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists("aws_route.bar", &route),
-					testAccCheckRouteTableExists("aws_route_table.foo", &routeTable),
-					testCheckChange,
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteInternetGatewayRoute(igwResourceName, &route, changedCidr),
+					testAccCheckRouteTableExists(rtResourceName, &routeTable),
+					testAccCheckAWSRouteNumberOfRoutes(&routeTable, 2),
 				),
 			},
 			{
-				ResourceName:      "aws_route.bar",
+				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -363,14 +279,14 @@ func TestAccAWSRoute_noopdiff(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteNoopChange(),
+				Config: testAccAWSRouteNoopChange,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists("aws_route.test", &route),
 					testCheck,
 				),
 			},
 			{
-				Config: testAccAWSRouteNoopChange(),
+				Config: testAccAWSRouteNoopChange,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists("aws_route.test", &route),
 					testAccCheckRouteTableExists("aws_route_table.test", &routeTable),
@@ -545,34 +461,71 @@ func testAccAWSRouteImportStateIdFunc(resourceName string) resource.ImportStateI
 	}
 }
 
-func testAccAWSRouteBasicConfig() string {
+func testAccCheckAWSRouteInternetGatewayRoute(n string, route *ec2.Route, cidr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(route.DestinationCidrBlock) != cidr {
+			return fmt.Errorf("Destination CIDR (Expected=%s, Actual=%s)\n", cidr, aws.StringValue(route.DestinationCidrBlock))
+		}
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s\n", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		if aws.StringValue(route.GatewayId) != rs.Primary.ID {
+			return fmt.Errorf("Internet Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, aws.StringValue(route.GatewayId))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSRouteNumberOfRoutes(routeTable *ec2.RouteTable, n int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len := len(routeTable.Routes); len != n {
+			return fmt.Errorf("Route Table has incorrect number of routes (Expected=%d, Actual=%d)\n", n, len)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSRouteConfigBasic(rName, cidr string) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-route-basic"
+    Name = %[1]q
   }
 }
 
-resource "aws_internet_gateway" "foo" {
-  vpc_id = aws_vpc.foo.id
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-route-basic"
+    Name = %[1]q
   }
 }
 
-resource "aws_route_table" "foo" {
-  vpc_id = aws_vpc.foo.id
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
-resource "aws_route" "bar" {
-  route_table_id         = aws_route_table.foo.id
-  destination_cidr_block = "10.3.0.0/16"
-  gateway_id             = aws_internet_gateway.foo.id
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = %[2]q
+  gateway_id             = aws_internet_gateway.test.id
 }
-`)
+`, rName, cidr)
 }
 
 func testAccAWSRouteConfigIpv6InternetGateway() string {
@@ -1003,40 +956,7 @@ resource "aws_route" "bar" {
 `)
 }
 
-func testAccAWSRouteBasicConfigChangeCidr() string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-route-change-cidr"
-  }
-}
-
-resource "aws_internet_gateway" "foo" {
-  vpc_id = aws_vpc.foo.id
-
-  tags = {
-    Name = "terraform-testacc-route-change-cidr"
-  }
-}
-
-resource "aws_route_table" "foo" {
-  vpc_id = aws_vpc.foo.id
-}
-
-resource "aws_route" "bar" {
-  route_table_id         = aws_route_table.foo.id
-  destination_cidr_block = "10.2.0.0/16"
-  gateway_id             = aws_internet_gateway.foo.id
-}
-`)
-}
-
-func testAccAWSRouteNoopChange() string {
-	return testAccAvailableEc2InstanceTypeForAvailabilityZone("aws_subnet.test.availability_zone", "t2.nano", "t3.nano") +
-		testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		fmt.Sprint(`
+var testAccAWSRouteNoopChange = fmt.Sprint(`
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -1080,7 +1000,6 @@ resource "aws_instance" "nat" {
   subnet_id     = aws_subnet.test.id
 }
 `)
-}
 
 func testAccAWSRouteWithVPCEndpoint() string {
 	return fmt.Sprintf(`
@@ -1123,68 +1042,10 @@ resource "aws_vpc_endpoint" "baz" {
 `)
 }
 
-func testAccAWSRouteNewRouteTable() string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "foo" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-route-basic"
-  }
-}
-
-resource "aws_vpc" "bar" {
-  cidr_block = "10.2.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-route-new-route-table"
-  }
-}
-
-resource "aws_internet_gateway" "foo" {
-  vpc_id = aws_vpc.foo.id
-
-  tags = {
-    Name = "terraform-testacc-route-basic"
-  }
-}
-
-resource "aws_internet_gateway" "bar" {
-  vpc_id = aws_vpc.bar.id
-
-  tags = {
-    Name = "terraform-testacc-route-new-route-table"
-  }
-}
-
-resource "aws_route_table" "foo" {
-  vpc_id = aws_vpc.foo.id
-
-  tags = {
-    Name = "terraform-testacc-route-basic"
-  }
-}
-
-resource "aws_route_table" "bar" {
-  vpc_id = aws_vpc.bar.id
-
-  tags = {
-    Name = "terraform-testacc-route-new-route-table"
-  }
-}
-
-resource "aws_route" "bar" {
-  route_table_id         = aws_route_table.bar.id
-  destination_cidr_block = "10.4.0.0/16"
-  gateway_id             = aws_internet_gateway.bar.id
-}
-`)
-}
-
 func testAccAWSRouteConfigTransitGatewayIDDestinatationCidrBlock() string {
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() +
 		fmt.Sprintf(`
-# IncorrectState: Transit Gateway is not available in availability zone usw2-az4	
+# IncorrectState: Transit Gateway is not available in availability zone usw2-az4
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -79,6 +79,30 @@ func TestAccAWSRoute_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_routeTableDisappears(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	rtResourceName := "aws_route_table.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.3.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4InternetGateway(rName, destinationCidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsRouteTable(), rtResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -943,6 +943,147 @@ func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_IPv6_Update_Target(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	vgwResourceName := "aws_vpn_gateway.test"
+	instanceResourceName := "aws_instance.test"
+	igwResourceName := "aws_internet_gateway.test"
+	eniResourceName := "aws_network_interface.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
+	eoigwResourceName := "aws_egress_only_internet_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "::/0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "instance_id", instanceResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "egress_only_gateway_id", eoigwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "egress_only_gateway_id", eoigwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "network_interface_id", eniResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateBlackhole),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1969,6 +2110,125 @@ resource "aws_route_table" "test" {
 resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = %[2]q
+
+  %[3]s = %[4]s.id
+}
+`, rName, destinationCidr, targetAttribute, targetValue))
+}
+
+func testAccAWSRouteConfigIpv6FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.current.names[0]
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  ipv6_address_count = 1
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "target" {
+  cidr_block                       = "10.0.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id      = aws_vpc.test.id
+  peer_vpc_id = aws_vpc.target.id
+  auto_accept = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_ipv6_cidr_block = %[2]q
 
   %[3]s = %[4]s.id
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+// IPv4 to Internet Gateway.
 func TestAccAWSRoute_basic(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
@@ -29,11 +29,21 @@ func TestAccAWSRoute_basic(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv4InternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteGatewayRoute(igwResourceName, &route),
 					testAccCheckRouteTableExists(rtResourceName, &routeTable),
 					testAccCheckAWSRouteNumberOfRoutes(&routeTable, 2),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -85,9 +95,19 @@ func TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv6EgressOnlyInternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteEgressOnlyInternetGatewayRoute(eoigwResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "egress_only_gateway_id", eoigwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -121,9 +141,19 @@ func TestAccAWSRoute_IPv6_To_InternetGateway(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv6InternetGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteGatewayRoute(igwResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -152,9 +182,19 @@ func TestAccAWSRoute_IPv6_To_Instance(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv6Instance(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteInstanceRoute(instanceResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -185,9 +225,19 @@ func TestAccAWSRoute_IPv6_To_NetworkInterface(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv6NetworkInterface(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteNetworkInterfaceRoute(eniResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -216,9 +266,19 @@ func TestAccAWSRoute_IPv6_To_VpcPeeringConnection(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv6VpcPeeringConnection(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteVpcPeeringConnectionRoute(pcxResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
 				),
 			},
 			{
@@ -249,11 +309,15 @@ func TestAccAWSRoute_IPv6_To_VpnGateway(t *testing.T) {
 					testAccCheckAWSRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
@@ -286,11 +350,15 @@ func TestAccAWSRoute_IPv4_To_VpnGateway(t *testing.T) {
 					testAccCheckAWSRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
@@ -321,9 +389,19 @@ func TestAccAWSRoute_IPv4_To_Instance(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv4Instance(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteInstanceRoute(instanceResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -354,9 +432,19 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv4NetworkInterface(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteNetworkInterfaceRoute(eniResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -385,9 +473,19 @@ func TestAccAWSRoute_IPv4_To_VpcPeeringConnection(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv4VpcPeeringConnection(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteVpcPeeringConnectionRoute(pcxResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
 				),
 			},
 			{
@@ -416,9 +514,19 @@ func TestAccAWSRoute_IPv4_To_NatGateway(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv4NatGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteNatGatewayRoute(ngwResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "nat_gateway_id", ngwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -477,10 +585,19 @@ func TestAccAWSRoute_IPv4_To_TransitGateway(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv4TransitGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteTransitGatewayRoute(tgwResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "instance_owner_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
 					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -597,139 +714,6 @@ func testAccAWSRouteImportStateIdFunc(resourceName string) resource.ImportStateI
 		}
 
 		return fmt.Sprintf("%s_%s", rs.Primary.Attributes["route_table_id"], destination), nil
-	}
-}
-
-func testAccCheckAWSRouteEgressOnlyInternetGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if gwId := aws.StringValue(route.EgressOnlyInternetGatewayId); gwId != rs.Primary.ID {
-			return fmt.Errorf("Egress Only Internet Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAWSRouteGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if gwId := aws.StringValue(route.GatewayId); gwId != rs.Primary.ID {
-			return fmt.Errorf("Internet Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAWSRouteInstanceRoute(n string, route *ec2.Route) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if gwId := aws.StringValue(route.InstanceId); gwId != rs.Primary.ID {
-			return fmt.Errorf("Instance ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAWSRouteNatGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if gwId := aws.StringValue(route.NatGatewayId); gwId != rs.Primary.ID {
-			return fmt.Errorf("NAT Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAWSRouteNetworkInterfaceRoute(n string, route *ec2.Route) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if gwId := aws.StringValue(route.NetworkInterfaceId); gwId != rs.Primary.ID {
-			return fmt.Errorf("Network Interface ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAWSRouteTransitGatewayRoute(n string, route *ec2.Route) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if gwId := aws.StringValue(route.TransitGatewayId); gwId != rs.Primary.ID {
-			return fmt.Errorf("Transit Gateway ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAWSRouteVpcPeeringConnectionRoute(n string, route *ec2.Route) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s\n", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if gwId := aws.StringValue(route.VpcPeeringConnectionId); gwId != rs.Primary.ID {
-			return fmt.Errorf("VPC Peering Connection ID (Expected=%s, Actual=%s)\n", rs.Primary.ID, gwId)
-		}
-
-		return nil
 	}
 }
 

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -525,6 +525,70 @@ func TestAccAWSRoute_IPv4_To_NetworkInterface_Attached(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	eni1ResourceName := "aws_network_interface.test1"
+	eni2ResourceName := "aws_network_interface.test2"
+	instanceResourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.3.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationCidr, eni1ResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eni1ResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationCidr, eni2ResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_prefix_list_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+					testAccCheckResourceAttrAccountID(resourceName, "instance_owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eni2ResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "origin", ec2.RouteOriginCreateRoute),
+					resource.TestCheckResourceAttr(resourceName, "state", ec2.RouteStateActive),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_IPv4_To_VpcPeeringConnection(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
@@ -1405,6 +1469,94 @@ resource "aws_route" "test" {
   depends_on = [aws_instance.test]
 }
 `, rName, destinationCidr))
+}
+
+func testAccAWSRouteConfigIpv4NetworkInterfaceTwoAttachments(rName, destinationCidr, targetResourceName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  exclude_zone_ids = ["usw2-az4"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.current.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test1" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test2" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+
+  network_interface {
+    device_index         = 0
+    network_interface_id = aws_network_interface.test1.id
+  }
+
+  network_interface {
+    device_index         = 1
+    network_interface_id = aws_network_interface.test2.id
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = %[2]q
+  network_interface_id   = %[3]s.id
+
+  # Wait for the ENI attachment.
+  depends_on = [aws_instance.test]
+}
+`, rName, destinationCidr, targetResourceName))
 }
 
 func testAccAWSRouteConfigIpv4VpcPeeringConnection(rName, destinationCidr string) string {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -404,6 +404,106 @@ func TestAccAWSRoute_IPv4_To_NatGateway(t *testing.T) {
 	})
 }
 
+/*
+func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	vgwResourceName := "aws_vpn_gateway.test"
+	instanceResourceName := "aws_instance.test"
+	igwResourceName := "aws_internet_gateway.test"
+	eniResourceName := "aws_network_interface.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
+	ngwResourceName := "aws_nat_gateway.test"
+	//tgwResourceName := "aws_ec2_transit_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.3.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteGatewayRoute(vgwResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "instance_id", instanceResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteInstanceRoute(instanceResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteGatewayRoute(igwResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "network_interface_id", eniResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteNetworkInterfaceRoute(eniResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteVpcPeeringConnectionRoute(pcxResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
+				),
+			},
+			{
+				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "nat_gateway_id", ngwResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteNatGatewayRoute(ngwResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "nat_gateway_id", ngwResourceName, "id"),
+				),
+			},
+			// {
+			// 	Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "transit_gateway_id", tgwResourceName),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		testAccCheckAWSRouteExists(resourceName, &route),
+			// 		testAccCheckAWSRouteTransitGatewayRoute(tgwResourceName, &route),
+			// 		resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+			// 		resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+			//      resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
+			// 	),
+			// },
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+*/
+
 func TestAccAWSRoute_DoesNotCrashWithVpcEndpoint(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
@@ -437,7 +537,7 @@ func TestAccAWSRoute_DoesNotCrashWithVpcEndpoint(t *testing.T) {
 func TestAccAWSRoute_IPv4_To_TransitGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
-	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
+	tgwResourceName := "aws_ec2_transit_gateway.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	destinationCidr := "10.3.0.0/16"
 
@@ -450,10 +550,10 @@ func TestAccAWSRoute_IPv4_To_TransitGateway(t *testing.T) {
 				Config: testAccAWSRouteConfigIpv4TransitGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteTransitGatewayRoute(transitGatewayResourceName, &route),
+					testAccCheckAWSRouteTransitGatewayRoute(tgwResourceName, &route),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
 				),
 			},
 			{
@@ -834,7 +934,6 @@ resource "aws_network_interface" "test" {
   }
 }
 
-
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
 
@@ -917,16 +1016,7 @@ resource "aws_route" "test" {
 
 func testAccAWSRouteConfigIpv6VpcPeeringConnection(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "source" {
-  cidr_block                       = "10.0.0.0/16"
-  assign_generated_ipv6_cidr_block = true
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpc" "target" {
+resource "aws_vpc" "test" {
   cidr_block                       = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
@@ -935,8 +1025,17 @@ resource "aws_vpc" "target" {
   }
 }
 
+resource "aws_vpc" "target" {
+  cidr_block                       = "10.0.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
 resource "aws_vpc_peering_connection" "test" {
-  vpc_id      = aws_vpc.source.id
+  vpc_id      = aws_vpc.test.id
   peer_vpc_id = aws_vpc.target.id
   auto_accept = true
 
@@ -946,7 +1045,7 @@ resource "aws_vpc_peering_connection" "test" {
 }
 
 resource "aws_route_table" "test" {
-  vpc_id = aws_vpc.source.id
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
@@ -1055,7 +1154,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "10.1.0.0/16"
 
   tags = {
     Name = %[1]q
@@ -1064,7 +1163,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = "10.0.0.0/24"
+  cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
 
   tags = {
@@ -1254,7 +1353,6 @@ resource "aws_network_interface" "test" {
   }
 }
 
-
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
 
@@ -1273,15 +1371,7 @@ resource "aws_route" "test" {
 
 func testAccAWSRouteConfigIpv4VpcPeeringConnection(rName, destinationCidr string) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "source" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpc" "target" {
+resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
@@ -1289,8 +1379,16 @@ resource "aws_vpc" "target" {
   }
 }
 
+resource "aws_vpc" "target" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
 resource "aws_vpc_peering_connection" "test" {
-  vpc_id      = aws_vpc.source.id
+  vpc_id      = aws_vpc.test.id
   peer_vpc_id = aws_vpc.target.id
   auto_accept = true
 
@@ -1300,7 +1398,7 @@ resource "aws_vpc_peering_connection" "test" {
 }
 
 resource "aws_route_table" "test" {
-  vpc_id = aws_vpc.source.id
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
@@ -1378,3 +1476,146 @@ resource "aws_route" "test" {
 }
 `, rName, destinationCidr)
 }
+
+/*
+func testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.current.names[0]
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+// resource "aws_ec2_transit_gateway" "test" {
+//   tags = {
+//     Name = %[1]q
+//   }
+// }
+
+// resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
+//   subnet_ids         = [aws_subnet.test.id]
+//   transit_gateway_id = aws_ec2_transit_gateway.test.id
+//   vpc_id             = aws_vpc.test.id
+
+//   tags = {
+//     Name = %[1]q
+//   }
+// }
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "target" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id      = aws_vpc.test.id
+  peer_vpc_id = aws_vpc.target.id
+  auto_accept = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_eip" "test" {
+  vpc = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_nat_gateway" "test" {
+  allocation_id = aws_eip.test.id
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  depends_on = [aws_internet_gateway.test]
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = %[2]q
+
+  %[3]s = %[4]s.id
+}
+`, rName, destinationCidr, targetAttribute, targetValue))
+}
+*/

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -79,7 +79,7 @@ func TestGetRouteDestinationAndTargetAttributeKeysFromMap(t *testing.T) {
 				"destination_cidr_block": {"0.0.0.0/0", true},
 				"egress_only_gateway_id": {"eoigw-0000000000000000", true},
 			},
-			expectedErr: regexp.MustCompile(`"destination_cidr_block" not allowed for "egress_only_gateway_id" target`),
+			expectedErr: regexp.MustCompile(`"destination_cidr_block" not supported for "egress_only_gateway_id" target`),
 		},
 		{
 			m: map[string]struct {
@@ -89,7 +89,7 @@ func TestGetRouteDestinationAndTargetAttributeKeysFromMap(t *testing.T) {
 				"destination_ipv6_cidr_block": {"::/0", true},
 				"nat_gateway_id":              {"ngw-0000000000000000", true},
 			},
-			expectedErr: regexp.MustCompile(`"destination_ipv6_cidr_block" not allowed for "nat_gateway_id" target`),
+			expectedErr: regexp.MustCompile(`"destination_ipv6_cidr_block" not supported for "nat_gateway_id" target`),
 		},
 	}
 

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -231,15 +231,12 @@ func TestAccAWSRoute_IPv6_To_VpcPeeringConnection(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute_IPv4_To_InternetGateway(t *testing.T) {
+func TestAccAWSRoute_IPv4_To_VpnGateway(t *testing.T) {
 	var route ec2.Route
-	var routeTable ec2.RouteTable
 	resourceName := "aws_route.test"
-	igwResourceName := "aws_internet_gateway.test"
-	rtResourceName := "aws_route_table.test"
+	vgwResourceName := "aws_vpn_gateway.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	destinationCidr := "10.3.0.0/16"
-	changedDestinationCidr := "10.2.0.0/16"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -247,25 +244,18 @@ func TestAccAWSRoute_IPv4_To_InternetGateway(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRouteConfigIpv4InternetGateway(rName, destinationCidr),
+				Config: testAccAWSRouteConfigIpv4VpnGateway(rName, destinationCidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteGatewayRoute(igwResourceName, &route),
-					testAccCheckRouteTableExists(rtResourceName, &routeTable),
-					testAccCheckAWSRouteNumberOfRoutes(&routeTable, 2),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
 					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-				),
-			},
-			{
-				Config: testAccAWSRouteConfigIpv4InternetGateway(rName, changedDestinationCidr),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteGatewayRoute(igwResourceName, &route),
-					testAccCheckRouteTableExists(rtResourceName, &routeTable),
-					testAccCheckAWSRouteNumberOfRoutes(&routeTable, 2),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", changedDestinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
 				),
 			},
 			{
@@ -403,106 +393,6 @@ func TestAccAWSRoute_IPv4_To_NatGateway(t *testing.T) {
 		},
 	})
 }
-
-/*
-func TestAccAWSRoute_IPv4_Update_Target(t *testing.T) {
-	var route ec2.Route
-	resourceName := "aws_route.test"
-	vgwResourceName := "aws_vpn_gateway.test"
-	instanceResourceName := "aws_instance.test"
-	igwResourceName := "aws_internet_gateway.test"
-	eniResourceName := "aws_network_interface.test"
-	pcxResourceName := "aws_vpc_peering_connection.test"
-	ngwResourceName := "aws_nat_gateway.test"
-	//tgwResourceName := "aws_ec2_transit_gateway.test"
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-	destinationCidr := "10.3.0.0/16"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRouteDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", vgwResourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteGatewayRoute(vgwResourceName, &route),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
-				),
-			},
-			{
-				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "instance_id", instanceResourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteInstanceRoute(instanceResourceName, &route),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "instance_id", instanceResourceName, "id"),
-				),
-			},
-			{
-				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "gateway_id", igwResourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteGatewayRoute(igwResourceName, &route),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", igwResourceName, "id"),
-				),
-			},
-			{
-				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "network_interface_id", eniResourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteNetworkInterfaceRoute(eniResourceName, &route),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", eniResourceName, "id"),
-				),
-			},
-			{
-				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "vpc_peering_connection_id", pcxResourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteVpcPeeringConnectionRoute(pcxResourceName, &route),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "vpc_peering_connection_id", pcxResourceName, "id"),
-				),
-			},
-			{
-				Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "nat_gateway_id", ngwResourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRouteExists(resourceName, &route),
-					testAccCheckAWSRouteNatGatewayRoute(ngwResourceName, &route),
-					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
-					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttrPair(resourceName, "nat_gateway_id", ngwResourceName, "id"),
-				),
-			},
-			// {
-			// 	Config: testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, "transit_gateway_id", tgwResourceName),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		testAccCheckAWSRouteExists(resourceName, &route),
-			// 		testAccCheckAWSRouteTransitGatewayRoute(tgwResourceName, &route),
-			// 		resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
-			// 		resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
-			//      resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", tgwResourceName, "id"),
-			// 	),
-			// },
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-*/
 
 func TestAccAWSRoute_DoesNotCrashWithVpcEndpoint(t *testing.T) {
 	var route ec2.Route
@@ -1477,24 +1367,8 @@ resource "aws_route" "test" {
 `, rName, destinationCidr)
 }
 
-/*
-func testAccAWSRouteConfigIpv4FlexiTarget(rName, destinationCidr, targetAttribute, targetValue string) string {
-	return composeConfig(
-		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
-		testAccAvailableEc2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		fmt.Sprintf(`
-data "aws_availability_zones" "current" {
-  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
-  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
-  blacklisted_zone_ids = ["usw2-az4"]
-  state                = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+func testAccAWSRouteConfigIpv4VpnGateway(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -1511,97 +1385,6 @@ resource "aws_vpn_gateway" "test" {
   }
 }
 
-resource "aws_internet_gateway" "test" {
-  vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  cidr_block        = "10.1.1.0/24"
-  vpc_id            = aws_vpc.test.id
-  availability_zone = data.aws_availability_zones.current.names[0]
-
-  map_public_ip_on_launch = true
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
-  subnet_id     = aws_subnet.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-// resource "aws_ec2_transit_gateway" "test" {
-//   tags = {
-//     Name = %[1]q
-//   }
-// }
-
-// resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
-//   subnet_ids         = [aws_subnet.test.id]
-//   transit_gateway_id = aws_ec2_transit_gateway.test.id
-//   vpc_id             = aws_vpc.test.id
-
-//   tags = {
-//     Name = %[1]q
-//   }
-// }
-
-resource "aws_network_interface" "test" {
-  subnet_id = aws_subnet.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpc" "target" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpc_peering_connection" "test" {
-  vpc_id      = aws_vpc.test.id
-  peer_vpc_id = aws_vpc.target.id
-  auto_accept = true
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_eip" "test" {
-  vpc = true
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_nat_gateway" "test" {
-  allocation_id = aws_eip.test.id
-  subnet_id     = aws_subnet.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-
-  depends_on = [aws_internet_gateway.test]
-}
-
 resource "aws_route_table" "test" {
   vpc_id = aws_vpc.test.id
 
@@ -1613,9 +1396,7 @@ resource "aws_route_table" "test" {
 resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = %[2]q
-
-  %[3]s = %[4]s.id
+  gateway_id             = aws_vpn_gateway.test.id
 }
-`, rName, destinationCidr, targetAttribute, targetValue))
+`, rName, destinationCidr)
 }
-*/

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -309,6 +309,39 @@ func TestAccAWSRoute_IPv4_To_Instance(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_IPv4_To_NetworkInterface(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	eniResourceName := "aws_network_interface.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "10.3.0.0/16"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv4NetworkInterface(rName, destinationCidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					testAccCheckAWSRouteNetworkInterfaceRoute(eniResourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_DoesNotCrashWithVpcEndpoint(t *testing.T) {
 	var route ec2.Route
 	var routeTable ec2.RouteTable
@@ -1094,9 +1127,65 @@ resource "aws_route_table" "test" {
 }
 
 resource "aws_route" "test" {
-  route_table_id              = aws_route_table.test.id
-  destination_cidr_block      = %[2]q
-  instance_id                 = aws_instance.test.id
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = %[2]q
+  instance_id            = aws_instance.test.id
 }
 `, rName, destinationCidr))
+}
+
+func testAccAWSRouteConfigIpv4NetworkInterface(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "current" {
+  # Exclude usw2-az4 (us-west-2d) as it has limited instance types.
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.current.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = %[2]q
+  network_interface_id   = aws_network_interface.test.id
+}
+`, rName, destinationCidr)
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -231,6 +231,43 @@ func TestAccAWSRoute_IPv6_To_VpcPeeringConnection(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_IPv6_To_VpnGateway(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	vgwResourceName := "aws_vpn_gateway.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	destinationCidr := "::/0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteConfigIpv6VpnGateway(rName, destinationCidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttr(resourceName, "destination_cidr_block", ""),
+					resource.TestCheckResourceAttr(resourceName, "destination_ipv6_cidr_block", destinationCidr),
+					resource.TestCheckResourceAttr(resourceName, "egress_only_gateway_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "gateway_id", vgwResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "nat_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "network_interface_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpc_peering_connection_id", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_IPv4_To_VpnGateway(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
@@ -1397,6 +1434,41 @@ resource "aws_route" "test" {
   route_table_id         = aws_route_table.test.id
   destination_cidr_block = %[2]q
   gateway_id             = aws_vpn_gateway.test.id
+}
+`, rName, destinationCidr)
+}
+
+func testAccAWSRouteConfigIpv6VpnGateway(rName, destinationCidr string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route" "test" {
+  route_table_id              = aws_route_table.test.id
+  destination_ipv6_cidr_block = %[2]q
+  gateway_id                  = aws_vpn_gateway.test.id
 }
 `, rName, destinationCidr)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -815,6 +815,7 @@ func validateIpv6CIDRBlock(cidr string) error {
 	return nil
 }
 
+// TODO Replace with tfnet.CIDRBlocksEqual.
 // cidrBlocksEqual returns whether or not two CIDR blocks are equal:
 // - Both CIDR blocks parse to an IP address and network
 // - The string representation of the IP addresses are equal


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/684.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/2270.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/11455.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/12631.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13302.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/13079.

Replaces https://github.com/terraform-providers/terraform-provider-aws/pull/14050 and https://github.com/terraform-providers/terraform-provider-aws/pull/14531.

Uses additional tests cases from https://github.com/terraform-providers/terraform-provider-aws/pull/14014.

Includes functionality from https://github.com/terraform-providers/terraform-provider-aws/pull/12062.

I will address some similar problems for the `aws_route_table` (and `aws_default_route_table`) resources in a separate PR.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_route: Correctly handle updates to the route target attributes (`egress_only_gateway_id`, `gateway_id`, `instance_id`, `nat_gateway_id`, `network_interface_id`, `network_interface_id`, `transit_gateway_id`, `vpc_peering_connection_id`)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSRoute_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSRoute_ -timeout 120m
=== RUN   TestAccAWSRoute_basic
=== PAUSE TestAccAWSRoute_basic
=== RUN   TestAccAWSRoute_disappears
=== PAUSE TestAccAWSRoute_disappears
=== RUN   TestAccAWSRoute_routeTableDisappears
=== PAUSE TestAccAWSRoute_routeTableDisappears
=== RUN   TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
=== PAUSE TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
=== RUN   TestAccAWSRoute_IPv6_To_InternetGateway
=== PAUSE TestAccAWSRoute_IPv6_To_InternetGateway
=== RUN   TestAccAWSRoute_IPv6_To_Instance
=== PAUSE TestAccAWSRoute_IPv6_To_Instance
=== RUN   TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRoute_IPv6_To_VpcPeeringConnection
=== PAUSE TestAccAWSRoute_IPv6_To_VpcPeeringConnection
=== RUN   TestAccAWSRoute_IPv6_To_VpnGateway
=== PAUSE TestAccAWSRoute_IPv6_To_VpnGateway
=== RUN   TestAccAWSRoute_IPv4_To_VpnGateway
=== PAUSE TestAccAWSRoute_IPv4_To_VpnGateway
=== RUN   TestAccAWSRoute_IPv4_To_Instance
=== PAUSE TestAccAWSRoute_IPv4_To_Instance
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
=== RUN   TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
=== PAUSE TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
=== RUN   TestAccAWSRoute_IPv4_To_VpcPeeringConnection
=== PAUSE TestAccAWSRoute_IPv4_To_VpcPeeringConnection
=== RUN   TestAccAWSRoute_IPv4_To_NatGateway
=== PAUSE TestAccAWSRoute_IPv4_To_NatGateway
=== RUN   TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
=== PAUSE TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
=== RUN   TestAccAWSRoute_IPv4_To_TransitGateway
=== PAUSE TestAccAWSRoute_IPv4_To_TransitGateway
=== RUN   TestAccAWSRoute_ConditionalCidrBlock
=== PAUSE TestAccAWSRoute_ConditionalCidrBlock
=== RUN   TestAccAWSRoute_IPv4_Update_Target
=== PAUSE TestAccAWSRoute_IPv4_Update_Target
=== RUN   TestAccAWSRoute_IPv6_Update_Target
=== PAUSE TestAccAWSRoute_IPv6_Update_Target
=== RUN   TestAccAWSRoute_LocalRoute
=== PAUSE TestAccAWSRoute_LocalRoute
=== CONT  TestAccAWSRoute_basic
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_Attached
--- PASS: TestAccAWSRoute_basic (39.45s)
=== CONT  TestAccAWSRoute_LocalRoute
--- PASS: TestAccAWSRoute_LocalRoute (25.87s)
=== CONT  TestAccAWSRoute_IPv6_Update_Target
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_Attached (95.47s)
=== CONT  TestAccAWSRoute_IPv4_Update_Target
--- PASS: TestAccAWSRoute_IPv6_Update_Target (230.90s)
=== CONT  TestAccAWSRoute_ConditionalCidrBlock
--- PASS: TestAccAWSRoute_ConditionalCidrBlock (59.53s)
=== CONT  TestAccAWSRoute_IPv4_To_TransitGateway
--- PASS: TestAccAWSRoute_IPv4_Update_Target (444.43s)
=== CONT  TestAccAWSRoute_DoesNotCrashWithVpcEndpoint
--- PASS: TestAccAWSRoute_DoesNotCrashWithVpcEndpoint (47.08s)
=== CONT  TestAccAWSRoute_IPv4_To_NatGateway
--- PASS: TestAccAWSRoute_IPv4_To_TransitGateway (310.93s)
=== CONT  TestAccAWSRoute_IPv4_To_VpcPeeringConnection
--- PASS: TestAccAWSRoute_IPv4_To_VpcPeeringConnection (30.09s)
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments
--- PASS: TestAccAWSRoute_IPv4_To_NatGateway (182.50s)
=== CONT  TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached
--- PASS: TestAccAWSRoute_IPv6_To_NetworkInterface_Unattached (33.65s)
=== CONT  TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_Unattached (32.16s)
=== CONT  TestAccAWSRoute_IPv4_To_Instance
--- PASS: TestAccAWSRoute_IPv4_To_Instance (100.80s)
=== CONT  TestAccAWSRoute_IPv4_To_VpnGateway
--- PASS: TestAccAWSRoute_IPv4_To_VpnGateway (54.04s)
=== CONT  TestAccAWSRoute_IPv6_To_VpnGateway
--- PASS: TestAccAWSRoute_IPv6_To_VpnGateway (46.14s)
=== CONT  TestAccAWSRoute_IPv6_To_VpcPeeringConnection
--- PASS: TestAccAWSRoute_IPv4_To_NetworkInterface_TwoAttachments (342.60s)
=== CONT  TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway
--- PASS: TestAccAWSRoute_IPv6_To_VpcPeeringConnection (30.27s)
=== CONT  TestAccAWSRoute_IPv6_To_Instance
--- PASS: TestAccAWSRoute_IPv6_To_EgressOnlyInternetGateway (45.15s)
=== CONT  TestAccAWSRoute_IPv6_To_InternetGateway
--- PASS: TestAccAWSRoute_IPv6_To_InternetGateway (38.80s)
=== CONT  TestAccAWSRoute_routeTableDisappears
    resource_aws_route_test.go:91: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSRoute_routeTableDisappears (36.80s)
=== CONT  TestAccAWSRoute_disappears
    resource_aws_route_test.go:67: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSRoute_disappears (36.21s)
--- PASS: TestAccAWSRoute_IPv6_To_Instance (134.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1201.075s
```
