### PR TITLE
tests/provider: Fix hardcoded AZs (launch config, template)

### DIFF
--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -700,27 +700,30 @@ resource "aws_launch_configuration" "test" {
 }
 
 func testAccAWSLaunchConfigurationConfigWithEncryptedRootBlockDevice(rInt int) string {
-	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
+	return composeConfig(
+		testAccAvailableAZsNoOptInConfig(),
+		testAccAWSLaunchConfigurationConfig_ami(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-instance-%d"
+    Name = "terraform-testacc-instance-%[1]d"
   }
 }
 
 resource "aws_subnet" "test" {
   cidr_block        = "10.1.1.0/24"
   vpc_id            = aws_vpc.test.id
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
-    Name = "terraform-testacc-instance-%d"
+    Name = "terraform-testacc-instance-%[1]d"
   }
 }
 
 resource "aws_launch_configuration" "test" {
-  name_prefix                 = "tf-acc-test-%d"
+  name_prefix                 = "tf-acc-test-%[1]d"
   image_id                    = data.aws_ami.ubuntu.id
   instance_type               = "t3.nano"
   user_data                   = "testtest-user-data"
@@ -732,7 +735,7 @@ resource "aws_launch_configuration" "test" {
     volume_size = 11
   }
 }
-`, rInt, rInt, rInt)
+`, rInt))
 }
 
 func testAccAWSLaunchConfigurationConfig() string {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -1346,7 +1346,7 @@ resource "aws_launch_template" "test" {
 }
 
 func testAccAWSLaunchTemplateConfig_data(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %q
 
@@ -1390,7 +1390,7 @@ resource "aws_launch_template" "test" {
   }
 
   placement {
-    availability_zone = "us-west-2b"
+    availability_zone = data.aws_availability_zones.available.names[0]
   }
 
   ram_disk_id = "ari-a12bc3de"
@@ -1429,7 +1429,7 @@ resource "aws_launch_template" "test" {
     }
   }
 }
-`, rName) //lintignore:AWSAT002
+`, rName)) //lintignore:AWSAT002
 }
 
 func testAccAWSLaunchTemplateConfig_tagsUpdate(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (7.64s)
--- FAIL^^: TestAccAWSLaunchConfiguration_basic (7.68s)
--- FAIL^^: TestAccAWSLaunchConfiguration_withBlockDevices (8.26s)
--- FAIL^^: TestAccAWSLaunchConfiguration_withSpotPrice (7.24s)
--- FAIL^^: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (7.36s)
--- FAIL^^: TestAccAWSLaunchConfiguration_withVpcClassicLink (7.76s)
--- FAIL^^: TestAccAWSLaunchConfiguration_withEncryption (6.44s)
--- FAIL^^: TestAccAWSLaunchConfiguration_withIAMProfile (6.83s)
--- FAIL^^: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (7.41s)
--- FAIL^^: TestAccAWSLaunchConfiguration_ebs_noDevice (6.96s)
--- FAIL^^: TestAccAWSLaunchConfiguration_userData (7.13s)
--- FAIL^^: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (5.24s)
--- FAIL^^: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (6.55s)
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (46.72s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (47.20s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (47.26s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (47.40s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_ebsNoDevice (48.01s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (48.48s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (49.60s)
--- PASS: TestAccAWSLaunchConfiguration_withInstanceStoreAMI (55.43s)
--- PASS: TestAccAWSLaunchTemplate_disappears (33.66s)
--- PASS: TestAccAWSLaunchTemplate_basic (47.88s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_VolumeSize (94.44s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (49.38s)
--- PASS: TestAccAWSLaunchTemplate_data (52.87s)
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (43.32s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (52.32s)
--- PASS: TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination (121.55s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (50.75s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (124.17s)
--- PASS: TestAccAWSLaunchTemplate_description (87.13s)
--- PASS: TestAccAWSLaunchTemplate_tags (86.34s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (88.91s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (49.80s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (45.15s)
--- FAIL++: TestAccAWSLaunchTemplate_licenseSpecification (12.92s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (49.92s)
--- PASS: TestAccAWSLaunchTemplate_update (110.47s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (54.37s)
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceAddresses (52.95s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (46.26s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (43.26s)
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (42.01s)
--- PASS: TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination (144.18s)
--- PASS: TestAccAWSLaunchTemplate_placement_partitionNum (72.16s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (163.40s)
--- PASS: TestAccAWSLaunchTemplate_associatePublicIPAddress (88.13s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (75.51s)
--- PASS: TestAccAWSLaunchTemplate_hibernation (66.87s)
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (64.14s)
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (69.57s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears (351.42s)
```

**^^** `Error: Your query returned no results. Please change your search criteria and try again.`

**++** `Error: Error creating License Manager license configuration: AccessDeniedException: Service role not found. Consult setup procedures in License Manager User Guide and create the required role for the service.`

Output from acceptance testing (commercial):
```
--- PASS: TestAccAWSLaunchTemplateDataSource_NonExistent (10.86s)
--- PASS: TestAccAWSLaunchTemplateDataSource_metadataOptions (59.28s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_ebsNoDevice (60.00s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_basic (60.69s)
--- PASS: TestAccAWSLaunchTemplateDataSource_filter_tags (63.08s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (64.22s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_basic (65.24s)
--- PASS: TestAccAWSLaunchConfigurationDataSource_securityGroups (65.98s)
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (70.81s)
--- PASS: TestAccAWSLaunchConfiguration_withInstanceStoreAMI (71.32s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (71.91s)
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (73.67s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (75.98s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (76.10s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (95.23s)
--- PASS: TestAccAWSLaunchTemplate_disappears (44.83s)
--- PASS: TestAccAWSLaunchConfiguration_basic (122.18s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_VolumeSize (125.83s)
--- PASS: TestAccAWSLaunchTemplate_basic (68.56s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (119.60s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (72.91s)
--- PASS: TestAccAWSLaunchTemplate_data (69.16s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (91.26s)
--- PASS: TestAccAWSLaunchTemplateDataSource_associatePublicIPAddress (162.51s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (67.97s)
--- PASS: TestAccAWSLaunchTemplateDataSource_networkInterfaces_deleteOnTermination (166.37s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (69.86s)
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (56.76s)
--- PASS: TestAccAWSLaunchConfiguration_userData (123.05s)
--- PASS: TestAccAWSLaunchTemplate_description (115.22s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (118.34s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (59.04s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (68.46s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (65.06s)
--- PASS: TestAccAWSLaunchTemplate_tags (119.72s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (67.23s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (140.05s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (67.50s)
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceAddresses (63.79s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (57.63s)
--- PASS: TestAccAWSLaunchTemplate_update (151.51s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (52.72s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (50.12s)
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (45.02s)
--- PASS: TestAccAWSLaunchTemplate_placement_partitionNum (83.29s)
--- PASS: TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination (177.94s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (195.11s)
--- PASS: TestAccAWSLaunchTemplate_associatePublicIPAddress (102.44s)
--- PASS: TestAccAWSLaunchTemplate_hibernation (76.92s)
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (76.26s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (93.25s)
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (82.77s)
--- PASS: TestAccAWSLaunchConfiguration_RootBlockDevice_AmiDisappears (392.61s)
```