### PR TITLE
tech-debt/appsync: add prechecks for service and remove custom disappears fns

### DIFF
--- a/aws/resource_aws_appsync_function_test.go
+++ b/aws/resource_aws_appsync_function_test.go
@@ -21,7 +21,7 @@ func TestAccAwsAppsyncFunction_basic(t *testing.T) {
 	var config appsync.FunctionConfiguration
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
 		Steps: []resource.TestStep{
@@ -59,7 +59,7 @@ func TestAccAwsAppsyncFunction_description(t *testing.T) {
 	var config appsync.FunctionConfiguration
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
 		Steps: []resource.TestStep{
@@ -93,7 +93,7 @@ func TestAccAwsAppsyncFunction_responseMappingTemplate(t *testing.T) {
 	var config appsync.FunctionConfiguration
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
 		Steps: []resource.TestStep{
@@ -119,7 +119,7 @@ func TestAccAwsAppsyncFunction_disappears(t *testing.T) {
 	var config appsync.FunctionConfiguration
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
 		Steps: []resource.TestStep{
@@ -127,7 +127,7 @@ func TestAccAwsAppsyncFunction_disappears(t *testing.T) {
 				Config: testAccAWSAppsyncFunctionConfig(rName1, rName2, testAccGetRegion()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppsyncFunctionExists(resourceName, &config),
-					testAccCheckAwsAppsyncFunctionDisappears(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsAppsyncFunction(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -191,34 +191,6 @@ func testAccCheckAwsAppsyncFunctionExists(name string, config *appsync.FunctionC
 		*config = *output.FunctionConfiguration
 
 		return nil
-	}
-}
-
-func testAccCheckAwsAppsyncFunctionDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No resource ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).appsyncconn
-		apiID, functionID, err := decodeAppsyncFunctionID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		input := &appsync.DeleteFunctionInput{
-			ApiId:      aws.String(apiID),
-			FunctionId: aws.String(functionID),
-		}
-
-		_, err = conn.DeleteFunction(input)
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_appsync_graphql_api_test.go
+++ b/aws/resource_aws_appsync_graphql_api_test.go
@@ -114,7 +114,7 @@ func TestAccAWSAppsyncGraphqlApi_disappears(t *testing.T) {
 				Config: testAccAppsyncGraphqlApiConfig_AuthenticationType(rName, "API_KEY"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppsyncGraphqlApiExists(resourceName, &api1),
-					testAccCheckAwsAppsyncGraphqlApiDisappears(&api1),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsAppsyncGraphqlApi(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -748,7 +748,7 @@ func TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_APIKey(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -780,7 +780,7 @@ func TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_AWSIAM(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -813,7 +813,7 @@ func TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_CognitoUserPools(t *te
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -846,7 +846,7 @@ func TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_OpenIDConnect(t *testi
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -880,7 +880,7 @@ func TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_Multiple(t *testing.T)
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -986,20 +986,6 @@ func testAccCheckAwsAppsyncGraphqlApiExists(name string, api *appsync.GraphqlApi
 		*api = *output.GraphqlApi
 
 		return nil
-	}
-}
-
-func testAccCheckAwsAppsyncGraphqlApiDisappears(api *appsync.GraphqlApi) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).appsyncconn
-
-		input := &appsync.DeleteGraphqlApiInput{
-			ApiId: api.ApiId,
-		}
-
-		_, err := conn.DeleteGraphqlApi(input)
-
-		return err
 	}
 }
 

--- a/aws/resource_aws_appsync_resolver_test.go
+++ b/aws/resource_aws_appsync_resolver_test.go
@@ -57,7 +57,7 @@ func TestAccAwsAppsyncResolver_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAppsyncGraphqlApiExists(appsyncGraphqlApiResourceName, &api1),
 					testAccCheckAwsAppsyncResolverExists(resourceName, &resolver1),
-					testAccCheckAwsAppsyncResolverDisappears(&api1, &resolver1),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsAppsyncResolver(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -199,7 +199,7 @@ func TestAccAwsAppsyncResolver_PipelineConfig(t *testing.T) {
 	resourceName := "aws_appsync_resolver.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{
@@ -226,7 +226,7 @@ func TestAccAwsAppsyncResolver_CachingConfig(t *testing.T) {
 	resourceName := "aws_appsync_resolver.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{
@@ -312,22 +312,6 @@ func testAccCheckAwsAppsyncResolverExists(name string, resolver *appsync.Resolve
 		*resolver = *output.Resolver
 
 		return nil
-	}
-}
-
-func testAccCheckAwsAppsyncResolverDisappears(api *appsync.GraphqlApi, resolver *appsync.Resolver) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).appsyncconn
-
-		input := &appsync.DeleteResolverInput{
-			ApiId:     api.ApiId,
-			FieldName: resolver.FieldName,
-			TypeName:  resolver.TypeName,
-		}
-
-		_, err := conn.DeleteResolver(input)
-
-		return err
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14937 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt/appsync: add prechecks for service and remove custom disappears fns
```

Output from acceptance testing (Commercial):

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSAppsyncGraphqlApi_disappears (28.12s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM (42.56s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools (57.83s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Name (65.27s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey (71.51s)
--- PASS: TestAccAwsAppsyncFunction_disappears (76.23s)
--- PASS: TestAccAWSAppsyncGraphqlApi_basic (91.42s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect (91.71s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer (93.43s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig (94.15s)
--- PASS: TestAccAwsAppsyncFunction_responseMappingTemplate (99.77s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL (112.74s)
--- PASS: TestAccAwsAppsyncFunction_basic (128.45s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL (128.86s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Schema (131.43s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_APIKey (69.21s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID (139.08s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig_ExcludeVerboseContent (142.68s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_AWSIAM (72.03s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion (119.60s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType (148.07s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_CognitoUserPools (72.36s)
--- PASS: TestAccAwsAppsyncFunction_description (150.44s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_OpenIDConnect (64.85s)
--- PASS: TestAccAwsAppsyncResolver_disappears (57.89s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_Multiple (67.14s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction (118.10s)
--- PASS: TestAccAwsAppsyncResolver_basic (67.60s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Tags (108.55s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel (174.05s)
--- PASS: TestAccAWSAppsyncGraphqlApi_XrayEnabled (83.18s)
--- PASS: TestAccAwsAppsyncResolver_multipleResolvers (46.31s)
--- PASS: TestAccAwsAppsyncResolver_PipelineConfig (43.91s)
--- PASS: TestAccAwsAppsyncResolver_CachingConfig (39.33s)
--- PASS: TestAccAwsAppsyncResolver_DataSource (71.83s)
--- PASS: TestAccAwsAppsyncResolver_ResponseTemplate (57.00s)
--- PASS: TestAccAwsAppsyncResolver_RequestTemplate (58.67s)
```
Output from acceptance testing (Gov Cloud):
```
--- SKIP: TestAccAwsAppsyncFunction_disappears (18.67s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey (19.79s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_LogConfig_ExcludeVerboseContent (20.30s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel (20.08s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_basic (20.44s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_LogConfig (21.52s)
--- SKIP: TestAccAwsAppsyncFunction_description (21.72s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_Schema (23.52s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect (23.67s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_disappears (24.22s)
--- SKIP: TestAccAwsAppsyncFunction_responseMappingTemplate (24.47s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools (24.67s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM (25.81s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType (26.59s)
--- SKIP: TestAccAwsAppsyncFunction_basic (27.70s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction (18.34s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID (21.85s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_Name (21.77s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer (22.36s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion (21.35s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL (24.91s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_Multiple (20.48s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_CognitoUserPools (22.62s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL (27.19s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_AWSIAM (23.71s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_APIKey (26.13s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_AdditionalAuthentication_OpenIDConnect (25.48s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_XrayEnabled (23.65s)
--- SKIP: TestAccAwsAppsyncResolver_basic (23.50s)
--- SKIP: TestAccAWSAppsyncGraphqlApi_Tags (28.30s)
--- SKIP: TestAccAwsAppsyncResolver_disappears (21.58s)
--- SKIP: TestAccAwsAppsyncResolver_DataSource (20.36s)
--- SKIP: TestAccAwsAppsyncResolver_multipleResolvers (19.83s)
--- SKIP: TestAccAwsAppsyncResolver_ResponseTemplate (23.02s)
--- SKIP: TestAccAwsAppsyncResolver_PipelineConfig (22.65s)
--- SKIP: TestAccAwsAppsyncResolver_RequestTemplate (24.66s)
--- SKIP: TestAccAwsAppsyncResolver_CachingConfig (24.11s)
```