### PR TITLE
Select Outpost by Arn in datasource

### DIFF
--- a/aws/data_source_aws_outposts_outpost.go
+++ b/aws/data_source_aws_outposts_outpost.go
@@ -14,8 +14,10 @@ func dataSourceAwsOutpostsOutpost() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateArn,
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,
@@ -73,6 +75,10 @@ func dataSourceAwsOutpostsOutpostRead(d *schema.ResourceData, meta interface{}) 
 			}
 
 			if v, ok := d.GetOk("name"); ok && v.(string) != aws.StringValue(outpost.Name) {
+				continue
+			}
+
+			if v, ok := d.GetOk("arn"); ok && v.(string) != aws.StringValue(outpost.OutpostArn) {
 				continue
 			}
 

--- a/aws/data_source_aws_outposts_outpost_test.go
+++ b/aws/data_source_aws_outposts_outpost_test.go
@@ -56,6 +56,31 @@ func TestAccAWSOutpostsOutpostDataSource_Name(t *testing.T) {
 	})
 }
 
+func TestAccAWSOutpostsOutpostDataSource_Arn(t *testing.T) {
+	sourceDataSourceName := "data.aws_outposts_outpost.source"
+	dataSourceName := "data.aws_outposts_outpost.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSOutpostsOutpostDataSourceConfigArn(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", sourceDataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone", sourceDataSourceName, "availability_zone"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_id", sourceDataSourceName, "availability_zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", sourceDataSourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", sourceDataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", sourceDataSourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", sourceDataSourceName, "owner_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSOutpostsOutpostDataSourceConfigId() string {
 	return `
 data "aws_outposts_outposts" "test" {}
@@ -76,6 +101,20 @@ data "aws_outposts_outpost" "source" {
 
 data "aws_outposts_outpost" "test" {
   name = data.aws_outposts_outpost.source.name
+}
+`
+}
+
+func testAccAWSOutpostsOutpostDataSourceConfigArn() string {
+	return `
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "source" {
+  arn = tolist(data.aws_outposts_outposts.test.arns)[0]
+}
+
+data "aws_outposts_outpost" "test" {
+  arn = data.aws_outposts_outpost.source.arn
 }
 `
 }

--- a/website/docs/d/outposts_outpost.html.markdown
+++ b/website/docs/d/outposts_outpost.html.markdown
@@ -24,12 +24,12 @@ The following arguments are supported:
 
 * `id` - (Optional) Identifier of the Outpost.
 * `name` - (Optional) Name of the Outpost.
+* `arn` - (Optional) Amazon Resource Name (ARN).
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - Amazon Resource Name (ARN).
 * `availability_zone` - Availability Zone name.
 * `availability_zone_id` - Availability Zone identifier.
 * `description` - Description.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #13929

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Select Outpost by Arn in datasource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=^TestAccAWSOutpostsOutpostDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=^TestAccAWSOutpostsOutpostDataSource -timeout 120m
=== RUN   TestAccAWSOutpostsOutpostDataSource_Id
=== PAUSE TestAccAWSOutpostsOutpostDataSource_Id
=== RUN   TestAccAWSOutpostsOutpostDataSource_Name
=== PAUSE TestAccAWSOutpostsOutpostDataSource_Name
=== RUN   TestAccAWSOutpostsOutpostDataSource_Arn
=== PAUSE TestAccAWSOutpostsOutpostDataSource_Arn
=== CONT  TestAccAWSOutpostsOutpostDataSource_Id
=== CONT  TestAccAWSOutpostsOutpostDataSource_Arn
=== CONT  TestAccAWSOutpostsOutpostDataSource_Name
--- PASS: TestAccAWSOutpostsOutpostDataSource_Id (41.59s)
--- PASS: TestAccAWSOutpostsOutpostDataSource_Name (46.61s)
--- PASS: TestAccAWSOutpostsOutpostDataSource_Arn (46.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       47.897s
...
```
