### PR TITLE
aws_worklink_fleet: TestAccAWSWorkLinkFleet_AuditStreamArn

### DIFF
--- a/aws/resource_aws_worklink_fleet_test.go
+++ b/aws/resource_aws_worklink_fleet_test.go
@@ -449,7 +449,7 @@ resource "aws_worklink_fleet" "test" {
 func testAccAWSWorkLinkFleetConfigAuditStreamArn(r string) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_stream" "test_stream" {
-  name        = "%s_kinesis_test"
+  name        = "AmazonWorkLink-%s_kinesis_test"
   shard_count = 1
 }
 

--- a/website/docs/r/worklink_fleet.html.markdown
+++ b/website/docs/r/worklink_fleet.html.markdown
@@ -51,7 +51,7 @@ resource "aws_worklink_fleet" "test" {
 The following arguments are supported:
 
 * `name` - (Required) A region-unique name for the AMI.
-* `audit_stream_arn` - (Optional) The ARN of the Amazon Kinesis data stream that receives the audit events.
+* `audit_stream_arn` - (Optional) The ARN of the Amazon Kinesis data stream that receives the audit events. Kinesis data stream name must begin with `"AmazonWorkLink-"`.
 * `device_ca_certificate` - (Optional) The certificate chain, including intermediate certificates and the root certificate authority certificate used to issue device certificates.
 * `identity_provider` - (Optional) Provide this to allow manage the identity provider configuration for the fleet. Fields documented below.
 * `display_name` - (Optional) The name of the fleet.


### PR DESCRIPTION
PASS: tests/resource/aws_worklink_fleet: TestAccAWSWorkLinkFleet_AuditStreamArn

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #14512

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSWorkLinkFleet_AuditStreamArn'
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSWorkLinkFleet_AuditStreamArn -timeout 120m
=== RUN   TestAccAWSWorkLinkFleet_AuditStreamArn
=== PAUSE TestAccAWSWorkLinkFleet_AuditStreamArn
=== CONT  TestAccAWSWorkLinkFleet_AuditStreamArn
--- PASS: TestAccAWSWorkLinkFleet_AuditStreamArn (184.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       184.433s
...
```
