### PR TITLE
Updates Terraform syntax for data source acceptance tests

### DIFF
--- a/aws/data_source_aws_acm_certificate_test.go
+++ b/aws/data_source_aws_acm_certificate_test.go
@@ -239,7 +239,7 @@ func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecent(domain string, 
 	return fmt.Sprintf(`
 data "aws_acm_certificate" "test" {
   domain      = "%s"
-  most_recent = %v
+  most_recent = %t
 }
 `, domain, mostRecent)
 }
@@ -249,7 +249,7 @@ func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndStatus(domain
 data "aws_acm_certificate" "test" {
   domain      = "%s"
   statuses    = ["%s"]
-  most_recent = %v
+  most_recent = %t
 }
 `, domain, status, mostRecent)
 }
@@ -259,7 +259,7 @@ func testAccCheckAwsAcmCertificateDataSourceConfigWithMostRecentAndTypes(domain,
 data "aws_acm_certificate" "test" {
   domain      = "%s"
   types       = ["%s"]
-  most_recent = %v
+  most_recent = %t
 }
 `, domain, certType, mostRecent)
 }

--- a/aws/data_source_aws_cloudhsm2_cluster_test.go
+++ b/aws/data_source_aws_cloudhsm2_cluster_test.go
@@ -59,7 +59,7 @@ resource "aws_subnet" "cloudhsm_v2_test_subnets" {
 
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = [aws_subnet.cloudhsm_v2_test_subnets[*].id]
+  subnet_ids = aws_subnet.cloudhsm_v2_test_subnets[*].id
 
   tags = {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-data-source-basic-%d"

--- a/aws/data_source_aws_cloudhsm2_cluster_test.go
+++ b/aws/data_source_aws_cloudhsm2_cluster_test.go
@@ -59,7 +59,7 @@ resource "aws_subnet" "cloudhsm_v2_test_subnets" {
 
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type   = "hsm1.medium"
-  subnet_ids = [aws_subnet.cloudhsm_v2_test_subnets.0.id, aws_subnet.cloudhsm_v2_test_subnets.1.id]
+  subnet_ids = [aws_subnet.cloudhsm_v2_test_subnets[*].id]
 
   tags = {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-data-source-basic-%d"

--- a/aws/data_source_aws_elb_test.go
+++ b/aws/data_source_aws_elb_test.go
@@ -42,7 +42,7 @@ resource "aws_elb" "elb_test" {
   name            = "%[1]s"
   internal        = true
   security_groups = [aws_security_group.elb_test.id]
-  subnets         = [aws_subnet.elb_test.0.id, aws_subnet.elb_test.1.id]
+  subnets         = aws_subnet.elb_test[*].id
 
   idle_timeout = 30
 

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -554,7 +554,7 @@ data "aws_instance" "test" {
 var testAccInstanceDataSourceConfig_gp2IopsDevice = testAccLatestAmazonLinuxHvmEbsAmiConfig() + `
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m3.medium"
+  instance_type = "t3.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -571,7 +571,7 @@ data "aws_instance" "test" {
 var testAccInstanceDataSourceConfig_blockDevices = testAccLatestAmazonLinuxHvmEbsAmiConfig() + `
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m3.medium"
+  instance_type = "t3.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -615,7 +615,7 @@ resource "aws_kms_key" "test" {
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m3.medium"
+  instance_type = "t3.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -642,7 +642,7 @@ resource "aws_kms_key" "test" {
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m3.medium"
+  instance_type = "t3.medium"
 
   root_block_device {
     encrypted   = true
@@ -660,7 +660,7 @@ data "aws_instance" "test" {
 var testAccInstanceDataSourceConfig_rootInstanceStore = testAccLatestAmazonLinuxHvmEbsAmiConfig() + `
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m3.medium"
+  instance_type = "t3.medium"
 }
 
 data "aws_instance" "test" {
@@ -707,7 +707,7 @@ resource "aws_key_pair" "test" {
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "t1.micro"
+  instance_type = "t2.micro"
   key_name      = aws_key_pair.test.key_name
 
   tags = {
@@ -757,7 +757,7 @@ resource "aws_placement_group" "test" {
 # Limitations: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#concepts-placement-groups
 resource "aws_instance" "test" {
   ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type               = "c3.large"
+  instance_type               = "c5.large"
   subnet_id                   = aws_subnet.test.id
   associate_public_ip_address = true
   placement_group             = aws_placement_group.test.name

--- a/aws/data_source_aws_instances_test.go
+++ b/aws/data_source_aws_instances_test.go
@@ -128,8 +128,8 @@ resource "aws_instance" "test" {
 
 data "aws_instances" "test" {
   instance_tags = {
-    Name      = aws_instance.test.0.tags["Name"]
-    SecondTag = aws_instance.test.1.tags["Name"]
+    Name      = aws_instance.test[0].tags["Name"]
+    SecondTag = aws_instance.test[1].tags["Name"]
   }
 }
 `, rInt, rInt)
@@ -165,7 +165,7 @@ resource "aws_instance" "test" {
 
 data "aws_instances" "test" {
   instance_tags = {
-    Name = aws_instance.test.0.tags["Name"]
+    Name = aws_instance.test[0].tags["Name"]
   }
 
   instance_state_names = ["pending", "running"]

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -124,7 +124,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test.0.id, aws_subnet.alb_test.1.id]
+  subnets         = aws_subnet.alb_test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -250,7 +250,7 @@ resource "aws_alb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test.0.id, aws_subnet.alb_test.1.id]
+  subnets         = aws_subnet.alb_test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -366,7 +366,7 @@ resource "aws_lb" "alb_test" {
   name            = "%[1]s"
   internal        = false
   security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test.0.id, aws_subnet.alb_test.1.id]
+  subnets         = aws_subnet.alb_test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -144,7 +144,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test.0.id, aws_subnet.alb_test.1.id]
+  subnets         = aws_subnet.alb_test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -261,7 +261,7 @@ resource "aws_alb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test.0.id, aws_subnet.alb_test.1.id]
+  subnets         = aws_subnet.alb_test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -114,7 +114,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test.0.id, aws_subnet.alb_test.1.id]
+  subnets         = aws_subnet.alb_test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -198,7 +198,7 @@ resource "aws_alb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = [aws_security_group.alb_test.id]
-  subnets         = [aws_subnet.alb_test.0.id, aws_subnet.alb_test.1.id]
+  subnets         = aws_subnet.alb_test[*].id
 
   idle_timeout               = 30
   enable_deletion_protection = false

--- a/aws/data_source_aws_mq_broker_test.go
+++ b/aws/data_source_aws_mq_broker_test.go
@@ -13,6 +13,10 @@ func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
 	prefix := "tf-acc-test-d-mq-broker"
 	brokerName := fmt.Sprintf("%s-%s", prefix, rString)
 
+	dataSourceByIdName := "data.aws_mq_broker.by_id"
+	dataSourceByNameName := "data.aws_mq_broker.by_name"
+	resourceName := "aws_mq_broker.acctest"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -20,71 +24,31 @@ func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAWSMqBrokerConfig_byId(brokerName, prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "arn",
-						"aws_mq_broker.acctest", "arn"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "broker_name",
-						"aws_mq_broker.acctest", "broker_name"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "auto_minor_version_upgrade",
-						"aws_mq_broker.acctest", "auto_minor_version_upgrade"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "deployment_mode",
-						"aws_mq_broker.acctest", "deployment_mode"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "configuration.#",
-						"aws_mq_broker.acctest", "configuration.#"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "encryption_options.#",
-						"aws_mq_broker.acctest", "encryption_options.#"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "encryption_options.0.use_aws_owned_key",
-						"aws_mq_broker.acctest", "encryption_options.0.use_aws_owned_key"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "engine_type",
-						"aws_mq_broker.acctest", "engine_type"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "engine_version",
-						"aws_mq_broker.acctest", "engine_version"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "host_instance_type",
-						"aws_mq_broker.acctest", "host_instance_type"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "instances.#",
-						"aws_mq_broker.acctest", "instances.#"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "logs.#",
-						"aws_mq_broker.acctest", "logs.#"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "maintenance_window_start_time.#",
-						"aws_mq_broker.acctest", "maintenance_window_start_time.#"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "publicly_accessible",
-						"aws_mq_broker.acctest", "publicly_accessible"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "security_groups.#",
-						"aws_mq_broker.acctest", "security_groups.#"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "subnet_ids.#",
-						"aws_mq_broker.acctest", "subnet_ids.#"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "tags.%",
-						"aws_mq_broker.acctest", "tags.%"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_id", "user.#",
-						"aws_mq_broker.acctest", "user.#"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "broker_name", resourceName, "broker_name"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "auto_minor_version_upgrade", resourceName, "auto_minor_version_upgrade"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "deployment_mode", resourceName, "deployment_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "configuration.#", resourceName, "configuration.#"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "encryption_options.#", resourceName, "encryption_options.#"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "encryption_options.0.use_aws_owned_key", resourceName, "encryption_options.0.use_aws_owned_key"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "engine_type", resourceName, "engine_type"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "engine_version", resourceName, "engine_version"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "host_instance_type", resourceName, "host_instance_type"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "instances.#", resourceName, "instances.#"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "logs.#", resourceName, "logs.#"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "maintenance_window_start_time.#", resourceName, "maintenance_window_start_time.#"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "publicly_accessible", resourceName, "publicly_accessible"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "security_groups.#", resourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "subnet_ids.#", resourceName, "subnet_ids.#"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceByIdName, "user.#", resourceName, "user.#"),
 				),
 			},
 			{
 				Config: testAccDataSourceAWSMqBrokerConfig_byName(brokerName, prefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_name", "broker_id",
-						"aws_mq_broker.acctest", "id"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_mq_broker.by_name", "broker_name",
-						"aws_mq_broker.acctest", "broker_name"),
+					resource.TestCheckResourceAttrPair(dataSourceByNameName, "broker_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceByNameName, "broker_name", resourceName, "broker_name"),
 				),
 			},
 		},
@@ -184,8 +148,8 @@ resource "aws_mq_broker" "acctest" {
   }
 
   publicly_accessible = true
-  security_groups     = [aws_security_group.acctest.0.id, aws_security_group.acctest.1.id]
-  subnet_ids          = [aws_subnet.acctest.0.id, aws_subnet.acctest.1.id]
+  security_groups     = aws_security_group.acctest[*].id
+  subnet_ids          = aws_subnet.acctest[*].id
 
   user {
     username = "Ender"

--- a/aws/data_source_aws_network_acls_test.go
+++ b/aws/data_source_aws_network_acls_test.go
@@ -97,7 +97,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "testacc-acl-%s"
+    Name = "testacc-acl-%[1]s"
   }
 }
 
@@ -107,10 +107,10 @@ resource "aws_network_acl" "acl" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "testacc-acl-%s"
+    Name = "testacc-acl-%[1]s"
   }
 }
-`, rName, rName)
+`, rName)
 }
 
 func testAccDataSourceAwsNetworkAclsConfig_basic(rName string) string {

--- a/aws/data_source_aws_network_acls_test.go
+++ b/aws/data_source_aws_network_acls_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestAccDataSourceAwsNetworkAcls_basic(t *testing.T) {
 	rName := acctest.RandString(5)
+	dataSourceName := "data.aws_network_acls.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -24,7 +26,7 @@ func TestAccDataSourceAwsNetworkAcls_basic(t *testing.T) {
 				Config: testAccDataSourceAwsNetworkAclsConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					// At least 1
-					resource.TestMatchResourceAttr("data.aws_network_acls.test", "ids.#", regexp.MustCompile(`^[1-9][0-9]*`)),
+					resource.TestMatchResourceAttr(dataSourceName, "ids.#", regexp.MustCompile(`^[1-9][0-9]*`)),
 				),
 			},
 		},
@@ -33,6 +35,8 @@ func TestAccDataSourceAwsNetworkAcls_basic(t *testing.T) {
 
 func TestAccDataSourceAwsNetworkAcls_Filter(t *testing.T) {
 	rName := acctest.RandString(5)
+	dataSourceName := "data.aws_network_acls.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -41,7 +45,7 @@ func TestAccDataSourceAwsNetworkAcls_Filter(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsNetworkAclsConfig_Filter(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_network_acls.test", "ids.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 				),
 			},
 		},
@@ -50,6 +54,8 @@ func TestAccDataSourceAwsNetworkAcls_Filter(t *testing.T) {
 
 func TestAccDataSourceAwsNetworkAcls_Tags(t *testing.T) {
 	rName := acctest.RandString(5)
+	dataSourceName := "data.aws_network_acls.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -58,7 +64,7 @@ func TestAccDataSourceAwsNetworkAcls_Tags(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsNetworkAclsConfig_Tags(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_network_acls.test", "ids.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "2"),
 				),
 			},
 		},
@@ -67,6 +73,8 @@ func TestAccDataSourceAwsNetworkAcls_Tags(t *testing.T) {
 
 func TestAccDataSourceAwsNetworkAcls_VpcID(t *testing.T) {
 	rName := acctest.RandString(5)
+	dataSourceName := "data.aws_network_acls.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -76,7 +84,7 @@ func TestAccDataSourceAwsNetworkAcls_VpcID(t *testing.T) {
 				Config: testAccDataSourceAwsNetworkAclsConfig_VpcID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					// The VPC will have a default network ACL
-					resource.TestCheckResourceAttr("data.aws_network_acls.test", "ids.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "3"),
 				),
 			},
 		},
@@ -116,7 +124,7 @@ func testAccDataSourceAwsNetworkAclsConfig_Filter(rName string) string {
 data "aws_network_acls" "test" {
   filter {
     name   = "network-acl-id"
-    values = [aws_network_acl.acl.0.id]
+    values = [aws_network_acl.acl[0].id]
   }
 }
 `
@@ -126,7 +134,7 @@ func testAccDataSourceAwsNetworkAclsConfig_Tags(rName string) string {
 	return testAccDataSourceAwsNetworkAclsConfig_Base(rName) + `
 data "aws_network_acls" "test" {
   tags = {
-    Name = aws_network_acl.acl.0.tags.Name
+    Name = aws_network_acl.acl[0].tags.Name
   }
 }
 `
@@ -135,7 +143,7 @@ data "aws_network_acls" "test" {
 func testAccDataSourceAwsNetworkAclsConfig_VpcID(rName string) string {
 	return testAccDataSourceAwsNetworkAclsConfig_Base(rName) + `
 data "aws_network_acls" "test" {
-  vpc_id = aws_network_acl.acl.0.vpc_id
+  vpc_id = aws_network_acl.acl[0].vpc_id
 }
 `
 }

--- a/aws/data_source_aws_security_groups_test.go
+++ b/aws/data_source_aws_security_groups_test.go
@@ -64,7 +64,7 @@ resource "aws_security_group" "test" {
 
 data "aws_security_groups" "by_tag" {
   tags = {
-    Seed = aws_security_group.test.0.tags["Seed"]
+    Seed = aws_security_group.test[0].tags["Seed"]
   }
 }
 `, rInt)
@@ -98,7 +98,7 @@ data "aws_security_groups" "by_filter" {
 
   filter {
     name   = "group-name"
-    values = ["tf-${aws_security_group.test.0.tags["Seed"]}-*"]
+    values = ["tf-${aws_security_group.test[0].tags["Seed"]}-*"]
   }
 }
 `, rInt)

--- a/aws/data_source_aws_vpc_dhcp_options_test.go
+++ b/aws/data_source_aws_vpc_dhcp_options_test.go
@@ -46,7 +46,7 @@ func TestAccDataSourceAwsVpcDhcpOptions_basic(t *testing.T) {
 
 func TestAccDataSourceAwsVpcDhcpOptions_Filter(t *testing.T) {
 	rInt := acctest.RandInt()
-	resourceName := "aws_vpc_dhcp_options.test"
+	resourceName := "aws_vpc_dhcp_options.test.0"
 	datasourceName := "data.aws_vpc_dhcp_options.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/data_source_aws_vpc_dhcp_options_test.go
+++ b/aws/data_source_aws_vpc_dhcp_options_test.go
@@ -121,16 +121,16 @@ resource "aws_vpc_dhcp_options" "incorrect" {
 }
 
 resource "aws_vpc_dhcp_options" "test" {
-  count = %d
+  count = %[2]d
 
-  domain_name          = "tf-acc-test-%d.example.com"
+  domain_name          = "tf-acc-test-%[1]d.example.com"
   domain_name_servers  = ["127.0.0.1", "10.0.0.2"]
   netbios_name_servers = ["127.0.0.1"]
   netbios_node_type    = 2
   ntp_servers          = ["127.0.0.1"]
 
   tags = {
-    Name = "tf-acc-test-%d"
+    Name = "tf-acc-test-%[1]d"
   }
 }
 
@@ -142,8 +142,8 @@ data "aws_vpc_dhcp_options" "test" {
 
   filter {
     name   = "value"
-    values = [aws_vpc_dhcp_options.test.0.domain_name]
+    values = [aws_vpc_dhcp_options.test[0].domain_name]
   }
 }
-`, count, rInt, rInt)
+`, rInt, count)
 }

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1535,10 +1535,10 @@ func testAccProviderConfigAssumeRolePolicy(policy string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
 provider "aws" {
-	assume_role {
-		role_arn = %q
-		policy   = %q
-	}
+  assume_role {
+    role_arn = %q
+    policy   = %q
+  }
 }
 `, os.Getenv("TF_ACC_ASSUME_ROLE_ARN"), policy)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

Updates Terraform syntax for data source acceptance tests.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14417

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSAcmCertificateDataSource\|TestAccDataSourceAWSLBTargetGroup\|TestAccDataSourceAWSMqBroker\|TestAccDataSourceAwsVpcDhcpOptions\|TestAccAWSInstancesDataSource\|TestAccDataSourceAwsSecurityGroups\|TestAccAWSProvider\|TestAccDataSourceCloudHsmV2Cluster\|TestAccDataSourceAWSALBTargetGroup\|TestAccAWSInstanceDataSource\|TestAccDataSourceAWSELB\|TestAccDataSourceAWSLBListener\|TestAccDataSourceAWSLB\|TestAccDataSourceAwsNetworkAcls'

--- PASS: TestAccAWSAcmCertificateDataSource_KeyTypes (52.87s)
--- SKIP: TestAccAWSAcmCertificateDataSource_multipleIssued (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (0.00s)
--- SKIP: TestAccAWSAcmCertificateDataSource_singleIssued (0.00s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (99.12s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (130.98s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (123.41s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (108.84s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (70.24s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (141.05s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (116.88s)
--- PASS: TestAccAWSInstanceDataSource_VPC (103.35s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (113.00s)
--- PASS: TestAccAWSInstanceDataSource_basic (99.05s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (88.63s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (85.12s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (144.27s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (166.43s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (87.02s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (97.24s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (86.63s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (112.32s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (335.98s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (103.11s)
--- PASS: TestAccAWSInstanceDataSource_tags (106.10s)
--- PASS: TestAccAWSInstancesDataSource_basic (195.62s)
--- PASS: TestAccAWSInstancesDataSource_instance_state_names (196.59s)
--- PASS: TestAccAWSInstancesDataSource_tags (195.92s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (13.01s)
--- PASS: TestAccAWSProvider_Endpoints (18.83s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (19.75s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (19.50s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (18.76s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (18.14s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (19.22s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (19.38s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (20.07s)
--- PASS: TestAccAWSProvider_Region_AwsChina (15.97s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (15.16s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (11.15s)
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (198.56s)
--- PASS: TestAccDataSourceAWSELB_basic (34.02s)
--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (206.44s)
--- PASS: TestAccDataSourceAWSLBListener_basic (195.62s)
--- PASS: TestAccDataSourceAWSLBListener_https (198.84s)
--- PASS: TestAccDataSourceAWSLBTargetGroup_BackwardsCompatibility (207.36s)
--- PASS: TestAccDataSourceAWSLB_BackwardsCompatibility (207.32s)
--- PASS: TestAccDataSourceAWSLB_basic (199.34s)
--- PASS: TestAccDataSourceAWSMqBroker_basic (1185.23s)
--- PASS: TestAccDataSourceAwsNetworkAcls_Filter (14.64s)
--- PASS: TestAccDataSourceAwsNetworkAcls_Tags (18.57s)
--- PASS: TestAccDataSourceAwsNetworkAcls_VpcID (17.88s)
--- PASS: TestAccDataSourceAwsNetworkAcls_basic (25.60s)
--- PASS: TestAccDataSourceAwsSecurityGroups_filter (22.95s)
--- PASS: TestAccDataSourceAwsSecurityGroups_tag (20.14s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_Filter (44.43s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_basic (25.49s)
--- PASS: TestAccDataSourceCloudHsmV2Cluster_basic (287.00s)
```
