### PR TITLE
Fix TestAccAWSELB_swap_subnets

### DIFF
--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1876,7 +1876,7 @@ resource "aws_subnet" "public_a_two" {
 }
 
 resource "aws_elb" "test" {
-  name = "terraform-asg-deployment-example"
+  name = "terraform-asg-deployment-1-1"
 
   subnets = [
     aws_subnet.public_a_one.id,
@@ -1936,8 +1936,8 @@ resource "aws_subnet" "public_b_one" {
 
   cidr_block        = "10.1.7.0/24"
   availability_zone = data.aws_availability_zones.available.names[1]
- gs = {
-    Name = "tf-acc-elb-subnet-swap-b-on
+  tags = {
+    Name = "tf-acc-elb-subnet-swap-b-one"
   }
 }
 
@@ -1952,7 +1952,7 @@ resource "aws_subnet" "public_a_two" {
 }
 
 resource "aws_elb" "test" {
-  name = "terraform-asg-deployment-example"
+  name = "terraform-asg-deployment-2-1"
 
   subnets = [
     aws_subnet.public_a_two.id,

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1876,7 +1876,7 @@ resource "aws_subnet" "public_a_two" {
 }
 
 resource "aws_elb" "test" {
-  name = "terraform-asg-deployment-1-1"
+  name = "terraform-asg-deployment-example"
 
   subnets = [
     aws_subnet.public_a_one.id,

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1952,7 +1952,7 @@ resource "aws_subnet" "public_a_two" {
 }
 
 resource "aws_elb" "test" {
-  name = "terraform-asg-deployment-2-1"
+  name = "terraform-asg-deployment-example"
 
   subnets = [
     aws_subnet.public_a_two.id,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14803 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSELB_swap_subnets'
--- PASS: TestAccAWSELB_swap_subnets (169.42s)
...
```
