### PR TITLE
tech-debt/waf_rate_based_rule: update typeset checks, custom disappears func, and enumerated types

### DIFF
--- a/aws/resource_aws_waf_rate_based_rule.go
+++ b/aws/resource_aws_waf_rate_based_rule.go
@@ -52,7 +52,7 @@ func resourceAwsWafRateBasedRule() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validateWafPredicatesType(),
+							ValidateFunc: validation.StringInSlice(waf.PredicateType_Values(), false),
 						},
 					},
 				},

--- a/aws/resource_aws_waf_rate_based_rule_test.go
+++ b/aws/resource_aws_waf_rate_based_rule_test.go
@@ -5,15 +5,13 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
 
 func TestAccAWSWafRateBasedRule_basic(t *testing.T) {
@@ -97,7 +95,7 @@ func TestAccAWSWafRateBasedRule_disappears(t *testing.T) {
 				Config: testAccAWSWafRateBasedRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRateBasedRuleExists(resourceName, &v),
-					testAccCheckAWSWafRateBasedRuleDisappears(&v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsWafRateBasedRule(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -110,7 +108,6 @@ func TestAccAWSWafRateBasedRule_changePredicates(t *testing.T) {
 	var byteMatchSet waf.ByteMatchSet
 
 	var before, after waf.RateBasedRule
-	var idx int
 	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 
@@ -126,8 +123,7 @@ func TestAccAWSWafRateBasedRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRateBasedRuleExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					computeWafRateBasedRulePredicateWithIpSet(&ipset, false, "IPMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
 					}),
@@ -140,8 +136,7 @@ func TestAccAWSWafRateBasedRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRateBasedRuleExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicates.#", "1"),
-					computeWafRateBasedRulePredicateWithByteMatchSet(&byteMatchSet, true, "ByteMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
 						"negated": "true",
 						"type":    "ByteMatch",
 					}),
@@ -154,44 +149,6 @@ func TestAccAWSWafRateBasedRule_changePredicates(t *testing.T) {
 			},
 		},
 	})
-}
-
-// computeWafRateBasedRulePredicateWithIpSet calculates index
-// which isn't static because dataId is generated as part of the test
-func computeWafRateBasedRulePredicateWithIpSet(ipSet *waf.IPSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		predicateResource := resourceAwsWafRateBasedRule().Schema["predicates"].Elem.(*schema.Resource)
-
-		m := map[string]interface{}{
-			"data_id": *ipSet.IPSetId,
-			"negated": negated,
-			"type":    pType,
-		}
-
-		f := schema.HashResource(predicateResource)
-		*idx = f(m)
-
-		return nil
-	}
-}
-
-// computeWafRateBasedRulePredicateWithByteMatchSet calculates index
-// which isn't static because dataId is generated as part of the test
-func computeWafRateBasedRulePredicateWithByteMatchSet(set *waf.ByteMatchSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		predicateResource := resourceAwsWafRateBasedRule().Schema["predicates"].Elem.(*schema.Resource)
-
-		m := map[string]interface{}{
-			"data_id": *set.ByteMatchSetId,
-			"negated": negated,
-			"type":    pType,
-		}
-
-		f := schema.HashResource(predicateResource)
-		*idx = f(m)
-
-		return nil
-	}
 }
 
 func TestAccAWSWafRateBasedRule_noPredicates(t *testing.T) {
@@ -267,50 +224,6 @@ func TestAccAWSWafRateBasedRule_Tags(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckAWSWafRateBasedRuleDisappears(v *waf.RateBasedRule) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).wafconn
-
-		wr := newWafRetryer(conn)
-		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
-			req := &waf.UpdateRateBasedRuleInput{
-				ChangeToken: token,
-				RuleId:      v.RuleId,
-				RateLimit:   v.RateLimit,
-			}
-
-			for _, Predicate := range v.MatchPredicates {
-				Predicate := &waf.RuleUpdate{
-					Action: aws.String("DELETE"),
-					Predicate: &waf.Predicate{
-						Negated: Predicate.Negated,
-						Type:    Predicate.Type,
-						DataId:  Predicate.DataId,
-					},
-				}
-				req.Updates = append(req.Updates, Predicate)
-			}
-
-			return conn.UpdateRateBasedRule(req)
-		})
-		if err != nil {
-			return fmt.Errorf("Error Updating WAF Rule: %s", err)
-		}
-
-		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
-			opts := &waf.DeleteRateBasedRuleInput{
-				ChangeToken: token,
-				RuleId:      v.RuleId,
-			}
-			return conn.DeleteRateBasedRule(opts)
-		})
-		if err != nil {
-			return fmt.Errorf("Error Deleting WAF Rule: %s", err)
-		}
-		return nil
-	}
 }
 
 func testAccCheckAWSWafRateBasedRuleDestroy(s *terraform.State) error {

--- a/aws/resource_aws_wafregional_rate_based_rule.go
+++ b/aws/resource_aws_wafregional_rate_based_rule.go
@@ -52,7 +52,7 @@ func resourceAwsWafRegionalRateBasedRule() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validateWafPredicatesType(),
+							ValidateFunc: validation.StringInSlice(wafregional.PredicateType_Values(), false),
 						},
 					},
 				},

--- a/aws/resource_aws_wafregional_rate_based_rule_test.go
+++ b/aws/resource_aws_wafregional_rate_based_rule_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
@@ -242,7 +241,7 @@ func TestAccAWSWafRegionalRateBasedRule_disappears(t *testing.T) {
 				Config: testAccAWSWafRegionalRateBasedRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &v),
-					testAccCheckAWSWafRegionalRateBasedRuleDisappears(&v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsWafRegionalRateBasedRule(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -255,7 +254,6 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 	var byteMatchSet waf.ByteMatchSet
 
 	var before, after waf.RateBasedRule
-	var idx int
 	resourceName := "aws_wafregional_rate_based_rule.wafrule"
 	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 
@@ -271,8 +269,7 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &before),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
-					computeWafRegionalRateBasedRulePredicateWithIpSet(&ipset, false, "IPMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
 						"negated": "false",
 						"type":    "IPMatch",
 					}),
@@ -285,8 +282,7 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRegionalRateBasedRuleExists(resourceName, &after),
 					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
-					computeWafRegionalRateBasedRulePredicateWithByteMatchSet(&byteMatchSet, true, "ByteMatch", &idx),
-					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicates.*", map[string]string{
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "predicate.*", map[string]string{
 						"negated": "true",
 						"type":    "ByteMatch",
 					}),
@@ -338,44 +334,6 @@ func TestAccAWSWafRegionalRateBasedRule_changeRateLimit(t *testing.T) {
 	})
 }
 
-// computeWafRegionalRateBasedRulePredicateWithIpSet calculates index
-// which isn't static because dataId is generated as part of the test
-func computeWafRegionalRateBasedRulePredicateWithIpSet(ipSet *waf.IPSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		predicateResource := resourceAwsWafRegionalRateBasedRule().Schema["predicate"].Elem.(*schema.Resource)
-
-		m := map[string]interface{}{
-			"data_id": *ipSet.IPSetId,
-			"negated": negated,
-			"type":    pType,
-		}
-
-		f := schema.HashResource(predicateResource)
-		*idx = f(m)
-
-		return nil
-	}
-}
-
-// computeWafRegionalRateBasedRulePredicateWithByteMatchSet calculates index
-// which isn't static because dataId is generated as part of the test
-func computeWafRegionalRateBasedRulePredicateWithByteMatchSet(set *waf.ByteMatchSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		predicateResource := resourceAwsWafRegionalRateBasedRule().Schema["predicate"].Elem.(*schema.Resource)
-
-		m := map[string]interface{}{
-			"data_id": *set.ByteMatchSetId,
-			"negated": negated,
-			"type":    pType,
-		}
-
-		f := schema.HashResource(predicateResource)
-		*idx = f(m)
-
-		return nil
-	}
-}
-
 func TestAccAWSWafRegionalRateBasedRule_noPredicates(t *testing.T) {
 	var rule waf.RateBasedRule
 	resourceName := "aws_wafregional_rate_based_rule.wafrule"
@@ -407,51 +365,6 @@ func testAccCheckAWSWafRateBasedRuleIdDiffers(before, after *waf.RateBasedRule) 
 	return func(s *terraform.State) error {
 		if *before.RuleId == *after.RuleId {
 			return fmt.Errorf("Expected different IDs, given %q for both rules", *before.RuleId)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSWafRegionalRateBasedRuleDisappears(v *waf.RateBasedRule) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
-		region := testAccProvider.Meta().(*AWSClient).region
-
-		wr := newWafRegionalRetryer(conn, region)
-		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
-			req := &waf.UpdateRateBasedRuleInput{
-				ChangeToken: token,
-				RuleId:      v.RuleId,
-				RateLimit:   v.RateLimit,
-			}
-
-			for _, Predicate := range v.MatchPredicates {
-				Predicate := &waf.RuleUpdate{
-					Action: aws.String("DELETE"),
-					Predicate: &waf.Predicate{
-						Negated: Predicate.Negated,
-						Type:    Predicate.Type,
-						DataId:  Predicate.DataId,
-					},
-				}
-				req.Updates = append(req.Updates, Predicate)
-			}
-
-			return conn.UpdateRateBasedRule(req)
-		})
-		if err != nil {
-			return fmt.Errorf("Error Updating WAF Rule: %s", err)
-		}
-
-		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
-			opts := &waf.DeleteRateBasedRuleInput{
-				ChangeToken: token,
-				RuleId:      v.RuleId,
-			}
-			return conn.DeleteRateBasedRule(opts)
-		})
-		if err != nil {
-			return fmt.Errorf("Error Deleting WAF Rule: %s", err)
 		}
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14957 
Relates #14601 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt/waf_rate_based_rule: update typeset checks, custom disappears func, and enumerated types
tech-debt/waf_regional_rate_based_rule: update typeset checks, custom disappears func, and enumerated types

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSWafRateBasedRule_changePredicates (69.21s) -- previously failing
--- PASS: TestAccAWSWafRegionalRateBasedRule_changePredicates (69.54s) -- previously failing

--- PASS: TestAccAWSWafRegionalRateBasedRule_noPredicates (23.24s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_disappears (51.24s)
--- PASS: TestAccAWSWafRateBasedRule_basic (53.32s)
--- PASS: TestAccAWSWafRateBasedRule_noPredicates (54.98s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeRateLimit (73.29s)
--- PASS: TestAccAWSWafRateBasedRule_Tags (75.52s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_basic (76.60s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_tags (81.47s)
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (95.79s)
--- PASS: TestAccAWSWafRateBasedRule_changeNameForceNew (99.86s)
--- PASS: TestAccAWSWafRateBasedRule_disappears (106.69s)
```
