### PR TITLE
r/aws_route53_resolver_rule: Correct handling for single dot ('.') domain names

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -397,17 +397,23 @@ func cleanZoneID(ID string) string {
 
 // trimTrailingPeriod is used to remove the trailing period
 // of "name" or "domain name" attributes often returned from
-// the Route53 API or provided as user input
+// the Route53 API or provided as user input.
+// The single dot (".") domain name is returned as-is.
 func trimTrailingPeriod(v interface{}) string {
 	var str string
 	switch value := v.(type) {
 	case *string:
-		str = *value
+		str = aws.StringValue(value)
 	case string:
 		str = value
 	default:
 		return ""
 	}
+
+	if str == "." {
+		return str
+	}
+
 	return strings.TrimSuffix(str, ".")
 }
 

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -50,11 +50,19 @@ func TestCleanChangeID(t *testing.T) {
 
 func TestTrimTrailingPeriod(t *testing.T) {
 	cases := []struct {
-		Input, Output string
+		Input  interface{}
+		Output string
 	}{
 		{"example.com", "example.com"},
 		{"example.com.", "example.com"},
 		{"www.example.com.", "www.example.com"},
+		{"", ""},
+		{".", "."},
+		{aws.String("example.com"), "example.com"},
+		{aws.String("example.com."), "example.com"},
+		{(*string)(nil), ""},
+		{42, ""},
+		{nil, ""},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/14730.

I verified that no Route 53 Hosted Zones can be created for the `.` domain, so this won't affect any base `aws_route53_` resources.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_route53_resolver_rule: Correct handling of single dot `.` domain names
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ go test ./aws -v -run TestTrimTrailingPeriod
=== RUN   TestTrimTrailingPeriod
--- PASS: TestTrimTrailingPeriod (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.037s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsRoute53ResolverRule_justDotDomainName\|TestAccAwsRoute53ResolverRule_trailingDotDomainName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsRoute53ResolverRule_justDotDomainName\|TestAccAwsRoute53ResolverRule_trailingDotDomainName -timeout 120m
=== RUN   TestAccAwsRoute53ResolverRule_justDotDomainName
=== PAUSE TestAccAwsRoute53ResolverRule_justDotDomainName
=== RUN   TestAccAwsRoute53ResolverRule_trailingDotDomainName
=== PAUSE TestAccAwsRoute53ResolverRule_trailingDotDomainName
=== CONT  TestAccAwsRoute53ResolverRule_justDotDomainName
=== CONT  TestAccAwsRoute53ResolverRule_trailingDotDomainName
--- PASS: TestAccAwsRoute53ResolverRule_justDotDomainName (40.75s)
--- PASS: TestAccAwsRoute53ResolverRule_trailingDotDomainName (40.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	40.793s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsRoute53ResolverRule_basic' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsRoute53ResolverRule_basic -timeout 120m
=== RUN   TestAccAwsRoute53ResolverRule_basic
=== PAUSE TestAccAwsRoute53ResolverRule_basic
=== CONT  TestAccAwsRoute53ResolverRule_basic
--- PASS: TestAccAwsRoute53ResolverRule_basic (38.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	38.949s
```
