### PR TITLE
resource/aws_msk_configuration: Implement Update and Delete support

### DIFF
--- a/aws/internal/service/kafka/waiter/status.go
+++ b/aws/internal/service/kafka/waiter/status.go
@@ -1,0 +1,38 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kafka"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	ConfigurationStateDeleted = "Deleted"
+	ConfigurationStateUnknown = "Unknown"
+)
+
+// ConfigurationState fetches the Operation and its Status
+func ConfigurationState(conn *kafka.Kafka, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &kafka.DescribeConfigurationInput{
+			Arn: aws.String(arn),
+		}
+
+		output, err := conn.DescribeConfiguration(input)
+
+		if tfawserr.ErrMessageContains(err, kafka.ErrCodeBadRequestException, "Configuration ARN does not exist") {
+			return output, ConfigurationStateDeleted, nil
+		}
+
+		if err != nil {
+			return output, ConfigurationStateUnknown, err
+		}
+
+		if output == nil {
+			return output, ConfigurationStateUnknown, nil
+		}
+
+		return output, aws.StringValue(output.State), nil
+	}
+}

--- a/aws/internal/service/kafka/waiter/waiter.go
+++ b/aws/internal/service/kafka/waiter/waiter.go
@@ -1,0 +1,31 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/kafka"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	// Maximum amount of time to wait for an Configuration to return Deleted
+	ConfigurationDeletedTimeout = 5 * time.Minute
+)
+
+// ConfigurationDeleted waits for an Configuration to return Deleted
+func ConfigurationDeleted(conn *kafka.Kafka, arn string) (*kafka.DescribeConfigurationOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{kafka.ConfigurationStateDeleting},
+		Target:  []string{ConfigurationStateDeleted},
+		Refresh: ConfigurationState(conn, arn),
+		Timeout: ConfigurationDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*kafka.DescribeConfigurationOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/resource_aws_msk_configuration.go
+++ b/aws/resource_aws_msk_configuration.go
@@ -7,13 +7,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kafka"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/kafka/waiter"
 )
 
 func resourceAwsMskConfiguration() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsMskConfigurationCreate,
 		Read:   resourceAwsMskConfigurationRead,
-		Delete: schema.Noop,
+		Update: resourceAwsMskConfigurationUpdate,
+		Delete: resourceAwsMskConfigurationDelete,
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -27,7 +29,6 @@ func resourceAwsMskConfiguration() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"kafka_versions": {
 				Type:     schema.TypeSet,
@@ -49,7 +50,6 @@ func resourceAwsMskConfiguration() *schema.Resource {
 			"server_properties": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 		},
 	}
@@ -88,7 +88,7 @@ func resourceAwsMskConfigurationRead(d *schema.ResourceData, meta interface{}) e
 
 	configurationOutput, err := conn.DescribeConfiguration(configurationInput)
 
-	if isAWSErr(err, kafka.ErrCodeNotFoundException, "") {
+	if isAWSErr(err, kafka.ErrCodeBadRequestException, "Configuration ARN does not exist") {
 		log.Printf("[WARN] MSK Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -123,7 +123,7 @@ func resourceAwsMskConfigurationRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("arn", aws.StringValue(configurationOutput.Arn))
-	d.Set("description", aws.StringValue(configurationOutput.Description))
+	d.Set("description", aws.StringValue(revisionOutput.Description))
 
 	if err := d.Set("kafka_versions", aws.StringValueSlice(configurationOutput.KafkaVersions)); err != nil {
 		return fmt.Errorf("error setting kafka_versions: %s", err)
@@ -132,6 +132,47 @@ func resourceAwsMskConfigurationRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("latest_revision", aws.Int64Value(revision))
 	d.Set("name", aws.StringValue(configurationOutput.Name))
 	d.Set("server_properties", string(revisionOutput.ServerProperties))
+
+	return nil
+}
+
+func resourceAwsMskConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kafkaconn
+
+	input := &kafka.UpdateConfigurationInput{
+		Arn:              aws.String(d.Id()),
+		ServerProperties: []byte(d.Get("server_properties").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	_, err := conn.UpdateConfiguration(input)
+
+	if err != nil {
+		return fmt.Errorf("error updating MSK Configuration (%s): %w", d.Id(), err)
+	}
+
+	return resourceAwsMskConfigurationRead(d, meta)
+}
+
+func resourceAwsMskConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kafkaconn
+
+	input := &kafka.DeleteConfigurationInput{
+		Arn: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteConfiguration(input)
+
+	if err != nil {
+		return fmt.Errorf("error deleting MSK Configuration (%s): %w", d.Id(), err)
+	}
+
+	if _, err := waiter.ConfigurationDeleted(conn, d.Id()); err != nil {
+		return fmt.Errorf("error waiting for MSK Configuration (%s): %w", d.Id(), err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_msk_configuration_test.go
+++ b/aws/resource_aws_msk_configuration_test.go
@@ -2,15 +2,78 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kafka"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_msk_configuration", &resource.Sweeper{
+		Name: "aws_msk_configuration",
+		F:    testSweepMskConfigurations,
+		Dependencies: []string{
+			"aws_msk_cluster",
+		},
+	})
+}
+
+func testSweepMskConfigurations(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).kafkaconn
+	var sweeperErrs *multierror.Error
+
+	input := &kafka.ListConfigurationsInput{}
+
+	err = conn.ListConfigurationsPages(input, func(page *kafka.ListConfigurationsOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, configuration := range page.Configurations {
+			if configuration == nil {
+				continue
+			}
+
+			arn := aws.StringValue(configuration.Arn)
+			log.Printf("[INFO] Deleting MSK Configuration: %s", arn)
+
+			r := resourceAwsMskConfiguration()
+			d := r.Data(nil)
+			d.SetId(arn)
+			err := r.Delete(d, client)
+
+			if err != nil {
+				log.Printf("[ERROR] %s", err)
+				sweeperErrs = multierror.Append(sweeperErrs, err)
+				continue
+			}
+		}
+
+		return !isLast
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping MSK Configurations sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving MSK Configurations: %w", err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
 
 func TestAccAWSMskConfiguration_basic(t *testing.T) {
 	var configuration1 kafka.DescribeConfigurationOutput
@@ -43,8 +106,30 @@ func TestAccAWSMskConfiguration_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSMskConfiguration_Description(t *testing.T) {
+func TestAccAWSMskConfiguration_disappears(t *testing.T) {
 	var configuration1 kafka.DescribeConfigurationOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskConfigurationConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskConfigurationExists(resourceName, &configuration1),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsMskConfiguration(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSMskConfiguration_Description(t *testing.T) {
+	var configuration1, configuration2 kafka.DescribeConfigurationOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_msk_configuration.test"
 
@@ -64,6 +149,14 @@ func TestAccAWSMskConfiguration_Description(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMskConfigurationConfigDescription(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskConfigurationExists(resourceName, &configuration2),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
+				),
 			},
 		},
 	})
@@ -96,9 +189,11 @@ func TestAccAWSMskConfiguration_KafkaVersions(t *testing.T) {
 }
 
 func TestAccAWSMskConfiguration_ServerProperties(t *testing.T) {
-	var configuration1 kafka.DescribeConfigurationOutput
+	var configuration1, configuration2 kafka.DescribeConfigurationOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_msk_configuration.test"
+	serverProperty1 := "auto.create.topics.enable = false"
+	serverProperty2 := "auto.create.topics.enable = true"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
@@ -106,10 +201,10 @@ func TestAccAWSMskConfiguration_ServerProperties(t *testing.T) {
 		CheckDestroy: testAccCheckMskConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskConfigurationConfigServerProperties(rName),
+				Config: testAccMskConfigurationConfigServerProperties(rName, serverProperty1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMskConfigurationExists(resourceName, &configuration1),
-					resource.TestMatchResourceAttr(resourceName, "server_properties", regexp.MustCompile(`auto.create.topics.enable = false`)),
+					resource.TestMatchResourceAttr(resourceName, "server_properties", regexp.MustCompile(serverProperty1)),
 				),
 			},
 			{
@@ -117,17 +212,43 @@ func TestAccAWSMskConfiguration_ServerProperties(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccMskConfigurationConfigServerProperties(rName, serverProperty2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskConfigurationExists(resourceName, &configuration2),
+					resource.TestCheckResourceAttr(resourceName, "latest_revision", "2"),
+					resource.TestMatchResourceAttr(resourceName, "server_properties", regexp.MustCompile(serverProperty2)),
+				),
+			},
 		},
 	})
 }
 
 func testAccCheckMskConfigurationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).kafkaconn
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_msk_configuration" {
 			continue
 		}
 
-		// The API does not support deletions at this time
+		input := &kafka.DescribeConfigurationInput{
+			Arn: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeConfiguration(input)
+
+		if tfawserr.ErrMessageContains(err, kafka.ErrCodeBadRequestException, "Configuration ARN does not exist") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output != nil {
+			return fmt.Errorf("MSK Configuration (%s) still exists", rs.Primary.ID)
+		}
 	}
 
 	return nil
@@ -203,15 +324,15 @@ PROPERTIES
 `, rName)
 }
 
-func testAccMskConfigurationConfigServerProperties(rName string) string {
+func testAccMskConfigurationConfigServerProperties(rName string, serverProperty string) string {
 	return fmt.Sprintf(`
 resource "aws_msk_configuration" "test" {
   kafka_versions = ["2.1.0"]
   name           = %[1]q
 
   server_properties = <<PROPERTIES
-auto.create.topics.enable = false
+%[2]s
 PROPERTIES
 }
-`, rName)
+`, rName, serverProperty)
 }

--- a/website/docs/r/msk_configuration.html.markdown
+++ b/website/docs/r/msk_configuration.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages an Amazon Managed Streaming for Kafka configuration. More information can be found on the [MSK Developer Guide](https://docs.aws.amazon.com/msk/latest/developerguide/msk-configuration.html).
 
-~> **NOTE:** The API does not support deleting MSK configurations. Removing this Terraform resource will only remove the Terraform state for it.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14822

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_msk_configuration: Support resource in-place updates and deletion
```

Fixes consistent test failures like the following, since the deletion API did not exist previously:

```
=== CONT  TestAccAWSMskConfigurationDataSource_Name
TestAccAWSMskConfigurationDataSource_Name: data_source_aws_msk_configuration_test.go:16: Step 1/1 error: terraform failed: exit status 1
stderr:
Error: error creating MSK Configuration: LimitExceededException:
  status code: 429, request id: 2d1a5f7b-9810-4721-8aba-5873760578f7
--- FAIL: TestAccAWSMskConfigurationDataSource_Name (3942.73s)
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSMskConfiguration_disappears (12.73s)
--- PASS: TestAccAWSMskConfiguration_KafkaVersions (14.77s)
--- PASS: TestAccAWSMskConfiguration_basic (16.57s)
--- PASS: TestAccAWSMskConfiguration_ServerProperties (25.72s)
--- PASS: TestAccAWSMskConfiguration_Description (33.98s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSMskConfiguration_KafkaVersions (46.89s)
--- PASS: TestAccAWSMskConfiguration_basic (46.93s)
--- PASS: TestAccAWSMskConfiguration_Description (49.54s)
--- PASS: TestAccAWSMskConfiguration_disappears (51.76s)
--- PASS: TestAccAWSMskConfiguration_ServerProperties (56.04s)
```

Output from sweeper in AWS Commercial:

```
2020/08/25 09:17:54 [DEBUG] Running Sweepers for region (us-west-2):
2020/08/25 09:17:54 [DEBUG] Running Sweeper (aws_msk_cluster) in region (us-west-2)
2020/08/25 09:17:56 [DEBUG] Running Sweeper (aws_msk_configuration) in region (us-west-2)
2020/08/25 09:17:56 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-2998826609693633558/f51185e9-77c7-423f-8914-da44be1529ff-3
2020/08/25 09:17:57 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3027667580775728998/511bb04f-1500-4e87-90c4-19e50dc6c6b1-3
2020/08/25 09:17:58 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3055323783620387905/fcfdd9d0-a87a-47f4-b158-f452c3ca3e45-3
2020/08/25 09:17:59 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3059725946454559129/f19ce5ae-bc4f-475e-8786-9154388e6246-3
2020/08/25 09:18:00 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3066553746248942425/a162e77b-201e-4e10-862c-03a8ac2f1611-3
2020/08/25 09:18:00 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3126297066868053741/6d4f7fef-ffb2-4b8f-a149-beba084f28bc-3
2020/08/25 09:18:01 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3240933168728163222/e4a4b51a-9238-46d5-b751-212956eebd7d-3
2020/08/25 09:18:02 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3247401781287898711/11d87e46-db2a-45ff-a3bb-1be9af2f73d7-3
2020/08/25 09:18:03 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-330965340849997366/49d3979f-babf-43bd-bad6-c1ef6c41f9f8-3
2020/08/25 09:18:04 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3310608829544488674/436dc3e6-c84e-4363-b4c0-a496a9d4d001-3
2020/08/25 09:18:04 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3313923551848709622/3334a9c7-f31e-4729-8053-6bc9d89073a1-3
2020/08/25 09:18:05 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3335476946638944838/8fb7c2e5-6298-418f-b135-aa150a98425d-3
2020/08/25 09:18:06 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3362333853822579926/8a13285f-3411-4d91-81a5-4dd3a4c03cec-3
2020/08/25 09:18:07 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-341957367663788071/7bd5c940-db40-4f63-aa04-a22ac4952b47-3
2020/08/25 09:18:07 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3430274460101238752/e858597e-c6ea-4705-b4c6-f8af715d0c16-3
2020/08/25 09:18:08 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3469384134337508717/c2aac5aa-14fb-4a9f-b0e8-16df9a1f2739-3
2020/08/25 09:18:09 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3492696438978487088/8b553bb8-7c05-45f1-afcb-521692f63a7b-3
2020/08/25 09:18:10 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3505488824927855606/abd58e32-e463-4cd7-83d9-42b93ee80485-3
2020/08/25 09:18:11 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3517280147726839098/51199eac-1f96-4268-99c6-fdee3d129533-3
2020/08/25 09:18:12 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3532062516258081546/66b3c3c7-716e-4852-a386-b69c5c1aa04b-3
2020/08/25 09:18:14 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3542276377159695236/ee8025b2-752a-42e9-a0b4-cf7e80885b42-3
2020/08/25 09:18:14 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-365592488337885867/06b50bf8-8589-44d6-88b3-bd648013d8d1-3
2020/08/25 09:18:15 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3691491520954646179/bb2f3dd4-c726-4fc4-92e1-d863fa5442da-3
2020/08/25 09:18:16 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3714402973459119691/ef9024b1-745f-4967-8dc0-b1aecfc74bda-3
2020/08/25 09:18:17 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3746698572713884647/da8b2816-5890-45c2-9f67-ee2453dc129f-3
2020/08/25 09:18:18 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3799843326986103560/61318dc1-7d67-437f-951a-3b0868094a4d-3
2020/08/25 09:18:18 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3835788946599073560/b0ede49a-859b-464f-87ee-164629b32c30-3
2020/08/25 09:18:19 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3878402292444202134/d7aa1215-111c-4b3c-97bb-bb6ce1bd6b3a-3
2020/08/25 09:18:20 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3927733247184159017/d03cc0ad-7116-40c0-b5b7-1fae800a7bee-3
2020/08/25 09:18:21 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3941768762354558381/cfb61244-8564-447a-9527-539a1c62f42c-3
2020/08/25 09:18:22 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-3948371266152941766/ae960176-4c3e-4e04-b9fe-5da2fe9c8be5-3
2020/08/25 09:18:23 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4045044228972713706/c26c61b8-dfef-4632-aed7-b540bfd70663-3
2020/08/25 09:18:24 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4061544981468403588/e9fb9b45-f327-4ae1-9d11-8e419abfdcd7-3
2020/08/25 09:18:25 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4099844004761565964/691b0588-1ade-42c5-94cc-0e9c7a78a387-3
2020/08/25 09:18:27 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4118998442213515561/80cd1184-30dc-4456-825d-99990a778c35-3
2020/08/25 09:18:28 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4193869022900475617/f900a463-f334-4113-b2eb-aa2608ed30ed-3
2020/08/25 09:18:28 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4195052801527715978/66716872-0850-4b35-bdf4-927c21ab32e7-3
2020/08/25 09:18:29 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4215134217882764476/0d6293db-bdb7-480d-b73d-c78ece8c7ddf-3
2020/08/25 09:18:30 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4230667522990459842/ae4de624-5ee2-43ba-8b07-0c463d1cf920-3
2020/08/25 09:18:31 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4255279552375862893/28695eaa-eecb-4732-8e12-ac859ccf67d2-3
2020/08/25 09:18:32 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4306360035081087525/7e38d273-5a8d-45e2-a166-31baaa8962de-3
2020/08/25 09:18:33 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4367360503547837511/6ecbd7e6-806f-48c1-a329-e1d4c6038795-3
2020/08/25 09:18:33 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-444839635238308244/4e082270-14e0-4b58-a7ec-5960c401b954-3
2020/08/25 09:18:34 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4457598778317649257/15c519e4-34b9-473e-88ab-ef4ac500f5a1-3
2020/08/25 09:18:35 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4468542283426253319/d8f168ad-0afe-481e-ba94-03507d1f0325-3
2020/08/25 09:18:36 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4476754170345478834/4ff51847-4b31-4213-b471-53b071c6b1ce-3
2020/08/25 09:18:36 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4483505642966959651/83d1699d-6df3-4407-a9a1-908223f78c09-3
2020/08/25 09:18:37 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4503284456489189758/74d04d4a-387f-4d2f-b794-6ece7579f5b0-3
2020/08/25 09:18:39 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4510106135439187915/83f1787d-0ccd-4f69-be61-7f9a29c0e4e4-3
2020/08/25 09:18:40 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4521761298456514781/5116918e-ca1b-48a3-a17f-12b19e9e8050-3
2020/08/25 09:18:41 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4531174048331064774/d456f031-daea-4a3c-8ed9-2749e83c17c2-3
2020/08/25 09:18:42 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4546523190973151703/c36247fe-1a24-4f8c-b495-02b74251323f-3
2020/08/25 09:18:43 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4621879072841525465/8efe98b6-5ba9-4546-a2d3-0c98b3eb64bf-3
2020/08/25 09:18:43 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4649503655276421729/0659afa7-b18e-4fb9-b785-e28bdc69f2e9-3
2020/08/25 09:18:44 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-468473341123000243/62042486-6af0-4105-a221-16373b38f2c2-3
2020/08/25 09:18:45 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4696417304845202012/4bbd4f09-e5ba-4031-abb6-5d3f93607018-3
2020/08/25 09:18:47 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4705734953902994655/c782fb3a-b985-4a05-9e92-bfc6dae8b430-3
2020/08/25 09:18:47 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4709794118061607752/ae46cd8c-9e61-46b1-94b9-dba1a600ed4a-3
2020/08/25 09:18:48 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4721992311501283162/cc31015d-13cd-42fe-85f2-6ce4ffdf065c-3
2020/08/25 09:18:49 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4728785587325053889/cfdde5ba-6be6-458f-b6ab-c7db9f979d56-3
2020/08/25 09:18:49 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4745746920452290977/20d3ca3f-45af-4e42-bae8-bb5347d7a492-3
2020/08/25 09:18:50 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4816709737674197808/036149ae-ccf2-4d94-9958-3810733ad149-3
2020/08/25 09:18:51 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4890866385574611692/587ac900-5229-4a1f-854e-fb88e60a5dd4-3
2020/08/25 09:18:52 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4908198226176057909/fb3e7151-81db-4639-9ce7-3b763bd92cc2-3
2020/08/25 09:18:52 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4910141971206111608/25a721f9-edc9-4c53-ab53-10000f07d4f4-3
2020/08/25 09:18:53 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-4964753204431650630/fb1d0164-2b4c-4e48-aea3-1fcc69ce2930-3
2020/08/25 09:18:54 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5021952722562740746/f413739b-07ae-40ad-9ec4-be630755ada5-3
2020/08/25 09:18:55 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-50303130160759236/88bd810e-827c-40a7-9227-fd9f8a63d7de-3
2020/08/25 09:18:55 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5109108510297325571/ba97277f-90ef-4f59-bb65-a21f714d6a8f-3
2020/08/25 09:18:56 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5157538540581841968/75baed12-289a-4062-b7e3-60339dd8bb11-3
2020/08/25 09:18:57 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5159995864584485356/3357908a-f3ad-4414-b99f-772b959ade1b-3
2020/08/25 09:18:57 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-517372645951808844/b3c1770f-8d89-4ddf-abe6-80a4651a0240-3
2020/08/25 09:18:59 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5197226359006896333/c7e5d1eb-66cb-4989-99bd-7cf10deeb9a6-3
2020/08/25 09:19:00 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5211435691301756938/e5fd78ee-1b3a-47f0-ba61-6b002fd2f6be-3
2020/08/25 09:19:00 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5214709167402194301/f0c3752a-06e3-4a21-8c04-f6fb94dd6c4f-3
2020/08/25 09:19:01 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-523616056111576017/f7238c7c-61ba-440e-b2af-4b1f32f6b61a-3
2020/08/25 09:19:03 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5240158268031697803/f167ebac-0e51-44b8-b8da-984798fe12db-3
2020/08/25 09:19:03 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5305519582857831271/69732e59-2f42-48e3-a455-ef3f788d9d8c-3
2020/08/25 09:19:04 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5514019142830436937/331bd120-b42d-458b-a039-d16beee35401-3
2020/08/25 09:19:05 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5545701213480848415/a1110782-1f81-4fcd-b70a-cce5f141b5b1-3
2020/08/25 09:19:07 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5549502733591811716/3b51c5ea-05c7-48e4-af3d-5297b8f7b594-3
2020/08/25 09:19:08 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5552561757673285470/1374da8b-0119-4fa0-b1ad-bb6932d1da90-3
2020/08/25 09:19:08 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5599720503288271498/43efd873-247e-4bb1-aea7-6c342d2e9f81-3
2020/08/25 09:19:10 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5641182497478131376/b75ee50c-2620-4a75-8f25-553953c122e8-3
2020/08/25 09:19:11 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-570905879401818858/6a3d471a-3bf7-493c-84df-d42c17bd0315-3
2020/08/25 09:19:12 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5718668956869399803/7a3e2df1-93ed-4acf-b73f-a4a91c7391ae-3
2020/08/25 09:19:13 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5754455038335698249/7cb80d9b-ffd2-4a55-891b-b5cf374b13a4-3
2020/08/25 09:19:15 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5763637774363125160/7b1dddcc-82ed-448b-bade-d7e99558867f-3
2020/08/25 09:19:16 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-579289373443448026/b6c3f6eb-b64c-41ff-97fd-e66c0b386208-3
2020/08/25 09:19:17 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5829678774617725270/6c870b42-2f65-4a47-936b-742c2f946b29-3
2020/08/25 09:19:18 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5860693953411302662/f3609891-b443-4650-8701-c94aa4addcb2-3
2020/08/25 09:19:18 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5884026476090027136/e5e69c64-46ba-4326-ac52-9063cd6c3f1f-3
2020/08/25 09:19:19 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5886127876811990769/9e7bc661-a537-45bb-b453-3890bb14ba8f-3
2020/08/25 09:19:20 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-5953534426439999002/b73fb7ed-0bc3-4ef5-9c2b-164aac2e79c9-3
2020/08/25 09:19:21 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6020515800514871081/4c4d373e-d986-4134-89af-78cc76a7dfee-3
2020/08/25 09:19:22 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6033762356081980205/4c56f1db-88f3-4331-8d48-33feb4a03bfb-3
2020/08/25 09:19:23 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6059534069149604674/b55300dd-67ce-4cdc-bc9f-e74031530ddd-3
2020/08/25 09:19:23 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6117483733558948403/a319c187-33df-4791-bd47-78525e92348c-3
2020/08/25 09:19:24 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-616224521876476771/4a8ea70d-2fc6-4ac9-9105-7ae8d0897caa-3
2020/08/25 09:19:25 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6178315240291837005/137fd3d7-6e61-4c94-b648-1011f80648fe-3
2020/08/25 09:19:27 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6181572211019772375/1f37f489-5e2f-49a8-b690-f459ba6d4758-3
2020/08/25 09:19:28 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6200295570871931433/2e51f99c-b1a9-4283-885d-86611044107e-3
2020/08/25 09:19:28 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6209659091219425864/71b9703a-af1e-4d4d-a741-e1c215cd28f9-3
2020/08/25 09:19:29 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6265245070746088250/5e24d0e4-dd37-4d7d-9c41-8b19413f7658-3
2020/08/25 09:19:30 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-627945634654524635/81b16417-1d53-4b02-b520-254995339dc0-3
2020/08/25 09:19:31 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6310837058057912936/35675f1b-6469-421b-87c7-9dfca86deef6-3
2020/08/25 09:19:32 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6376948450818690681/d175d272-e465-4496-9f41-5398c2394406-3
2020/08/25 09:19:33 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6386269097059087462/8f3dffb7-b538-4673-9505-c41d8a7b3ccf-3
2020/08/25 09:19:33 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6398435264636468684/cce9ca21-feac-44df-a250-0239b0fc7003-3
2020/08/25 09:19:34 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6503187174653236503/d345158d-71d4-4667-9405-1b5d7d57a9bf-3
2020/08/25 09:19:35 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-655359387456183361/c3907016-3845-4f1e-8717-bbab0f5be5aa-3
2020/08/25 09:19:36 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6598913741363432712/cfd1316c-0fba-4cdb-990f-f526d7a80d65-3
2020/08/25 09:19:37 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6647669417566336221/7ad9095a-a920-4a4f-8aeb-1cd0754a60c3-3
2020/08/25 09:19:38 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6648939364118854304/360a366a-b16d-4962-bfbf-af91bcbca56b-3
2020/08/25 09:19:39 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6649516010344789677/1d4848b3-9258-4285-8b9a-cf58bcd7f3d0-3
2020/08/25 09:19:40 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6651631390449318773/6aa3c66a-866e-4ead-b090-cfa2364cda7a-3
2020/08/25 09:19:41 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6686987129636800231/77358242-b445-4123-8b6d-61c45f18b88f-3
2020/08/25 09:19:42 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6747671306271279782/3e144c15-c028-4a54-9ef0-940456dd2df8-3
2020/08/25 09:19:43 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6752259462141639049/8d298944-dfa7-4a96-81f5-b71114fce181-3
2020/08/25 09:19:44 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-67740585715233356/a470892b-b356-49a5-b852-cf8f16912d0e-3
2020/08/25 09:19:45 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6793402394832935481/e1fbb5cb-4c3f-4351-ac61-f3b7ed6b568a-3
2020/08/25 09:19:46 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6806165106343725391/29e739a2-77e9-4da3-b759-da24d4d5a4a6-3
2020/08/25 09:19:47 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6874490225714482937/e9964fcc-3b2d-41a3-b2ed-339794e7e272-3
2020/08/25 09:19:47 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6918084868626325792/2b6a678f-9033-4c0b-8592-84f6d540d2af-3
2020/08/25 09:19:48 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6930635634402309047/742cafa9-ddb2-4c8b-8756-a74a0407ec40-3
2020/08/25 09:19:49 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6932447936371455414/54d89151-d680-4823-b72f-668dd648b92f-3
2020/08/25 09:19:50 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6937680197765190711/ee58a1c6-9f01-400f-ab89-3d9a57c22cc0-3
2020/08/25 09:19:51 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6975255555926362166/b88124c9-7761-4df4-856f-23cde7d960c9-3
2020/08/25 09:19:51 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-6978041556735977557/e171373d-0c82-46c0-93d4-7f130aab9658-3
2020/08/25 09:19:52 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-699475818296184237/985fed5e-d762-4bed-afbc-d6450a4032d4-3
2020/08/25 09:19:53 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7007954843300355067/0b0c2b26-e697-4bf8-ae57-1df03b235e3e-3
2020/08/25 09:19:54 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7070430613823883616/9adac94e-3c42-4f59-8b0a-f6f9f3b79cb3-3
2020/08/25 09:19:55 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7087415138946161180/651a91e1-dac3-48d5-9f09-f3bf6880c674-3
2020/08/25 09:19:56 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7127175373380008966/88c71650-4c15-44cc-a462-88563a052bc8-3
2020/08/25 09:19:56 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7159977896486535483/874cca8e-c42d-4707-a323-ec86b75b9f0c-3
2020/08/25 09:19:57 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7222889303491065034/64cfd202-46bb-47ba-a5cc-092b96cc7a7c-3
2020/08/25 09:19:58 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7225343309938363243/afce918e-0151-408a-ba91-5fdd09f9fbe7-3
2020/08/25 09:19:59 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-72651067619881147/c4e4cc3d-1033-408d-a5fc-76f3524d793f-3
2020/08/25 09:20:00 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7266152004581022360/6944f768-ec9b-4450-ad20-a50bf89cc9cb-3
2020/08/25 09:20:00 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7270775769798710453/adb5a8f9-3843-4171-bbae-22bc93263ba3-3
2020/08/25 09:20:01 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7287211775724124685/dfb4d09b-8cc2-41cf-90b7-42772d6bbe26-3
2020/08/25 09:20:03 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7296284960534319991/a9697140-e02a-4639-abc1-49458ae276dd-3
2020/08/25 09:20:04 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-732724131202085664/eb6ceb86-f19c-4f66-bdd6-e0a570ff5f21-3
2020/08/25 09:20:05 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7369857277964646312/55a45675-feee-4f8b-bbe3-3c921b2d6aa3-3
2020/08/25 09:20:06 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7394911653074844704/38940eef-0cfd-4432-9cb0-fccc5135c901-3
2020/08/25 09:20:06 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-741274857012233210/a51c2ece-a91a-4873-89d7-bffd28b9cdc6-3
2020/08/25 09:20:08 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7522180917141420576/0ea5c060-b45b-4dc5-9765-570a45cb62cd-3
2020/08/25 09:20:09 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7537744698254228305/683c81ee-12f0-4182-9d72-18381068e837-3
2020/08/25 09:20:10 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7614510757517073056/60b48939-0719-40f9-b9dd-a4a983feeb67-3
2020/08/25 09:20:11 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7636588738072857096/c844059d-f2ab-49b8-a409-488cf3ad9b50-3
2020/08/25 09:20:12 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7732237243218384468/1eee9e0a-93cf-4181-b725-cf2f1404dd81-3
2020/08/25 09:20:13 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7734164911292270655/4479d9a1-5c90-4485-b361-faee1f8b0250-3
2020/08/25 09:20:14 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7781062993298418332/ec3e7249-6ac8-4706-beda-6a00fa72d153-3
2020/08/25 09:20:14 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7782464899646262978/3e69982c-1822-4d37-9747-07aee79538da-3
2020/08/25 09:20:15 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7784439451034614110/839b6133-6376-49d2-bcdd-b1a5eae646ce-3
2020/08/25 09:20:16 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7845686108082486237/52297c44-9a15-4d5f-b5ca-083323366ff8-3
2020/08/25 09:20:17 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7954659784080515005/d3d29731-58bb-46fb-b257-f73f9507eb03-3
2020/08/25 09:20:17 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7975984699108244468/31b5832d-2f39-413f-8967-fac27dfa8f5d-3
2020/08/25 09:20:18 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-7997208216583440172/19db92ea-b8c2-4479-9004-08161f3cf923-3
2020/08/25 09:20:19 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8037751350308861892/cbfbc6c6-2a81-4baf-a9d1-a99174bdbf4c-3
2020/08/25 09:20:20 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8131077917378624650/924544bb-6063-4197-a3d5-37cc0a5ccd2a-3
2020/08/25 09:20:21 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8137696129810035251/98ff4a27-27b3-4966-a531-8ad9ba4916ef-3
2020/08/25 09:20:22 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8203983253063082443/26f45c68-e83b-44f9-9862-aca132959495-3
2020/08/25 09:20:23 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8209172746454603980/58dca790-9364-41b4-a5c5-e0cd1cf15b1c-3
2020/08/25 09:20:24 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8223380412576624239/0a569797-c5a3-45f3-af79-b6357674ddf5-3
2020/08/25 09:20:24 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-822817190442348687/e6727717-503f-439a-8c28-b0b4c7fc48fb-3
2020/08/25 09:20:26 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8239694393872819771/1aa71c0b-ca71-4295-9ff7-b54bf23b2a8c-3
2020/08/25 09:20:27 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8290129747237993333/50eca79c-9fac-48a5-a992-a62b1d0cddd5-3
2020/08/25 09:20:28 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8359836332238495734/c2057cd9-bdfc-4df6-b0a3-3a027a5dd85e-3
2020/08/25 09:20:29 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8432231424159673113/2fb33ed7-b1c9-48da-80c7-921664944bb8-3
2020/08/25 09:20:30 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8490278010893900656/d61d2441-ec07-42e8-a548-9ad23fba5502-3
2020/08/25 09:20:31 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8513964082121495410/55a1925a-78ce-4270-b4a5-895688f07df5-3
2020/08/25 09:20:32 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8528486320742068050/3a232d10-4bac-486b-adde-94733626c9dc-3
2020/08/25 09:20:33 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8545038210415444/c5dc8cbe-4ee6-49f1-b1a1-9c874eb98eb3-3
2020/08/25 09:20:34 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8559871182230415174/b9cda536-bdc6-4881-a9ab-6696ffd48b92-3
2020/08/25 09:20:35 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8568327474560936547/f054e2db-f769-4365-b66a-45c9d3a0e3f5-3
2020/08/25 09:20:36 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-85850001949707334/cec6e696-b34e-4c5e-aaa5-047d19d3f8cd-3
2020/08/25 09:20:36 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8615659489274429506/97135279-d438-4cca-821b-1307e2d0abb2-3
2020/08/25 09:20:37 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8616130176474481411/e10c1ea4-fb2d-49dc-95f1-e1c84e313774-3
2020/08/25 09:20:38 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8670700157787928911/8ed37807-446a-460a-b62f-6d1985ac1ea3-3
2020/08/25 09:20:39 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8678780982674588800/4c746bfd-c37a-485d-8da1-5f0bae6afa96-3
2020/08/25 09:20:39 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8679136377526542716/4711614b-74f3-4315-9a3f-4c024e5d50d6-3
2020/08/25 09:20:40 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8694832672340841256/9dfc5df2-5e9d-4f4e-9635-d5c7fb847ba1-3
2020/08/25 09:20:41 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8705747733123837286/17f7d16a-b5e3-4fc9-bbdc-80ea46f51b52-3
2020/08/25 09:20:42 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8731219902388621462/265b3b0b-9408-475e-8fbd-9eb2e0e9e5d9-3
2020/08/25 09:20:43 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-876870080451850176/19009737-b557-4374-9d2f-b94625cda4c0-3
2020/08/25 09:20:44 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8856682775043727993/a9e822c0-b916-43de-969c-ea9bbe8b1b4f-3
2020/08/25 09:20:45 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8858922176558807690/8e27243e-98dd-4fc8-ad4e-13745ba1beee-3
2020/08/25 09:20:45 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8861604661910544832/bdfd4c95-d2ac-4fbe-88d4-2c9ca12548d1-3
2020/08/25 09:20:47 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8890301628030394406/35a85e7f-7b95-468b-83a3-79e3380055d0-3
2020/08/25 09:20:48 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8998135887424244381/fcde21e9-5e33-4ede-8102-b54b8ba1d3b7-3
2020/08/25 09:20:50 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-8998478846377263326/8be1344e-8ed7-4c7f-9ef5-b65e57e48912-3
2020/08/25 09:20:51 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-9019000513186681324/5f6e42d4-fc00-4cfc-96b4-05673251c29b-3
2020/08/25 09:20:51 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-9023215830832842266/6a63a341-24ab-49d2-a5e8-0d6a42f43160-3
2020/08/25 09:20:52 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-9026846151554987092/6aa3825c-12a1-454f-886e-1ee12a2cc4d9-3
2020/08/25 09:20:53 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-9106533357285612547/efdf8769-c20a-4144-8446-1ec1ae46453f-3
2020/08/25 09:20:54 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-9107003403065148481/b2b287e0-9f19-48f3-9c17-941648637838-3
2020/08/25 09:20:55 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-9210079012945135494/325d396f-d3da-4978-94a1-8e11a287c0b0-3
2020/08/25 09:20:56 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-930210423767651997/a84fcd18-bc0c-4d00-b764-8630013951b9-3
2020/08/25 09:20:56 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-west-2:--OMITTED--:configuration/tf-acc-test-998993871761410850/f03efd33-214d-4436-aaf6-ebaf163bd998-3
2020/08/25 09:20:58 Sweeper Tests ran successfully:
  - aws_msk_cluster
  - aws_msk_configuration
2020/08/25 09:20:58 [DEBUG] Running Sweepers for region (us-east-1):
2020/08/25 09:20:58 [DEBUG] Running Sweeper (aws_msk_cluster) in region (us-east-1)
2020/08/25 09:20:58 [DEBUG] Running Sweeper (aws_msk_configuration) in region (us-east-1)
2020/08/25 09:20:59 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-east-1:--OMITTED--:configuration/mskconfig/f46bd080-0994-4974-9b7b-905e6583b8ef-1
2020/08/25 09:21:36 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-east-1:--OMITTED--:configuration/mskconfig2/63af42ec-07ed-484a-964c-aab109633a6d-1
2020/08/25 09:21:38 [INFO] Deleting MSK Configuration: arn:aws:kafka:us-east-1:--OMITTED--:configuration/tf-acc-test-4041291024461617083/1f3ab2ce-f163-4b46-86ce-7aac7806d4fa-7
2020/08/25 09:22:05 Sweeper Tests ran successfully:
  - aws_msk_cluster
  - aws_msk_configuration
ok    github.com/terraform-providers/terraform-provider-aws/aws 251.682s
```

Output from sweeper in AWS GovCloud (US):

```
2020/08/25 09:18:02 [DEBUG] Running Sweepers for region (us-gov-west-1):
2020/08/25 09:18:02 [DEBUG] Running Sweeper (aws_msk_cluster) in region (us-gov-west-1)
2020/08/25 09:18:04 [DEBUG] Running Sweeper (aws_msk_configuration) in region (us-gov-west-1)
2020/08/25 09:18:05 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-1766945530084718736/a6c9085e-7fa3-4837-ae12-8424f9d9a25d-3
2020/08/25 09:18:06 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-1812448219371945788/56495de9-87d7-4843-be63-d8fce6cac030-3
2020/08/25 09:18:08 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2048267839271300422/87a5e6be-864d-4c13-ae27-f7b3b4d1bfc5-3
2020/08/25 09:18:09 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2130295074428159191/8d5ffcdc-b2ad-427d-ba49-8d694046f983-3
2020/08/25 09:18:10 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2262725139559256713/96d29db2-1da9-4cc3-8f6b-e4bbab92ba8e-3
2020/08/25 09:18:12 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2381997420602764899/4824c13b-2a28-48cb-9b4f-bd62c983e2e3-3
2020/08/25 09:18:13 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2406216114610189719/efd4f670-5d04-47cf-b78d-f899ec7dddb5-3
2020/08/25 09:18:14 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2444168938634471571/7645ed1a-693e-4dca-b6f6-66b9141cee25-3
2020/08/25 09:18:16 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2571419247020630643/46fb774e-06d9-4f1d-8ad8-240500c24a48-3
2020/08/25 09:18:17 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2631916287153676379/0cee7852-8968-480d-938c-c509f0980db6-3
2020/08/25 09:18:19 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2663420074913165693/dbae0898-69f4-424e-9b71-9410426131b8-3
2020/08/25 09:18:20 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2674395964858812659/d307c730-536e-4ab0-8a18-29506f5e9dc9-3
2020/08/25 09:18:21 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2679531915812613362/ecc4787c-e68f-45f5-879d-afbbd6be15b5-3
2020/08/25 09:18:23 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2785383241142131154/14f2bb2e-5fca-4ff2-a3f9-4b92ebbc47a8-3
2020/08/25 09:18:25 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-283741972151913555/caeb9790-088b-4f74-8bda-197e3eead8fb-3
2020/08/25 09:18:26 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2971841375393022049/a0102722-6585-4362-a6b3-33db3429f49b-3
2020/08/25 09:18:27 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-2975021396728709399/efbc2117-4690-495f-8145-78eba84d78a9-3
2020/08/25 09:18:28 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3050629442214916417/807930ec-e73b-446d-9899-086b03540c22-3
2020/08/25 09:18:30 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3075429549228492513/f2bdc869-02ed-4aa3-9098-a365984d8c6a-3
2020/08/25 09:18:31 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3078912749843843347/bd4ce043-5aff-42fc-925d-dadf9d37adcd-3
2020/08/25 09:18:32 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3178287379039604837/cd230922-b892-440d-be41-b74932aac659-3
2020/08/25 09:18:34 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3234098433137648726/0a625873-16a4-4621-9d52-5b8e703ccf30-3
2020/08/25 09:18:35 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3308181365215947636/fde22d6b-dc53-4b56-9b92-ef09b6d9764a-3
2020/08/25 09:18:36 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3471212286063960401/a9bbbdc0-d6e1-4556-ab43-a8f1d9f8d3b6-3
2020/08/25 09:18:38 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3655723367691216943/fe1bde90-3776-46f4-afc5-2d41eb7557e8-3
2020/08/25 09:18:39 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3660510174178299041/f99152b4-47d8-4cab-98bd-f5723b469b04-3
2020/08/25 09:18:40 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3665165304648383902/0b6eacf7-a39a-49bc-ba2c-1a0c7e2e2086-3
2020/08/25 09:18:41 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-371485530713792120/ef3420ba-54fd-4506-b7c2-41a49a27bbc5-3
2020/08/25 09:18:43 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-3995646853943729334/58497549-62eb-47b2-8169-4828beeda9f8-3
2020/08/25 09:18:44 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4001547961759890530/54c059f9-e707-429f-94f8-9d4b4373b694-3
2020/08/25 09:18:45 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4140514697275713491/423131e8-029c-42c5-85b6-80eac7fbda7e-3
2020/08/25 09:18:47 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4191297236869630753/194c139c-2684-4ef8-b35c-bf593afffbe2-3
2020/08/25 09:18:48 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4274054836325914347/e7c16549-6fae-410b-a941-535868d2f896-3
2020/08/25 09:18:50 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4352596246113308190/74d6634c-8046-47c1-be3a-6765095bf096-3
2020/08/25 09:18:51 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4405819894808496640/f1e1bca8-d61d-4a62-81f2-a348edea9b74-3
2020/08/25 09:18:52 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-44358305475879460/e208afaf-51c7-445e-8a2d-6c51b8c9da0e-3
2020/08/25 09:18:54 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4451471661362710778/4e999d14-0744-45ca-934e-30ddc206e691-3
2020/08/25 09:18:55 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4533734859148648780/dd28e313-a558-4582-9e68-767d917a1a7e-3
2020/08/25 09:18:56 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4554038117478607555/275ac7cd-1495-49d7-a7aa-7f0871d23388-3
2020/08/25 09:18:57 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4559918643590208440/0f3ae60c-5843-461e-b873-bf84a8eae805-3
2020/08/25 09:18:59 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4691522670768554723/2faf97fd-beb2-4353-a363-4f17c854ddee-3
2020/08/25 09:19:00 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-47272170832453175/bed7b1fa-9c95-4e69-b86e-ab5f8349e114-3
2020/08/25 09:19:02 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-4816101616326847045/30a8c848-77db-451b-810a-e32156ea4f25-3
2020/08/25 09:19:03 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-516172764614398981/0c64f2e9-be6f-45c0-9c66-6cf3f7593768-3
2020/08/25 09:19:05 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-5369782125662894816/2e99cb8c-2286-4328-b507-d38246753c44-3
2020/08/25 09:19:06 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-5470641958859418471/667075c5-43a4-4ba6-a95c-40b843050be6-3
2020/08/25 09:19:07 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-5470784237849242682/7062f372-6f39-4c3f-b0a6-2f847303eba5-3
2020/08/25 09:19:09 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-550014694536548023/925c9589-7bfe-4f10-a611-115ab0a267ca-3
2020/08/25 09:19:10 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-5710679554935715105/2a037779-c184-4493-abaa-9bbb32503927-3
2020/08/25 09:19:11 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-575535459707650413/4e98bd7a-569a-4071-9efd-a1762bc39227-3
2020/08/25 09:19:13 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-5840184038747520415/ac4a0fbf-85ae-47dc-9bb0-ffa21b1950a1-3
2020/08/25 09:19:14 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-5865315843079331236/fa78b1b2-4024-4dab-9aec-2c83f214dabd-3
2020/08/25 09:19:15 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-5956808472219415243/ea3ad155-7de9-4877-a712-0c629feda730-3
2020/08/25 09:19:17 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6072203658206445058/290dfaf1-1bf9-4d36-8a36-219b94663d64-3
2020/08/25 09:19:18 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6127735212450027370/010577e7-3300-46ce-9763-ddf53f530cdd-3
2020/08/25 09:19:19 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6189316511607580121/ae1fb98c-bab4-4677-9912-3a0e92f19140-3
2020/08/25 09:19:20 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6259196939359742427/2fe39914-2c64-4137-8aa3-60d037fa82f7-3
2020/08/25 09:19:22 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6261032857309560775/41acc881-8e64-4533-9e6f-66c36a67fd2e-3
2020/08/25 09:19:23 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-630209904971897451/697ac12f-31ef-4fd3-9a97-e5384cddab26-3
2020/08/25 09:19:24 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6506159600148467933/84cc1c15-417e-4f6a-bd84-76b619302f87-3
2020/08/25 09:19:26 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6549117195053174300/71437d93-268c-4241-a85b-120c44729225-3
2020/08/25 09:19:28 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6632279947521287405/f12a70e0-8191-4469-be37-6eac7cf3e236-3
2020/08/25 09:19:29 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6699944523952936987/2362c59b-2a08-475d-b009-5fff3278246a-3
2020/08/25 09:19:31 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6878668637958776397/a6dd7780-a854-47b7-a11c-4604eb12e446-3
2020/08/25 09:19:32 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-693002043552991754/effce900-dd8a-4ef8-8442-e37376a6a527-3
2020/08/25 09:19:33 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-6954355798606168771/ec956b23-4724-4ab2-afe3-a968696d90df-3
2020/08/25 09:19:34 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7043530592815593158/11c6dca5-1709-463f-abca-837e54f333ef-3
2020/08/25 09:19:36 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7063088780824940335/85360613-22b1-444b-a254-78e5b2b8a161-3
2020/08/25 09:19:37 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7085798936978980066/6b6ed252-39be-4104-8cd3-678dffbfc68f-3
2020/08/25 09:19:38 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7177930162417693222/760c25bf-10ac-4c57-b3c4-cbed2c09034d-3
2020/08/25 09:19:39 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7312653542510012119/4933a670-1091-4b8a-8fba-dd82ccc08f42-3
2020/08/25 09:19:41 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7359114386638611356/9d65409e-f2cb-4056-87ef-6c5111f98ccf-3
2020/08/25 09:19:42 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7368931673567324477/3be1f562-bbcf-4a85-9fc5-6e35b2a38706-3
2020/08/25 09:19:43 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7430554933553627933/1d1fc59c-bc10-44bd-8031-3631f1baba42-3
2020/08/25 09:19:45 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7536893383861655905/190ee7df-a128-4c3c-855b-55109900c1bf-3
2020/08/25 09:19:46 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7553270197084329901/28e3d905-bb8a-44e2-8460-fcff339ea251-3
2020/08/25 09:19:47 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-766006214589602851/71bdddf6-0aec-40e0-bff7-0ae6a033271c-3
2020/08/25 09:19:48 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-768523028929354890/4ee9f08e-1986-42f7-9294-a4df791a4e6b-3
2020/08/25 09:19:50 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7698231996843859858/50624e7e-0530-43fc-8bb0-b79732ba9281-3
2020/08/25 09:19:51 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7766217620345249335/6cc985ef-2a26-4fbf-895d-6cb6883fbc7c-3
2020/08/25 09:19:53 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7853309106513342674/623018b9-ea0b-454f-96a7-2faadcb87e8d-3
2020/08/25 09:19:55 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7947907097691516466/3b9979e8-8bb6-463e-8bfe-bb14a1faea0e-3
2020/08/25 09:19:56 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-7972256427205172728/bec66eb9-5ac8-48e5-9f2d-c9d90b4bff7b-3
2020/08/25 09:19:58 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8122205135999838702/fad886e5-ccd7-498f-bd20-73cee3c3d92e-3
2020/08/25 09:19:59 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8298848041316010601/7f525e8c-44b4-4b46-9dcd-564c7b05f215-3
2020/08/25 09:20:00 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8322443384672534837/923031e4-71a7-4810-98f9-972f4f6649d4-3
2020/08/25 09:20:02 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-846099935335152386/ec4d0ec2-34dc-4106-a895-ad7ba2f2c07b-3
2020/08/25 09:20:03 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8594593887963782650/680cb84b-7a1f-4092-a36b-6344244c6307-3
2020/08/25 09:20:04 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8634793397598544774/111a28d8-1100-4efd-aa34-0f6ab2121dda-3
2020/08/25 09:20:05 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8677276411360846222/a5fbddcd-6e6d-42c2-921c-356b6b5a39f9-3
2020/08/25 09:20:07 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8711227849003778580/63fbceeb-efbe-4805-a736-ac8afd0d6d27-3
2020/08/25 09:20:08 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8801691919658380590/7394b3f2-7c0a-4f69-886a-92178a203a2e-3
2020/08/25 09:20:10 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8920424606962586343/d63b1e6f-4115-41eb-8a5f-fd5a90da0048-3
2020/08/25 09:20:11 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-8995819247188396827/96f1f9b8-9f7c-42f8-ab19-4688cc5bb3fe-3
2020/08/25 09:20:12 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-9005988860029373272/37dd0053-6514-41ae-ac9f-ef93f3b48626-3
2020/08/25 09:20:13 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-9062236110270865699/4c28dc5a-8aed-4e22-abef-04b6c4d49f6e-3
2020/08/25 09:20:15 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-9065564219469548475/0fd48923-f5ed-4748-9d90-c682b5d4b270-3
2020/08/25 09:20:16 [INFO] Deleting MSK Configuration: arn:aws-us-gov:kafka:us-gov-west-1:--OMITTED--:configuration/tf-acc-test-9214820287541927642/6434c0a7-ef11-40ce-b051-1ae713f9c354-3
2020/08/25 09:20:17 Sweeper Tests ran successfully:
  - aws_msk_cluster
  - aws_msk_configuration
ok    github.com/terraform-providers/terraform-provider-aws/aws 136.035s
```