### PR TITLE
d/docdb_orderable_db_instance: Fix naming

### DIFF
--- a/aws/data_source_aws_docdb_orderable_db_instance.go
+++ b/aws/data_source_aws_docdb_orderable_db_instance.go
@@ -19,7 +19,7 @@ func dataSourceAwsDocdbOrderableDbInstance() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"db_instance_class": {
+			"instance_class": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -42,7 +42,7 @@ func dataSourceAwsDocdbOrderableDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
-			"preferred_db_instance_classes": {
+			"preferred_instance_classes": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -62,7 +62,7 @@ func dataSourceAwsDocdbOrderableDbInstanceRead(d *schema.ResourceData, meta inte
 
 	input := &docdb.DescribeOrderableDBInstanceOptionsInput{}
 
-	if v, ok := d.GetOk("db_instance_class"); ok {
+	if v, ok := d.GetOk("instance_class"); ok {
 		input.DBInstanceClass = aws.String(v.(string))
 	}
 
@@ -106,7 +106,7 @@ func dataSourceAwsDocdbOrderableDbInstanceRead(d *schema.ResourceData, meta inte
 
 	// preferred classes
 	var found *docdb.OrderableDBInstanceOption
-	if l := d.Get("preferred_db_instance_classes").([]interface{}); len(l) > 0 {
+	if l := d.Get("preferred_instance_classes").([]interface{}); len(l) > 0 {
 		for _, elem := range l {
 			preferredInstanceClass, ok := elem.(string)
 
@@ -141,7 +141,7 @@ func dataSourceAwsDocdbOrderableDbInstanceRead(d *schema.ResourceData, meta inte
 
 	d.SetId(aws.StringValue(found.DBInstanceClass))
 
-	d.Set("db_instance_class", found.DBInstanceClass)
+	d.Set("instance_class", found.DBInstanceClass)
 
 	var availabilityZones []string
 	for _, az := range found.AvailabilityZones {

--- a/aws/data_source_aws_docdb_orderable_db_instance_test.go
+++ b/aws/data_source_aws_docdb_orderable_db_instance_test.go
@@ -24,7 +24,7 @@ func TestAccAWSDocdbOrderableDbInstanceDataSource_basic(t *testing.T) {
 			{
 				Config: testAccAWSDocdbOrderableDbInstanceDataSourceConfigBasic(class, engine, engineVersion, license),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", class),
+					resource.TestCheckResourceAttr(dataSourceName, "instance_class", class),
 					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
 					resource.TestCheckResourceAttr(dataSourceName, "engine_version", engineVersion),
 					resource.TestCheckResourceAttr(dataSourceName, "license_model", license),
@@ -52,7 +52,7 @@ func TestAccAWSDocdbOrderableDbInstanceDataSource_preferred(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
 					resource.TestCheckResourceAttr(dataSourceName, "engine_version", engineVersion),
 					resource.TestCheckResourceAttr(dataSourceName, "license_model", license),
-					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", preferredOption),
+					resource.TestCheckResourceAttr(dataSourceName, "instance_class", preferredOption),
 				),
 			},
 		},
@@ -80,10 +80,10 @@ func testAccPreCheckAWSDocdbOrderableDbInstance(t *testing.T) {
 func testAccAWSDocdbOrderableDbInstanceDataSourceConfigBasic(class, engine, version, license string) string {
 	return fmt.Sprintf(`
 data "aws_docdb_orderable_db_instance" "test" {
-  db_instance_class = %q
-  engine            = %q
-  engine_version    = %q
-  license_model     = %q
+  instance_class = %q
+  engine         = %q
+  engine_version = %q
+  license_model  = %q
 }
 `, class, engine, version, license)
 }
@@ -95,7 +95,7 @@ data "aws_docdb_orderable_db_instance" "test" {
   engine_version = %q
   license_model  = %q
 
-  preferred_db_instance_classes = ["db.xyz.xlarge", %q, "db.t3.small"]
+  preferred_instance_classes = ["db.xyz.xlarge", %q, "db.t3.small"]
 }
 `, engine, version, license, preferredOption)
 }

--- a/website/docs/d/docdb_orderable_db_instance.markdown
+++ b/website/docs/d/docdb_orderable_db_instance.markdown
@@ -18,7 +18,7 @@ data "aws_docdb_orderable_db_instance" "test" {
   engine_version = "3.6.0"
   license_model  = "na"
 
-  preferred_db_instance_classes = ["db.r5.large", "db.r4.large", "db.t3.medium"]
+  preferred_instance_classes = ["db.r5.large", "db.r4.large", "db.t3.medium"]
 }
 ```
 
@@ -27,10 +27,10 @@ data "aws_docdb_orderable_db_instance" "test" {
 The following arguments are supported:
 
 * `engine` - (Required) DB engine. Engine values include `docdb`.
-* `db_instance_class` - (Optional) DB instance class. Examples of classes are `db.r5.12xlarge`, `db.r5.24xlarge`, `db.r5.2xlarge`, `db.r5.4xlarge`, `db.r5.large`, `db.r5.xlarge`, and `db.t3.medium`.
+* `instance_class` - (Optional) DB instance class. Examples of classes are `db.r5.12xlarge`, `db.r5.24xlarge`, `db.r5.2xlarge`, `db.r5.4xlarge`, `db.r5.large`, `db.r5.xlarge`, and `db.t3.medium`.
 * `engine_version` - (Optional) Version of the DB engine. For example, `3.6.0`.
 * `license_model` - (Optional) License model. Examples of license models are `general-public-license`, `na`, `bring-your-own-license`, and `amazon-license`.
-* `preferred_db_instance_classes` - (Optional) Ordered list of preferred DocumentDB DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
+* `preferred_instance_classes` - (Optional) Ordered list of preferred DocumentDB DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
 * `vpc` - (Optional) Boolean that indicates whether to show only VPC or non-VPC offerings.
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14992, #14990, #14984

This PR is part of changing the `db_instance_class` argument to `instance_class` to be consistent with `aws_db_instance` and `aws_db_option_group`.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):


```
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_basic (16.78s)
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_preferred (16.88s)
```

Output from acceptance testing (commercial):


```
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_basic (12.18s)
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_preferred (12.29s)
```