### PR TITLE
fix for aws_lambda_function_event_invoke_config - unexpected format of function resource

### DIFF
--- a/aws/resource_aws_lambda_function_event_invoke_config.go
+++ b/aws/resource_aws_lambda_function_event_invoke_config.go
@@ -289,7 +289,7 @@ func resourceAwsLambdaFunctionEventInvokeConfigParseId(id string) (string, strin
 			return id, "", nil
 		}
 
-		functionParts := strings.Split(id, ":")
+		functionParts := strings.Split(function, ":")
 
 		if len(functionParts) != 2 || functionParts[0] == "" || functionParts[1] == "" {
 			return "", "", fmt.Errorf("unexpected format of function resource (%s), expected name:qualifier", id)

--- a/aws/resource_aws_lambda_function_event_invoke_config_test.go
+++ b/aws/resource_aws_lambda_function_event_invoke_config_test.go
@@ -261,6 +261,33 @@ func TestAccAWSLambdaFunctionEventInvokeConfig_FunctionName_Arn(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	lambdaFunctionResourceName := "aws_lambda_function.test"
+	resourceName := "aws_lambda_function_event_invoke_config.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionEventInvokeConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaFunctionEventInvokeConfigQualifierFunctionNameArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionEventInvokeConfigExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", lambdaFunctionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "qualifier", "$LATEST"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSLambdaFunctionEventInvokeConfig_MaximumEventAgeInSeconds(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_lambda_function_event_invoke_config.test"
@@ -677,6 +704,15 @@ func testAccAWSLambdaFunctionEventInvokeConfigFunctionNameArn(rName string) stri
 	return testAccAWSLambdaFunctionEventInvokeConfigBase(rName) + `
 resource "aws_lambda_function_event_invoke_config" "test" {
   function_name = aws_lambda_function.test.arn
+}
+`
+}
+
+func testAccAWSLambdaFunctionEventInvokeConfigQualifierFunctionNameArn(rName string) string {
+	return testAccAWSLambdaFunctionEventInvokeConfigBase(rName) + `
+resource "aws_lambda_function_event_invoke_config" "test" {
+  function_name = aws_lambda_function.test.arn
+  qualifier     = "$LATEST"
 }
 `
 }


### PR DESCRIPTION
Lambda Function ARN not supported along with qualifier.
Reason: functionParts := strings.Split(id, ":") -> id is the arn and the length of variable functionParts was always greater then 2 hence if case was always true.
modified it to functionParts := strings.Split(function, ":") -> length of variable functionParts will either be 1 or 2 based on if user provides qualifier or not.

Failed Acceptance test log:
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn -timeout 120m
=== RUN   TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn
=== PAUSE TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn
=== CONT  TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn
    resource_aws_lambda_function_event_invoke_config_test.go:269: Step 1/2 error: terraform failed: exit status 1
        stderr:
        Error: unexpected format of function resource (arn:aws:lambda:us-west-2::function:tf-acc-test-:$LATEST), expected n
ame:qualifier
    testing_new.go:22: WARNING: destroy failed, so remote objects may still exist and be subject to billing
    testing_new.go:22: failed to destroy: terraform failed: exit status 1
        stderr:
        Error: unexpected format of function resource (arn:aws:lambda:us-west-2::function:tf-acc-test-:$LATEST), expected n
ame:qualifier
--- FAIL: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn (86.72s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       89.725s
FAIL

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13166

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn -timeout 120m
=== RUN   TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn
=== PAUSE TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn
=== CONT  TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn
--- PASS: TestAccAWSLambdaFunctionEventInvokeConfig_Qualifier_FunctionName_Arn (114.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       115.367s

...
```
