### PR TITLE
Paginate aws_route53_route_association

### DIFF
--- a/aws/resource_aws_route53_zone_association.go
+++ b/aws/resource_aws_route53_zone_association.go
@@ -214,19 +214,25 @@ func route53GetZoneAssociation(conn *route53.Route53, zoneID, vpcID, vpcRegion s
 		VPCRegion: aws.String(vpcRegion),
 	}
 
-	output, err := conn.ListHostedZonesByVPC(input)
+	for {
+		output, err := conn.ListHostedZonesByVPC(input)
 
-	if err != nil {
-		return nil, err
-	}
+		if err != nil {
+			return nil, err
+		}
 
-	var associatedHostedZoneSummary *route53.HostedZoneSummary
-	for _, hostedZoneSummary := range output.HostedZoneSummaries {
-		if zoneID == aws.StringValue(hostedZoneSummary.HostedZoneId) {
-			associatedHostedZoneSummary = hostedZoneSummary
+		var associatedHostedZoneSummary *route53.HostedZoneSummary
+		for _, hostedZoneSummary := range output.HostedZoneSummaries {
+			if zoneID == aws.StringValue(hostedZoneSummary.HostedZoneId) {
+				associatedHostedZoneSummary = hostedZoneSummary
+				return associatedHostedZoneSummary, nil
+			}
+		}
+		if output.NextToken == nil {
 			break
 		}
+		input.NextToken = output.NextToken
 	}
 
-	return associatedHostedZoneSummary, nil
+	return nil, nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14872 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds support for VPCs with large numbers (>100) of hosted zones attached by properly handling pagination.
```

Output from acceptance testing:

I (my company) unfortunately do not have an account setup that allows for testing cross-zone/cross-account tests.

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
