### PR TITLE
tests/provider: Fix hardcoded (lb listener policy)

### DIFF
--- a/aws/resource_aws_load_balancer_listener_policy_test.go
+++ b/aws/resource_aws_load_balancer_listener_policy_test.go
@@ -147,10 +147,10 @@ func testAccCheckAWSLoadBalancerListenerPolicyState(loadBalancerName string, loa
 }
 
 func testAccAWSLoadBalancerListenerPolicyConfig_basic0(lbName, mcName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "test-lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 80
@@ -183,14 +183,14 @@ resource "aws_load_balancer_listener_policy" "test-lb-listener-policies-80" {
     aws_load_balancer_policy.magic-cookie-sticky.policy_name,
   ]
 }
-`, lbName, mcName)
+`, lbName, mcName))
 }
 
 func testAccAWSLoadBalancerListenerPolicyConfig_basic1(lbName, mcName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "test-lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 80
@@ -223,14 +223,14 @@ resource "aws_load_balancer_listener_policy" "test-lb-listener-policies-80" {
     aws_load_balancer_policy.magic-cookie-sticky.policy_name,
   ]
 }
-`, lbName, mcName)
+`, lbName, mcName))
 }
 
 func testAccAWSLoadBalancerListenerPolicyConfig_basic2(lbName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "test-lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 80
@@ -243,5 +243,5 @@ resource "aws_elb" "test-lb" {
     Name = "tf-acc-test"
   }
 }
-`, lbName)
+`, lbName))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSLoadBalancerListenerPolicy_basic (70.41s)
```

Output from acceptance testing (Commercial):

```
--- PASS: TestAccAWSLoadBalancerListenerPolicy_basic (66.69s)
```