### PR TITLE
r/rds_orderable_db_instance: Improve filters

### DIFF
--- a/aws/data_source_aws_rds_orderable_db_instance_test.go
+++ b/aws/data_source_aws_rds_orderable_db_instance_test.go
@@ -23,9 +23,9 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_basic(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfigBasic(class, engine, engineVersion, licenseModel, storageType),
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_basic(class, engine, engineVersion, licenseModel, storageType),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", class),
+					resource.TestCheckResourceAttr(dataSourceName, "instance_class", class),
 					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
 					resource.TestCheckResourceAttr(dataSourceName, "engine_version", engineVersion),
 					resource.TestCheckResourceAttr(dataSourceName, "license_model", licenseModel),
@@ -36,13 +36,9 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRdsOrderableDbInstanceDataSource_preferred(t *testing.T) {
+func TestAccAWSRdsOrderableDbInstanceDataSource_preferredClass(t *testing.T) {
 	dataSourceName := "data.aws_rds_orderable_db_instance.test"
-	engine := "mysql"
-	engineVersion := "5.7.22"
-	licenseModel := "general-public-license"
-	storageType := "standard"
-	preferredOption := "db.t2.small"
+	preferredClass := "db.t2.micro"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
@@ -50,13 +46,179 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_preferred(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfigPreferred(engine, engineVersion, licenseModel, storageType, preferredOption),
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_preferredClass(preferredClass),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
-					resource.TestCheckResourceAttr(dataSourceName, "engine_version", engineVersion),
-					resource.TestCheckResourceAttr(dataSourceName, "license_model", licenseModel),
-					resource.TestCheckResourceAttr(dataSourceName, "storage_type", storageType),
-					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", preferredOption),
+					resource.TestCheckResourceAttr(dataSourceName, "instance_class", preferredClass),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_preferredVersion(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+	preferredVersion := "5.7.22"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_preferredVersion(preferredVersion),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "engine_version", preferredVersion),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_preferredClassAndVersion(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+	preferredClass := "db.m3.medium"
+	preferredVersion := "5.7.22"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_preferredClassAndVersion(preferredClass, preferredVersion),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "instance_class", preferredClass),
+					resource.TestCheckResourceAttr(dataSourceName, "engine_version", preferredVersion),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_supportsEnhancedMonitoring(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsEnhancedMonitoring(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "supports_enhanced_monitoring", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_supportsIAMDatabaseAuthentication(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsIAMDatabaseAuthentication(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "supports_iam_database_authentication", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_supportsIops(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsIops(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "supports_iops", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_supportsKerberosAuthentication(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsKerberosAuthentication(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "supports_kerberos_authentication", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_supportsPerformanceInsights(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSRdsOrderableDbInstance(t)
+			testAccPreCheckAWSRdsOrderableDbInstanceStandardPartition(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsPerformanceInsights(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "supports_performance_insights", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageAutoscaling(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsStorageAutoscaling(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "supports_storage_autoscaling", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageEncryption(t *testing.T) {
+	dataSourceName := "data.aws_rds_orderable_db_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsStorageEncryption(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "supports_storage_encryption", "true"),
 				),
 			},
 		},
@@ -81,27 +243,151 @@ func testAccPreCheckAWSRdsOrderableDbInstance(t *testing.T) {
 	}
 }
 
-func testAccAWSRdsOrderableDbInstanceDataSourceConfigBasic(class, engine, version, license, storage string) string {
-	return fmt.Sprintf(`
-data "aws_rds_orderable_db_instance" "test" {
-  db_instance_class = %q
-  engine            = %q
-  engine_version    = %q
-  license_model     = %q
-  storage_type      = %q
-}
-`, class, engine, version, license, storage)
+func testAccPreCheckAWSRdsOrderableDbInstanceStandardPartition(t *testing.T) {
+	if testAccGetPartition() != "aws" {
+		t.Skipf("skipping acceptance testing, not in standard partition (partition: %s)", testAccGetPartition())
+	}
 }
 
-func testAccAWSRdsOrderableDbInstanceDataSourceConfigPreferred(engine, version, license, storage, preferredOption string) string {
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_basic(class, engine, version, license, storage string) string {
 	return fmt.Sprintf(`
 data "aws_rds_orderable_db_instance" "test" {
+  instance_class = %q
   engine         = %q
   engine_version = %q
   license_model  = %q
   storage_type   = %q
-
-  preferred_db_instance_classes = ["db.xyz.xlarge", %q, "db.t3.small"]
 }
-`, engine, version, license, storage, preferredOption)
+`, class, engine, version, license, storage)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_preferredClass(preferredClass string) string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine         = "mysql"
+  engine_version = "5.7.22"
+  license_model  = "general-public-license"
+
+  preferred_instance_classes = ["db.xyz.xlarge", %q, "db.t3.small"]
+}
+`, preferredClass)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_preferredVersion(preferredVersion string) string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine        = "mysql"
+  license_model = "general-public-license"
+  storage_type  = "standard"
+
+  preferred_engine_versions = ["18.42.32", %q, "not.a.version"]
+}
+`, preferredVersion)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_preferredClassAndVersion(preferredClass, preferredVersion string) string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine        = "mysql"
+  license_model = "general-public-license"
+
+  preferred_instance_classes = ["db.xyz.xlarge", %q, "db.t3.small"]
+  preferred_engine_versions  = ["18.42.32", %q, "not.a.version"]
+}
+`, preferredClass, preferredVersion)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsEnhancedMonitoring() string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                       = "mysql"
+  license_model                = "general-public-license"
+  storage_type                 = "standard"
+  supports_enhanced_monitoring = true
+
+  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
+}
+`)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsIAMDatabaseAuthentication() string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                               = "mysql"
+  license_model                        = "general-public-license"
+  storage_type                         = "standard"
+  supports_iam_database_authentication = true
+
+  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
+}
+`)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsIops() string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine        = "mysql"
+  license_model = "general-public-license"
+  supports_iops = true
+
+  preferred_engine_versions  = ["8.0.20", "8.0.19", "8.0.17"]
+  preferred_instance_classes = ["db.t3.small", "db.t2.xlarge", "db.t2.small"]
+}
+`)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsKerberosAuthentication() string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                           = "postgres"
+  license_model                    = "postgresql-license"
+  storage_type                     = "standard"
+  supports_kerberos_authentication = true
+
+  preferred_engine_versions  = ["12.3", "11.1", "10.13"]
+  preferred_instance_classes = ["db.m5.xlarge", "db.r5.large", "db.t3.large"]
+}
+`)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsPerformanceInsights() string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = "mysql"
+  license_model                 = "general-public-license"
+  supports_performance_insights = true
+
+  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
+}
+`)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsStorageAutoscaling() string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                       = "mysql"
+  license_model                = "general-public-license"
+  supports_storage_autoscaling = true
+
+  preferred_engine_versions  = ["8.0.20", "8.0.19", "5.7.30"]
+  preferred_instance_classes = ["db.t3.medium", "db.t2.large", "db.t3.xlarge"]
+}
+`)
+}
+
+func testAccAWSRdsOrderableDbInstanceDataSourceConfig_supportsStorageEncryption() string {
+	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                      = "mysql"
+  license_model               = "general-public-license"
+  storage_type                = "standard"
+  supports_storage_encryption = true
+
+  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
+}
+`)
 }

--- a/website/docs/d/rds_orderable_db_instance.markdown
+++ b/website/docs/d/rds_orderable_db_instance.markdown
@@ -19,7 +19,7 @@ data "aws_rds_orderable_db_instance" "test" {
   license_model  = "general-public-license"
   storage_type   = "standard"
 
-  preferred_db_instance_classes = ["db.r6.xlarge", "db.m4.large", "db.t3.small"]
+  preferred_instance_classes = ["db.r6.xlarge", "db.m4.large", "db.t3.small"]
 }
 ```
 
@@ -29,11 +29,19 @@ The following arguments are supported:
 
 * `engine` - (Required) DB engine. Engine values include `aurora`, `aurora-mysql`, `aurora-postgresql`, `docdb`, `mariadb`, `mysql`, `neptune`, `oracle-ee`, `oracle-se`, `oracle-se1`, `oracle-se2`, `postgres`, `sqlserver-ee`, `sqlserver-ex`, `sqlserver-se`, and `sqlserver-web`.
 * `availability_zone_group` - (Optional) Availability zone group.
-* `db_instance_class` - (Optional) DB instance class. Examples of classes are `db.m3.2xlarge`, `db.t2.small`, and `db.m3.medium`.
+* `instance_class` - (Optional) DB instance class. Examples of classes are `db.m3.2xlarge`, `db.t2.small`, and `db.m3.medium`.
 * `engine_version` - (Optional) Version of the DB engine.
 * `license_model` - (Optional) License model. Examples of license models are `general-public-license`, `bring-your-own-license`, and `amazon-license`.
-* `preferred_db_instance_classes` - (Optional) Ordered list of preferred RDS DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
+* `preferred_instance_classes` - (Optional) Ordered list of preferred RDS DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
 * `storage_type` - (Optional) Storage types. Examples of storage types are `standard`, `io1`, `gp2`, and `aurora`.
+* `supports_enhanced_monitoring` - (Optional) Enable this to ensure a DB instance supports Enhanced Monitoring at intervals from 1 to 60 seconds.
+* `supports_global_databases` - (Optional) Enable this to ensure a DB instance supports Aurora global databases with a specific combination of other DB engine attributes.
+* `supports_iam_database_authentication` - (Optional) Enable this to ensure a DB instance supports IAM database authentication.
+* `supports_iops` - (Optional) Enable this to ensure a DB instance supports provisioned IOPS.
+* `supports_kerberos_authentication` - (Optional) Enable this to ensure a DB instance supports Kerberos Authentication.
+* `supports_performance_insights` - (Optional) Enable this to ensure a DB instance supports Performance Insights.
+* `supports_storage_autoscaling` - (Optional) Enable this to ensure Amazon RDS can automatically scale storage for DB instances that use the specified DB instance class.
+* `supports_storage_encryption` - (Optional) Enable this to ensure a DB instance supports encrypted storage.
 * `vpc` - (Optional) Boolean that indicates whether to show only VPC or non-VPC offerings.
 
 ## Attribute Reference
@@ -51,11 +59,3 @@ In addition to all arguments above, the following attributes are exported:
 * `outpost_capable` - Whether a DB instance supports RDS on Outposts.
 * `read_replica_capable` - Whether a DB instance can have a read replica.
 * `supported_engine_modes` - A list of the supported DB engine modes.
-* `supports_enhanced_monitoring` - Whether a DB instance supports Enhanced Monitoring at intervals from 1 to 60 seconds.
-* `supports_global_databases` - Whether you can use Aurora global databases with a specific combination of other DB engine attributes.
-* `supports_iam_database_authentication` - Whether a DB instance supports IAM database authentication.
-* `supports_iops` - Whether a DB instance supports provisioned IOPS.
-* `supports_kerberos_authentication` - Whether a DB instance supports Kerberos Authentication.
-* `supports_performance_insights` - Whether a DB instance supports Performance Insights.
-* `supports_storage_autoscaling` - Whether Amazon RDS can automatically scale storage for DB instances that use the specified DB instance class.
-* `supports_storage_encryption` - Whether a DB instance supports encrypted storage.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14984

This PR:

1. adds a `preferred_engine_versions` argument
2. changes the `db_instance_class` argument to `instance_class` to be consistent with `aws_db_instance` and `aws_db_option_group` (see also #14991 and #14992) and 
3. adds additional filters

New filters:

* `supports_enhanced_monitoring`
* `supports_global_databases`
* `supports_iam_database_authentication`
* `supports_iops`
* `supports_kerberos_authentication`
* `supports_performance_insights`
* `supports_storage_autoscaling`
* `supports_storage_encryption`

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSRdsOrderableDbInstanceDataSource_supportsPerformanceInsights (2.08s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_basic (17.20s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredClass (17.33s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsIops (53.09s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredClassAndVersion (57.46s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredVersion (58.39s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsEnhancedMonitoring (62.41s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageAutoscaling (62.56s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageEncryption (63.59s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsIAMDatabaseAuthentication (72.15s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsKerberosAuthentication (121.73s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_basic (13.72s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredClass (15.27s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsPerformanceInsights (166.24s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsIAMDatabaseAuthentication (171.44s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredVersion (171.79s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageEncryption (172.04s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsIops (173.09s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageAutoscaling (173.51s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredClassAndVersion (173.53s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsEnhancedMonitoring (173.65s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsKerberosAuthentication (223.17s)
```
