### PR TITLE
resource/rds_cluster_endpoint: add Create Timeout

### DIFF
--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	AWSRDSClusterEndpointCreateTimeout   = 30 * time.Minute
 	AWSRDSClusterEndpointRetryDelay      = 5 * time.Second
 	AWSRDSClusterEndpointRetryMinTimeout = 3 * time.Second
 )
@@ -104,7 +105,7 @@ func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{
 
 	d.SetId(endpointId)
 
-	err = resourceAwsRDSClusterEndpointWaitForAvailable(d.Timeout(schema.TimeoutDelete), d.Id(), conn)
+	err = resourceAwsRDSClusterEndpointWaitForAvailable(AWSRDSClusterEndpointCreateTimeout, d.Id(), conn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14570

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/rds_cluster_endpoint: increase Create Timeout to 30 minutes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSRDSClusterEndpoint_basic (1160.15s)
--- PASS: TestAccAWSRDSClusterEndpoint_tags (1218.53s)
```
