### PR TITLE
Updated ClientVpnAuthorizationRuleActiveTimeout and ClientVpnAuthoriz…

### DIFF
--- a/aws/internal/service/ec2/waiter/waiter.go
+++ b/aws/internal/service/ec2/waiter/waiter.go
@@ -73,9 +73,9 @@ func ClientVpnEndpointDeleted(conn *ec2.EC2, id string) (*ec2.ClientVpnEndpoint,
 }
 
 const (
-	ClientVpnAuthorizationRuleActiveTimeout = 1 * time.Minute
+	ClientVpnAuthorizationRuleActiveTimeout = 5 * time.Minute
 
-	ClientVpnAuthorizationRuleRevokedTimeout = 1 * time.Minute
+	ClientVpnAuthorizationRuleRevokedTimeout = 5 * time.Minute
 )
 
 func ClientVpnAuthorizationRuleAuthorized(conn *ec2.EC2, authorizationRuleID string) (*ec2.AuthorizationRule, error) {


### PR DESCRIPTION
Updated ClientVpnAuthorizationRuleActiveTimeout and ClientVpnAuthorizationRuleRevokedTimeout to 5 minute timeout

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #14156 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ec2_client_vpn_authorization_rule: Update timeout from 1min to 5min
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at  .
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEc2ClientVpnAuthorizationRules_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEc2ClientVpnAuthorizationRules_ -timeout 120m
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       4.167s [no tests to run]

...
```
