### PR TITLE
tests/provider: Fix hardcoded (RDS cluster endpoint)

### DIFF
--- a/aws/resource_aws_rds_cluster_endpoint_test.go
+++ b/aws/resource_aws_rds_cluster_endpoint_test.go
@@ -206,10 +206,20 @@ func testAccCheckAWSRDSClusterEndpointExistsWithProvider(resourceName string, en
 }
 
 func testAccAWSClusterEndpointConfigBase(n int) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+   engine                     = aws_rds_cluster.default.engine
+   engine_version             = aws_rds_cluster.default.engine_version
+   preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
+}
+
 resource "aws_rds_cluster" "default" {
   cluster_identifier              = "tf-aurora-cluster-%[1]d"
-  availability_zones              = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  availability_zones              = [
+    data.aws_availability_zones.available.names[0],
+    data.aws_availability_zones.available.names[1],
+    data.aws_availability_zones.available.names[2]
+  ]
   database_name                   = "mydb"
   master_username                 = "foo"
   master_password                 = "mustbeeightcharaters"
@@ -221,16 +231,16 @@ resource "aws_rds_cluster_instance" "test1" {
   apply_immediately  = true
   cluster_identifier = aws_rds_cluster.default.id
   identifier         = "tf-aurora-cluster-instance-test1-%[1]d"
-  instance_class     = "db.t2.small"
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
 
 resource "aws_rds_cluster_instance" "test2" {
   apply_immediately  = true
   cluster_identifier = aws_rds_cluster.default.id
   identifier         = "tf-aurora-cluster-instance-test2-%[1]d"
-  instance_class     = "db.t2.small"
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
 }
-`, n)
+`, n))
 }
 
 func testAccAWSClusterEndpointConfig(n int) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- FAIL: TestAccAWSRDSClusterEndpoint_tags (790.96s)
Error: Error creating RDS Cluster Endpoint: InvalidParameterValue: Tagging endpoints is currently not available
        	status code: 400, request id: 89d2ddd4-a2cc-4e68-a694-ab07c529b87b

--- FAIL: TestAccAWSRDSClusterEndpoint_basic (946.55s)
Error: error listing tags for RDS Cluster Endpoint (arn:aws-us-gov:rds:us-gov-west-1:357342307427:cluster-endpoint:reader-6910710774328620347): InvalidParameterValue: The specified resource name does not match an RDS resource in this region.
        	status code: 400, request id: cadfaeaa-2001-4e44-823e-af840be8aa89
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSRDSClusterEndpoint_basic (926.44s)
--- PASS: TestAccAWSRDSClusterEndpoint_tags (1063.67s)
```