### PR TITLE
Fix incorrect import doc instructions in aws_guardduty_filter resource

### DIFF
--- a/website/docs/r/guardduty_filter.html.markdown
+++ b/website/docs/r/guardduty_filter.html.markdown
@@ -77,8 +77,8 @@ In addition to all arguments above, the following attribute is exported:
 
 ## Import
 
-GuardDuty filters can be imported using the detector ID and filter's name separated by underscore, e.g.
+GuardDuty filters can be imported using the detector ID and filter's name separated by a colon, e.g.
 
 ```
-$ terraform import aws_guardduty_filter.MyFilter 00b00fd5aecc0ab60a708659477e9617_MyFilter
+$ terraform import aws_guardduty_filter.MyFilter 00b00fd5aecc0ab60a708659477e9617:MyFilter
 ```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix incorrect import doc instructions for aws_guardduty_filter resource
```

Here's the error message that one gets when trying to import a resource:

```
Error: GuardDuty filter ID must be of the form <Detector ID>:<Filter name>. Got "detectorId_myName".
```
