### PR TITLE
tests/provider: Add precheck for ep config type edge (API Gateway Gateway & Integration)

### DIFF
--- a/aws/resource_aws_api_gateway_gateway_response_test.go
+++ b/aws/resource_aws_api_gateway_gateway_response_test.go
@@ -19,7 +19,7 @@ func TestAccAWSAPIGatewayGatewayResponse_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_gateway_response.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayGatewayResponseDestroy,
 		Steps: []resource.TestStep{
@@ -61,7 +61,7 @@ func TestAccAWSAPIGatewayGatewayResponse_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_gateway_response.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayGatewayResponseDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_api_gateway_integration_response_test.go
+++ b/aws/resource_aws_api_gateway_integration_response_test.go
@@ -18,7 +18,7 @@ func TestAccAWSAPIGatewayIntegrationResponse_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_integration_response.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationResponseDestroy,
 		Steps: []resource.TestStep{
@@ -65,7 +65,7 @@ func TestAccAWSAPIGatewayIntegrationResponse_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_integration_response.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationResponseDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -20,7 +20,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationDestroy,
 		Steps: []resource.TestStep{
@@ -134,7 +134,7 @@ func TestAccAWSAPIGatewayIntegration_contentHandling(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationDestroy,
 		Steps: []resource.TestStep{
@@ -209,7 +209,7 @@ func TestAccAWSAPIGatewayIntegration_cache_key_parameters(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationDestroy,
 		Steps: []resource.TestStep{
@@ -251,7 +251,7 @@ func TestAccAWSAPIGatewayIntegration_integrationType(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationDestroy,
 		Steps: []resource.TestStep{
@@ -295,7 +295,7 @@ func TestAccAWSAPIGatewayIntegration_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_integration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #15071 
See also hashicorp/terraform-plugin-sdk#568

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
    resource_aws_api_gateway_rest_api_test.go:653: skipping test; Endpoint Configuration type EDGE is not supported in this partition (aws-us-gov)
--- SKIP: TestAccAWSAPIGatewayGatewayResponse_disappears (1.44s)
--- SKIP: TestAccAWSAPIGatewayGatewayResponse_basic (1.45s)
--- SKIP: TestAccAWSAPIGatewayIntegration_contentHandling (1.35s)
--- SKIP: TestAccAWSAPIGatewayIntegration_cache_key_parameters (1.36s)
--- SKIP: TestAccAWSAPIGatewayIntegration_integrationType (1.36s)
--- SKIP: TestAccAWSAPIGatewayIntegration_disappears (1.37s)
--- SKIP: TestAccAWSAPIGatewayIntegration_basic (1.37s)
--- SKIP: TestAccAWSAPIGatewayIntegrationResponse_basic (1.56s)
--- SKIP: TestAccAWSAPIGatewayIntegrationResponse_disappears (1.56s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSAPIGatewayGatewayResponse_disappears (17.44s)
--- PASS: TestAccAWSAPIGatewayGatewayResponse_basic (59.58s)
--- PASS: TestAccAWSAPIGatewayIntegration_disappears (17.49s)
--- PASS: TestAccAWSAPIGatewayIntegration_contentHandling (56.83s)
--- PASS: TestAccAWSAPIGatewayIntegration_basic (82.55s)
--- PASS: TestAccAWSAPIGatewayIntegration_cache_key_parameters (175.82s)
--- PASS: TestAccAWSAPIGatewayIntegration_integrationType (734.66s)
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_disappears (18.97s)
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_basic (60.45s)
```