### PR TITLE
r/glue_crawler - add support for `scan_all` and `scan_rate` arguments for ddb targets

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -127,6 +127,17 @@ func resourceAwsGlueCrawler() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"scan_all": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"scan_rate": {
+							Type:         schema.TypeFloat,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.FloatBetween(0.1, 1.5),
+						},
 					},
 				},
 			},
@@ -373,7 +384,12 @@ func expandGlueDynamoDBTargets(targets []interface{}) []*glue.DynamoDBTarget {
 
 func expandGlueDynamoDBTarget(cfg map[string]interface{}) *glue.DynamoDBTarget {
 	target := &glue.DynamoDBTarget{
-		Path: aws.String(cfg["path"].(string)),
+		Path:    aws.String(cfg["path"].(string)),
+		ScanAll: aws.Bool(cfg["scan_all"].(bool)),
+	}
+
+	if v, ok := cfg["scan_rate"].(float64); ok {
+		target.ScanRate = aws.Float64(v)
 	}
 
 	return target
@@ -615,6 +631,8 @@ func flattenGlueDynamoDBTargets(dynamodbTargets []*glue.DynamoDBTarget) []map[st
 	for _, dynamodbTarget := range dynamodbTargets {
 		attrs := make(map[string]interface{})
 		attrs["path"] = aws.StringValue(dynamodbTarget.Path)
+		attrs["scan_all"] = aws.BoolValue(dynamodbTarget.ScanAll)
+		attrs["scan_rate"] = aws.Float64Value(dynamodbTarget.ScanRate)
 
 		result = append(result, attrs)
 	}

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -135,7 +135,6 @@ func resourceAwsGlueCrawler() *schema.Resource {
 						"scan_rate": {
 							Type:         schema.TypeFloat,
 							Optional:     true,
-							Computed:     true,
 							ValidateFunc: validation.FloatBetween(0.1, 1.5),
 						},
 					},
@@ -388,7 +387,7 @@ func expandGlueDynamoDBTarget(cfg map[string]interface{}) *glue.DynamoDBTarget {
 		ScanAll: aws.Bool(cfg["scan_all"].(bool)),
 	}
 
-	if v, ok := cfg["scan_rate"].(float64); ok {
+	if v, ok := cfg["scan_rate"].(float64); ok && v != 0 {
 		target.ScanRate = aws.Float64(v)
 	}
 

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -197,7 +197,7 @@ func TestAccAWSGlueCrawler_DynamodbTarget_scanRate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.path", "table1"),
-					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.scan_rate", "0.5"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.scan_rate", "1.5"),
 				),
 			},
 			{
@@ -1351,8 +1351,8 @@ resource "aws_glue_crawler" "test" {
   role          = aws_iam_role.test.name
 
   dynamodb_target {
-    path     = %[2]q
-    scan_all = %[3]f
+    path      = %[2]q
+    scan_rate = %[3]g
   }
 }
 `, rName, path, scanRate)

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -169,6 +169,49 @@ func TestAccAWSGlueCrawler_DynamodbTarget_scanAll(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCrawler_DynamodbTarget_scanRate(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerConfig_DynamodbTargetScanRate(rName, "table1", 0.5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.path", "table1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.scan_rate", "0.5"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccGlueCrawlerConfig_DynamodbTargetScanRate(rName, "table1", 1.5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.path", "table1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.scan_rate", "0.5"),
+				),
+			},
+			{
+				Config: testAccGlueCrawlerConfig_DynamodbTargetScanRate(rName, "table1", 0.5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.path", "table1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.scan_rate", "0.5"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueCrawler_JdbcTarget(t *testing.T) {
 	var crawler glue.Crawler
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1291,7 +1334,28 @@ resource "aws_glue_crawler" "test" {
     scan_all = %[3]t
   }
 }
-`, rName, path)
+`, rName, path, scanAll)
+}
+
+func testAccGlueCrawlerConfig_DynamodbTargetScanRate(rName, path string, scanRate float64) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
+
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
+
+  dynamodb_target {
+    path     = %[2]q
+    scan_all = %[3]f
+  }
+}
+`, rName, path, scanRate)
 }
 
 func testAccGlueCrawlerConfig_JdbcTarget(rName, path string) string {

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -108,6 +108,8 @@ The following arguments are supported:
 ### dynamodb_target Argument Reference
 
 * `path` - (Required) The name of the DynamoDB table to crawl.
+* `scan_all` - (Optional) Indicates whether to scan all the records, or to sample rows from the table. Scanning all the records can take a long time when the table is not a high throughput table.  defaults to `true`.
+* `scan_rate` - (Optional) The percentage of the configured read capacity units to use by the AWS Glue crawler. The valid values are null or a value between 0.1 to 1.5. 
 
 ### jdbc_target Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_glue_crawler - add support for `scan_all` and `scan_rate` arguments for ddb targets
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCrawler_DynamodbTarget'
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget_scanAll (252.19s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget_scanRate (302.13s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (130.64s)
```
