### PR TITLE
tests/provider: Update hardcoded AZs (EBS Snapshot IDs)

### DIFF
--- a/aws/data_source_aws_ebs_snapshot_ids_test.go
+++ b/aws/data_source_aws_ebs_snapshot_ids_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceAwsEbsSnapshotIds_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsEbsSnapshotIdsConfig_basic,
+				Config: testAccDataSourceAwsEbsSnapshotIdsConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEbsSnapshotDataSourceID("data.aws_ebs_snapshot_ids.test"),
 				),
@@ -70,9 +70,10 @@ func TestAccDataSourceAwsEbsSnapshotIds_empty(t *testing.T) {
 	})
 }
 
-const testAccDataSourceAwsEbsSnapshotIdsConfig_basic = `
+func testAccDataSourceAwsEbsSnapshotIdsConfig_basic() string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   size              = 1
 }
 
@@ -83,12 +84,13 @@ resource "aws_ebs_snapshot" "test" {
 data "aws_ebs_snapshot_ids" "test" {
   owners = ["self"]
 }
-`
+`))
+}
 
 func testAccDataSourceAwsEbsSnapshotIdsConfig_sorted1(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   size              = 1
 
   count = 2
@@ -96,23 +98,23 @@ resource "aws_ebs_volume" "test" {
 
 resource "aws_ebs_snapshot" "a" {
   volume_id   = aws_ebs_volume.test.*.id[0]
-  description = %q
+  description = %[1]q
 }
 
 resource "aws_ebs_snapshot" "b" {
   volume_id   = aws_ebs_volume.test.*.id[1]
-  description = %q
+  description = %[1]q
 
   # We want to ensure that 'aws_ebs_snapshot.a.creation_date' is less than
   # 'aws_ebs_snapshot.b.creation_date'/ so that we can ensure that the
   # snapshots are being sorted correctly.
   depends_on = [aws_ebs_snapshot.a]
 }
-`, rName, rName)
+`, rName))
 }
 
 func testAccDataSourceAwsEbsSnapshotIdsConfig_sorted2(rName string) string {
-	return testAccDataSourceAwsEbsSnapshotIdsConfig_sorted1(rName) + fmt.Sprintf(`
+	return composeConfig(testAccDataSourceAwsEbsSnapshotIdsConfig_sorted1(rName), fmt.Sprintf(`
 data "aws_ebs_snapshot_ids" "test" {
   owners = ["self"]
 
@@ -121,7 +123,7 @@ data "aws_ebs_snapshot_ids" "test" {
     values = [%q]
   }
 }
-`, rName)
+`, rName))
 }
 
 const testAccDataSourceAwsEbsSnapshotIdsConfig_empty = `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing (Commercial):

```
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_empty (14.06s)
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_basic (44.87s)
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_sorted (45.54s)
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_empty (20.56s)
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_basic (50.34s)
--- PASS: TestAccDataSourceAwsEbsSnapshotIds_sorted (70.24s)
```