### PR TITLE
tech-debt: add additional handling for checking paired attributes within TypeSets

### DIFF
--- a/aws/internal/tfawsresource/testing_test.go
+++ b/aws/internal/tfawsresource/testing_test.go
@@ -778,7 +778,7 @@ func TestTestCheckTypeSetElemAttrPair(t *testing.T) {
 				},
 			},
 			ExpectedError: func(err error) bool {
-				return strings.Contains(err.Error(), "does not end with the special value")
+				return strings.Contains(err.Error(), `no TypeSet element "az.34812", with value "uswst3" in state`)
 			},
 		},
 		{
@@ -937,6 +937,56 @@ func TestTestCheckTypeSetElemAttrPair(t *testing.T) {
 										"names.0": "uswst3",
 										"names.1": "uswst2",
 										"names.2": "uswst1",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:             "single nested TypeSet argument and root TypeSet argument",
+			FirstResourceAddress:    "spot_fleet_request.bar",
+			FirstResourceAttribute:  "launch_specification.*.instance_type",
+			SecondResourceAddress:   "data.ec2_instances.available",
+			SecondResourceAttribute: "instance_type",
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"spot_fleet_request.bar": {
+								Type:     "spot_fleet_request",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                      "1",
+										"id":                     "11111",
+										"launch_specification.#": "1",
+										"launch_specification.12345.instance_type": "t2.micro",
+									},
+								},
+							},
+							"data.ec2_instances.available": {
+								Type:     "data.ec2_instances",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "3579",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":             "1",
+										"id":            "3579",
+										"instance_type": "t2.micro",
 									},
 								},
 							},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Supports testing for https://github.com/terraform-providers/terraform-provider-aws/pull/14841

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt: add additional handling for checking paired attributes within TypeSets
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestTestCheckTypeSetElemAttr (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/no_resources (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/resource_not_found (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/no_primary_instance (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/attribute_path_does_not_end_with_sentinel_value (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/attribute_not_found (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/single_root_TypeSet_attribute_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/single_root_TypeSet_attribute_mismatch (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/multiple_root_TypeSet_attribute_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/multiple_root_TypeSet_attribute_mismatch (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/single_nested_TypeSet_attribute_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttr/single_nested_TypeSet_attribute_mismatch (0.00s)

--- PASS: TestTestCheckTypeSetElemAttrPair (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/first_resource_no_primary_instance (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/second_resource_no_primary_instance (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/no_resources (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/first_resource_not_found (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/second_resource_not_found (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/first_resource_attribute_not_found (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/second_resource_attribute_not_found (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/first_resource_attribute_does_not_end_with_sentinel (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/second_resource_attribute_ends_with_sentinel (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/match_zero_attribute (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/match_non-zero_attribute (0.00s)
    --- PASS: TestTestCheckTypeSetElemAttrPair/single_nested_TypeSet_argument_and_root_TypeSet_argument (0.00s)

--- PASS: TestTestMatchTypeSetElemNestedAttrs (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/no_resources (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/resource_not_found (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/no_primary_instance (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/value_map_has_no_non-empty_values (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/attribute_path_does_not_end_with_sentinel_value (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/attribute_not_found (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_single_value_match (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_single_value_mismatch (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_single_nested_value_match (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_single_nested_value_mismatch (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_multiple_value_match (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_unset/empty_value_match (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_root_TypeSet_attribute_multiple_value_mismatch (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/multiple_root_TypeSet_attribute_single_value_match (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/multiple_root_TypeSet_attribute_multiple_value_match (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_nested_TypeSet_attribute_single_value_match (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_nested_TypeSet_attribute_single_value_mismatch (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_nested_TypeSet_attribute_single_nested_value_match (0.00s)
    --- PASS: TestTestMatchTypeSetElemNestedAttrs/single_nested_TypeSet_attribute_single_nested_value_mismatch (0.00s)

--- PASS: TestTestCheckTypeSetElemNestedAttrs (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/no_resources (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/resource_not_found (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/no_primary_instance (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/value_map_has_no_non-empty_values (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/attribute_path_does_not_end_with_sentinel_value (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/attribute_not_found (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_root_TypeSet_attribute_single_value_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_root_TypeSet_attribute_single_value_mismatch (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_root_TypeSet_attribute_single_nested_value_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_root_TypeSet_attribute_single_nested_value_mismatch (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_root_TypeSet_attribute_multiple_value_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_root_TypeSet_attribute_unset/empty_value_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_root_TypeSet_attribute_multiple_value_mismatch (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/multiple_root_TypeSet_attribute_single_value_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/multiple_root_TypeSet_attribute_multiple_value_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_nested_TypeSet_attribute_single_value_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_nested_TypeSet_attribute_single_value_mismatch (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_nested_TypeSet_attribute_single_nested_value_match (0.00s)
    --- PASS: TestTestCheckTypeSetElemNestedAttrs/single_nested_TypeSet_attribute_single_nested_value_mismatch (0.00s)
```
