### PR TITLE
tests/provider: Fix hardcoded AZs (neptune)

### DIFF
--- a/aws/resource_aws_neptune_cluster_instance_test.go
+++ b/aws/resource_aws_neptune_cluster_instance_test.go
@@ -43,7 +43,7 @@ func TestAccAWSNeptuneClusterInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine", "neptune"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttr(resourceName, "identifier", clusterInstanceName),
-					resource.TestCheckResourceAttr(resourceName, "instance_class", "db.r4.large"),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_class", "data.aws_neptune_orderable_db_instance.test", "instance_class"),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "neptune_parameter_group_name", parameterGroupResourceName, "name"),
 					resource.TestCheckResourceAttr(resourceName, "neptune_subnet_group_name", "default"),
@@ -255,12 +255,20 @@ func testAccCheckNeptuneClusterAddress(v *neptune.DBInstance, resourceName strin
 
 func testAccAWSNeptuneClusterInstanceConfig(instanceName string, n int) string {
 	return composeConfig(
-		testAccAWSNeptuneClusterConfigBase,
+		testAccAWSNeptuneClusterConfigBase(),
 		fmt.Sprintf(`
+data "aws_neptune_orderable_db_instance" "test" {
+  engine         = "neptune"
+  license_model  = "amazon-license"
+
+  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+}
+
 resource "aws_neptune_cluster_instance" "cluster_instances" {
   identifier                   = %[1]q
   cluster_identifier           = aws_neptune_cluster.default.id
-  instance_class               = "db.r4.large"
+  instance_class               = data.aws_neptune_orderable_db_instance.test.instance_class
+  engine_version               = data.aws_neptune_orderable_db_instance.test.engine_version
   neptune_parameter_group_name = aws_neptune_parameter_group.test.name
   promotion_tier               = "3"
 }
@@ -269,6 +277,7 @@ resource "aws_neptune_cluster" "default" {
   cluster_identifier  = "tf-neptune-cluster-test-%[2]d"
   availability_zones  = local.availability_zone_names
   skip_final_snapshot = true
+  engine_version      = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_neptune_parameter_group" "test" {
@@ -289,12 +298,20 @@ resource "aws_neptune_parameter_group" "test" {
 
 func testAccAWSNeptuneClusterInstanceConfigModified(instanceName string, n int) string {
 	return composeConfig(
-		testAccAWSNeptuneClusterConfigBase,
+		testAccAWSNeptuneClusterConfigBase(),
 		fmt.Sprintf(`
+data "aws_neptune_orderable_db_instance" "test" {
+  engine         = "neptune"
+  license_model  = "amazon-license"
+
+  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+}
+
 resource "aws_neptune_cluster_instance" "cluster_instances" {
   identifier                   = %[1]q
   cluster_identifier           = aws_neptune_cluster.default.id
-  instance_class               = "db.r4.large"
+  instance_class               = data.aws_neptune_orderable_db_instance.test.instance_class
+  engine_version               = data.aws_neptune_orderable_db_instance.test.engine_version
   neptune_parameter_group_name = aws_neptune_parameter_group.test.name
   auto_minor_version_upgrade   = false
   promotion_tier               = "3"
@@ -304,6 +321,7 @@ resource "aws_neptune_cluster" "default" {
   cluster_identifier  = "tf-neptune-cluster-test-%[2]d"
   availability_zones  = local.availability_zone_names
   skip_final_snapshot = true
+  engine_version      = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_neptune_parameter_group" "test" {
@@ -324,12 +342,20 @@ resource "aws_neptune_parameter_group" "test" {
 
 func testAccAWSNeptuneClusterInstanceConfig_az(n int) string {
 	return composeConfig(
-		testAccAWSNeptuneClusterConfigBase,
+		testAccAWSNeptuneClusterConfigBase(),
 		fmt.Sprintf(`
+data "aws_neptune_orderable_db_instance" "test" {
+  engine         = "neptune"
+  license_model  = "amazon-license"
+
+  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+}
+
 resource "aws_neptune_cluster_instance" "cluster_instances" {
   identifier                   = "tf-cluster-instance-%[1]d"
   cluster_identifier           = aws_neptune_cluster.default.id
-  instance_class               = "db.r4.large"
+  instance_class               = data.aws_neptune_orderable_db_instance.test.instance_class
+  engine_version               = data.aws_neptune_orderable_db_instance.test.engine_version
   neptune_parameter_group_name = aws_neptune_parameter_group.test.name
   promotion_tier               = "3"
   availability_zone            = data.aws_availability_zones.available.names[0]
@@ -339,6 +365,7 @@ resource "aws_neptune_cluster" "default" {
   cluster_identifier  = "tf-neptune-cluster-test-%[1]d"
   availability_zones  = local.availability_zone_names
   skip_final_snapshot = true
+  engine_version      = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_neptune_parameter_group" "test" {
@@ -359,18 +386,27 @@ resource "aws_neptune_parameter_group" "test" {
 
 func testAccAWSNeptuneClusterInstanceConfig_withSubnetGroup(n int) string {
 	return composeConfig(
-		testAccAWSNeptuneClusterConfigBase,
+		testAccAWSNeptuneClusterConfigBase(),
 		fmt.Sprintf(`
+data "aws_neptune_orderable_db_instance" "test" {
+  engine         = "neptune"
+  license_model  = "amazon-license"
+
+  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+}
+
 resource "aws_neptune_cluster_instance" "test" {
   identifier         = "tf-cluster-instance-%[1]d"
   cluster_identifier = aws_neptune_cluster.test.id
-  instance_class     = "db.r4.large"
+  instance_class     = data.aws_neptune_orderable_db_instance.test.instance_class
+  engine_version     = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_neptune_cluster" "test" {
   cluster_identifier        = "tf-neptune-cluster-%[1]d"
   neptune_subnet_group_name = aws_neptune_subnet_group.test.name
   skip_final_snapshot       = true
+  engine_version            = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_vpc" "test" {
@@ -384,7 +420,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.0.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-a"
@@ -394,7 +430,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-b"
@@ -410,18 +446,27 @@ resource "aws_neptune_subnet_group" "test" {
 
 func testAccAWSNeptuneClusterInstanceConfig_namePrefix(namePrefix string, n int) string {
 	return composeConfig(
-		testAccAWSNeptuneClusterConfigBase,
+		testAccAWSNeptuneClusterConfigBase(),
 		fmt.Sprintf(`
+data "aws_neptune_orderable_db_instance" "test" {
+  engine         = "neptune"
+  license_model  = "amazon-license"
+
+  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+}
+
 resource "aws_neptune_cluster_instance" "test" {
   identifier_prefix  = %[1]q
   cluster_identifier = aws_neptune_cluster.test.id
-  instance_class     = "db.r4.large"
+  instance_class     = data.aws_neptune_orderable_db_instance.test.instance_class
+  engine_version     = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_neptune_cluster" "test" {
   cluster_identifier        = "tf-neptune-cluster-%[2]d"
   neptune_subnet_group_name = aws_neptune_subnet_group.test.name
   skip_final_snapshot       = true
+  engine_version            = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_vpc" "test" {
@@ -435,7 +480,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.0.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-a"
@@ -445,7 +490,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-b"
@@ -461,17 +506,26 @@ resource "aws_neptune_subnet_group" "test" {
 
 func testAccAWSNeptuneClusterInstanceConfig_generatedName(n int) string {
 	return composeConfig(
-		testAccAWSNeptuneClusterConfigBase,
+		testAccAWSNeptuneClusterConfigBase(),
 		fmt.Sprintf(`
+data "aws_neptune_orderable_db_instance" "test" {
+  engine         = "neptune"
+  license_model  = "amazon-license"
+
+  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+}
+
 resource "aws_neptune_cluster_instance" "test" {
   cluster_identifier = aws_neptune_cluster.test.id
-  instance_class     = "db.r4.large"
+  instance_class     = data.aws_neptune_orderable_db_instance.test.instance_class
+  engine_version     = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_neptune_cluster" "test" {
   cluster_identifier        = "tf-neptune-cluster-%[1]d"
   neptune_subnet_group_name = aws_neptune_subnet_group.test.name
   skip_final_snapshot       = true
+  engine_version            = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_vpc" "test" {
@@ -485,7 +539,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.0.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-a"
@@ -495,7 +549,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-b"
@@ -511,7 +565,7 @@ resource "aws_neptune_subnet_group" "test" {
 
 func testAccAWSNeptuneClusterInstanceConfigKmsKey(n int) string {
 	return composeConfig(
-		testAccAWSNeptuneClusterConfigBase,
+		testAccAWSNeptuneClusterConfigBase(),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = "Terraform acc test %[1]d"
@@ -535,18 +589,27 @@ resource "aws_kms_key" "test" {
 POLICY
 }
 
+data "aws_neptune_orderable_db_instance" "test" {
+  engine         = "neptune"
+  license_model  = "amazon-license"
+
+  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+}
+
 resource "aws_neptune_cluster" "default" {
   cluster_identifier  = "tf-neptune-cluster-test-%[1]d"
   availability_zones  = local.availability_zone_names
   skip_final_snapshot = true
   storage_encrypted   = true
   kms_key_arn         = aws_kms_key.test.arn
+  engine_version      = data.aws_neptune_orderable_db_instance.test.engine_version
 }
 
 resource "aws_neptune_cluster_instance" "cluster_instances" {
   identifier                   = "tf-cluster-instance-%[1]d"
   cluster_identifier           = aws_neptune_cluster.default.id
-  instance_class               = "db.r4.large"
+  instance_class               = data.aws_neptune_orderable_db_instance.test.instance_class
+  engine_version               = data.aws_neptune_orderable_db_instance.test.engine_version
   neptune_parameter_group_name = aws_neptune_parameter_group.test.name
 }
 

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -570,23 +570,16 @@ func testAccCheckAWSNeptuneClusterSnapshot(rName string) resource.TestCheckFunc 
 	}
 }
 
-var testAccAWSNeptuneClusterConfigBase = `
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+func testAccAWSNeptuneClusterConfigBase() string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 locals {
   availability_zone_names = slice(data.aws_availability_zones.available.names, 0, min(3, length(data.aws_availability_zones.available.names)))
 }
-`
+`))
+}
 
 func testAccAWSNeptuneClusterConfig(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %q
   availability_zones                   = local.availability_zone_names
@@ -594,11 +587,11 @@ resource "aws_neptune_cluster" "test" {
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot                  = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfigDeleteProtection(rName string, isProtected bool) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %q
   availability_zones                   = local.availability_zone_names
@@ -607,7 +600,7 @@ resource "aws_neptune_cluster" "test" {
   skip_final_snapshot                  = true
   deletion_protection                  = %t
 }
-`, rName, isProtected)
+`, rName, isProtected))
 }
 
 func testAccAWSNeptuneClusterConfig_namePrefix(rName string) string {
@@ -622,18 +615,18 @@ resource "aws_neptune_cluster" "test" {
 }
 
 func testAccAWSNeptuneClusterConfigWithFinalSnapshot(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
   neptune_cluster_parameter_group_name = "default.neptune1"
   final_snapshot_identifier            = %[1]q
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
@@ -645,11 +638,11 @@ resource "aws_neptune_cluster" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccAWSNeptuneClusterConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
@@ -662,11 +655,11 @@ resource "aws_neptune_cluster" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccAWSNeptuneClusterConfigIncludingIamRoles(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
   path = "/"
@@ -749,11 +742,11 @@ resource "aws_neptune_cluster" "test" {
 
   depends_on = [aws_iam_role.test, aws_iam_role.test-2]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfigAddIamRoles(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
   path = "/"
@@ -836,11 +829,11 @@ resource "aws_neptune_cluster" "test" {
 
   depends_on = [aws_iam_role.test, aws_iam_role.test-2]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfigRemoveIamRoles(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
   path = "/"
@@ -886,11 +879,11 @@ resource "aws_neptune_cluster" "test" {
 
   depends_on = [aws_iam_role.test]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfig_kmsKey(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 
 resource "aws_kms_key" "test" {
   description = "Terraform acc test"
@@ -923,22 +916,22 @@ resource "aws_neptune_cluster" "test" {
   kms_key_arn                          = aws_kms_key.test.arn
   skip_final_snapshot                  = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfig_encrypted(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier  = %q
   availability_zones  = local.availability_zone_names
   storage_encrypted   = true
   skip_final_snapshot = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfig_backups(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier           = %q
   availability_zones           = local.availability_zone_names
@@ -947,11 +940,11 @@ resource "aws_neptune_cluster" "test" {
   preferred_maintenance_window = "tue:04:00-tue:04:30"
   skip_final_snapshot          = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfig_backupsUpdate(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier           = %q
   availability_zones           = local.availability_zone_names
@@ -961,27 +954,27 @@ resource "aws_neptune_cluster" "test" {
   apply_immediately            = true
   skip_final_snapshot          = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfig_iamAuth(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                  = %q
   availability_zones                  = local.availability_zone_names
   iam_database_authentication_enabled = true
   skip_final_snapshot                 = true
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSNeptuneClusterConfig_cloudwatchLogsExports(rName string) string {
-	return testAccAWSNeptuneClusterConfigBase + fmt.Sprintf(`
+	return composeConfig(testAccAWSNeptuneClusterConfigBase(), fmt.Sprintf(`
 resource "aws_neptune_cluster" "test" {
   cluster_identifier             = %q
   availability_zones             = local.availability_zone_names
   skip_final_snapshot            = true
   enable_cloudwatch_logs_exports = ["audit"]
 }
-`, rName)
+`, rName))
 }

--- a/aws/resource_aws_neptune_subnet_group_test.go
+++ b/aws/resource_aws_neptune_subnet_group_test.go
@@ -53,7 +53,7 @@ func TestAccAWSNeptuneSubnetGroup_namePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckNeptuneSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNeptuneSubnetGroupConfig_namePrefix,
+				Config: testAccNeptuneSubnetGroupConfig_namePrefix(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNeptuneSubnetGroupExists(
 						"aws_neptune_subnet_group.test", &v),
@@ -80,7 +80,7 @@ func TestAccAWSNeptuneSubnetGroup_generatedName(t *testing.T) {
 		CheckDestroy: testAccCheckNeptuneSubnetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNeptuneSubnetGroupConfig_generatedName,
+				Config: testAccNeptuneSubnetGroupConfig_generatedName(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNeptuneSubnetGroupExists(
 						"aws_neptune_subnet_group.test", &v),
@@ -192,7 +192,7 @@ func testAccCheckNeptuneSubnetGroupExists(n string, v *neptune.DBSubnetGroup) re
 }
 
 func testAccNeptuneSubnetGroupConfig(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -203,7 +203,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -213,7 +213,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -229,11 +229,11 @@ resource "aws_neptune_subnet_group" "foo" {
     Name = "tf-neptunesubnet-group-test"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccNeptuneSubnetGroupConfig_updatedDescription(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -244,7 +244,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -254,7 +254,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
   vpc_id            = aws_vpc.foo.id
 
   tags = {
@@ -271,10 +271,11 @@ resource "aws_neptune_subnet_group" "foo" {
     Name = "tf-neptunesubnet-group-test"
   }
 }
-`, rName)
+`, rName))
 }
 
-const testAccNeptuneSubnetGroupConfig_namePrefix = `
+func testAccNeptuneSubnetGroupConfig_namePrefix() string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -286,7 +287,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-neptune-subnet-group-name-prefix-a"
@@ -296,7 +297,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-neptune-subnet-group-name-prefix-b"
@@ -307,9 +308,11 @@ resource "aws_neptune_subnet_group" "test" {
   name_prefix = "tf_test-"
   subnet_ids  = [aws_subnet.a.id, aws_subnet.b.id]
 }
-`
+`))
+}
 
-const testAccNeptuneSubnetGroupConfig_generatedName = `
+func testAccNeptuneSubnetGroupConfig_generatedName() string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -321,7 +324,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-neptune-subnet-group-generated-name-a"
@@ -331,7 +334,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-neptune-subnet-group-generated-name-a"
@@ -341,4 +344,5 @@ resource "aws_subnet" "b" {
 resource "aws_neptune_subnet_group" "test" {
   subnet_ids = [aws_subnet.a.id, aws_subnet.b.id]
 }
-`
+`))
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSNeptuneClusterParameterGroup_generatedName (30.02s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_namePrefix (30.15s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Description (31.46s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_basic (31.88s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Parameter (40.37s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Tags (46.30s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (131.38s)
--- PASS: TestAccAWSNeptuneCluster_basic (132.78s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (127.35s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (129.60s)
--- PASS: TestAccAWSNeptuneCluster_tags (139.91s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (140.97s)
--- PASS: TestAccAWSNeptuneSubnetGroup_basic (13.64s)
--- PASS: TestAccAWSNeptuneSubnetGroup_namePrefix (13.57s)
--- PASS: TestAccAWSNeptuneSubnetGroup_generatedName (12.36s)
--- PASS: TestAccAWSNeptuneSubnetGroup_updateDescription (19.93s)
--- PASS: TestAccAWSNeptuneClusterSnapshot_basic (215.90s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (208.40s)
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (206.54s)
--- PASS: TestAccAWSNeptuneCluster_iamAuth (131.26s)
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (141.59s)
--- PASS: TestAccAWSNeptuneCluster_deleteProtection (160.63s)
--- PASS: TestAccAWSNeptuneClusterInstance_namePrefix (639.07s)
--- PASS: TestAccAWSNeptuneClusterInstance_withSubnetGroup (640.53s)
--- PASS: TestAccAWSNeptuneClusterInstance_generatedName (670.91s)
--- PASS: TestAccAWSNeptuneClusterInstance_kmsKey (719.97s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (740.00s)
--- PASS: TestAccAWSNeptuneClusterInstance_basic (764.55s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSNeptuneClusterParameterGroup_generatedName (34.30s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_basic (36.76s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_namePrefix (36.89s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Description (36.93s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Parameter (46.99s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Tags (56.77s)
--- PASS: TestAccAWSNeptuneSubnetGroup_basic (16.70s)
--- PASS: TestAccAWSNeptuneSubnetGroup_namePrefix (16.45s)
--- PASS: TestAccAWSNeptuneSubnetGroup_generatedName (16.36s)
--- PASS: TestAccAWSNeptuneSubnetGroup_updateDescription (32.19s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (153.20s)
--- PASS: TestAccAWSNeptuneCluster_basic (156.34s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (175.30s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (176.25s)
--- PASS: TestAccAWSNeptuneCluster_iamAuth (144.54s)
--- PASS: TestAccAWSNeptuneCluster_tags (195.70s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (216.82s)
--- PASS: TestAccAWSNeptuneCluster_updateCloudwatchLogsExports (183.69s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (220.83s)
--- PASS: TestAccAWSNeptuneCluster_deleteProtection (185.00s)
--- PASS: TestAccAWSNeptuneClusterSnapshot_basic (225.10s)
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (236.03s)
--- PASS: TestAccAWSNeptuneClusterInstance_withSubnetGroup (728.20s)
--- PASS: TestAccAWSNeptuneClusterInstance_generatedName (789.23s)
--- PASS: TestAccAWSNeptuneClusterInstance_namePrefix (861.87s)
--- PASS: TestAccAWSNeptuneClusterInstance_kmsKey (867.99s)
--- PASS: TestAccAWSNeptuneClusterInstance_basic (898.47s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (899.13s)
```