### PR TITLE
r/glue_connection - Add support network connection type + disappears test

### DIFF
--- a/aws/resource_aws_glue_connection.go
+++ b/aws/resource_aws_glue_connection.go
@@ -40,15 +40,10 @@ func resourceAwsGlueConnection() *schema.Resource {
 				Elem:      &schema.Schema{Type: schema.TypeString},
 			},
 			"connection_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  glue.ConnectionTypeJdbc,
-				ValidateFunc: validation.StringInSlice([]string{
-					glue.ConnectionTypeJdbc,
-					glue.ConnectionTypeSftp,
-					glue.ConnectionTypeMongodb,
-					glue.ConnectionTypeKafka,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      glue.ConnectionTypeJdbc,
+				ValidateFunc: validation.StringInSlice(glue.ConnectionType_Values(), false),
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -76,7 +71,7 @@ func resourceAwsGlueConnection() *schema.Resource {
 							Optional: true,
 						},
 						"security_group_id_list": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -109,7 +104,7 @@ func resourceAwsGlueConnectionCreate(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Creating Glue Connection: %s", input)
 	_, err := conn.CreateConnection(input)
 	if err != nil {
-		return fmt.Errorf("error creating Glue Connection (%s): %s", name, err)
+		return fmt.Errorf("error creating Glue Connection (%s): %w", name, err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", catalogID, name))
@@ -138,7 +133,7 @@ func resourceAwsGlueConnectionRead(d *schema.ResourceData, meta interface{}) err
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading Glue Connection (%s): %s", d.Id(), err)
+		return fmt.Errorf("error reading Glue Connection (%s): %w", d.Id(), err)
 	}
 
 	connection := output.Connection
@@ -159,16 +154,16 @@ func resourceAwsGlueConnectionRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("catalog_id", catalogID)
 	if err := d.Set("connection_properties", aws.StringValueMap(connection.ConnectionProperties)); err != nil {
-		return fmt.Errorf("error setting connection_properties: %s", err)
+		return fmt.Errorf("error setting connection_properties: %w", err)
 	}
 	d.Set("connection_type", connection.ConnectionType)
 	d.Set("description", connection.Description)
 	if err := d.Set("match_criteria", flattenStringList(connection.MatchCriteria)); err != nil {
-		return fmt.Errorf("error setting match_criteria: %s", err)
+		return fmt.Errorf("error setting match_criteria: %w", err)
 	}
 	d.Set("name", connection.Name)
 	if err := d.Set("physical_connection_requirements", flattenGluePhysicalConnectionRequirements(connection.PhysicalConnectionRequirements)); err != nil {
-		return fmt.Errorf("error setting physical_connection_requirements: %s", err)
+		return fmt.Errorf("error setting physical_connection_requirements: %w", err)
 	}
 
 	return nil
@@ -191,7 +186,7 @@ func resourceAwsGlueConnectionUpdate(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Updating Glue Connection: %s", input)
 	_, err = conn.UpdateConnection(input)
 	if err != nil {
-		return fmt.Errorf("error updating Glue Connection (%s): %s", d.Id(), err)
+		return fmt.Errorf("error updating Glue Connection (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -208,7 +203,7 @@ func resourceAwsGlueConnectionDelete(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Deleting Glue Connection: %s", d.Id())
 	err = deleteGlueConnection(conn, catalogID, connectionName)
 	if err != nil {
-		return fmt.Errorf("error deleting Glue Connection (%s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting Glue Connection (%s): %w", d.Id(), err)
 	}
 
 	return nil
@@ -276,7 +271,7 @@ func expandGluePhysicalConnectionRequirements(m map[string]interface{}) *glue.Ph
 	}
 
 	if v, ok := m["security_group_id_list"]; ok {
-		physicalConnectionRequirements.SecurityGroupIdList = expandStringList(v.([]interface{}))
+		physicalConnectionRequirements.SecurityGroupIdList = expandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := m["subnet_id"]; ok {
@@ -293,7 +288,7 @@ func flattenGluePhysicalConnectionRequirements(physicalConnectionRequirements *g
 
 	m := map[string]interface{}{
 		"availability_zone":      aws.StringValue(physicalConnectionRequirements.AvailabilityZone),
-		"security_group_id_list": flattenStringList(physicalConnectionRequirements.SecurityGroupIdList),
+		"security_group_id_list": flattenStringSet(physicalConnectionRequirements.SecurityGroupIdList),
 		"subnet_id":              aws.StringValue(physicalConnectionRequirements.SubnetId),
 	}
 

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -273,6 +273,29 @@ func TestAccAWSGlueConnection_PhysicalConnectionRequirements(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueConnection_disappears(t *testing.T) {
+	var connection glue.Connection
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_glue_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueConnectionConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueConnectionExists(resourceName, &connection),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsGlueConnection(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSGlueConnectionExists(resourceName string, connection *glue.Connection) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `catalog_id` – (Optional) The ID of the Data Catalog in which to create the connection. If none is supplied, the AWS account ID is used by default.
 * `connection_properties` – (Required) A map of key-value pairs used as parameters for this connection.
-* `connection_type` – (Optional) The type of the connection. Supported are: `JDBC`, `MONGODB`, `KAFKA`. Defaults to `JBDC`.
+* `connection_type` – (Optional) The type of the connection. Supported are: `JDBC`, `MONGODB`, `KAFKA`, `NETWORK`. Defaults to `JBDC`.
 * `description` – (Optional) Description of the connection.
 * `match_criteria` – (Optional) A list of criteria that can be used in selecting this connection.
 * `name` – (Required) The name of the connection.

--- a/website/docs/r/glue_connection.html.markdown
+++ b/website/docs/r/glue_connection.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `catalog_id` – (Optional) The ID of the Data Catalog in which to create the connection. If none is supplied, the AWS account ID is used by default.
 * `connection_properties` – (Required) A map of key-value pairs used as parameters for this connection.
-* `connection_type` – (Optional) The type of the connection. Supported are: `JDBC`, `MONGODB`, `KAFKA`, `NETWORK`. Defaults to `JBDC`.
+* `connection_type` – (Optional) The type of the connection. Supported are: `JDBC`, `MONGODB`, `KAFKA`, and `NETWORK`. Defaults to `JBDC`.
 * `description` – (Optional) Description of the connection.
 * `match_criteria` – (Optional) A list of criteria that can be used in selecting this connection.
 * `name` – (Required) The name of the connection.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14769
Relates #13826
Relates #14601

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_connection - support `NETWORK` connection type
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueConnection_'
--- PASS: TestAccAWSGlueConnection_basic (66.82s)
--- PASS: TestAccAWSGlueConnection_MongoDB (56.21s)
--- PASS: TestAccAWSGlueConnection_Kafka (50.82s)
--- PASS: TestAccAWSGlueConnection_Description (82.73s)
--- PASS: TestAccAWSGlueConnection_MatchCriteria (120.87s)
--- PASS: TestAccAWSGlueConnection_PhysicalConnectionRequirements (571.28s)
--- PASS: TestAccAWSGlueConnection_disappears (39.92s)
```
