### PR TITLE
service/ec2: Prevent aws_default_route_table panic caused by aws_route_table local_gateway_id attribute changes

### DIFF
--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -324,7 +324,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 				RouteTableId: aws.String(d.Id()),
 			}
 
-			if s := m["ipv6_cidr_block"].(string); s != "" {
+			if s, ok := m["ipv6_cidr_block"].(string); ok && s != "" {
 				deleteOpts.DestinationIpv6CidrBlock = aws.String(s)
 
 				log.Printf(
@@ -332,7 +332,7 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 					d.Id(), m["ipv6_cidr_block"].(string))
 			}
 
-			if s := m["cidr_block"].(string); s != "" {
+			if s, ok := m["cidr_block"].(string); ok && s != "" {
 				deleteOpts.DestinationCidrBlock = aws.String(s)
 
 				log.Printf(
@@ -358,43 +358,43 @@ func resourceAwsRouteTableUpdate(d *schema.ResourceData, meta interface{}) error
 				RouteTableId: aws.String(d.Id()),
 			}
 
-			if s := m["transit_gateway_id"].(string); s != "" {
+			if s, ok := m["transit_gateway_id"].(string); ok && s != "" {
 				opts.TransitGatewayId = aws.String(s)
 			}
 
-			if s := m["vpc_peering_connection_id"].(string); s != "" {
+			if s, ok := m["vpc_peering_connection_id"].(string); ok && s != "" {
 				opts.VpcPeeringConnectionId = aws.String(s)
 			}
 
-			if s := m["network_interface_id"].(string); s != "" {
+			if s, ok := m["network_interface_id"].(string); ok && s != "" {
 				opts.NetworkInterfaceId = aws.String(s)
 			}
 
-			if s := m["instance_id"].(string); s != "" {
+			if s, ok := m["instance_id"].(string); ok && s != "" {
 				opts.InstanceId = aws.String(s)
 			}
 
-			if s := m["ipv6_cidr_block"].(string); s != "" {
+			if s, ok := m["ipv6_cidr_block"].(string); ok && s != "" {
 				opts.DestinationIpv6CidrBlock = aws.String(s)
 			}
 
-			if s := m["cidr_block"].(string); s != "" {
+			if s, ok := m["cidr_block"].(string); ok && s != "" {
 				opts.DestinationCidrBlock = aws.String(s)
 			}
 
-			if s := m["gateway_id"].(string); s != "" {
+			if s, ok := m["gateway_id"].(string); ok && s != "" {
 				opts.GatewayId = aws.String(s)
 			}
 
-			if s := m["egress_only_gateway_id"].(string); s != "" {
+			if s, ok := m["egress_only_gateway_id"].(string); ok && s != "" {
 				opts.EgressOnlyInternetGatewayId = aws.String(s)
 			}
 
-			if s := m["nat_gateway_id"].(string); s != "" {
+			if s, ok := m["nat_gateway_id"].(string); ok && s != "" {
 				opts.NatGatewayId = aws.String(s)
 			}
 
-			if s := m["local_gateway_id"].(string); s != "" {
+			if s, ok := m["local_gateway_id"].(string); ok && s != "" {
 				opts.LocalGatewayId = aws.String(s)
 			}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/14864

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE (caught before release)
```

Decoupling of the two resources can occur separately, but opting for this small fix as we cannot verify whether the `aws_default_route_table` resource can support `local_gateway_id` or not ourselves before tomorrow's release.

Previously:

```
=== CONT  TestAccAWSDefaultRouteTable_Route
------- Stderr: -------
panic: interface conversion: interface {} is nil, not string
goroutine 492 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsRouteTableUpdate(0xc00179f200, 0x5bf4d20, 0xc0017ccf00, 0x5a5f0c0, 0xc00144ab40)
  /opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_route_table.go:397 +0x2cbd
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsDefaultRouteTableCreate(0xc00179f200, 0x5bf4d20, 0xc0017ccf00, 0x3, 0xffffffffffffffff)
  /opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_default_route_table.go:149 +0x5b2
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc0008c7760, 0x7763460, 0xc001ec8580, 0xc00179f200, 0x5bf4d20, 0xc0017ccf00, 0x0, 0x0, 0x0)
  /opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:269 +0x88
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDefaultRouteTable_disappears_Vpc (20.85s)
--- PASS: TestAccAWSDefaultRouteTable_basic (39.08s)
--- PASS: TestAccAWSDefaultRouteTable_vpc_endpoint (54.68s)
--- PASS: TestAccAWSDefaultRouteTable_ConditionalCidrBlock (69.75s)
--- PASS: TestAccAWSDefaultRouteTable_tags (70.91s)
--- PASS: TestAccAWSDefaultRouteTable_swap (83.45s)
--- PASS: TestAccAWSDefaultRouteTable_Route (107.71s)
--- PASS: TestAccAWSDefaultRouteTable_Route_TransitGatewayID (331.13s)

--- FAIL: TestAccAWSRouteTable_panicEmptyRoute (17.11s) # See also: https://github.com/terraform-providers/terraform-provider-aws/issues/14383
--- PASS: TestAccAWSRouteTable_ipv6 (38.51s)
--- PASS: TestAccAWSRouteTable_vpcPeering (44.24s)
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (45.36s)
--- PASS: TestAccAWSRouteTable_ConditionalCidrBlock (70.65s)
--- PASS: TestAccAWSRouteTable_basic (80.26s)
--- PASS: TestAccAWSRouteTable_tags (90.73s)
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (92.20s)
--- PASS: TestAccAWSRouteTable_instance (116.15s)
--- PASS: TestAccAWSRouteTable_Route_TransitGatewayID (321.82s)
```
