### PR TITLE
tests/provider: Fix hardcoded (lb cookie sticky policy)

### DIFF
--- a/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -182,10 +182,10 @@ func TestAccAWSLBCookieStickinessPolicy_missingLB(t *testing.T) {
 }
 
 func testAccLBCookieStickinessPolicyConfig(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 8000
@@ -200,15 +200,15 @@ resource "aws_lb_cookie_stickiness_policy" "foo" {
   load_balancer = aws_elb.lb.id
   lb_port       = 80
 }
-`, rName)
+`, rName))
 }
 
 // Sets the cookie_expiration_period to 300s.
 func testAccLBCookieStickinessPolicyConfigUpdate(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 8000
@@ -224,15 +224,15 @@ resource "aws_lb_cookie_stickiness_policy" "foo" {
   lb_port                  = 80
   cookie_expiration_period = 300
 }
-`, rName)
+`, rName))
 }
 
 // attempt to destroy the policy, but we'll delete the LB in the PreConfig
 func testAccLBCookieStickinessPolicyConfigDestroy(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 8000
@@ -241,5 +241,5 @@ resource "aws_elb" "lb" {
     lb_protocol       = "http"
   }
 }
-`, rName)
+`, rName))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSLBCookieStickinessPolicy_missingLB (48.17s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_drift (48.40s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (48.68s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSLBCookieStickinessPolicy_drift (41.41s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_missingLB (43.08s)
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (43.09s)
```
