### PR TITLE
tests/provider: Fix hardcoded AZs (lb policy)

### DIFF
--- a/aws/resource_aws_load_balancer_policy_test.go
+++ b/aws/resource_aws_load_balancer_policy_test.go
@@ -238,10 +238,10 @@ func testAccCheckAWSLoadBalancerPolicyState(elbResource string, policyResource s
 }
 
 func testAccAWSLoadBalancerPolicyConfig_basic(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "test-lb" {
-  name               = "test-lb-%d"
-  availability_zones = ["us-west-2a"]
+  name               = "test-lb-%[1]d"
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 80
@@ -257,7 +257,7 @@ resource "aws_elb" "test-lb" {
 
 resource "aws_load_balancer_policy" "test-policy" {
   load_balancer_name = aws_elb.test-lb.name
-  policy_name        = "test-policy-%d"
+  policy_name        = "test-policy-%[1]d"
   policy_type_name   = "AppCookieStickinessPolicyType"
 
   policy_attribute {
@@ -265,14 +265,14 @@ resource "aws_load_balancer_policy" "test-policy" {
     value = "magic_cookie"
   }
 }
-`, rInt, rInt)
+`, rInt))
 }
 
 func testAccAWSLoadBalancerPolicyConfig_updateWhileAssigned0(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "test-lb" {
-  name               = "test-lb-%d"
-  availability_zones = ["us-west-2a"]
+  name               = "test-lb-%[1]d"
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 80
@@ -288,7 +288,7 @@ resource "aws_elb" "test-lb" {
 
 resource "aws_load_balancer_policy" "test-policy" {
   load_balancer_name = aws_elb.test-lb.name
-  policy_name        = "test-policy-%d"
+  policy_name        = "test-policy-%[1]d"
   policy_type_name   = "AppCookieStickinessPolicyType"
 
   policy_attribute {
@@ -305,14 +305,14 @@ resource "aws_load_balancer_listener_policy" "test-lb-test-policy-80" {
     aws_load_balancer_policy.test-policy.policy_name,
   ]
 }
-`, rInt, rInt)
+`, rInt))
 }
 
 func testAccAWSLoadBalancerPolicyConfig_updateWhileAssigned1(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "test-lb" {
-  name               = "test-lb-%d"
-  availability_zones = ["us-west-2a"]
+  name               = "test-lb-%[1]d"
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 80
@@ -328,7 +328,7 @@ resource "aws_elb" "test-lb" {
 
 resource "aws_load_balancer_policy" "test-policy" {
   load_balancer_name = aws_elb.test-lb.name
-  policy_name        = "test-policy-%d"
+  policy_name        = "test-policy-%[1]d"
   policy_type_name   = "AppCookieStickinessPolicyType"
 
   policy_attribute {
@@ -345,5 +345,5 @@ resource "aws_load_balancer_listener_policy" "test-lb-test-policy-80" {
     aws_load_balancer_policy.test-policy.policy_name,
   ]
 }
-`, rInt, rInt)
+`, rInt))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSLoadBalancerPolicy_basic (13.98s)
--- PASS: TestAccAWSLoadBalancerPolicy_disappears (20.14s)
--- PASS: TestAccAWSLoadBalancerPolicy_updateWhileAssigned (20.23s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSLoadBalancerPolicy_basic (20.30s)
--- PASS: TestAccAWSLoadBalancerPolicy_disappears (25.81s)
--- PASS: TestAccAWSLoadBalancerPolicy_updateWhileAssigned (28.64s)
```