### PR TITLE
resource/cloudfront_distribution: conditionally flatten cache behavior forwarded_values

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -265,10 +265,12 @@ func flattenCloudFrontDefaultCacheBehavior(dcb *cloudfront.DefaultCacheBehavior)
 		"field_level_encryption_id": aws.StringValue(dcb.FieldLevelEncryptionId),
 		"viewer_protocol_policy":    aws.StringValue(dcb.ViewerProtocolPolicy),
 		"target_origin_id":          aws.StringValue(dcb.TargetOriginId),
-		"forwarded_values":          []interface{}{flattenForwardedValues(dcb.ForwardedValues)},
 		"min_ttl":                   aws.Int64Value(dcb.MinTTL),
 	}
 
+	if dcb.ForwardedValues != nil {
+		m["forwarded_values"] = []interface{}{flattenForwardedValues(dcb.ForwardedValues)}
+	}
 	if len(dcb.TrustedSigners.Items) > 0 {
 		m["trusted_signers"] = flattenTrustedSigners(dcb.TrustedSigners)
 	}
@@ -301,9 +303,11 @@ func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
 	m["field_level_encryption_id"] = aws.StringValue(cb.FieldLevelEncryptionId)
 	m["viewer_protocol_policy"] = aws.StringValue(cb.ViewerProtocolPolicy)
 	m["target_origin_id"] = aws.StringValue(cb.TargetOriginId)
-	m["forwarded_values"] = []interface{}{flattenForwardedValues(cb.ForwardedValues)}
 	m["min_ttl"] = int(aws.Int64Value(cb.MinTTL))
 
+	if cb.ForwardedValues != nil {
+		m["forwarded_values"] = []interface{}{flattenForwardedValues(cb.ForwardedValues)}
+	}
 	if len(cb.TrustedSigners.Items) > 0 {
 		m["trusted_signers"] = flattenTrustedSigners(cb.TrustedSigners)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14986

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/cloudfront_distribution: Prevent panic on import 
```

Notes:
* changes to prevent relevant panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5: [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x445734f]
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5:
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5: goroutine 88 [running]:
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5: github.com/terraform-providers/terraform-provider-aws/aws.flattenForwardedValues(0x0, 0xc0015f3b00)
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5:   /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-aws/aws/cloudfront_distribution_configuration_structure.go:430 +0x2f
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5: github.com/terraform-providers/terraform-provider-aws/aws.flattenCacheBehavior(0xc0007b5580, 0x64a34e0)
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5:   /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-aws/aws/cloudfront_distribution_configuration_structure.go:304 +0x245
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5: github.com/terraform-providers/terraform-provider-aws/aws.flattenCacheBehaviors(0xc001c76a20, 0x666980e, 0x15, 0x64a34e0)
2020-09-02T20:33:07.083+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5:   /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-aws/aws/cloudfront_distribution_configuration_structure.go:185 +0x89
2020-09-02T20:33:07.084+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5: github.com/terraform-providers/terraform-provider-aws/aws.flattenDistributionConfig(0xc0014cea00, 0xc000e330e0, 0xc001e30220, 0x0)
2020-09-02T20:33:07.084+0100 [DEBUG] plugin.terraform-provider-aws_v3.4.0_x5:   /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-aws/aws/cloudfront_distribution_configuration_structure.go:123 +0xa5b
```
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- FAIL: TestAccAWSCloudFrontDistribution_RetainOnDelete (287.04s) --- from the test history, looks like an ongoing test failure
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (7.23s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (8.38s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (218.49s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_TrustedSigners (289.02s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (290.61s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (291.17s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (557.80s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (558.18s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (558.71s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (559.64s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (559.78s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (562.71s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (565.42s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (570.26s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (582.37s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (590.50s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (531.55s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (750.11s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (753.77s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (799.97s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1026.09s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (1028.85s)
```
