### PR TITLE
tests/provider: Fix hardcoded AZs (Redshift cluster ds)

### DIFF
--- a/aws/data_source_aws_redshift_cluster_test.go
+++ b/aws/data_source_aws_redshift_cluster_test.go
@@ -98,35 +98,35 @@ data "aws_redshift_cluster" "test" {
 }
 
 func testAccAWSDataSourceRedshiftClusterConfigWithVpc(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.test.id
 }
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.test.id
 }
 
 resource "aws_redshift_subnet_group" "test" {
-  name       = "tf-redshift-subnet-group-%d"
+  name       = "tf-redshift-subnet-group-%[1]d"
   subnet_ids = [aws_subnet.foo.id, aws_subnet.bar.id]
 }
 
 resource "aws_security_group" "test" {
-  name   = "tf-redshift-sg-%d"
+  name   = "tf-redshift-sg-%[1]d"
   vpc_id = aws_vpc.test.id
 }
 
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier = "tf-redshift-cluster-%d"
+  cluster_identifier = "tf-redshift-cluster-%[1]d"
 
   database_name             = "testdb"
   master_username           = "foo"
@@ -143,7 +143,7 @@ resource "aws_redshift_cluster" "test" {
 data "aws_redshift_cluster" "test" {
   cluster_identifier = aws_redshift_cluster.test.cluster_identifier
 }
-`, rInt, rInt, rInt)
+`, rInt))
 }
 
 func testAccAWSDataSourceRedshiftClusterConfigWithLogging(rInt int) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
# It's over 15000!

Relates #12995

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSDataSourceRedshiftCluster_basic (410.20s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_logging (462.13s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_vpc (971.17s)
```

Output from acceptance testing (Commercial):

```
--- PASS: TestAccAWSDataSourceRedshiftCluster_basic (283.58s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_logging (410.77s)
--- PASS: TestAccAWSDataSourceRedshiftCluster_vpc (451.63s)
```