### PR TITLE
tests/provider: Fix hardcoded AZs (nat gateway ds)

### DIFF
--- a/aws/data_source_aws_nat_gateway_test.go
+++ b/aws/data_source_aws_nat_gateway_test.go
@@ -42,9 +42,9 @@ func TestAccDataSourceAwsNatGateway_basic(t *testing.T) {
 }
 
 func testAccDataSourceAwsNatGatewayConfig(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  cidr_block = "172.%d.0.0/16"
+  cidr_block = "172.%[1]d.0.0/16"
 
   tags = {
     Name = "terraform-testacc-nat-gw-data-source"
@@ -53,8 +53,8 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
-  cidr_block        = "172.%d.123.0/24"
-  availability_zone = "us-west-2a"
+  cidr_block        = "172.%[1]d.123.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-nat-gw-data-source"
@@ -71,7 +71,7 @@ resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-nat-gateway-data-source-%d"
+    Name = "terraform-testacc-nat-gateway-data-source-%[1]d"
   }
 }
 
@@ -80,7 +80,7 @@ resource "aws_nat_gateway" "test" {
   allocation_id = aws_eip.test.id
 
   tags = {
-    Name     = "terraform-testacc-nat-gw-data-source-%d"
+    Name     = "terraform-testacc-nat-gw-data-source-%[1]d"
     OtherTag = "some-value"
   }
 
@@ -100,5 +100,5 @@ data "aws_nat_gateway" "test_by_tags" {
     Name = aws_nat_gateway.test.tags["Name"]
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt))
 }

--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -205,7 +205,7 @@ data "aws_route" "by_instance_id" {
 
 func testAccAWSRouteDataSourceConfigTransitGatewayID() string {
 	return testAccAvailableAZsNoOptInDefaultExcludeConfig() + `
-# IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+# IncorrectState: Transit Gateway is not available in some availability zones
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSRouteDataSource_LocalGatewayID (0.00s)
--- PASS: TestAccAWSRouteDataSource_basic (183.48s)
--- PASS: TestAccDataSourceAwsNatGateway_basic (194.64s)
--- PASS: TestAccAWSRouteDataSource_TransitGatewayID (345.71s)
```

Output from acceptance testing (commercial):

```
--- SKIP: TestAccAWSRouteDataSource_LocalGatewayID (0.00s)
--- PASS: TestAccAWSRouteDataSource_basic (79.17s)
--- PASS: TestAccDataSourceAwsNatGateway_basic (170.91s)
--- PASS: TestAccAWSRouteDataSource_TransitGatewayID (285.68s)
```