### PR TITLE
tech-debt: update opsworks_slack attr and tests and enumerated values in opsworks resources

### DIFF
--- a/aws/resource_aws_opsworks_application.go
+++ b/aws/resource_aws_opsworks_application.go
@@ -34,17 +34,9 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 				ForceNew: true,
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					opsworks.AppTypeAwsFlowRuby,
-					opsworks.AppTypeJava,
-					opsworks.AppTypeRails,
-					opsworks.AppTypePhp,
-					opsworks.AppTypeNodejs,
-					opsworks.AppTypeStatic,
-					opsworks.AppTypeOther,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(opsworks.AppType_Values(), false),
 			},
 			"stack_id": {
 				Type:     schema.TypeString,
@@ -77,15 +69,9 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								opsworks.SourceTypeGit,
-								opsworks.SourceTypeSvn,
-								opsworks.SourceTypeArchive,
-								opsworks.SourceTypeS3,
-								"other",
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(opsworks.SourceType_Values(), false),
 						},
 
 						"url": {

--- a/aws/resource_aws_opsworks_application.go
+++ b/aws/resource_aws_opsworks_application.go
@@ -71,7 +71,7 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice(opsworks.SourceType_Values(), false),
+							ValidateFunc: validation.StringInSlice(append(opsworks.SourceType_Values(), "other"), false),
 						},
 
 						"url": {

--- a/aws/resource_aws_opsworks_instance.go
+++ b/aws/resource_aws_opsworks_instance.go
@@ -46,22 +46,16 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 			},
 
 			"architecture": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "x86_64",
-				ValidateFunc: validation.StringInSlice([]string{
-					opsworks.ArchitectureX8664,
-					opsworks.ArchitectureI386,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "x86_64",
+				ValidateFunc: validation.StringInSlice(opsworks.Architecture_Values(), false),
 			},
 
 			"auto_scaling_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					opsworks.AutoScalingTypeLoad,
-					opsworks.AutoScalingTypeTimer,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(opsworks.AutoScalingType_Values(), false),
 			},
 
 			"availability_zone": {
@@ -223,14 +217,11 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 			},
 
 			"root_device_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					opsworks.RootDeviceTypeEbs,
-					opsworks.RootDeviceTypeInstanceStore,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(opsworks.RootDeviceType_Values(), false),
 			},
 
 			"root_device_volume_id": {
@@ -305,14 +296,11 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 			},
 
 			"virtualization_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					opsworks.VirtualizationTypeParavirtual,
-					opsworks.VirtualizationTypeHvm,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(opsworks.VirtualizationType_Values(), false),
 			},
 
 			"ebs_block_device": {

--- a/aws/resource_aws_opsworks_stack.go
+++ b/aws/resource_aws_opsworks_stack.go
@@ -131,8 +131,9 @@ func resourceAwsOpsworksStack() *schema.Resource {
 			},
 
 			"custom_json": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
 			},
 
 			"default_availability_zone": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: #8950, #14417, #14601 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/opsworks_slack: Add DiffSuppressFunc to custom_json argument
tech-debt: update opsworks_slack tests and enumerated values in opsworks_application and opsworks_instance resources
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSOpsworksStack_CustomCookbooks_SetPrivateProperties (30.24s)
--- PASS: TestAccAWSOpsworksStack_vpc (60.31s)
--- PASS: TestAccAWSOpsworksStack_noVpcBasic (24.57s)
--- PASS: TestAccAWSOpsworksMysqlLayer_basic (70.46s)
--- PASS: TestAccAWSOpsworksHAProxyLayer_basic (70.45s)
--- PASS: TestAccAWSOpsworksGangliaLayer_basic (83.00s)
--- PASS: TestAccAWSOpsworksMemcachedLayer_basic (83.36s)
--- PASS: TestAccAWSOpsworksJavaAppLayer_basic (88.66s)
--- PASS: TestAccAWSOpsworksNodejsAppLayer_basic (98.68s)
--- PASS: TestAccAWSOpsworksCustomLayer_basic (99.46s)
--- PASS: TestAccAWSOpsworksApplication_basic (123.79s)
--- PASS: TestAccAWSOpsworksInstance_UpdateHostNameForceNew (135.35s)
--- PASS: TestAccAWSOpsworksPermission_Self (135.47s)
--- PASS: TestAccAWSOpsworksCustomLayer_noVPC (140.08s)
--- PASS: TestAccAWSOpsworksInstance_basic (144.05s)
--- PASS: TestAccAWSOpsworksPhpAppLayer_basic (74.41s)
--- PASS: TestAccAWSOpsworksGangliaLayer_tags (160.73s)
--- PASS: TestAccAWSOpsworksHAProxyLayer_tags (169.59s)
--- PASS: TestAccAWSOpsworksMysqlLayer_tags (171.41s)
--- PASS: TestAccAWSOpsworksJavaAppLayer_tags (175.30s)
--- PASS: TestAccAWSOpsworksCustomLayer_tags (176.14s)
--- PASS: TestAccAWSOpsworksMemcachedLayer_tags (183.41s)
--- PASS: TestAccAWSOpsworksNodejsAppLayer_tags (184.67s)
--- PASS: TestAccAWSOpsworksRailsAppLayer_basic (107.00s)
--- PASS: TestAccAWSOpsworksPermission_basic (191.52s)
--- PASS: TestAccAWSOpsworksStaticWebLayer_basic (53.71s)
--- PASS: TestAccAWSOpsworksUserProfile_basic (57.25s)
--- PASS: TestAccAWSOpsworksPhpAppLayer_tags (135.82s)
--- PASS: TestAccAWSOpsworksStack_noVpcCreateTags (72.14s)
--- PASS: TestAccAWSOpsworksStack_noVpcChangeServiceRoleForceNew (108.44s)
--- PASS: TestAccAWSOpsworksRailsAppLayer_tags (125.30s)
--- PASS: TestAccAWSOpsworksStaticWebLayer_tags (81.18s)
--- PASS: TestAccAWSOpsworksRdsDbInstance_basic (771.28s)
```
