### PR TITLE
tests/provider: Fix hardcoded (rds cluster instance)

### DIFF
--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -101,6 +101,7 @@ func TestAccAWSRDSClusterInstance_isAlreadyBeingDeleted(t *testing.T) {
 func TestAccAWSRDSClusterInstance_az(t *testing.T) {
 	var v rds.DBInstance
 	resourceName := "aws_rds_cluster_instance.cluster_instances"
+	availabilityZonesDataSourceName := "data.aws_availability_zones.available"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -112,7 +113,7 @@ func TestAccAWSRDSClusterInstance_az(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
-					resource.TestMatchResourceAttr(resourceName, "availability_zone", regexp.MustCompile("^us-west-2[a-z]{1}$")),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", availabilityZonesDataSourceName, "names.0"),
 				),
 			},
 			{
@@ -319,7 +320,6 @@ func TestAccAWSRDSClusterInstance_CopyTagsToSnapshot(t *testing.T) {
 
 func testAccCheckAWSDBClusterInstanceAttributes(v *rds.DBInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
 		if *v.Engine != "aurora" && *v.Engine != "aurora-postgresql" && *v.Engine != "aurora-mysql" {
 			return fmt.Errorf("bad engine, expected \"aurora\", \"aurora-mysql\" or \"aurora-postgresql\": %#v", *v.Engine)
 		}
@@ -558,14 +558,15 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1(t *tes
 	var dbInstance rds.DBInstance
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, engine) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql1(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql1(rName, engine),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -588,14 +589,16 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2(t *tes
 	var dbInstance rds.DBInstance
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora-mysql"
+	engineVersion := "5.7.mysql_aurora.2.04.2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsPreCheck(t, engine, engineVersion) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName, engine, engineVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -618,14 +621,15 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql(t 
 	var dbInstance rds.DBInstance
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora-postgresql"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, engine) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName, engine),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -649,14 +653,15 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1(t *te
 	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, engine) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName, engine),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -680,14 +685,15 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_Defau
 	var dbInstance rds.DBInstance
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, engine) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql1(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql1(rName, engine),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -703,7 +709,7 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_Defau
 				},
 			},
 			{
-				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName),
+				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName, engine),
 				ExpectError: regexp.MustCompile(`InvalidParameterCombination: You cannot change your Performance Insights KMS key`),
 			},
 		},
@@ -715,14 +721,16 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2(t *te
 	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora-mysql"
+	engineVersion := "5.7.mysql_aurora.2.04.2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsPreCheck(t, engine, engineVersion) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName, engine, engineVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -746,14 +754,16 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_Defau
 	var dbInstance rds.DBInstance
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora-mysql"
+	engineVersion := "5.7.mysql_aurora.2.04.2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsPreCheck(t, engine, engineVersion) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName, engine, engineVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -769,7 +779,7 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_Defau
 				},
 			},
 			{
-				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName),
+				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName, engine, engineVersion),
 				ExpectError: regexp.MustCompile(`InvalidParameterCombination: You cannot change your Performance Insights KMS key`),
 			},
 		},
@@ -781,14 +791,15 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql(t
 	kmsKeyResourceName := "aws_kms_key.test"
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora-postgresql"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, engine) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName, engine),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -812,14 +823,15 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_D
 	var dbInstance rds.DBInstance
 	resourceName := "aws_rds_cluster_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	engine := "aurora-postgresql"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, engine) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName),
+				Config: testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName, engine),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", "true"),
@@ -835,7 +847,7 @@ func TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_D
 				},
 			},
 			{
-				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName),
+				Config:      testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName, engine),
 				ExpectError: regexp.MustCompile(`InvalidParameterCombination: You cannot change your Performance Insights KMS key`),
 			},
 		},
@@ -872,12 +884,78 @@ func TestAccAWSRDSClusterInstance_CACertificateIdentifier(t *testing.T) {
 	})
 }
 
+func testAccRDSPerformanceInsightsDefaultVersionPreCheck(t *testing.T, engine string) {
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+	input := &rds.DescribeDBEngineVersionsInput{
+		DefaultOnly: aws.Bool(true),
+		Engine:      aws.String(engine),
+	}
+
+	result, err := conn.DescribeDBEngineVersions(input)
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+
+	if len(result.DBEngineVersions) < 1 {
+		t.Fatalf("unexpected PreCheck error, no default version for engine: %s", engine)
+	}
+
+	testAccRDSPerformanceInsightsPreCheck(t, engine, aws.StringValue(result.DBEngineVersions[0].EngineVersion))
+}
+
+func testAccRDSPerformanceInsightsPreCheck(t *testing.T, engine string, engineVersion string) {
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+	input := &rds.DescribeOrderableDBInstanceOptionsInput{
+		Engine:        aws.String(engine),
+		EngineVersion: aws.String(engineVersion), // version cuts response time
+	}
+
+	supportsPerformanceInsights := false
+	err := conn.DescribeOrderableDBInstanceOptionsPages(input, func(resp *rds.DescribeOrderableDBInstanceOptionsOutput, lastPage bool) bool {
+		for _, instanceOption := range resp.OrderableDBInstanceOptions {
+			if instanceOption == nil {
+				continue
+			}
+
+			if aws.BoolValue(instanceOption.SupportsPerformanceInsights) {
+				supportsPerformanceInsights = true
+				return false // stop processing pages
+			}
+		}
+		return !lastPage
+	})
+
+	if isAWSErr(err, "InvalidParameterCombination", "") {
+		t.Skipf("RDS Performance Insights not supported, skipping acceptance test")
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+
+	if !supportsPerformanceInsights {
+		t.Skipf("RDS Performance Insights not supported, skipping acceptance test")
+	}
+}
+
 // Add some random to the name, to avoid collision
 func testAccAWSClusterInstanceConfig(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.default.engine
+  engine_version             = aws_rds_cluster.default.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster" "default" {
-  cluster_identifier  = "tf-aurora-cluster-test-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-aurora-cluster-test-%[1]d"
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
   database_name       = "mydb"
   master_username     = "foo"
   master_password     = "mustbeeightcharacters"
@@ -885,15 +963,15 @@ resource "aws_rds_cluster" "default" {
 }
 
 resource "aws_rds_cluster_instance" "cluster_instances" {
-  identifier              = "tf-cluster-instance-%d"
+  identifier              = "tf-cluster-instance-%[1]d"
   cluster_identifier      = aws_rds_cluster.default.id
-  instance_class          = "db.t2.small"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   db_parameter_group_name = aws_db_parameter_group.bar.name
   promotion_tier          = "3"
 }
 
 resource "aws_db_parameter_group" "bar" {
-  name   = "tfcluster-test-group-%d"
+  name   = "tfcluster-test-group-%[1]d"
   family = "aurora5.6"
 
   parameter {
@@ -906,31 +984,41 @@ resource "aws_db_parameter_group" "bar" {
     foo = "bar"
   }
 }
-`, n, n, n)
+`, n))
 }
 
 func testAccAWSClusterInstanceConfigModified(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
-  cluster_identifier  = "tf-aurora-cluster-test-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-aurora-cluster-test-%[1]d"
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
   database_name       = "mydb"
   master_username     = "foo"
   master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.default.engine
+  engine_version             = aws_rds_cluster.default.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "cluster_instances" {
-  identifier                 = "tf-cluster-instance-%d"
+  identifier                 = "tf-cluster-instance-%[1]d"
   cluster_identifier         = aws_rds_cluster.default.id
-  instance_class             = "db.t2.small"
+  instance_class             = data.aws_rds_orderable_db_instance.test.instance_class
   db_parameter_group_name    = aws_db_parameter_group.bar.name
   auto_minor_version_upgrade = false
   promotion_tier             = "3"
 }
 
 resource "aws_db_parameter_group" "bar" {
-  name   = "tfcluster-test-group-%d"
+  name   = "tfcluster-test-group-%[1]d"
   family = "aurora5.6"
 
   parameter {
@@ -943,40 +1031,41 @@ resource "aws_db_parameter_group" "bar" {
     foo = "bar"
   }
 }
-`, n, n, n)
+`, n))
 }
 
 func testAccAWSClusterInstanceConfig_az(n int) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
-  cluster_identifier  = "tf-aurora-cluster-test-%d"
-  availability_zones  = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]
+  cluster_identifier = "tf-aurora-cluster-test-%[1]d"
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
   database_name       = "mydb"
   master_username     = "foo"
   master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.default.engine
+  engine_version             = aws_rds_cluster.default.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "cluster_instances" {
-  identifier              = "tf-cluster-instance-%d"
+  identifier              = "tf-cluster-instance-%[1]d"
   cluster_identifier      = aws_rds_cluster.default.id
-  instance_class          = "db.t2.small"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   db_parameter_group_name = aws_db_parameter_group.bar.name
   promotion_tier          = "3"
   availability_zone       = data.aws_availability_zones.available.names[0]
 }
 
 resource "aws_db_parameter_group" "bar" {
-  name   = "tfcluster-test-group-%d"
+  name   = "tfcluster-test-group-%[1]d"
   family = "aurora5.6"
 
   parameter {
@@ -989,19 +1078,25 @@ resource "aws_db_parameter_group" "bar" {
     foo = "bar"
   }
 }
-`, n, n, n)
+`, n))
 }
 
 func testAccAWSClusterInstanceConfig_namePrefix(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.test.engine
+  engine_version             = aws_rds_cluster.test.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "test" {
   identifier_prefix  = "tf-cluster-instance-"
   cluster_identifier = aws_rds_cluster.test.id
-  instance_class     = "db.t2.small"
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier   = "tf-aurora-cluster-%d"
+  cluster_identifier   = "tf-aurora-cluster-%[1]d"
   master_username      = "root"
   master_password      = "password"
   db_subnet_group_name = aws_db_subnet_group.test.name
@@ -1019,7 +1114,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.0.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-rds-cluster-instance-name-prefix-a"
@@ -1029,7 +1124,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-rds-cluster-instance-name-prefix-b"
@@ -1037,21 +1132,27 @@ resource "aws_subnet" "b" {
 }
 
 resource "aws_db_subnet_group" "test" {
-  name       = "tf-test-%d"
+  name       = "tf-test-%[1]d"
   subnet_ids = [aws_subnet.a.id, aws_subnet.b.id]
 }
-`, n, n)
+`, n))
 }
 
 func testAccAWSClusterInstanceConfig_generatedName(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.test.engine
+  engine_version             = aws_rds_cluster.test.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "test" {
   cluster_identifier = aws_rds_cluster.test.id
-  instance_class     = "db.t2.small"
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier   = "tf-aurora-cluster-%d"
+  cluster_identifier   = "tf-aurora-cluster-%[1]d"
   master_username      = "root"
   master_password      = "password"
   db_subnet_group_name = aws_db_subnet_group.test.name
@@ -1069,7 +1170,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.0.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "tf-acc-rds-cluster-instance-generated-name-a"
@@ -1079,7 +1180,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
   vpc_id            = aws_vpc.test.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "tf-acc-rds-cluster-instance-generated-name-b"
@@ -1087,16 +1188,16 @@ resource "aws_subnet" "b" {
 }
 
 resource "aws_db_subnet_group" "test" {
-  name       = "tf-test-%d"
+  name       = "tf-test-%[1]d"
   subnet_ids = [aws_subnet.a.id, aws_subnet.b.id]
 }
-`, n, n)
+`, n))
 }
 
 func testAccAWSClusterInstanceConfigKmsKey(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_kms_key" "foo" {
-  description = "Terraform acc test %d"
+  description = "Terraform acc test %[1]d"
 
   policy = <<POLICY
 {
@@ -1118,8 +1219,12 @@ POLICY
 }
 
 resource "aws_rds_cluster" "default" {
-  cluster_identifier  = "tf-aurora-cluster-test-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-aurora-cluster-test-%[1]d"
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
   database_name       = "mydb"
   master_username     = "foo"
   master_password     = "mustbeeightcharacters"
@@ -1128,15 +1233,21 @@ resource "aws_rds_cluster" "default" {
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.default.engine
+  engine_version             = aws_rds_cluster.default.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "cluster_instances" {
-  identifier              = "tf-cluster-instance-%d"
+  identifier              = "tf-cluster-instance-%[1]d"
   cluster_identifier      = aws_rds_cluster.default.id
-  instance_class          = "db.t2.small"
+  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   db_parameter_group_name = aws_db_parameter_group.bar.name
 }
 
 resource "aws_db_parameter_group" "bar" {
-  name   = "tfcluster-test-group-%d"
+  name   = "tfcluster-test-group-%[1]d"
   family = "aurora5.6"
 
   parameter {
@@ -1149,7 +1260,7 @@ resource "aws_db_parameter_group" "bar" {
     foo = "bar"
   }
 }
-`, n, n, n, n)
+`, n))
 }
 
 func testAccAWSClusterInstanceConfigMonitoringInterval(rName string, monitoringInterval int) string {
@@ -1189,12 +1300,18 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.test.engine
+  engine_version             = aws_rds_cluster.test.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "test" {
   depends_on = [aws_iam_role_policy_attachment.test]
 
   cluster_identifier  = aws_rds_cluster.test.id
   identifier          = %[1]q
-  instance_class      = "db.t2.small"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   monitoring_interval = %[2]d
   monitoring_role_arn = aws_iam_role.test.arn
 }
@@ -1211,10 +1328,16 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.test.engine
+  engine_version             = aws_rds_cluster.test.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "test" {
   cluster_identifier = aws_rds_cluster.test.id
   identifier         = %[1]q
-  instance_class     = "db.t2.small"
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 `, rName)
 }
@@ -1256,49 +1379,69 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.test.engine
+  engine_version             = aws_rds_cluster.test.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "test" {
   depends_on = [aws_iam_role_policy_attachment.test]
 
   cluster_identifier  = aws_rds_cluster.test.id
   identifier          = %[1]q
-  instance_class      = "db.t2.small"
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   monitoring_interval = 5
   monitoring_role_arn = aws_iam_role.test.arn
 }
 `, rName)
 }
 
-func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql1(rName string) string {
+func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql1(rName, engine string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
-  engine              = "aurora"
+  engine              = %[2]q
   master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = aws_rds_cluster.test.engine
+  engine_version                = aws_rds_cluster.test.engine_version
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.t3.medium", "db.r5.large", "db.r4.large"]
 }
 
 resource "aws_rds_cluster_instance" "test" {
   cluster_identifier           = aws_rds_cluster.test.id
   engine                       = aws_rds_cluster.test.engine
   identifier                   = %[1]q
-  instance_class               = "db.r4.large"
+  instance_class               = data.aws_rds_orderable_db_instance.test.instance_class
   performance_insights_enabled = true
 }
-`, rName)
+`, rName, engine)
 }
 
-func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName string) string {
+func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraMysql2(rName, engine, engineVersion string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
-  engine              = "aurora-mysql"
-  engine_version      = "5.7.mysql_aurora.2.04.2"
+  engine              = %[2]q
+  engine_version      = %[3]q
   master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = aws_rds_cluster.test.engine
+  engine_version                = aws_rds_cluster.test.engine_version
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.t3.medium", "db.r5.large", "db.r4.large"]
 }
 
 resource "aws_rds_cluster_instance" "test" {
@@ -1306,34 +1449,41 @@ resource "aws_rds_cluster_instance" "test" {
   engine                       = aws_rds_cluster.test.engine
   engine_version               = aws_rds_cluster.test.engine_version
   identifier                   = %[1]q
-  instance_class               = "db.r4.large"
+  instance_class               = data.aws_rds_orderable_db_instance.test.instance_class
   performance_insights_enabled = true
 }
-`, rName)
+`, rName, engine, engineVersion)
 }
 
-func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName string) string {
+func testAccAWSClusterInstanceConfigPerformanceInsightsEnabledAuroraPostgresql(rName, engine string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
-  engine              = "aurora-postgresql"
+  engine              = %[2]q
   master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = aws_rds_cluster.test.engine
+  engine_version                = aws_rds_cluster.test.engine_version
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.t3.medium", "db.r5.large", "db.r4.large"]
 }
 
 resource "aws_rds_cluster_instance" "test" {
   cluster_identifier           = aws_rds_cluster.test.id
   engine                       = aws_rds_cluster.test.engine
   identifier                   = %[1]q
-  instance_class               = "db.r4.large"
+  instance_class               = data.aws_rds_orderable_db_instance.test.instance_class
   performance_insights_enabled = true
 }
-`, rName)
+`, rName, engine)
 }
 
-func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName string) string {
+func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql1(rName, engine string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -1342,24 +1492,31 @@ resource "aws_kms_key" "test" {
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
-  engine              = "aurora"
+  engine              = %[2]q
   master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = aws_rds_cluster.test.engine
+  engine_version                = aws_rds_cluster.test.engine_version
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.t3.medium", "db.r5.large", "db.r4.large"]
 }
 
 resource "aws_rds_cluster_instance" "test" {
   cluster_identifier              = aws_rds_cluster.test.id
   engine                          = aws_rds_cluster.test.engine
   identifier                      = %[1]q
-  instance_class                  = "db.r4.large"
+  instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
   performance_insights_enabled    = true
   performance_insights_kms_key_id = aws_kms_key.test.arn
 }
-`, rName)
+`, rName, engine)
 }
 
-func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName string) string {
+func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraMysql2(rName, engine, engineVersion string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -1368,11 +1525,18 @@ resource "aws_kms_key" "test" {
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
-  engine              = "aurora-mysql"
-  engine_version      = "5.7.mysql_aurora.2.04.2"
+  engine              = %[2]q
+  engine_version      = %[3]q
   master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = aws_rds_cluster.test.engine
+  engine_version                = aws_rds_cluster.test.engine_version
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.t3.medium", "db.r5.large", "db.r4.large"]
 }
 
 resource "aws_rds_cluster_instance" "test" {
@@ -1380,14 +1544,14 @@ resource "aws_rds_cluster_instance" "test" {
   engine                          = aws_rds_cluster.test.engine
   engine_version                  = aws_rds_cluster.test.engine_version
   identifier                      = %[1]q
-  instance_class                  = "db.r4.large"
+  instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
   performance_insights_enabled    = true
   performance_insights_kms_key_id = aws_kms_key.test.arn
 }
-`, rName)
+`, rName, engine, engineVersion)
 }
 
-func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName string) string {
+func testAccAWSClusterInstanceConfigPerformanceInsightsKmsKeyIdAuroraPostgresql(rName, engine string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -1396,78 +1560,107 @@ resource "aws_kms_key" "test" {
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
   database_name       = "mydb"
-  engine              = "aurora-postgresql"
+  engine              = %[2]q
   master_password     = "mustbeeightcharacters"
   master_username     = "foo"
   skip_final_snapshot = true
+}
+
+data "aws_rds_orderable_db_instance" "test" {
+  engine                        = aws_rds_cluster.test.engine
+  engine_version                = aws_rds_cluster.test.engine_version
+  supports_performance_insights = true
+  preferred_instance_classes    = ["db.t3.medium", "db.r5.large", "db.r4.large"]
 }
 
 resource "aws_rds_cluster_instance" "test" {
   cluster_identifier              = aws_rds_cluster.test.id
   engine                          = aws_rds_cluster.test.engine
   identifier                      = %[1]q
-  instance_class                  = "db.r4.large"
+  instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
   performance_insights_enabled    = true
   performance_insights_kms_key_id = aws_kms_key.test.arn
 }
-`, rName)
+`, rName, engine)
 }
 
 func testAccAWSRDSClusterInstanceConfig_PubliclyAccessible(rName string, publiclyAccessible bool) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
-  cluster_identifier  = %q
+  cluster_identifier  = %[1]q
   master_username     = "foo"
   master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.test.engine
+  engine_version             = aws_rds_cluster.test.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "test" {
   apply_immediately   = true
   cluster_identifier  = aws_rds_cluster.test.id
-  identifier          = %q
-  instance_class      = "db.t2.small"
-  publicly_accessible = %t
+  identifier          = %[1]q
+  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
+  publicly_accessible = %[2]t
 }
-`, rName, rName, publiclyAccessible)
+`, rName, publiclyAccessible)
 }
 
 func testAccAWSClusterInstanceConfig_CopyTagsToSnapshot(n int, f bool) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_rds_cluster" "default" {
-  cluster_identifier  = "tf-aurora-cluster-test-%d"
-  availability_zones  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  cluster_identifier = "tf-aurora-cluster-test-%[1]d"
+  availability_zones = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
   database_name       = "mydb"
   master_username     = "foo"
   master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.default.engine
+  engine_version             = aws_rds_cluster.default.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "cluster_instances" {
-  identifier            = "tf-cluster-instance-%d"
+  identifier            = "tf-cluster-instance-%[1]d"
   cluster_identifier    = aws_rds_cluster.default.id
-  instance_class        = "db.t2.small"
+  instance_class        = data.aws_rds_orderable_db_instance.test.instance_class
   promotion_tier        = "3"
   copy_tags_to_snapshot = %t
 }
-`, n, n, f)
+`, n, f))
 }
 
 func testAccAWSRDSClusterInstanceConfig_CACertificateIdentifier(rName string, caCertificateIdentifier string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
-  cluster_identifier  = %q
+  cluster_identifier  = %[1]q
   master_username     = "foo"
   master_password     = "mustbeeightcharacters"
   skip_final_snapshot = true
 }
 
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = aws_rds_cluster.test.engine
+  engine_version             = aws_rds_cluster.test.engine_version
+  preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster_instance" "test" {
   apply_immediately  = true
   cluster_identifier = aws_rds_cluster.test.id
-  identifier         = %q
-  instance_class     = "db.t2.small"
-  ca_cert_identifier = %q
+  identifier         = %[1]q
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
+  ca_cert_identifier = %[2]q
 }
-`, rName, rName, caCertificateIdentifier)
+`, rName, caCertificateIdentifier)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSRDSClusterInstance_basic (1385.39s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (568.23s)
--- PASS: TestAccAWSRDSClusterInstance_generatedName (570.13s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (611.42s)
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (663.63s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraPostgresql (689.00s)
--- PASS: TestAccAWSRDSClusterInstance_isAlreadyBeingDeleted (711.95s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (712.53s)
--- PASS: TestAccAWSRDSClusterInstance_az (714.00s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql2 (753.35s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1 (783.43s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToRemoved (783.79s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql1_DefaultKeyToCustomKey (799.15s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2 (802.36s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsEnabled_AuroraMysql1 (802.83s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraMysql2_DefaultKeyToCustomKey (826.01s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_RemovedToEnabled (860.74s)
--- PASS: TestAccAWSRDSClusterInstance_MonitoringRoleArn_EnabledToDisabled (1024.74s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql_DefaultKeyToCustomKey (577.20s)
--- PASS: TestAccAWSRDSClusterInstance_CACertificateIdentifier (612.95s)
--- PASS: TestAccAWSRDSClusterInstance_PerformanceInsightsKmsKeyId_AuroraPostgresql (725.28s)
--- PASS: TestAccAWSRDSClusterInstance_disappears (1351.19s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1401.42s)
--- FAIL: TestAccAWSRDSClusterInstance_MonitoringInterval (1627.27s)
```

The fail on commercial:

```
Error modifying DB Instance tf-acc-test-854893840051788754: InvalidDBInstanceState: Database
instance is not in available state.
```