### PR TITLE
r/aws_mq_configuration: Don't update the configuration if only tags change

### DIFF
--- a/aws/resource_aws_mq_configuration.go
+++ b/aws/resource_aws_mq_configuration.go
@@ -152,21 +152,23 @@ func resourceAwsMqConfigurationRead(d *schema.ResourceData, meta interface{}) er
 func resourceAwsMqConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).mqconn
 
-	rawData := d.Get("data").(string)
-	data := base64.StdEncoding.EncodeToString([]byte(rawData))
+	if d.HasChanges("data", "description") {
+		rawData := d.Get("data").(string)
+		data := base64.StdEncoding.EncodeToString([]byte(rawData))
 
-	input := mq.UpdateConfigurationRequest{
-		ConfigurationId: aws.String(d.Id()),
-		Data:            aws.String(data),
-	}
-	if v, ok := d.GetOk("description"); ok {
-		input.Description = aws.String(v.(string))
-	}
+		input := mq.UpdateConfigurationRequest{
+			ConfigurationId: aws.String(d.Id()),
+			Data:            aws.String(data),
+		}
+		if v, ok := d.GetOk("description"); ok {
+			input.Description = aws.String(v.(string))
+		}
 
-	log.Printf("[INFO] Updating MQ Configuration %s: %s", d.Id(), input)
-	_, err := conn.UpdateConfiguration(&input)
-	if err != nil {
-		return err
+		log.Printf("[INFO] Updating MQ Configuration %s: %s", d.Id(), input)
+		_, err := conn.UpdateConfiguration(&input)
+		if err != nil {
+			return err
+		}
 	}
 
 	if d.HasChange("tags") {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14842.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_mq_configuration: Don't cause `latest_revision` to change if only `tags` are updated
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSMqConfiguration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSMqConfiguration_ -timeout 120m
=== RUN   TestAccAWSMqConfiguration_basic
=== PAUSE TestAccAWSMqConfiguration_basic
=== RUN   TestAccAWSMqConfiguration_withData
=== PAUSE TestAccAWSMqConfiguration_withData
=== RUN   TestAccAWSMqConfiguration_updateTags
=== PAUSE TestAccAWSMqConfiguration_updateTags
=== CONT  TestAccAWSMqConfiguration_basic
=== CONT  TestAccAWSMqConfiguration_updateTags
=== CONT  TestAccAWSMqConfiguration_withData
--- PASS: TestAccAWSMqConfiguration_withData (19.15s)
--- PASS: TestAccAWSMqConfiguration_basic (38.12s)
--- PASS: TestAccAWSMqConfiguration_updateTags (47.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.394s
```
