### PR TITLE
aws_ebs_volume io2 support

### DIFF
--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -47,7 +47,7 @@ func resourceAwsEbsVolume() *schema.Resource {
 				Computed: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return (d.Get("type").(string) != ec2.VolumeTypeIo1 && new == "0") ||
-					       (d.Get("type").(string) != ec2.VolumeTypeIo2 && new == "0")
+					    (d.Get("type").(string) != ec2.VolumeTypeIo2 && new == "0")
 				},
 			},
 			"kms_key_id": {

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -46,7 +46,8 @@ func resourceAwsEbsVolume() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return d.Get("type").(string) != ec2.VolumeTypeIo1 && new == "0"
+					return (d.Get("type").(string) != ec2.VolumeTypeIo1 && new == "0") ||
+					       (d.Get("type").(string) != ec2.VolumeTypeIo2 && new == "0")
 				},
 			},
 			"kms_key_id": {
@@ -114,7 +115,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 		request.OutpostArn = aws.String(value.(string))
 	}
 
-	// IOPs are only valid, and required for, storage type io1. The current minimum
+	// IOPs are only valid, and required for, storage type io1 and io2. The current minimum
 	// is 100. Hard validation in place to return an error if IOPs are provided
 	// for an unsupported storage type.
 	// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12667
@@ -125,7 +126,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if iops := d.Get("iops").(int); iops > 0 {
-		if t != ec2.VolumeTypeIo1 {
+		if t != ec2.VolumeTypeIo1 && t != ec2.VolumeTypeIo2 {
 			if t == "" {
 				// Volume creation would default to gp2
 				t = ec2.VolumeTypeGp2

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -46,8 +46,7 @@ func resourceAwsEbsVolume() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return (d.Get("type").(string) != ec2.VolumeTypeIo1 && new == "0") ||
-					    (d.Get("type").(string) != ec2.VolumeTypeIo2 && new == "0")
+					return (d.Get("type").(string) != ec2.VolumeTypeIo1 && new == "0") || (d.Get("type").(string) != ec2.VolumeTypeIo2 && new == "0")
 				},
 			},
 			"kms_key_id": {

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -199,7 +199,7 @@ func TestAccAWSEBSVolume_updateType(t *testing.T) {
 	})
 }
 
-func TestAccAWSEBSVolume_updateIops(t *testing.T) {
+func TestAccAWSEBSVolume_updateIops_Io1(t *testing.T) {
 	var v ec2.Volume
 	resourceName := "aws_ebs_volume.test"
 
@@ -210,7 +210,7 @@ func TestAccAWSEBSVolume_updateIops(t *testing.T) {
 		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsEbsVolumeConfigWithIops,
+				Config: testAccAwsEbsVolumeConfigWithIopsIo1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "100"),
@@ -222,7 +222,40 @@ func TestAccAWSEBSVolume_updateIops(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAwsEbsVolumeConfigWithIopsUpdated,
+				Config: testAccAwsEbsVolumeConfigWithIopsIo1Updated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iops", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEBSVolume_updateIops_Io2(t *testing.T) {
+	var v ec2.Volume
+	resourceName := "aws_ebs_volume.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEbsVolumeConfigWithIopsIo2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "iops", "100"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsEbsVolumeConfigWithIopsIo2Updated,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iops", "200"),
@@ -646,7 +679,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithIops = `
+const testAccAwsEbsVolumeConfigWithIopsIo1 = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -668,7 +701,7 @@ resource "aws_ebs_volume" "test" {
 }
 `
 
-const testAccAwsEbsVolumeConfigWithIopsUpdated = `
+const testAccAwsEbsVolumeConfigWithIopsIo1Updated = `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -681,6 +714,50 @@ data "aws_availability_zones" "available" {
 resource "aws_ebs_volume" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
   type              = "io1"
+  size              = 4
+  iops              = 200
+
+  tags = {
+    Name = "tf-acc-test-ebs-volume-test"
+  }
+}
+`
+
+const testAccAwsEbsVolumeConfigWithIopsIo2 = `
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  type              = "io2"
+  size              = 4
+  iops              = 100
+
+  tags = {
+    Name = "tf-acc-test-ebs-volume-test"
+  }
+}
+`
+
+const testAccAwsEbsVolumeConfigWithIopsIo2Updated = `
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  type              = "io2"
   size              = 4
   iops              = 200
 

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
 * `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost.
-* `type` - (Optional) The type of EBS volume. Can be "standard", "gp2", "io1", "sc1" or "st1" (Default: "gp2").
+* `type` - (Optional) The type of EBS volume. Can be "standard", "gp2", "io1", "io2", "sc1" or "st1" (Default: "gp2").
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true.
 * `tags` - (Optional) A map of tags to assign to the resource.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #14817

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEBSVolume'
--- SKIP: TestAccAWSEBSVolume_outpost (5.58s)
--- PASS: TestAccAWSEBSVolume_InvalidIopsForType (52.15s)
--- PASS: TestAccAWSEBSVolume_disappears (134.14s)
--- PASS: TestAccAWSEBSVolume_NoIops (147.67s)
--- PASS: TestAccAWSEBSVolume_basic (155.59s)
--- PASS: TestAccAWSEBSVolume_multiAttach (160.93s)
--- PASS: TestAccAWSEBSVolume_withTags (162.88s)
--- PASS: TestAccAWSEBSVolume_kmsKey (169.59s)
--- PASS: TestAccAWSEBSVolume_updateType (221.98s)
--- PASS: TestAccAWSEBSVolume_updateSize (224.16s)
--- PASS: TestAccAWSEBSVolume_updateIops_Io2 (230.68s)
--- PASS: TestAccAWSEBSVolume_updateIops_Io1 (230.75s)
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (342.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       342.879s
...
```
