### PR TITLE
tests/provider: Fix hardcoded AZs (docdb cluster)

### DIFF
--- a/aws/resource_aws_docdb_cluster_test.go
+++ b/aws/resource_aws_docdb_cluster_test.go
@@ -597,10 +597,16 @@ func testAccCheckDocDBClusterSnapshot(rInt int) resource.TestCheckFunc {
 }
 
 func testAccDocDBClusterConfig(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier              = "tf-docdb-cluster-%d"
-  availability_zones              = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%d"
+
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.docdb3.6"
@@ -615,7 +621,7 @@ resource "aws_docdb_cluster" "default" {
     "profiler",
   ]
 }
-`, n)
+`, n))
 }
 
 func testAccDocDBClusterConfig_namePrefix() string {
@@ -640,37 +646,55 @@ resource "aws_docdb_cluster" "test" {
 }
 
 func testAccDocDBClusterConfigWithFinalSnapshot(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier              = "tf-docdb-cluster-%d"
-  availability_zones              = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%[1]d"
+
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.docdb3.6"
-  final_snapshot_identifier       = "tf-acctest-docdbcluster-snapshot-%d"
+  final_snapshot_identifier       = "tf-acctest-docdbcluster-snapshot-%[1]d"
 
   tags = {
     Environment = "production"
   }
 }
-`, n, n)
+`, n))
 }
 
 func testAccDocDBClusterConfigWithoutUserNameAndPassword(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier  = "tf-docdb-cluster-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%d"
+
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   skip_final_snapshot = true
 }
-`, n)
+`, n))
 }
 
 func testAccDocDBClusterConfigUpdatedTags(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier              = "tf-docdb-cluster-%d"
-  availability_zones              = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%d"
+
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.docdb3.6"
@@ -681,14 +705,20 @@ resource "aws_docdb_cluster" "default" {
     AnotherTag  = "test"
   }
 }
-`, n)
+`, n))
 }
 
 func testAccDocDBClusterNoCloudwatchLogsConfig(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier              = "tf-docdb-cluster-%d"
-  availability_zones              = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%d"
+
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.docdb3.6"
@@ -698,14 +728,15 @@ resource "aws_docdb_cluster" "default" {
     Environment = "production"
   }
 }
-`, n)
+`, n))
 }
 
 func testAccDocDBClusterConfig_kmsKey(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_kms_key" "foo" {
-  description = "Terraform acc test %d"
-  policy      = <<POLICY
+  description = "Terraform acc test %[1]d"
+
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",
@@ -725,8 +756,13 @@ POLICY
 }
 
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier              = "tf-docdb-cluster-%d"
-  availability_zones              = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%[1]d"
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.docdb3.6"
@@ -734,27 +770,39 @@ resource "aws_docdb_cluster" "default" {
   kms_key_id                      = aws_kms_key.foo.arn
   skip_final_snapshot             = true
 }
-`, n, n)
+`, n))
 }
 
 func testAccDocDBClusterConfig_encrypted(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier  = "tf-docdb-cluster-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%d"
+
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   master_username     = "foo"
   master_password     = "mustbeeightcharaters"
   storage_encrypted   = true
   skip_final_snapshot = true
 }
-`, n)
+`, n))
 }
 
 func testAccDocDBClusterConfig_backups(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier           = "tf-docdb-cluster-%d"
-  availability_zones           = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%d"
+
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   master_username              = "foo"
   master_password              = "mustbeeightcharaters"
   backup_retention_period      = 5
@@ -762,14 +810,20 @@ resource "aws_docdb_cluster" "default" {
   preferred_maintenance_window = "tue:04:00-tue:04:30"
   skip_final_snapshot          = true
 }
-`, n)
+`, n))
 }
 
 func testAccDocDBClusterConfig_backupsUpdate(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "default" {
-  cluster_identifier           = "tf-docdb-cluster-%d"
-  availability_zones           = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-docdb-cluster-%d"
+
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   master_username              = "foo"
   master_password              = "mustbeeightcharaters"
   backup_retention_period      = 10
@@ -778,22 +832,18 @@ resource "aws_docdb_cluster" "default" {
   apply_immediately            = true
   skip_final_snapshot          = true
 }
-`, n)
+`, n))
 }
 
 func testAccDocDBClusterConfig_Port(rInt, port int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "test" {
-  availability_zones              = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
+
   cluster_identifier              = "tf-acc-test-%d"
   db_cluster_parameter_group_name = "default.docdb3.6"
   engine                          = "docdb"
@@ -802,7 +852,7 @@ resource "aws_docdb_cluster" "test" {
   port                            = %d
   skip_final_snapshot             = true
 }
-`, rInt, port)
+`, rInt, port))
 }
 
 func testAccDocDBClusterConfigDeleteProtection(isProtected bool) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSDocDBCluster_basic (131.12s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (141.59s)
--- PASS: TestAccAWSDocDBCluster_generatedName (141.18s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (139.72s)
--- PASS: TestAccAWSDocDBCluster_encrypted (139.62s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (164.92s)
--- PASS: TestAccAWSDocDBCluster_updateTags (178.30s)
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (176.28s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (212.69s)
--- PASS: TestAccAWSDocDBCluster_Port (256.30s)
--- PASS: TestAccAWSDocDBCluster_deleteProtection (255.36s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSDocDBCluster_missingUserNameCausesError (24.10s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (140.71s)
--- PASS: TestAccAWSDocDBCluster_generatedName (141.76s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (124.67s)
--- PASS: TestAccAWSDocDBCluster_updateTags (184.72s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (177.09s)
--- PASS: TestAccAWSDocDBCluster_encrypted (194.71s)
--- PASS: TestAccAWSDocDBCluster_basic (233.90s)
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (195.05s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (236.63s)
--- PASS: TestAccAWSDocDBCluster_deleteProtection (256.03s)
--- PASS: TestAccAWSDocDBCluster_Port (327.80s)
```