### PR TITLE
fix: remove 's' for consistancy between aws_waf_ipset and aws_wafregi…

### DIFF
--- a/aws/resource_aws_waf_ipset.go
+++ b/aws/resource_aws_waf_ipset.go
@@ -34,7 +34,7 @@ func resourceAwsWafIPSet() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ip_set_descriptors": {
+			"ip_set_descriptor": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -76,7 +76,7 @@ func resourceAwsWafIPSetCreate(d *schema.ResourceData, meta interface{}) error {
 	resp := out.(*waf.CreateIPSetOutput)
 	d.SetId(*resp.IPSet.IPSetId)
 
-	if v, ok := d.GetOk("ip_set_descriptors"); ok && v.(*schema.Set).Len() > 0 {
+	if v, ok := d.GetOk("ip_set_descriptor"); ok && v.(*schema.Set).Len() > 0 {
 
 		err := updateWafIpSetDescriptors(d.Id(), nil, v.(*schema.Set).List(), conn)
 		if err != nil {
@@ -115,7 +115,7 @@ func resourceAwsWafIPSetRead(d *schema.ResourceData, meta interface{}) error {
 		descriptors = append(descriptors, d)
 	}
 
-	d.Set("ip_set_descriptors", descriptors)
+	d.Set("ip_set_descriptor", descriptors)
 
 	d.Set("name", resp.IPSet.Name)
 
@@ -133,8 +133,8 @@ func resourceAwsWafIPSetRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsWafIPSetUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	if d.HasChange("ip_set_descriptors") {
-		o, n := d.GetChange("ip_set_descriptors")
+	if d.HasChange("ip_set_descriptor") {
+		o, n := d.GetChange("ip_set_descriptor")
 		oldD, newD := o.(*schema.Set).List(), n.(*schema.Set).List()
 
 		err := updateWafIpSetDescriptors(d.Id(), oldD, newD, conn)
@@ -149,7 +149,7 @@ func resourceAwsWafIPSetUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsWafIPSetDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	oldDescriptors := d.Get("ip_set_descriptors").(*schema.Set).List()
+	oldDescriptors := d.Get("ip_set_descriptor").(*schema.Set).List()
 
 	if len(oldDescriptors) > 0 {
 		err := updateWafIpSetDescriptors(d.Id(), oldDescriptors, nil, conn)

--- a/aws/resource_aws_waf_ipset_test.go
+++ b/aws/resource_aws_waf_ipset_test.go
@@ -31,7 +31,7 @@ func TestAccAWSWafIPSet_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -85,7 +85,7 @@ func TestAccAWSWafIPSet_changeNameForceNew(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -101,7 +101,7 @@ func TestAccAWSWafIPSet_changeNameForceNew(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", uName),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -126,8 +126,8 @@ func TestAccAWSWafIPSet_changeDescriptors(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.7.0/24",
 					}),
@@ -143,8 +143,8 @@ func TestAccAWSWafIPSet_changeDescriptors(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "1"),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptors.*", map[string]string{
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_set_descriptor.*", map[string]string{
 						"type":  "IPV4",
 						"value": "192.0.8.0/24",
 					}),
@@ -169,7 +169,7 @@ func TestAccAWSWafIPSet_noDescriptors(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &ipset),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "0"),
 				),
 			},
 			{
@@ -202,7 +202,7 @@ func TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit(t *testing.T) {
 	}
 	ipSetDescriptors := make([]string, 0, 2048)
 	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); incrementIP(ip) {
-		ipSetDescriptors = append(ipSetDescriptors, fmt.Sprintf("ip_set_descriptors {\ntype=\"IPV4\"\nvalue=\"%s/32\"\n}", ip))
+		ipSetDescriptors = append(ipSetDescriptors, fmt.Sprintf("ip_set_descriptor {\ntype=\"IPV4\"\nvalue=\"%s/32\"\n}", ip))
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -214,7 +214,7 @@ func TestAccAWSWafIPSet_IpSetDescriptors_1000UpdateLimit(t *testing.T) {
 				Config: testAccAWSWafIPSetConfig_IpSetDescriptors(rName, strings.Join(ipSetDescriptors, "\n")),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafIPSetExists(resourceName, &ipset),
-					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptors.#", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "ip_set_descriptor.#", "2048"),
 				),
 			},
 			{
@@ -461,7 +461,7 @@ func testAccAWSWafIPSetConfig(name string) string {
 resource "aws_waf_ipset" "test" {
   name = %[1]q
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -474,7 +474,7 @@ func testAccAWSWafIPSetConfigChangeName(name string) string {
 resource "aws_waf_ipset" "test" {
   name = %[1]q
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -487,7 +487,7 @@ func testAccAWSWafIPSetConfigChangeIPSetDescriptors(name string) string {
 resource "aws_waf_ipset" "test" {
   name = %[1]q
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.8.0/24"
   }
@@ -518,7 +518,7 @@ func testAccAWSWafIPSetIPV6Config(name string) string {
 resource "aws_waf_ipset" "test" {
   name = %[1]q
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV6"
     value = "1234:5678:9abc:6811:0000:0000:0000:0000/64"
   }

--- a/aws/resource_aws_waf_rate_based_rule_test.go
+++ b/aws/resource_aws_waf_rate_based_rule_test.go
@@ -378,7 +378,7 @@ func testAccAWSWafRateBasedRuleConfig(name string) string {
 resource "aws_waf_ipset" "ipset" {
   name = "%s"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -405,7 +405,7 @@ func testAccAWSWafRateBasedRuleConfigChangeName(name string) string {
 resource "aws_waf_ipset" "ipset" {
   name = "%s"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -432,7 +432,7 @@ func testAccAWSWafRateBasedRuleConfig_changePredicates(name string) string {
 resource "aws_waf_ipset" "ipset" {
   name = "%s"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }

--- a/aws/resource_aws_waf_rule_test.go
+++ b/aws/resource_aws_waf_rule_test.go
@@ -432,7 +432,7 @@ func testAccAWSWafRuleConfig(name string) string {
 resource "aws_waf_ipset" "ipset" {
   name = "%s"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -457,7 +457,7 @@ func testAccAWSWafRuleConfigChangeName(name string) string {
 resource "aws_waf_ipset" "ipset" {
   name = "%s"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -482,7 +482,7 @@ func testAccAWSWafRuleConfig_changePredicates(name string) string {
 resource "aws_waf_ipset" "ipset" {
   name = "%s"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -554,7 +554,7 @@ func testAccAWSWafRuleConfigTags1(rName, tag1Key, tag1Value string) string {
 resource "aws_waf_ipset" "ipset" {
   name = "%s"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -583,7 +583,7 @@ func testAccAWSWafRuleConfigTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value 
 resource "aws_waf_ipset" "ipset" {
   name = "%s"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }

--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -509,7 +509,7 @@ func testAccAWSWafWebAclConfig_Rules_Single_Rule(rName string) string {
 resource "aws_waf_ipset" "test" {
   name = %q
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -579,7 +579,7 @@ func testAccAWSWafWebAclConfig_Rules_Multiple(rName string) string {
 resource "aws_waf_ipset" "test" {
   name = %q
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }

--- a/website/docs/r/waf_ipset.html.markdown
+++ b/website/docs/r/waf_ipset.html.markdown
@@ -16,12 +16,12 @@ Provides a WAF IPSet Resource
 resource "aws_waf_ipset" "ipset" {
   name = "tfIPSet"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "10.16.16.0/16"
   }
@@ -33,11 +33,11 @@ resource "aws_waf_ipset" "ipset" {
 The following arguments are supported:
 
 * `name` - (Required) The name or description of the IPSet.
-* `ip_set_descriptors` - (Optional) One or more pairs specifying the IP address type (IPV4 or IPV6) and the IP address range (in CIDR format) from which web requests originate.
+* `ip_set_descriptor` - (Optional) One or more pairs specifying the IP address type (IPV4 or IPV6) and the IP address range (in CIDR format) from which web requests originate.
 
 ## Nested Blocks
 
-### `ip_set_descriptors`
+### `ip_set_descriptor`
 
 #### Arguments
 

--- a/website/docs/r/waf_rate_based_rule.html.markdown
+++ b/website/docs/r/waf_rate_based_rule.html.markdown
@@ -16,7 +16,7 @@ Provides a WAF Rate Based Rule Resource
 resource "aws_waf_ipset" "ipset" {
   name = "tfIPSet"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -16,7 +16,7 @@ Provides a WAF Rule Resource
 resource "aws_waf_ipset" "ipset" {
   name = "tfIPSet"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }

--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -16,7 +16,7 @@ Provides a WAF Web ACL Resource
 resource "aws_waf_ipset" "ipset" {
   name = "tfIPSet"
 
-  ip_set_descriptors {
+  ip_set_descriptor {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_waf_ipset: Rename block ip_set_descriptors to ip_set_descriptor for consistancy with ressource/aws_wafregional_ipset
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
unable to pay to run acceptance tests
```
