### PR TITLE
Add local gateway routes and route table entries

### DIFF
--- a/aws/data_source_aws_route.go
+++ b/aws/data_source_aws_route.go
@@ -47,6 +47,11 @@ func dataSourceAwsRoute() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"local_gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"transit_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -110,6 +115,7 @@ func dataSourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("gateway_id", route.GatewayId)
 	d.Set("instance_id", route.InstanceId)
 	d.Set("nat_gateway_id", route.NatGatewayId)
+	d.Set("local_gateway_id", route.LocalGatewayId)
 	d.Set("transit_gateway_id", route.TransitGatewayId)
 	d.Set("vpc_peering_connection_id", route.VpcPeeringConnectionId)
 	d.Set("network_interface_id", route.NetworkInterfaceId)
@@ -165,6 +171,12 @@ func getRoutes(table *ec2.RouteTable, d *schema.ResourceData) []*ec2.Route {
 
 		if v, ok := d.GetOk("nat_gateway_id"); ok {
 			if r.NatGatewayId == nil || *r.NatGatewayId != v.(string) {
+				continue
+			}
+		}
+
+		if v, ok := d.GetOk("local_gateway_id"); ok {
+			if r.LocalGatewayId == nil || *r.LocalGatewayId != v.(string) {
 				continue
 			}
 		}

--- a/aws/data_source_aws_route_table.go
+++ b/aws/data_source_aws_route_table.go
@@ -72,6 +72,11 @@ func dataSourceAwsRouteTable() *schema.Resource {
 							Computed: true,
 						},
 
+						"local_gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"transit_gateway_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -227,6 +232,9 @@ func dataSourceRoutesRead(ec2Routes []*ec2.Route) []map[string]interface{} {
 		}
 		if r.NatGatewayId != nil {
 			m["nat_gateway_id"] = *r.NatGatewayId
+		}
+		if r.LocalGatewayId != nil {
+			m["local_gateway_id"] = *r.LocalGatewayId
 		}
 		if r.InstanceId != nil {
 			m["instance_id"] = *r.InstanceId

--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -61,7 +61,7 @@ func TestAccAWSRouteDataSource_LocalGatewayID(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: AccAWSRouteDataSourceConfigLocalGatewayID(),
+				Config: testAccAWSRouteDataSourceConfigLocalGatewayID(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_cidr_block", dataSourceName, "destination_cidr_block"),
@@ -246,7 +246,7 @@ data "aws_route" "test" {
 `
 }
 
-func AccAWSRouteDataSourceConfigLocalGatewayID() string {
+func testAccAWSRouteDataSourceConfigLocalGatewayID() string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
 data "aws_ec2_local_gateway" "first" {

--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -56,7 +56,7 @@ func TestAccAWSRouteDataSource_LocalGatewayID(t *testing.T) {
 	resourceName := "aws_route.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -50,6 +50,29 @@ func TestAccAWSRouteDataSource_TransitGatewayID(t *testing.T) {
 	})
 }
 
+func TestAccAWSRouteDataSource_LocalGatewayID(t *testing.T) {
+	var route ec2.Route
+	dataSourceName := "data.aws_route.by_local_gateway_id"
+	resourceName := "aws_route.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: AccAWSRouteDataSourceConfigLocalGatewayID(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_cidr_block", dataSourceName, "destination_cidr_block"),
+					resource.TestCheckResourceAttrPair(resourceName, "route_table_id", dataSourceName, "route_table_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "local_gateway_id", dataSourceName, "local_gateway_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsRouteCheck(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -221,4 +244,44 @@ data "aws_route" "test" {
   transit_gateway_id = aws_route.test.transit_gateway_id
 }
 `
+}
+
+func AccAWSRouteDataSourceConfigLocalGatewayID() string {
+	return fmt.Sprintf(`
+data "aws_ec2_local_gateways" "all" {}
+data "aws_ec2_local_gateway" "first" {
+  id = tolist(data.aws_ec2_local_gateways.all.ids)[0]
+}
+
+data "aws_ec2_local_gateway_route_tables" "all" {}
+data "aws_ec2_local_gateway_route_table" "first" {
+  local_gateway_route_table_id = tolist(data.aws_ec2_local_gateway_route_tables.all.ids)[0]
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_ec2_local_gateway_route_table_vpc_association" "example" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.first.id
+  vpc_id                       = aws_vpc.test.id
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = "172.16.1.0/24"
+  local_gateway_id       = data.aws_ec2_local_gateway.first.id
+  depends_on             = [aws_ec2_local_gateway_route_table_vpc_association.example]
+}
+
+data "aws_route" "by_local_gateway_id" {
+  route_table_id   = aws_route_table.test.id
+  local_gateway_id = data.aws_ec2_local_gateway.first.id
+  depends_on       = [aws_route.test]
+}
+`)
 }

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -17,7 +17,7 @@ import (
 
 // How long to sleep if a limit-exceeded event happens
 var routeTargetValidationError = errors.New("Error: more than 1 target specified. Only 1 of gateway_id, " +
-	"egress_only_gateway_id, nat_gateway_id, instance_id, network_interface_id or " +
+	"egress_only_gateway_id, nat_gateway_id, instance_id, network_interface_id, local_gateway_id or " +
 	"vpc_peering_connection_id is allowed.")
 
 // AWS Route resource Schema declaration
@@ -96,6 +96,12 @@ func resourceAwsRoute() *schema.Resource {
 				Computed: true,
 			},
 
+			"local_gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"instance_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -150,6 +156,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		"egress_only_gateway_id",
 		"gateway_id",
 		"nat_gateway_id",
+		"local_gateway_id",
 		"instance_id",
 		"network_interface_id",
 		"transit_gateway_id",
@@ -196,6 +203,12 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
 			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
 			NatGatewayId:         aws.String(d.Get("nat_gateway_id").(string)),
+		}
+	case "local_gateway_id":
+		createOpts = &ec2.CreateRouteInput{
+			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
+			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
+			LocalGatewayId:       aws.String(d.Get("local_gateway_id").(string)),
 		}
 	case "instance_id":
 		createOpts = &ec2.CreateRouteInput{
@@ -369,6 +382,7 @@ func resourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("gateway_id", route.GatewayId)
 	d.Set("egress_only_gateway_id", route.EgressOnlyInternetGatewayId)
 	d.Set("nat_gateway_id", route.NatGatewayId)
+	d.Set("local_gateway_id", route.LocalGatewayId)
 	d.Set("instance_id", route.InstanceId)
 	d.Set("instance_owner_id", route.InstanceOwnerId)
 	d.Set("network_interface_id", route.NetworkInterfaceId)
@@ -389,6 +403,7 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 		"egress_only_gateway_id",
 		"gateway_id",
 		"nat_gateway_id",
+		"local_gateway_id",
 		"network_interface_id",
 		"instance_id",
 		"transit_gateway_id",
@@ -436,6 +451,12 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
 			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
 			NatGatewayId:         aws.String(d.Get("nat_gateway_id").(string)),
+		}
+	case "local_gateway_id":
+		replaceOpts = &ec2.ReplaceRouteInput{
+			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
+			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
+			LocalGatewayId:       aws.String(d.Get("local_gateway_id").(string)),
 		}
 	case "instance_id":
 		replaceOpts = &ec2.ReplaceRouteInput{

--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -87,6 +87,11 @@ func resourceAwsRouteTable() *schema.Resource {
 							Optional: true,
 						},
 
+						"local_gateway_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"transit_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -211,6 +216,9 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		if r.NatGatewayId != nil {
 			m["nat_gateway_id"] = *r.NatGatewayId
+		}
+		if r.LocalGatewayId != nil {
+			m["local_gateway_id"] = *r.LocalGatewayId
 		}
 		if r.InstanceId != nil {
 			m["instance_id"] = *r.InstanceId
@@ -386,6 +394,10 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 				opts.NatGatewayId = aws.String(s)
 			}
 
+			if s := m["local_gateway_id"].(string); s != "" {
+				opts.LocalGatewayId = aws.String(s)
+			}
+
 			log.Printf("[INFO] Creating route for %s: %#v", d.Id(), opts)
 			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 				_, err := conn.CreateRoute(&opts)
@@ -528,6 +540,10 @@ func resourceAwsRouteTableHash(v interface{}) int {
 	}
 
 	if v, ok := m["transit_gateway_id"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	}
+
+	if v, ok := m["local_gateway_id"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -382,7 +382,7 @@ func TestAccAWSRouteTable_Route_LocalGatewayID(t *testing.T) {
 	resourceName := "aws_route_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -377,6 +377,30 @@ func TestAccAWSRouteTable_Route_TransitGatewayID(t *testing.T) {
 	})
 }
 
+func TestAccAWSRouteTable_Route_LocalGatewayID(t *testing.T) {
+	var routeTable1 ec2.RouteTable
+	resourceName := "aws_route_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRouteTableConfigRouteLocalGatewayID(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists(resourceName, &routeTable1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckRouteTableDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -957,6 +981,48 @@ resource "aws_route_table" "test" {
     cidr_block         = "0.0.0.0/0"
     transit_gateway_id = aws_ec2_transit_gateway_vpc_attachment.test.transit_gateway_id
   }
+}
+`
+}
+
+func testAccAWSRouteTableConfigRouteLocalGatewayID() string {
+	return `
+data "aws_ec2_local_gateways" "all" {}
+data "aws_ec2_local_gateway" "first" {
+  id = tolist(data.aws_ec2_local_gateways.all.ids)[0]
+}
+
+data "aws_ec2_local_gateway_route_tables" "all" {}
+data "aws_ec2_local_gateway_route_table" "first" {
+  local_gateway_route_table_id = tolist(data.aws_ec2_local_gateway_route_tables.all.ids)[0]
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-ec2-route-table-transit-gateway-id"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = aws_vpc.test.id
+}
+
+resource "aws_ec2_local_gateway_route_table_vpc_association" "example" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.first.id
+  vpc_id                       = aws_vpc.test.id
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block         = "0.0.0.0/0"
+    local_gateway_id = data.aws_ec2_local_gateway.first.id
+  }
+  depends_on = [aws_ec2_local_gateway_route_table_vpc_association.example]
 }
 `
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -444,7 +444,7 @@ func TestAccAWSRoute_LocalGatewayID(t *testing.T) {
 	localGatewayDataSourceName := "data.aws_ec2_local_gateway.first"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -449,7 +449,7 @@ func TestAccAWSRoute_LocalGatewayID(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: AccAWSRouteResourceConfigLocalGatewayID(),
+				Config: testAccAWSRouteResourceConfigLocalGatewayID(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists(resourceName, &route),
 					resource.TestCheckResourceAttrPair(resourceName, "local_gateway_id", localGatewayDataSourceName, "id"),
@@ -1298,7 +1298,7 @@ resource "aws_route" "test" {
 `, rName, ipv6Route)
 }
 
-func AccAWSRouteResourceConfigLocalGatewayID() string {
+func testAccAWSRouteResourceConfigLocalGatewayID() string {
 	return fmt.Sprintf(`
 data "aws_ec2_local_gateways" "all" {}
 data "aws_ec2_local_gateway" "first" {

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -438,6 +438,33 @@ func TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock(t *testing.T) {
 	})
 }
 
+func TestAccAWSRoute_LocalGatewayID(t *testing.T) {
+	var route ec2.Route
+	resourceName := "aws_route.test"
+	localGatewayDataSourceName := "data.aws_ec2_local_gateway.first"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRouteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: AccAWSRouteResourceConfigLocalGatewayID(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRouteExists(resourceName, &route),
+					resource.TestCheckResourceAttrPair(resourceName, "local_gateway_id", localGatewayDataSourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSRoute_ConditionalCidrBlock(t *testing.T) {
 	var route ec2.Route
 	resourceName := "aws_route.test"
@@ -1269,4 +1296,38 @@ resource "aws_route" "test" {
   destination_ipv6_cidr_block = local.ipv6 ? local.destination_ipv6 : ""
 }
 `, rName, ipv6Route)
+}
+
+func AccAWSRouteResourceConfigLocalGatewayID() string {
+	return fmt.Sprintf(`
+data "aws_ec2_local_gateways" "all" {}
+data "aws_ec2_local_gateway" "first" {
+  id = tolist(data.aws_ec2_local_gateways.all.ids)[0]
+}
+
+data "aws_ec2_local_gateway_route_tables" "all" {}
+data "aws_ec2_local_gateway_route_table" "first" {
+  local_gateway_route_table_id = tolist(data.aws_ec2_local_gateway_route_tables.all.ids)[0]
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_ec2_local_gateway_route_table_vpc_association" "example" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.first.id
+  vpc_id                       = aws_vpc.test.id
+}
+
+resource "aws_route_table" "test" {
+  vpc_id     = aws_vpc.test.id
+  depends_on = [aws_ec2_local_gateway_route_table_vpc_association.example]
+}
+
+resource "aws_route" "test" {
+  route_table_id         = aws_route_table.test.id
+  destination_cidr_block = "172.16.1.0/24"
+  local_gateway_id       = data.aws_ec2_local_gateway.first.id
+}
+`)
 }

--- a/website/docs/d/route.html.markdown
+++ b/website/docs/d/route.html.markdown
@@ -56,6 +56,8 @@ Route whose data will be exported as attributes.
 
 * `nat_gateway_id` - (Optional) The NAT Gateway ID of the Route belonging to the Route Table.
 
+* `local_gateway_id` - (Optional) The Local Gateway ID of the Route belonging to the Route Table.
+
 * `transit_gateway_id` - (Optional) The EC2 Transit Gateway ID of the Route belonging to the Route Table.
 
 * `vpc_peering_connection_id` - (Optional) The VPC Peering Connection ID of the Route belonging to the Route Table.

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -78,6 +78,7 @@ Each route supports the following:
 * `egress_only_gateway_id` - The ID of the Egress Only Internet Gateway.
 * `gateway_id` - The Internet Gateway ID.
 * `nat_gateway_id` - The NAT Gateway ID.
+* `local_gateway_id` - The Local Gateway ID.
 * `instance_id` - The EC2 instance ID.
 * `transit_gateway_id` - The EC2 Transit Gateway ID.
 * `vpc_peering_connection_id` - The VPC Peering ID.

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -63,6 +63,7 @@ One of the following target arguments must be supplied:
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional) Identifier of an EC2 instance.
 * `nat_gateway_id` - (Optional) Identifier of a VPC NAT gateway.
+* `local_gateway_id` - (Optional) Identifier of a Outpost local gateway.
 * `network_interface_id` - (Optional) Identifier of an EC2 network interface.
 * `transit_gateway_id` - (Optional) Identifier of an EC2 Transit Gateway.
 * `vpc_peering_connection_id` - (Optional) Identifier of a VPC peering connection.

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -73,6 +73,7 @@ One of the following target arguments must be supplied:
 * `gateway_id` - (Optional) Identifier of a VPC internet gateway or a virtual private gateway.
 * `instance_id` - (Optional) Identifier of an EC2 instance.
 * `nat_gateway_id` - (Optional) Identifier of a VPC NAT gateway.
+* `local_gateway_id` - (Optional) Identifier of a Outpost local gateway.
 * `network_interface_id` - (Optional) Identifier of an EC2 network interface.
 * `transit_gateway_id` - (Optional) Identifier of an EC2 Transit Gateway.
 * `vpc_peering_connection_id` - (Optional) Identifier of a VPC peering connection.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #13888

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Add Local Gateway Routes
* Add support for Local Gateway routes in Route Tables
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=LocalGatewayID$'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=LocalGatewayID -timeout 120m
=== RUN   TestAccAWSRouteDataSource_LocalGatewayID
=== PAUSE TestAccAWSRouteDataSource_LocalGatewayID
=== RUN   TestAccAWSRouteTable_Route_LocalGatewayID
=== PAUSE TestAccAWSRouteTable_Route_LocalGatewayID
=== RUN   TestAccAWSRoute_LocalGatewayID
=== PAUSE TestAccAWSRoute_LocalGatewayID
=== CONT  TestAccAWSRouteDataSource_LocalGatewayID
=== CONT  TestAccAWSRouteTable_Route_LocalGatewayID
=== CONT  TestAccAWSRoute_LocalGatewayID
--- PASS: TestAccAWSRouteDataSource_LocalGatewayID (70.98s)
--- PASS: TestAccAWSRouteTable_Route_LocalGatewayID (74.51s)
--- PASS: TestAccAWSRoute_LocalGatewayID (78.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       80.880s
```

Additional note: Default route table resource and datasource is not modified. This is because AWS does not allow Local Gateways to be associated with the default vpc route table.