### PR TITLE
tests/provider: Add precheck for ep config type edge (API Gateway Doc Version)

### DIFF
--- a/aws/resource_aws_api_gateway_documentation_version_test.go
+++ b/aws/resource_aws_api_gateway_documentation_version_test.go
@@ -21,7 +21,7 @@ func TestAccAWSAPIGatewayDocumentationVersion_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
 		Steps: []resource.TestStep{
@@ -55,7 +55,7 @@ func TestAccAWSAPIGatewayDocumentationVersion_allFields(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
 		Steps: []resource.TestStep{
@@ -96,7 +96,7 @@ func TestAccAWSAPIGatewayDocumentationVersion_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_documentation_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayDocumentationVersionDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Relates #15071 
See also hashicorp/terraform-plugin-sdk#568

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
    resource_aws_api_gateway_rest_api_test.go:653: skipping test; Endpoint Configuration type EDGE is not supported in this partition (aws-us-gov)
--- SKIP: TestAccAWSAPIGatewayDocumentationVersion_disappears (1.56s)
--- SKIP: TestAccAWSAPIGatewayDocumentationVersion_basic (1.57s)
--- SKIP: TestAccAWSAPIGatewayDocumentationVersion_allFields (1.58s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_disappears (15.70s)
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_allFields (51.07s)
--- PASS: TestAccAWSAPIGatewayDocumentationVersion_basic (76.70s)
```