### PR TITLE
fix issue-10446, add test case for ebs_config.volumes_per_instance check

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -1424,8 +1424,7 @@ func flattenEBSConfig(ebsBlockDevices []*emr.EbsBlockDevice) *schema.Set {
 		if ebs.VolumeSpecification.VolumeType != nil {
 			ebsAttrs["type"] = *ebs.VolumeSpecification.VolumeType
 		}
-		ebsAttrs["volumes_per_instance"] = 1
-
+		ebsAttrs["volumes_per_instance"] = len(ebsBlockDevices)
 		ebsConfig = append(ebsConfig, ebsAttrs)
 	}
 

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -1411,7 +1411,7 @@ func flattenEmrStepSummary(stepSummary *emr.StepSummary) map[string]interface{} 
 }
 
 func flattenEBSConfig(ebsBlockDevices []*emr.EbsBlockDevice) *schema.Set {
-
+	uniqueEBS := make(map[int]int)
 	ebsConfig := make([]interface{}, 0)
 	for _, ebs := range ebsBlockDevices {
 		ebsAttrs := make(map[string]interface{})
@@ -1424,10 +1424,14 @@ func flattenEBSConfig(ebsBlockDevices []*emr.EbsBlockDevice) *schema.Set {
 		if ebs.VolumeSpecification.VolumeType != nil {
 			ebsAttrs["type"] = *ebs.VolumeSpecification.VolumeType
 		}
-		ebsAttrs["volumes_per_instance"] = len(ebsBlockDevices)
+		ebsAttrs["volumes_per_instance"] = 1
+		uniqueEBS[resourceAwsEMRClusterEBSConfigHash(ebsAttrs)] += 1
 		ebsConfig = append(ebsConfig, ebsAttrs)
 	}
 
+	for _, ebs := range ebsConfig {
+		ebs.(map[string]interface{})["volumes_per_instance"] = uniqueEBS[resourceAwsEMRClusterEBSConfigHash(ebs)]
+	}
 	return schema.NewSet(resourceAwsEMRClusterEBSConfigHash, ebsConfig)
 }
 

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -3447,13 +3447,17 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
   master_instance_group {
     instance_type = "m4.large"
-    ebs_config {
+	ebs_config {
       size                 = 32
       type                 = "gp2"
       volumes_per_instance = %[2]d
     }
+	ebs_config {
+	  size                 = 50
+	  type                 = "gp2"
+	  volumes_per_instance = %[2]d
+	}
   }
-
   core_instance_group {
     instance_count = 1
     instance_type  = "m4.large"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #10446 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES

* resource/aws_emr_cluster: Prevent EMR cluster recreate when `ebs_config.volumes_per_instance` is greater than 1
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEMRCluster_ebs_config'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEMRCluster_ebs_config -timeout 120m
=== RUN   TestAccAWSEMRCluster_ebs_config
=== PAUSE TestAccAWSEMRCluster_ebs_config
=== CONT  TestAccAWSEMRCluster_ebs_config
2020/08/26 17:29:07 [INFO] Test: Using us-east-1 as test region
2020/08/26 17:29:07 [INFO] AWS Auth provider used: "EnvProvider"
--- PASS: TestAccAWSEMRCluster_ebs_config (576.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	576.948s
```
