### PR TITLE
tests/provider: Fix hardcoded AZs (docdb subnet)

### DIFF
--- a/aws/resource_aws_docdb_subnet_group_test.go
+++ b/aws/resource_aws_docdb_subnet_group_test.go
@@ -75,7 +75,7 @@ func TestAccAWSDocDBSubnetGroup_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckDocDBSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDocDBSubnetGroupConfig_namePrefix,
+				Config: testAccDocDBSubnetGroupConfig_namePrefix(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDocDBSubnetGroupExists(
 						"aws_docdb_subnet_group.test", &v),
@@ -102,7 +102,7 @@ func TestAccAWSDocDBSubnetGroup_generatedName(t *testing.T) {
 		CheckDestroy: testAccCheckDocDBSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDocDBSubnetGroupConfig_generatedName,
+				Config: testAccDocDBSubnetGroupConfig_generatedName(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDocDBSubnetGroupExists(
 						"aws_docdb_subnet_group.test", &v),
@@ -231,7 +231,7 @@ func testAccCheckDocDBSubnetGroupExists(n string, v *docdb.DBSubnetGroup) resour
 }
 
 func testAccDocDBSubnetGroupConfig(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -242,7 +242,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -252,7 +252,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -268,11 +268,11 @@ resource "aws_docdb_subnet_group" "foo" {
     Name = "tf-docdb-subnet-group-test"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccDocDBSubnetGroupConfig_updatedDescription(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -283,7 +283,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -293,7 +293,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -310,12 +310,14 @@ resource "aws_docdb_subnet_group" "foo" {
     Name = "tf-docdb-subnet-group-test"
   }
 }
-`, rName)
+`, rName))
 }
 
-const testAccDocDBSubnetGroupConfig_namePrefix = `
+func testAccDocDBSubnetGroupConfig_namePrefix() string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-docdb-subnet-group-name-prefix"
   }
@@ -324,7 +326,8 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
   tags = {
     Name = "tf-acc-docdb-subnet-group-name-prefix-a"
   }
@@ -333,7 +336,8 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
+
   tags = {
     Name = "tf-acc-docdb-subnet-group-name-prefix-b"
   }
@@ -342,11 +346,14 @@ resource "aws_subnet" "b" {
 resource "aws_docdb_subnet_group" "test" {
   name_prefix = "tf_test-"
   subnet_ids  = [aws_subnet.a.id, aws_subnet.b.id]
-}`
+}`))
+}
 
-const testAccDocDBSubnetGroupConfig_generatedName = `
+func testAccDocDBSubnetGroupConfig_generatedName() string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
+
   tags = {
     Name = "terraform-testacc-docdb-subnet-group-generated-name"
   }
@@ -355,7 +362,8 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
   tags = {
     Name = "tf-acc-docdb-subnet-group-generated-name-a"
   }
@@ -364,7 +372,8 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
+
   tags = {
     Name = "tf-acc-docdb-subnet-group-generated-name-a"
   }
@@ -372,4 +381,5 @@ resource "aws_subnet" "b" {
 
 resource "aws_docdb_subnet_group" "test" {
   subnet_ids = [aws_subnet.a.id, aws_subnet.b.id]
-}`
+}`))
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSDocDBSubnetGroup_disappears (20.23s)
--- PASS: TestAccAWSDocDBSubnetGroup_namePrefix (25.25s)
--- PASS: TestAccAWSDocDBSubnetGroup_generatedName (25.54s)
--- PASS: TestAccAWSDocDBSubnetGroup_basic (25.75s)
--- PASS: TestAccAWSDocDBSubnetGroup_updateDescription (36.23s)
```
