### PR TITLE
tests/provider: Update hardcoded AZs (DMS related)

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -153,6 +153,25 @@ func testAccCheckResourceAttrRegionalARNAccountID(resourceName, attributeName, a
 	}
 }
 
+// testAccCheckResourceAttrRegionalHostname ensures the Terraform state exactly matches a formatted DNS hostname with region and partition DNS suffix
+func testAccCheckResourceAttrRegionalHostname(resourceName, attributeName, serviceName, hostnamePrefix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		hostname := fmt.Sprintf("%s.%s.%s.%s", hostnamePrefix, serviceName, testAccGetRegion(), testAccGetPartitionDNSSuffix())
+
+		return resource.TestCheckResourceAttr(resourceName, attributeName, hostname)(s)
+	}
+}
+
+// testAccCheckResourceAttrHostnameWithPort ensures the Terraform state regexp matches a formatted DNS hostname with prefix, partition DNS suffix, and given port
+func testAccCheckResourceAttrHostnameWithPort(resourceName, attributeName, serviceName, hostnamePrefix string, port int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// kafka broker example: "ec2-12-345-678-901.compute-1.amazonaws.com:2345"
+		hostname := fmt.Sprintf("%s.%s.%s:%d", hostnamePrefix, serviceName, testAccGetPartitionDNSSuffix(), port)
+
+		return resource.TestCheckResourceAttr(resourceName, attributeName, hostname)(s)
+	}
+}
+
 // testAccMatchResourceAttrRegionalARN ensures the Terraform state regexp matches a formatted ARN with region
 func testAccMatchResourceAttrRegionalARN(resourceName, attributeName, arnService string, arnResourceRegexp *regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/aws/resource_aws_dms_replication_subnet_group_test.go
+++ b/aws/resource_aws_dms_replication_subnet_group_test.go
@@ -100,22 +100,22 @@ func dmsReplicationSubnetGroupDestroy(s *terraform.State) error {
 }
 
 func dmsReplicationSubnetGroupConfig(randId string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "dms_vpc" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-dms-replication-subnet-group"
+    Name = "terraform-testacc-dms-replication-subnet-group-%[1]s"
   }
 }
 
 resource "aws_subnet" "dms_subnet_1" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.dms_vpc.id
 
   tags = {
-    Name = "tf-acc-dms-replication-subnet-group-1"
+    Name = "tf-acc-dms-replication-subnet-group-1-%[1]s"
   }
 
   depends_on = [aws_vpc.dms_vpc]
@@ -123,11 +123,11 @@ resource "aws_subnet" "dms_subnet_1" {
 
 resource "aws_subnet" "dms_subnet_2" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.dms_vpc.id
 
   tags = {
-    Name = "tf-acc-dms-replication-subnet-group-2"
+    Name = "tf-acc-dms-replication-subnet-group-2-%[1]s"
   }
 
   depends_on = [aws_vpc.dms_vpc]
@@ -135,11 +135,11 @@ resource "aws_subnet" "dms_subnet_2" {
 
 resource "aws_subnet" "dms_subnet_3" {
   cidr_block        = "10.1.3.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.dms_vpc.id
 
   tags = {
-    Name = "tf-acc-dms-replication-subnet-group-3"
+    Name = "tf-acc-dms-replication-subnet-group-3-%[1]s"
   }
 
   depends_on = [aws_vpc.dms_vpc]
@@ -156,26 +156,26 @@ resource "aws_dms_replication_subnet_group" "dms_replication_subnet_group" {
     Remove = "to-remove"
   }
 }
-`, randId)
+`, randId))
 }
 
 func dmsReplicationSubnetGroupConfigUpdate(randId string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "dms_vpc" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-dms-replication-subnet-group"
+    Name = "terraform-testacc-dms-replication-subnet-group-%[1]s"
   }
 }
 
 resource "aws_subnet" "dms_subnet_1" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.dms_vpc.id
 
   tags = {
-    Name = "tf-acc-dms-replication-subnet-group-1"
+    Name = "tf-acc-dms-replication-subnet-group-1-%[1]s"
   }
 
   depends_on = [aws_vpc.dms_vpc]
@@ -183,11 +183,11 @@ resource "aws_subnet" "dms_subnet_1" {
 
 resource "aws_subnet" "dms_subnet_2" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.dms_vpc.id
 
   tags = {
-    Name = "tf-acc-dms-replication-subnet-group-2"
+    Name = "tf-acc-dms-replication-subnet-group-2-%[1]s"
   }
 
   depends_on = [aws_vpc.dms_vpc]
@@ -195,11 +195,11 @@ resource "aws_subnet" "dms_subnet_2" {
 
 resource "aws_subnet" "dms_subnet_3" {
   cidr_block        = "10.1.3.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.dms_vpc.id
 
   tags = {
-    Name = "tf-acc-dms-replication-subnet-group-3"
+    Name = "tf-acc-dms-replication-subnet-group-3-%[1]s"
   }
 
   depends_on = [aws_vpc.dms_vpc]
@@ -216,5 +216,5 @@ resource "aws_dms_replication_subnet_group" "dms_replication_subnet_group" {
     Add    = "added"
   }
 }
-`, randId)
+`, randId))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing (GovCloud partition):

```
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch (53.84s)
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch_ErrorRetryDuration (53.98s)
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch_FullLoadErrorPercentage (55.46s)
--- PASS: TestAccAwsDmsEndpoint_DocDB (65.59s)
--- PASS: TestAccAwsDmsEndpoint_Db2 (66.67s)
--- PASS: TestAccAwsDmsEndpoint_basic (66.72s)
--- PASS: TestAccAwsDmsEndpoint_Kafka_Broker (67.39s)
--- PASS: TestAccAwsDmsEndpoint_Kafka_Topic (68.31s)
--- PASS: TestAccAwsDmsEndpoint_MongoDb (68.81s)
--- PASS: TestAccAWSDmsReplicationSubnetGroup_basic (70.37s)
--- PASS: TestAccAwsDmsEndpoint_S3 (72.42s)
--- PASS: TestAccAwsDmsEndpoint_DynamoDb (72.93s)
--- PASS: TestAccAwsDmsEndpoint_Kinesis (86.61s)
--- FAIL: TestAccAWSDmsReplicationTask_basic (372.55s)
```

Output from acceptance testing (commercial/standard partition):

```
--- PASS: TestAccAwsDmsEndpoint_DocDB (59.13s)
--- PASS: TestAccAwsDmsEndpoint_basic (60.07s)
--- PASS: TestAccAwsDmsEndpoint_Db2 (60.10s)
--- PASS: TestAccAwsDmsEndpoint_Kafka_Broker (63.24s)
--- PASS: TestAccAwsDmsEndpoint_Kafka_Topic (63.57s)
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch_ErrorRetryDuration (63.83s)
--- PASS: TestAccAwsDmsEndpoint_MongoDb (64.19s)
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch_FullLoadErrorPercentage (64.32s)
--- PASS: TestAccAwsDmsEndpoint_Elasticsearch (64.75s)
--- PASS: TestAccAWSDmsReplicationSubnetGroup_basic (66.19s)
--- PASS: TestAccAwsDmsEndpoint_S3 (75.12s)
--- PASS: TestAccAwsDmsEndpoint_DynamoDb (85.01s)
--- PASS: TestAccAwsDmsEndpoint_Kinesis (98.84s)
--- FAIL: TestAccAWSDmsReplicationTask_basic (414.97s)
```

Seems that `TestAccAWSDmsReplicationTask_basic` has been failing for a while and is unrelated.