### PR TITLE
Update CloudFront distribution to support cache

### DIFF
--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -66,15 +66,18 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"default_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  86400,
 						},
 						"field_level_encryption_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"cache_policy_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"forwarded_values": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -144,12 +147,10 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"max_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  31536000,
 						},
 						"min_ttl": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  0,
 						},
 						"path_pattern": {
 							Type:     schema.TypeString,

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -82,23 +82,11 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
   # Cache behavior with precedence 0
   ordered_cache_behavior {
-    path_pattern     = "/content/immutable/*"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = local.s3_origin_id
-
-    forwarded_values {
-      query_string = false
-      headers      = ["Origin"]
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
+    path_pattern           = "/content/immutable/*"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id       = local.s3_origin_id
+    cache_policy_id        = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # Managed policy to disable caching
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
   }
@@ -233,7 +221,7 @@ of several sub-resources - these resources are laid out below.
     distribution (multiples allowed).
 
 * `origin_group` (Optional) - One or more [origin_group](#origin-group-arguments) for this
-  distribution (multiples allowed).  
+  distribution (multiples allowed).
 
 * `price_class` (Optional) - The price class for this distribution. One of
     `PriceClass_All`, `PriceClass_200`, `PriceClass_100`
@@ -280,7 +268,11 @@ of several sub-resources - these resources are laid out below.
 
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
-* `forwarded_values` (Required) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
+* `cache_policy_id` (Optional) - The unique identifier of the cache
+    policy that is attached to this cache behavior. This approach should be used to
+    replace the deprecated explicit configuration using `forwarded_values`. Conflicts with `forwarded_values`, `min_ttl`, `max_ttl` and `default_ttl`.
+
+* `forwarded_values` (Optional/Deprecated) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
     handles query strings, cookies and headers (maximum one).
 
 * `lambda_function_association` (Optional) - A config block that triggers a lambda function with
@@ -307,7 +299,7 @@ of several sub-resources - these resources are laid out below.
     CloudFront to route requests to when a request matches the path pattern
     either for a cache behavior or for the default cache behavior.
 
-* `trusted_signers` (Optional) - List of AWS account IDs (or `self`) that you want to allow to create signed URLs for private content. 
+* `trusted_signers` (Optional) - List of AWS account IDs (or `self`) that you want to allow to create signed URLs for private content.
 See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
 
 * `viewer_protocol_policy` (Required) - Use this element to specify the
@@ -428,7 +420,7 @@ argument should not be specified.
 
 * `s3_origin_config` - The [CloudFront S3 origin](#s3-origin-config-arguments)
     configuration information. If a custom origin is required, use
-    `custom_origin_config` instead.    
+    `custom_origin_config` instead.
 
 ##### Custom Origin Config Arguments
 
@@ -499,7 +491,7 @@ The arguments of `geo_restriction` are:
     this, `acm_certificate_arn`, or `cloudfront_default_certificate`.
 
 * `minimum_protocol_version` - The minimum version of the SSL protocol that
-    you want CloudFront to use for HTTPS connections. Can only be set if 
+    you want CloudFront to use for HTTPS connections. Can only be set if
     `cloudfront_default_certificate = false`. One of `SSLv3`, `TLSv1`,
     `TLSv1_2016`, `TLSv1.1_2016`, `TLSv1.2_2018` or `TLSv1.2_2019`. Default: `TLSv1`. **NOTE**:
     If you are using a custom certificate (specified with `acm_certificate_arn`


### PR DESCRIPTION
This PR updates `aws_cloudfront_distribution` in order to align with the latest AWS API specs, deprecating `ForwardedValues` in when declaring `ordered_cache_behavior`.

When using the newly suggested approach with `CachePolicyId`, no `ForwardedValues`, `MinTTL` should be specified. I tried to use the `ConflictWith` in the schema spec, but without success, and couldn't find a clear explanation in the SDK docs. If someone can suggest to me how to use it adequately, I can make the update!

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

This relates to #14373. It partially closes it as it brings support for cache policy as following:

```hcl
resource "aws_cloudfront_cache_policy" "test1" {
  name = "test1"
  comment = ".."
  ...
}

resource "aws_cloudfront_distribution" "foo" {
  ..
  ordered_cache_behavior {
    ..
    cache_policy_id              = aws_cloudfront_cache_policy.test1.id
  }
}
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for cache policy in Cloudfront distribution
Deprecate ForwardedValues in Cloudfront distribution
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_* -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== RUN   TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_CachePolicyId
=== PAUSE TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_CachePolicyId
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_CachePolicyId
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers
=== CONT  TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_CachePolicyId
    resource_aws_cloudfront_distribution_test.go:763: Step 1/2 error: terraform failed: exit status 1
        
        stderr:
        
        Error: error creating CloudFront Distribution: InvalidArgument: The parameter MinTTL cannot be used when a cache policy is associated to the cache behavior.
        	status code: 400, request id: eea60a82-ac27-4d50-a092-7202d8ab0730
        
        
--- FAIL: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_CachePolicyId (6.35s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (236.32s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (236.74s)

...
```
