### PR TITLE
Removes non-existent fields from RDS cluster documentation

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -198,7 +198,6 @@ In addition to all arguments above, the following attributes are exported:
 * `cluster_identifier` - The RDS Cluster Identifier
 * `cluster_resource_id` - The RDS Cluster Resource ID
 * `cluster_members` – List of RDS Instances that are a part of this cluster
-* `allocated_storage` - The amount of allocated storage
 * `availability_zones` - The availability zone of the instance
 * `backup_retention_period` - The backup retention period
 * `preferred_backup_window` - The daily time range during which the backups happen
@@ -208,10 +207,8 @@ In addition to all arguments above, the following attributes are exported:
 load-balanced across replicas
 * `engine` - The database engine
 * `engine_version` - The database engine version
-* `maintenance_window` - The instance maintenance window
 * `database_name` - The database name
 * `port` - The database port
-* `status` - The RDS instance status
 * `master_username` - The master username for the database
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted
 * `replication_source_identifier` - ARN of the source DB cluster or DB instance if this DB cluster is created as a Read Replica.

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -94,14 +94,11 @@ In addition to all arguments above, the following attributes are exported:
 * `identifier` - The Instance identifier
 * `id` - The Instance identifier
 * `writer` – Boolean indicating if this instance is writable. `False` indicates this instance is a read replica.
-* `allocated_storage` - The amount of allocated storage
 * `availability_zone` - The availability zone of the instance
 * `endpoint` - The DNS address for this instance. May not be writable
 * `engine` - The database engine
 * `engine_version` - The database engine version
-* `database_name` - The database name
 * `port` - The database port
-* `status` - The RDS instance status
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted.
 * `kms_key_id` - The ARN for the KMS encryption key if one is set to the cluster.
 * `dbi_resource_id` - The region-unique, immutable identifier for the DB instance.


### PR DESCRIPTION
Removes a number of non-existent fields from `aws_rds_cluster` and `aws_rds_cluster_instance` documentation

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14985
Closes #13594
Closes #4797

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

N/A