### PR TITLE
data-source/aws_rds_orderable_db_instance: New data source

### DIFF
--- a/aws/data_source_aws_rds_orderable_db_instance.go
+++ b/aws/data_source_aws_rds_orderable_db_instance.go
@@ -1,0 +1,291 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsRdsOrderableDbInstance() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRdsOrderableDbInstanceRead,
+		Schema: map[string]*schema.Schema{
+			"availability_zone_group": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"db_instance_class": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"engine": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"license_model": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"max_iops_per_db_instance": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_iops_per_gib": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+
+			"max_storage_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"min_iops_per_db_instance": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"min_iops_per_gib": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+
+			"min_storage_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"multi_az_capable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"outpost_capable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"preferred_db_instance_classes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"read_replica_capable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"storage_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"supported_engine_modes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"supports_enhanced_monitoring": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"supports_global_databases": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"supports_iam_database_authentication": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"supports_iops": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"supports_kerberos_authentication": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"supports_performance_insights": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"supports_storage_autoscaling": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"supports_storage_encryption": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"vpc": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsRdsOrderableDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	input := &rds.DescribeOrderableDBInstanceOptionsInput{}
+
+	if v, ok := d.GetOk("availability_zone_group"); ok {
+		input.AvailabilityZoneGroup = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("db_instance_class"); ok {
+		input.DBInstanceClass = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("engine"); ok {
+		input.Engine = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("engine_version"); ok {
+		input.EngineVersion = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("license_model"); ok {
+		input.LicenseModel = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("vpc"); ok {
+		input.Vpc = aws.Bool(v.(bool))
+	}
+
+	log.Printf("[DEBUG] Reading RDS Orderable DB Instance Options: %v", input)
+	var instanceClassResults []*rds.OrderableDBInstanceOption
+
+	err := conn.DescribeOrderableDBInstanceOptionsPages(input, func(resp *rds.DescribeOrderableDBInstanceOptionsOutput, lastPage bool) bool {
+		for _, instanceOption := range resp.OrderableDBInstanceOptions {
+			if instanceOption == nil {
+				continue
+			}
+
+			if v, ok := d.GetOk("storage_type"); ok {
+				if aws.StringValue(instanceOption.StorageType) != v.(string) {
+					continue
+				}
+			}
+
+			instanceClassResults = append(instanceClassResults, instanceOption)
+		}
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading RDS orderable DB instance options: %w", err)
+	}
+
+	if len(instanceClassResults) == 0 {
+		return fmt.Errorf("no RDS Orderable DB Instance options found matching criteria; try different search")
+	}
+
+	// preferred classes
+	var found *rds.OrderableDBInstanceOption
+	if l := d.Get("preferred_db_instance_classes").([]interface{}); len(l) > 0 {
+		for _, elem := range l {
+			preferredInstanceClass, ok := elem.(string)
+
+			if !ok {
+				continue
+			}
+
+			for _, instanceClassResult := range instanceClassResults {
+				if preferredInstanceClass == aws.StringValue(instanceClassResult.DBInstanceClass) {
+					found = instanceClassResult
+					break
+				}
+			}
+
+			if found != nil {
+				break
+			}
+		}
+	}
+
+	if found == nil && len(instanceClassResults) > 1 {
+		return fmt.Errorf("multiple RDS DB Instance Classes (%v) match the criteria; try a different search", instanceClassResults)
+	}
+
+	if found == nil && len(instanceClassResults) == 1 {
+		found = instanceClassResults[0]
+	}
+
+	if found == nil {
+		return fmt.Errorf("no RDS DB Instance Classes match the criteria; try a different search")
+	}
+
+	d.SetId(aws.StringValue(found.DBInstanceClass))
+
+	d.Set("db_instance_class", found.DBInstanceClass)
+	d.Set("availability_zone_group", found.AvailabilityZoneGroup)
+
+	var availabilityZones []string
+	for _, az := range found.AvailabilityZones {
+		availabilityZones = append(availabilityZones, aws.StringValue(az.Name))
+	}
+	d.Set("availability_zones", availabilityZones)
+
+	d.Set("engine", found.Engine)
+	d.Set("engine_version", found.EngineVersion)
+	d.Set("license_model", found.LicenseModel)
+	d.Set("max_iops_per_db_instance", found.MaxIopsPerDbInstance)
+	d.Set("max_iops_per_gib", found.MaxIopsPerGib)
+	d.Set("max_storage_size", found.MaxStorageSize)
+	d.Set("min_iops_per_db_instance", found.MinIopsPerDbInstance)
+	d.Set("min_iops_per_gib", found.MinIopsPerGib)
+	d.Set("min_storage_size", found.MinStorageSize)
+	d.Set("multi_az_capable", found.MultiAZCapable)
+	d.Set("outpost_capable", found.OutpostCapable)
+	d.Set("read_replica_capable", found.ReadReplicaCapable)
+	d.Set("storage_type", found.StorageType)
+	d.Set("supported_engine_modes", found.SupportedEngineModes)
+	d.Set("supports_enhanced_monitoring", found.SupportsEnhancedMonitoring)
+	d.Set("supports_global_databases", found.SupportsGlobalDatabases)
+	d.Set("supports_iam_database_authentication", found.SupportsIAMDatabaseAuthentication)
+	d.Set("supports_iops", found.SupportsIops)
+	d.Set("supports_kerberos_authentication", found.SupportsKerberosAuthentication)
+	d.Set("supports_performance_insights", found.SupportsPerformanceInsights)
+	d.Set("supports_storage_autoscaling", found.SupportsStorageAutoscaling)
+	d.Set("supports_storage_encryption", found.SupportsStorageEncryption)
+	d.Set("vpc", found.Vpc)
+
+	return nil
+}

--- a/aws/data_source_aws_rds_orderable_db_instance_test.go
+++ b/aws/data_source_aws_rds_orderable_db_instance_test.go
@@ -1,0 +1,107 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+	class := "db.t2.small"
+	engine := "mysql"
+	engineVersion := "5.7.22"
+	licenseModel := "general-public-license"
+	storageType := "standard"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfigBasic(class, engine, engineVersion, licenseModel, storageType),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", class),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
+					resource.TestCheckResourceAttr(dataSourceName, "engine_version", engineVersion),
+					resource.TestCheckResourceAttr(dataSourceName, "license_model", licenseModel),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_type", storageType),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_preferred(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+	engine := "mysql"
+	engineVersion := "5.7.22"
+	licenseModel := "general-public-license"
+	storageType := "standard"
+	preferredOption := "db.t2.small"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfigPreferred(engine, engineVersion, licenseModel, storageType, preferredOption),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
+					resource.TestCheckResourceAttr(dataSourceName, "engine_version", engineVersion),
+					resource.TestCheckResourceAttr(dataSourceName, "license_model", licenseModel),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_type", storageType),
+					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", preferredOption),
+				),
+			},
+		},
+	})
+}
+
+func testAccPreCheckAWSRdsOrderableDbInstance(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+	input := &rds.DescribeOrderableDBInstanceOptionsInput{
+		Engine: aws.String("mysql"),
+	}
+
+	_, err := conn.DescribeOrderableDBInstanceOptions(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfigBasic(class, engine, version, license, storage string) string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  db_instance_class = %q
+  engine            = %q
+  engine_version    = %q
+  license_model     = %q
+  storage_type      = %q
+}
+`, class, engine, version, license, storage)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfigPreferred(engine, version, license, storage, preferredOption string) string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = %q
+  engine_version = %q
+  license_model  = %q
+  storage_type   = %q
+
+  preferred_db_instance_classes = ["db.xyz.xlarge", %q, "db.t3.small"]
+}
+`, engine, version, license, storage, preferredOption)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -302,6 +302,7 @@ func Provider() *schema.Provider {
 			"aws_qldb_ledger":                                dataSourceAwsQLDBLedger(),
 			"aws_ram_resource_share":                         dataSourceAwsRamResourceShare(),
 			"aws_rds_cluster":                                dataSourceAwsRdsCluster(),
+			"aws_rds_orderable_db_instance":                  dataSourceAwsRdsOrderableDbInstance(),
 			"aws_redshift_cluster":                           dataSourceAwsRedshiftCluster(),
 			"aws_redshift_service_account":                   dataSourceAwsRedshiftServiceAccount(),
 			"aws_region":                                     dataSourceAwsRegion(),

--- a/website/docs/d/rds_orderable_db_instance.markdown
+++ b/website/docs/d/rds_orderable_db_instance.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "RDS"
+layout: "aws"
+page_title: "AWS: aws_rds_orderable_db_instance"
+description: |-
+  Information about RDS orderable DB instances.
+---
+
+# Data Source: aws_rds_orderable_db_instance
+
+Information about RDS orderable DB instances.
+
+## Example Usage
+
+```hcl
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = "mysql"
+  engine_version = "5.7.22"
+  license_model  = "general-public-license"
+  storage_type   = "standard"
+
+  preferred_db_instance_classes = ["db.r6.xlarge", "db.m4.large", "db.t3.small"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `engine` - (Required) DB engine. Engine values include `aurora`, `aurora-mysql`, `aurora-postgresql`, `docdb`, `mariadb`, `mysql`, `neptune`, `oracle-ee`, `oracle-se`, `oracle-se1`, `oracle-se2`, `postgres`, `sqlserver-ee`, `sqlserver-ex`, `sqlserver-se`, and `sqlserver-web`.
+* `availability_zone_group` - (Optional) Availability zone group.
+* `db_instance_class` - (Optional) DB instance class. Examples of classes are `db.m3.2xlarge`, `db.t2.small`, and `db.m3.medium`.
+* `engine_version` - (Optional) Version of the DB engine.
+* `license_model` - (Optional) License model. Examples of license models are `general-public-license`, `bring-your-own-license`, and `amazon-license`.
+* `preferred_db_instance_classes` - (Optional) Ordered list of preferred RDS DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
+* `storage_type` - (Optional) Storage types. Examples of storage types are `standard`, `io1`, `gp2`, and `aurora`.
+* `vpc` - (Optional) Boolean that indicates whether to show only VPC or non-VPC offerings.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `availability_zones` - Availability zones where the instance is available.
+* `max_iops_per_db_instance` - Maximum total provisioned IOPS for a DB instance.
+* `max_iops_per_gib` - Maximum provisioned IOPS per GiB for a DB instance.
+* `max_storage_size` - Maximum storage size for a DB instance.
+* `min_iops_per_db_instance` - Minimum total provisioned IOPS for a DB instance.
+* `min_iops_per_gib` - Minimum provisioned IOPS per GiB for a DB instance.
+* `min_storage_size` - Minimum storage size for a DB instance.
+* `multi_az_capable` - Whether a DB instance is Multi-AZ capable.
+* `outpost_capable` - Whether a DB instance supports RDS on Outposts.
+* `read_replica_capable` - Whether a DB instance can have a read replica.
+* `supported_engine_modes` - A list of the supported DB engine modes.
+* `supports_enhanced_monitoring` - Whether a DB instance supports Enhanced Monitoring at intervals from 1 to 60 seconds.
+* `supports_global_databases` - Whether you can use Aurora global databases with a specific combination of other DB engine attributes.
+* `supports_iam_database_authentication` - Whether a DB instance supports IAM database authentication.
+* `supports_iops` - Whether a DB instance supports provisioned IOPS.
+* `supports_kerberos_authentication` - Whether a DB instance supports Kerberos Authentication.
+* `supports_performance_insights` - Whether a DB instance supports Performance Insights.
+* `supports_storage_autoscaling` - Whether Amazon RDS can automatically scale storage for DB instances that use the specified DB instance class.
+* `supports_storage_encryption` - Whether a DB instance supports encrypted storage.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14834 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* data-source/aws_rds_orderable_db_instance: New data source to find valid RDS DB instance parameter
combinations
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Testing on GovCloud:
```
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_basic (17.07s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferred (17.53s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_versionPrefix (17.54s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredVersionPrefix (37.74s)
```

Testing on commercial/standard partition:
```
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_basic (13.75s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_versionPrefix (15.11s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferred (15.60s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredVersionPrefix (178.14s)
```