### PR TITLE
tech-debt/waf_xss_match_set: update test configuration params, disappears methods, and enumerated vals

### DIFF
--- a/aws/resource_aws_waf_xss_match_set.go
+++ b/aws/resource_aws_waf_xss_match_set.go
@@ -47,32 +47,17 @@ func resourceAwsWafXssMatchSet() *schema.Resource {
 										Optional: true,
 									},
 									"type": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											waf.MatchFieldTypeUri,
-											waf.MatchFieldTypeSingleQueryArg,
-											waf.MatchFieldTypeQueryString,
-											waf.MatchFieldTypeMethod,
-											waf.MatchFieldTypeHeader,
-											waf.MatchFieldTypeBody,
-											waf.MatchFieldTypeAllQueryArgs,
-										}, false),
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(waf.MatchFieldType_Values(), false),
 									},
 								},
 							},
 						},
 						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								waf.TextTransformationUrlDecode,
-								waf.TextTransformationNone,
-								waf.TextTransformationHtmlEntityDecode,
-								waf.TextTransformationCompressWhiteSpace,
-								waf.TextTransformationCmdLine,
-								waf.TextTransformationLowercase,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(waf.TextTransformation_Values(), false),
 						},
 					},
 				},
@@ -100,12 +85,12 @@ func resourceAwsWafXssMatchSetCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	resp := out.(*waf.CreateXssMatchSetOutput)
 
-	d.SetId(*resp.XssMatchSet.XssMatchSetId)
+	d.SetId(aws.StringValue(resp.XssMatchSet.XssMatchSetId))
 
 	if v, ok := d.GetOk("xss_match_tuples"); ok && v.(*schema.Set).Len() > 0 {
 		err := updateXssMatchSetResource(d.Id(), nil, v.(*schema.Set).List(), conn)
 		if err != nil {
-			return fmt.Errorf("Error setting WAF XSS Match Set tuples: %s", err)
+			return fmt.Errorf("Error setting WAF XSS Match Set tuples: %w", err)
 		}
 	}
 	return resourceAwsWafXssMatchSetRead(d, meta)
@@ -130,7 +115,9 @@ func resourceAwsWafXssMatchSetRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.Set("name", resp.XssMatchSet.Name)
-	d.Set("xss_match_tuples", flattenWafXssMatchTuples(resp.XssMatchSet.XssMatchTuples))
+	if err := d.Set("xss_match_tuples", flattenWafXssMatchTuples(resp.XssMatchSet.XssMatchTuples)); err != nil {
+		return fmt.Errorf("error setting xss_match_tuples: %w", err)
+	}
 
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
@@ -152,7 +139,7 @@ func resourceAwsWafXssMatchSetUpdate(d *schema.ResourceData, meta interface{}) e
 
 		err := updateXssMatchSetResource(d.Id(), oldT, newT, conn)
 		if err != nil {
-			return fmt.Errorf("Error updating WAF XSS Match Set: %s", err)
+			return fmt.Errorf("Error updating WAF XSS Match Set: %w", err)
 		}
 	}
 
@@ -166,7 +153,7 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 	if len(oldTuples) > 0 {
 		err := updateXssMatchSetResource(d.Id(), oldTuples, nil, conn)
 		if err != nil {
-			return fmt.Errorf("Error removing WAF XSS Match Set tuples: %s", err)
+			return fmt.Errorf("Error removing WAF XSS Match Set tuples: %w", err)
 		}
 	}
 
@@ -180,7 +167,7 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 		return conn.DeleteXssMatchSet(req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error deleting WAF XSS Match Set: %s", err)
+		return fmt.Errorf("Error deleting WAF XSS Match Set: %w", err)
 	}
 
 	return nil
@@ -199,7 +186,7 @@ func updateXssMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WA
 		return conn.UpdateXssMatchSet(req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error updating WAF XSS Match Set: %s", err)
+		return fmt.Errorf("Error updating WAF XSS Match Set: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_waf_xss_match_set_test.go
+++ b/aws/resource_aws_waf_xss_match_set_test.go
@@ -103,7 +103,7 @@ func TestAccAWSWafXssMatchSet_disappears(t *testing.T) {
 				Config: testAccAWSWafXssMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafXssMatchSetExists(resourceName, &v),
-					testAccCheckAWSWafXssMatchSetDisappears(&v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsWafXssMatchSet(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -149,7 +149,7 @@ func TestAccAWSWafXssMatchSet_changeTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuples.#", "2"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuples.*", map[string]string{
 						"field_to_match.#":      "1",
-						"field_to_match.0.data": "GET",
+						"field_to_match.0.data": "",
 						"field_to_match.0.type": "METHOD",
 						"text_transformation":   "HTML_ENTITY_DECODE",
 					}),
@@ -195,47 +195,6 @@ func TestAccAWSWafXssMatchSet_noTuples(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckAWSWafXssMatchSetDisappears(v *waf.XssMatchSet) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).wafconn
-
-		wr := newWafRetryer(conn)
-		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
-			req := &waf.UpdateXssMatchSetInput{
-				ChangeToken:   token,
-				XssMatchSetId: v.XssMatchSetId,
-			}
-
-			for _, xssMatchTuple := range v.XssMatchTuples {
-				xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
-					Action: aws.String(waf.ChangeActionDelete),
-					XssMatchTuple: &waf.XssMatchTuple{
-						FieldToMatch:       xssMatchTuple.FieldToMatch,
-						TextTransformation: xssMatchTuple.TextTransformation,
-					},
-				}
-				req.Updates = append(req.Updates, xssMatchTupleUpdate)
-			}
-			return conn.UpdateXssMatchSet(req)
-		})
-		if err != nil {
-			return fmt.Errorf("Error updating XssMatchSet: %s", err)
-		}
-
-		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
-			opts := &waf.DeleteXssMatchSetInput{
-				ChangeToken:   token,
-				XssMatchSetId: v.XssMatchSetId,
-			}
-			return conn.DeleteXssMatchSet(opts)
-		})
-		if err != nil {
-			return fmt.Errorf("Error deleting WAF XSS Match Set: %s", err)
-		}
-		return nil
-	}
 }
 
 func testAccCheckAWSWafXssMatchSetExists(n string, v *waf.XssMatchSet) resource.TestCheckFunc {
@@ -362,7 +321,6 @@ resource "aws_waf_xss_match_set" "test" {
 
     field_to_match {
       type = "METHOD"
-      data = "GET"
     }
   }
 }

--- a/aws/resource_aws_wafregional_xss_match_set.go
+++ b/aws/resource_aws_wafregional_xss_match_set.go
@@ -43,32 +43,17 @@ func resourceAwsWafRegionalXssMatchSet() *schema.Resource {
 										Optional: true,
 									},
 									"type": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											wafregional.MatchFieldTypeUri,
-											wafregional.MatchFieldTypeSingleQueryArg,
-											wafregional.MatchFieldTypeQueryString,
-											wafregional.MatchFieldTypeMethod,
-											wafregional.MatchFieldTypeHeader,
-											wafregional.MatchFieldTypeBody,
-											wafregional.MatchFieldTypeAllQueryArgs,
-										}, false),
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(wafregional.MatchFieldType_Values(), false),
 									},
 								},
 							},
 						},
 						"text_transformation": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								wafregional.TextTransformationUrlDecode,
-								wafregional.TextTransformationNone,
-								wafregional.TextTransformationHtmlEntityDecode,
-								wafregional.TextTransformationCompressWhiteSpace,
-								wafregional.TextTransformationCmdLine,
-								wafregional.TextTransformationLowercase,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(wafregional.TextTransformation_Values(), false),
 						},
 					},
 				},
@@ -93,7 +78,7 @@ func resourceAwsWafRegionalXssMatchSetCreate(d *schema.ResourceData, meta interf
 		return conn.CreateXssMatchSet(params)
 	})
 	if err != nil {
-		return fmt.Errorf("Failed creating regional WAF XSS Match Set: %s", err)
+		return fmt.Errorf("Failed creating regional WAF XSS Match Set: %w", err)
 	}
 	resp := out.(*waf.CreateXssMatchSetOutput)
 
@@ -102,7 +87,7 @@ func resourceAwsWafRegionalXssMatchSetCreate(d *schema.ResourceData, meta interf
 	if v, ok := d.Get("xss_match_tuple").(*schema.Set); ok && v.Len() > 0 {
 		err := updateXssMatchSetResourceWR(d.Id(), nil, v.List(), conn, region)
 		if err != nil {
-			return fmt.Errorf("Failed updating regional WAF XSS Match Set: %s", err)
+			return fmt.Errorf("Failed updating regional WAF XSS Match Set: %w", err)
 		}
 	}
 
@@ -129,7 +114,9 @@ func resourceAwsWafRegionalXssMatchSetRead(d *schema.ResourceData, meta interfac
 
 	set := resp.XssMatchSet
 
-	d.Set("xss_match_tuple", flattenWafXssMatchTuples(set.XssMatchTuples))
+	if err := d.Set("xss_match_tuple", flattenWafXssMatchTuples(set.XssMatchTuples)); err != nil {
+		return fmt.Errorf("error setting xss_match_tuple: %w", err)
+	}
 	d.Set("name", set.Name)
 
 	return nil
@@ -145,7 +132,7 @@ func resourceAwsWafRegionalXssMatchSetUpdate(d *schema.ResourceData, meta interf
 
 		err := updateXssMatchSetResourceWR(d.Id(), oldT, newT, conn, region)
 		if err != nil {
-			return fmt.Errorf("Failed updating regional WAF XSS Match Set: %s", err)
+			return fmt.Errorf("Failed updating regional WAF XSS Match Set: %w", err)
 		}
 	}
 
@@ -162,7 +149,7 @@ func resourceAwsWafRegionalXssMatchSetDelete(d *schema.ResourceData, meta interf
 			noTuples := []interface{}{}
 			err := updateXssMatchSetResourceWR(d.Id(), oldTuples, noTuples, conn, region)
 			if err != nil {
-				return fmt.Errorf("Error updating regional WAF XSS Match Set: %s", err)
+				return fmt.Errorf("Error updating regional WAF XSS Match Set: %w", err)
 			}
 		}
 	}
@@ -177,7 +164,7 @@ func resourceAwsWafRegionalXssMatchSetDelete(d *schema.ResourceData, meta interf
 		return conn.DeleteXssMatchSet(req)
 	})
 	if err != nil {
-		return fmt.Errorf("Failed deleting regional WAF XSS Match Set: %s", err)
+		return fmt.Errorf("Failed deleting regional WAF XSS Match Set: %w", err)
 	}
 
 	return nil
@@ -196,7 +183,7 @@ func updateXssMatchSetResourceWR(id string, oldT, newT []interface{}, conn *wafr
 		return conn.UpdateXssMatchSet(req)
 	})
 	if err != nil {
-		return fmt.Errorf("Failed updating regional WAF XSS Match Set: %s", err)
+		return fmt.Errorf("Failed updating regional WAF XSS Match Set: %w", err)
 	}
 
 	return nil

--- a/aws/resource_aws_wafregional_xss_match_set_test.go
+++ b/aws/resource_aws_wafregional_xss_match_set_test.go
@@ -102,7 +102,7 @@ func TestAccAWSWafRegionalXssMatchSet_disappears(t *testing.T) {
 				Config: testAccAWSWafRegionalXssMatchSetConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists(resourceName, &v),
-					testAccCheckAWSWafRegionalXssMatchSetDisappears(&v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsWafRegionalXssMatchSet(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -153,7 +153,7 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "xss_match_tuple.#", "2"),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "xss_match_tuple.*", map[string]string{
 						"field_to_match.#":      "1",
-						"field_to_match.0.data": "GET",
+						"field_to_match.0.data": "",
 						"field_to_match.0.type": "METHOD",
 						"text_transformation":   "HTML_ENTITY_DECODE",
 					}),
@@ -194,48 +194,6 @@ func TestAccAWSWafRegionalXssMatchSet_noTuples(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckAWSWafRegionalXssMatchSetDisappears(v *waf.XssMatchSet) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
-		region := testAccProvider.Meta().(*AWSClient).region
-
-		wr := newWafRegionalRetryer(conn, region)
-		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
-			req := &waf.UpdateXssMatchSetInput{
-				ChangeToken:   token,
-				XssMatchSetId: v.XssMatchSetId,
-			}
-
-			for _, xssMatchTuple := range v.XssMatchTuples {
-				xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
-					Action: aws.String(wafregional.ChangeActionDelete),
-					XssMatchTuple: &waf.XssMatchTuple{
-						FieldToMatch:       xssMatchTuple.FieldToMatch,
-						TextTransformation: xssMatchTuple.TextTransformation,
-					},
-				}
-				req.Updates = append(req.Updates, xssMatchTupleUpdate)
-			}
-			return conn.UpdateXssMatchSet(req)
-		})
-		if err != nil {
-			return fmt.Errorf("Error updating regional WAF XSS Match Set: %s", err)
-		}
-
-		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
-			opts := &waf.DeleteXssMatchSetInput{
-				ChangeToken:   token,
-				XssMatchSetId: v.XssMatchSetId,
-			}
-			return conn.DeleteXssMatchSet(opts)
-		})
-		if err != nil {
-			return fmt.Errorf("Error deleting regional WAF XSS Match Set: %s", err)
-		}
-		return nil
-	}
 }
 
 func testAccCheckAWSWafRegionalXssMatchSetExists(n string, v *waf.XssMatchSet) resource.TestCheckFunc {
@@ -362,7 +320,6 @@ resource "aws_wafregional_xss_match_set" "test" {
 
     field_to_match {
       type = "METHOD"
-      data = "GET"
     }
   }
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3301,9 +3301,12 @@ func expandFieldToMatch(d map[string]interface{}) *waf.FieldToMatch {
 
 func flattenFieldToMatch(fm *waf.FieldToMatch) []interface{} {
 	m := make(map[string]interface{})
-	m["data"] = aws.StringValue(fm.Data)
-	m["type"] = aws.StringValue(fm.Type)
-
+	if fm.Data != nil {
+		m["data"] = *fm.Data
+	}
+	if fm.Type != nil {
+		m["type"] = *fm.Type
+	}
 	return []interface{}{m}
 }
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3301,12 +3301,9 @@ func expandFieldToMatch(d map[string]interface{}) *waf.FieldToMatch {
 
 func flattenFieldToMatch(fm *waf.FieldToMatch) []interface{} {
 	m := make(map[string]interface{})
-	if fm.Data != nil {
-		m["data"] = *fm.Data
-	}
-	if fm.Type != nil {
-		m["type"] = *fm.Type
-	}
+	m["data"] = aws.StringValue(fm.Data)
+	m["type"] = aws.StringValue(fm.Type)
+
 	return []interface{}{m}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates  #14957 
Relates #14601 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt/waf_xss_match_set: update configuration params, disappears methods and enumerated vals
tech-debt/waf_regional_xss_match_set: update configuration params, disappears methods and enumerated vals
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeTuples (42.65s)
--- PASS: TestAccAWSWafXssMatchSet_changeTuples (59.45s)

--- PASS: TestAccAWSWafRegionalXssMatchSet_basic (27.22s)
--- PASS: TestAccAWSWafRegionalXssMatchSet_disappears (27.42s)
--- PASS: TestAccAWSWafXssMatchSet_noTuples (34.67s)
--- PASS: TestAccAWSWafRegionalXssMatchSet_noTuples (36.26s)
--- PASS: TestAccAWSWafXssMatchSet_disappears (37.10s)
--- PASS: TestAccAWSWafXssMatchSet_basic (45.68s)
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeNameForceNew (47.83s)
--- PASS: TestAccAWSWafXssMatchSet_changeNameForceNew (54.72s)
```
