### PR TITLE
r/Xray_sampling_rule - add support for tags

### DIFF
--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -114,6 +114,7 @@ var serviceNames = []string{
 	"wafv2",
 	"worklink",
 	"workspaces",
+	"xray",
 }
 
 type TemplateData struct {

--- a/aws/internal/keyvaluetags/generators/servicetags/main.go
+++ b/aws/internal/keyvaluetags/generators/servicetags/main.go
@@ -96,6 +96,7 @@ var sliceServiceNames = []string{
 	"wafregional",
 	"wafv2",
 	"workspaces",
+	"xray",
 }
 
 var mapServiceNames = []string{

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -121,6 +121,7 @@ var serviceNames = []string{
 	"wafv2",
 	"worklink",
 	"workspaces",
+	"xray",
 }
 
 type TemplateData struct {

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -101,6 +101,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/wafv2"
 	"github.com/aws/aws-sdk-go/service/worklink"
 	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/aws/aws-sdk-go/service/xray"
 )
 
 // AccessanalyzerListTags lists accessanalyzer service tags.
@@ -1757,4 +1758,21 @@ func WorkspacesListTags(conn *workspaces.WorkSpaces, identifier string) (KeyValu
 	}
 
 	return WorkspacesKeyValueTags(output.TagList), nil
+}
+
+// XrayListTags lists xray service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func XrayListTags(conn *xray.XRay, identifier string) (KeyValueTags, error) {
+	input := &xray.ListTagsForResourceInput{
+		ResourceARN: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return XrayKeyValueTags(output.Tags), nil
 }

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -735,6 +735,8 @@ func ServiceTagInputIdentifierField(serviceName string) string {
 		return "ResourceARN"
 	case "workspaces":
 		return "ResourceId"
+	case "xray":
+		return "ResourceARN"
 	default:
 		return "ResourceArn"
 	}

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -112,6 +112,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/wafv2"
 	"github.com/aws/aws-sdk-go/service/worklink"
 	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/aws/aws-sdk-go/service/xray"
 )
 
 // ServiceClientType determines the service client Go type.
@@ -333,6 +334,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(worklink.New)
 	case "workspaces":
 		funcType = reflect.TypeOf(workspaces.New)
+	case "xray":
+		funcType = reflect.TypeOf(xray.New)
 	default:
 		panic(fmt.Sprintf("unrecognized ServiceClientType: %s", serviceName))
 	}

--- a/aws/internal/keyvaluetags/service_tags_gen.go
+++ b/aws/internal/keyvaluetags/service_tags_gen.go
@@ -80,6 +80,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafv2"
 	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/aws/aws-sdk-go/service/xray"
 )
 
 // map[string]*string handling
@@ -2555,6 +2556,33 @@ func (tags KeyValueTags) WorkspacesTags() []*workspaces.Tag {
 
 // WorkspacesKeyValueTags creates KeyValueTags from workspaces service tags.
 func WorkspacesKeyValueTags(tags []*workspaces.Tag) KeyValueTags {
+	m := make(map[string]*string, len(tags))
+
+	for _, tag := range tags {
+		m[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	return New(m)
+}
+
+// XrayTags returns xray service tags.
+func (tags KeyValueTags) XrayTags() []*xray.Tag {
+	result := make([]*xray.Tag, 0, len(tags))
+
+	for k, v := range tags.Map() {
+		tag := &xray.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+
+		result = append(result, tag)
+	}
+
+	return result
+}
+
+// XrayKeyValueTags creates KeyValueTags from xray service tags.
+func XrayKeyValueTags(tags []*xray.Tag) KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -110,6 +110,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/wafv2"
 	"github.com/aws/aws-sdk-go/service/worklink"
 	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/aws/aws-sdk-go/service/xray"
 )
 
 // AccessanalyzerUpdateTags updates accessanalyzer service tags.
@@ -3852,6 +3853,42 @@ func WorkspacesUpdateTags(conn *workspaces.WorkSpaces, identifier string, oldTag
 		}
 
 		_, err := conn.CreateTags(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}
+
+// XrayUpdateTags updates xray service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func XrayUpdateTags(conn *xray.XRay, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+		input := &xray.UntagResourceInput{
+			ResourceARN: aws.String(identifier),
+			TagKeys:     aws.StringSlice(removedTags.IgnoreAws().Keys()),
+		}
+
+		_, err := conn.UntagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+		input := &xray.TagResourceInput{
+			ResourceARN: aws.String(identifier),
+			Tags:        updatedTags.IgnoreAws().XrayTags(),
+		}
+
+		_, err := conn.TagResource(input)
 
 		if err != nil {
 			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)

--- a/aws/resource_aws_xray_sampling_rule_test.go
+++ b/aws/resource_aws_xray_sampling_rule_test.go
@@ -51,8 +51,7 @@ func TestAccAWSXraySamplingRule_basic(t *testing.T) {
 func TestAccAWSXraySamplingRule_update(t *testing.T) {
 	var samplingRule xray.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rString := acctest.RandString(8)
-	ruleName := fmt.Sprintf("tf_acc_sampling_rule_%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	updatedPriority := acctest.RandIntRange(0, 9999)
 	updatedReservoirSize := acctest.RandIntRange(0, 2147483647)
 
@@ -62,10 +61,10 @@ func TestAccAWSXraySamplingRule_update(t *testing.T) {
 		CheckDestroy: testAccCheckAWSXraySamplingRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSXraySamplingRuleConfig_update(ruleName, acctest.RandIntRange(0, 9999), acctest.RandIntRange(0, 2147483647)),
+				Config: testAccAWSXraySamplingRuleConfig_update(rName, acctest.RandIntRange(0, 9999), acctest.RandIntRange(0, 2147483647)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckXraySamplingRuleExists(resourceName, &samplingRule),
-					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "xray", fmt.Sprintf("sampling-rule/%s", ruleName)),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "xray", fmt.Sprintf("sampling-rule/%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "priority"),
 					resource.TestCheckResourceAttrSet(resourceName, "reservoir_size"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -80,10 +79,10 @@ func TestAccAWSXraySamplingRule_update(t *testing.T) {
 				),
 			},
 			{ // Update attributes
-				Config: testAccAWSXraySamplingRuleConfig_update(ruleName, updatedPriority, updatedReservoirSize),
+				Config: testAccAWSXraySamplingRuleConfig_update(rName, updatedPriority, updatedReservoirSize),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckXraySamplingRuleExists(resourceName, &samplingRule),
-					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "xray", fmt.Sprintf("sampling-rule/%s", ruleName)),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "xray", fmt.Sprintf("sampling-rule/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "priority", fmt.Sprintf("%d", updatedPriority)),
 					resource.TestCheckResourceAttr(resourceName, "reservoir_size", fmt.Sprintf("%d", updatedReservoirSize)),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
@@ -145,6 +144,28 @@ func TestAccAWSXraySamplingRule_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSXraySamplingRule_disappears(t *testing.T) {
+	var samplingRule xray.SamplingRule
+	resourceName := "aws_xray_sampling_rule.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSXray(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSXraySamplingRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSXraySamplingRuleConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXraySamplingRuleExists(resourceName, &samplingRule),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsXraySamplingRule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/aws/resource_aws_xray_sampling_rule_test.go
+++ b/aws/resource_aws_xray_sampling_rule_test.go
@@ -13,8 +13,7 @@ import (
 func TestAccAWSXraySamplingRule_basic(t *testing.T) {
 	var samplingRule xray.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rString := acctest.RandString(8)
-	ruleName := fmt.Sprintf("tf_acc_sampling_rule_%s", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSXray(t) },
@@ -22,10 +21,10 @@ func TestAccAWSXraySamplingRule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSXraySamplingRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSXraySamplingRuleConfig_basic(ruleName),
+				Config: testAccAWSXraySamplingRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckXraySamplingRuleExists(resourceName, &samplingRule),
-					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "xray", fmt.Sprintf("sampling-rule/%s", ruleName)),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "xray", fmt.Sprintf("sampling-rule/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "priority", "5"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "reservoir_size", "10"),
@@ -37,6 +36,7 @@ func TestAccAWSXraySamplingRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "service_name", "*"),
 					resource.TestCheckResourceAttr(resourceName, "service_type", "*"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{

--- a/aws/resource_aws_xray_sampling_rule_test.go
+++ b/aws/resource_aws_xray_sampling_rule_test.go
@@ -106,6 +106,50 @@ func TestAccAWSXraySamplingRule_update(t *testing.T) {
 	})
 }
 
+func TestAccAWSXraySamplingRule_tags(t *testing.T) {
+	var samplingRule xray.SamplingRule
+	resourceName := "aws_xray_sampling_rule.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSXray(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSXraySamplingRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSXraySamplingRuleConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXraySamplingRuleExists(resourceName, &samplingRule),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSXraySamplingRuleConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXraySamplingRuleExists(resourceName, &samplingRule),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSXraySamplingRuleConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXraySamplingRuleExists(resourceName, &samplingRule),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckXraySamplingRuleExists(n string, samplingRule *xray.SamplingRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -206,4 +250,57 @@ resource "aws_xray_sampling_rule" "test" {
   version        = 1
 }
 `, ruleName, priority, reservoirSize)
+}
+
+func testAccAWSXraySamplingRuleConfigTags1(ruleName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_xray_sampling_rule" "test" {
+  rule_name      = %[1]q
+  priority       = 5
+  reservoir_size = 10
+  url_path       = "*"
+  host           = "*"
+  http_method    = "GET"
+  service_type   = "*"
+  service_name   = "*"
+  fixed_rate     = 0.3
+  resource_arn   = "*"
+  version        = 1
+
+  attributes = {
+    Hello = "World"
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, ruleName, tagKey1, tagValue1)
+}
+
+func testAccAWSXraySamplingRuleConfigTags2(ruleName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_xray_sampling_rule" "test" {
+  rule_name      = %[1]q
+  priority       = 5
+  reservoir_size = 10
+  url_path       = "*"
+  host           = "*"
+  http_method    = "GET"
+  service_type   = "*"
+  service_name   = "*"
+  fixed_rate     = 0.3
+  resource_arn   = "*"
+  version        = 1
+
+  attributes = {
+    Hello = "World"
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, ruleName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/r/xray_sampling_rule.html.markdown
+++ b/website/docs/r/xray_sampling_rule.html.markdown
@@ -46,6 +46,7 @@ resource "aws_xray_sampling_rule" "example" {
 * `url_path` - (Required) Matches the path from a request URL.
 * `version` - (Required) The version of the sampling rule format (`1` )
 * `attributes` - (Optional) Matches attributes derived from the request.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14823

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_xray_sampling_rule - add support for tags
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSXraySamplingRule_'
--- PASS: TestAccAWSXraySamplingRule_basic (96.69s)
--- PASS: TestAccAWSXraySamplingRule_update (97.74s)
--- PASS: TestAccAWSXraySamplingRule_tags (208.93s)
--- PASS: TestAccAWSXraySamplingRule_disappears (42.52s)
```
