### PR TITLE
tests/provider: Ensure GitHub Actions workflow for markdown-lint checks out code and can fetch latest v1

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,8 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: avto-dev/markdown-lint@v1.3.0
+      - uses: actions/checkout@v2
+      - uses: avto-dev/markdown-lint@v1
         with:
           config: '.markdownlint.yml'
           args: 'docs'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -43,7 +43,8 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: avto-dev/markdown-lint@v1.3.0
+      - uses: actions/checkout@v2
+      - uses: avto-dev/markdown-lint@v1
         with:
           config: '.markdownlint.yml'
           args: 'website/docs'

--- a/website/docs/r/emr_managed_scaling_policy.html.markdown
+++ b/website/docs/r/emr_managed_scaling_policy.html.markdown
@@ -57,6 +57,7 @@ The following arguments are supported:
 ## Import
 
 EMR Managed Scaling Policies can be imported via the EMR Cluster identifier, e.g.
+
 ```console
 $ terraform import aws_emr_managed_scaling_policy.example j-123456ABCDEF
 ```

--- a/website/docs/r/spot_instance_request.html.markdown
+++ b/website/docs/r/spot_instance_request.html.markdown
@@ -67,6 +67,7 @@ Spot Instance Requests support all the same arguments as
 * `valid_until` - (Optional) The end date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request. The default end date is 7 days from the current date.
 * `valid_from` - (Optional) The start date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). The default is to start fulfilling the request immediately.
 * `tags` - (Optional) A map of tags to assign to the Spot Instance Request. These tags are not automatically applied to the launched Instance.
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in GitHub Actions production it was exiting immediately with the help message and not failing the step (will need to report upstream):

```
/usr/bin/docker run --name b3ac6370f976814a74da68d2a7f92df15b742_274a0b --label 3b3ac6 --workdir /github/workspace --rm -e GO_VERSION -e GO111MODULE -e TFLINT_VERSION -e INPUT_CONFIG -e INPUT_ARGS -e INPUT_RULES -e INPUT_FIX -e INPUT_OUTPUT -e INPUT_IGNORE -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/terraform-provider-aws/terraform-provider-aws":"/github/workspace" 3b3ac6:370f976814a74da68d2a7f92df15b742  "website/docs"

  Usage: markdownlint [options] <files|directories|globs>

  MarkdownLint Command Line Interface

  Options:

    -h, --help                                  output usage information
    -V, --version                               output the version number
    -f, --fix                                   fix basic errors (does not work with STDIN)
    -s, --stdin                                 read from STDIN (does not work with files)
    -o, --output [outputFile]                   write issues to file (no console)
    -c, --config [configFile]                   configuration file (JSON, JSONC, JS, or YAML)
    -i, --ignore [file|directory|glob]          file(s) to ignore/exclude
    -p, --ignore-path [file]                    path to file with ignore pattern(s)
    -r, --rules  [file|directory|glob|package]  custom rule files
```

Which could also be seen with GitHub Actions testing in `act`:

```console
$ act push -j markdown-lint
[Website Checks/markdown-lint      ] 🚀  Start image=nektos/act-environments-ubuntu:18.04
[Documentation Checks/markdown-lint] 🚀  Start image=nektos/act-environments-ubuntu:18.04
[Documentation Checks/markdown-lint]   🐳  docker run image=nektos/act-environments-ubuntu:18.04 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Website Checks/markdown-lint      ]   🐳  docker run image=nektos/act-environments-ubuntu:18.04 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Documentation Checks/markdown-lint] ⭐  Run avto-dev/markdown-lint@v1.3.0
[Documentation Checks/markdown-lint]   ☁  git clone 'https://github.com/avto-dev/markdown-lint' # ref=v1.3.0
[Website Checks/markdown-lint      ] ⭐  Run avto-dev/markdown-lint@v1.3.0
[Website Checks/markdown-lint      ]   ☁  git clone 'https://github.com/avto-dev/markdown-lint' # ref=v1.3.0
[Documentation Checks/markdown-lint]   🐳  docker build -t act-avto-dev-markdown-lint-v1-3-0:latest /Users/bflad/.cache/act/avto-dev-markdown-lint@v1.3.0
[Documentation Checks/markdown-lint]   🐳  docker run image=act-avto-dev-markdown-lint-v1-3-0:latest entrypoint=[] cmd=["docs"]
[Website Checks/markdown-lint      ]   🐳  docker build -t act-avto-dev-markdown-lint-v1-3-0:latest /Users/bflad/.cache/act/avto-dev-markdown-lint@v1.3.0
[Website Checks/markdown-lint      ]   🐳  docker run image=act-avto-dev-markdown-lint-v1-3-0:latest entrypoint=[] cmd=["website/docs"]
|
|   Usage: markdownlint [options] <files|directories|globs>
|
|   MarkdownLint Command Line Interface
|
|   Options:
|
|     -h, --help                                  output usage information
|     -V, --version                               output the version number
|     -f, --fix                                   fix basic errors (does not work with STDIN)
|     -s, --stdin                                 read from STDIN (does not work with files)
|     -o, --output [outputFile]                   write issues to file (no console)
|     -c, --config [configFile]                   configuration file (JSON, JSONC, JS, or YAML)
|     -i, --ignore [file|directory|glob]          file(s) to ignore/exclude
|     -p, --ignore-path [file]                    path to file with ignore pattern(s)
|     -r, --rules  [file|directory|glob|package]  custom rule files
|
[Documentation Checks/markdown-lint]   ✅  Success - avto-dev/markdown-lint@v1.3.0
|
|   Usage: markdownlint [options] <files|directories|globs>
|
|   MarkdownLint Command Line Interface
|
|   Options:
|
|     -h, --help                                  output usage information
|     -V, --version                               output the version number
|     -f, --fix                                   fix basic errors (does not work with STDIN)
|     -s, --stdin                                 read from STDIN (does not work with files)
|     -o, --output [outputFile]                   write issues to file (no console)
|     -c, --config [configFile]                   configuration file (JSON, JSONC, JS, or YAML)
|     -i, --ignore [file|directory|glob]          file(s) to ignore/exclude
|     -p, --ignore-path [file]                    path to file with ignore pattern(s)
|     -r, --rules  [file|directory|glob|package]  custom rule files
|
[Website Checks/markdown-lint      ]   ✅  Success - avto-dev/markdown-lint@v1.3.0
```

Now with GitHub Actions testing in `act`:

```console
$ act push -j markdown-lint
[Website Checks/markdown-lint      ] 🚀  Start image=nektos/act-environments-ubuntu:18.04
[Documentation Checks/markdown-lint] 🚀  Start image=nektos/act-environments-ubuntu:18.04
[Documentation Checks/markdown-lint]   🐳  docker run image=nektos/act-environments-ubuntu:18.04 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Website Checks/markdown-lint      ]   🐳  docker run image=nektos/act-environments-ubuntu:18.04 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Website Checks/markdown-lint      ]   🐳  docker cp src=/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/. dst=/github/workspace
[Documentation Checks/markdown-lint]   🐳  docker cp src=/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/. dst=/github/workspace
[Documentation Checks/markdown-lint] Unable to copy link vendor --> ../../../../../../vendor
[Website Checks/markdown-lint      ] Unable to copy link vendor --> ../../../../../../vendor
[Website Checks/markdown-lint      ] Unable to copy link vendor --> ../../../../../../vendor
[Documentation Checks/markdown-lint] Unable to copy link vendor --> ../../../../../../vendor
[Documentation Checks/markdown-lint] Unable to copy link vendor --> ../../../../../../vendor
[Website Checks/markdown-lint      ] Unable to copy link vendor --> ../../../../../../vendor
[Documentation Checks/markdown-lint] Unable to copy link vendor --> ../../../../../../vendor
[Website Checks/markdown-lint      ] Unable to copy link vendor --> ../../../../../../vendor
[Documentation Checks/markdown-lint] Unable to copy link vendor --> ../../../../../../vendor
[Website Checks/markdown-lint      ] Unable to copy link vendor --> ../../../../../../vendor
[Documentation Checks/markdown-lint] Unable to copy link vendor --> ../../../../../../vendor
[Website Checks/markdown-lint      ] Unable to copy link vendor --> ../../../../../../vendor
[Documentation Checks/markdown-lint] Unable to copy link vendor --> ../../../../../../vendor
[Website Checks/markdown-lint      ] Unable to copy link vendor --> ../../../../../../vendor
[Website Checks/markdown-lint      ] ⭐  Run actions/checkout@v2
[Website Checks/markdown-lint      ]   ✅  Success - actions/checkout@v2
[Website Checks/markdown-lint      ] ⭐  Run avto-dev/markdown-lint@v1
[Website Checks/markdown-lint      ]   ☁  git clone 'https://github.com/avto-dev/markdown-lint' # ref=v1
[Documentation Checks/markdown-lint] ⭐  Run actions/checkout@v2
[Documentation Checks/markdown-lint]   ✅  Success - actions/checkout@v2
[Documentation Checks/markdown-lint] ⭐  Run avto-dev/markdown-lint@v1
[Documentation Checks/markdown-lint]   ☁  git clone 'https://github.com/avto-dev/markdown-lint' # ref=v1
[Website Checks/markdown-lint      ]   🐳  docker build -t act-avto-dev-markdown-lint-v1:latest /Users/bflad/.cache/act/avto-dev-markdown-lint@v1
[Documentation Checks/markdown-lint]   🐳  docker build -t act-avto-dev-markdown-lint-v1:latest /Users/bflad/.cache/act/avto-dev-markdown-lint@v1
[Website Checks/markdown-lint      ]   🐳  docker run image=act-avto-dev-markdown-lint-v1:latest entrypoint=[] cmd=["website/docs"]
[Documentation Checks/markdown-lint]   🐳  docker run image=act-avto-dev-markdown-lint-v1:latest entrypoint=[] cmd=["docs"]
[Documentation Checks/markdown-lint]   ✅  Success - avto-dev/markdown-lint@v1
| website/docs/r/emr_managed_scaling_policy.html.markdown:60 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```console"]
| website/docs/r/spot_instance_request.html.markdown:69 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `tags` - (Optional) A map of..."]
[Website Checks/markdown-lint      ]   ❌  Failure - avto-dev/markdown-lint@v1
Error: exit with `FAILURE`: 1
```

These failures will be addressed separately in followup commits.