### PR TITLE
missing min_adjustment_magnitude argument in the autoscaling_policy docs

### DIFF
--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 The following argument is only available to "SimpleScaling" and "StepScaling" type policies:
 
-* `min_adjustment_magnitude` - (Optional) Minimum number of instances to scale when `adjustment_type` is set to "PercentChangeInCapacity".
+* `min_adjustment_magnitude` - (Optional) Minimum value to scale by when `adjustment_type` is set to `PercentChangeInCapacity`.
 
 The following arguments are only available to "SimpleScaling" type policies:
 

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -49,6 +49,10 @@ The following arguments are supported:
 * `policy_type` - (Optional) The policy type, either "SimpleScaling", "StepScaling" or "TargetTrackingScaling". If this value isn't provided, AWS will default to "SimpleScaling."
 * `estimated_instance_warmup` - (Optional) The estimated time, in seconds, until a newly launched instance will contribute CloudWatch metrics. Without a value, AWS will default to the group's specified cooldown period.
 
+The following argument is only available to "SimpleScaling" and "StepScaling" type policies:
+
+* `min_adjustment_magnitude` - (Optional) Minimum number of instances to scale when `adjustment_type` is set to "PercentChangeInCapacity".
+
 The following arguments are only available to "SimpleScaling" type policies:
 
 * `cooldown` - (Optional) The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

While working with autoscaling policies, I noticed the docs were missing the reference to the [min_adjustment_magnitude](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_autoscaling_policy.go#L69) argument.

https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html

> With PercentChangeInCapacity, you can also specify the minimum number of instances to scale using the MinAdjustmentMagnitude parameter