### PR TITLE
tests/provider: Add precheck for ep config type edge (API Gateway Model-Stage)

### DIFF
--- a/aws/resource_aws_api_gateway_model_test.go
+++ b/aws/resource_aws_api_gateway_model_test.go
@@ -20,7 +20,7 @@ func TestAccAWSAPIGatewayModel_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_model.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayModelDestroy,
 		Steps: []resource.TestStep{
@@ -55,7 +55,7 @@ func TestAccAWSAPIGatewayModel_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_model.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayModelDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_api_gateway_request_validator_test.go
+++ b/aws/resource_aws_api_gateway_request_validator_test.go
@@ -18,7 +18,7 @@ func TestAccAWSAPIGatewayRequestValidator_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_request_validator.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayRequestValidatorDestroy,
 		Steps: []resource.TestStep{
@@ -62,7 +62,7 @@ func TestAccAWSAPIGatewayRequestValidator_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_request_validator.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayRequestValidatorDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_api_gateway_resource_test.go
+++ b/aws/resource_aws_api_gateway_resource_test.go
@@ -18,7 +18,7 @@ func TestAccAWSAPIGatewayResource_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayResourceDestroy,
 		Steps: []resource.TestStep{
@@ -49,7 +49,7 @@ func TestAccAWSAPIGatewayResource_update(t *testing.T) {
 	resourceName := "aws_api_gateway_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayResourceDestroy,
 		Steps: []resource.TestStep{
@@ -92,7 +92,7 @@ func TestAccAWSAPIGatewayResource_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_resource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayResourceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_api_gateway_stage_test.go
+++ b/aws/resource_aws_api_gateway_stage_test.go
@@ -19,7 +19,7 @@ func TestAccAWSAPIGatewayStage_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayStageDestroy,
 		Steps: []resource.TestStep{
@@ -84,7 +84,7 @@ func TestAccAWSAPIGatewayStage_disappears_ReferencingDeployment(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayStageDestroy,
 		Steps: []resource.TestStep{
@@ -110,7 +110,7 @@ func TestAccAWSAPIGatewayStage_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayStageDestroy,
 		Steps: []resource.TestStep{
@@ -137,7 +137,7 @@ func TestAccAWSAPIGatewayStage_accessLogSettings(t *testing.T) {
 	csv := `$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.resourcePath,$context.protocol,$context.status,$context.responseLength,$context.requestId`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayStageDestroy,
 		Steps: []resource.TestStep{
@@ -204,7 +204,7 @@ func TestAccAWSAPIGatewayStage_accessLogSettings_kinesis(t *testing.T) {
 	csv := `$context.identity.sourceIp,$context.identity.caller,$context.identity.user,$context.requestTime,$context.httpMethod,$context.resourcePath,$context.protocol,$context.status,$context.responseLength,$context.requestId`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayStageDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #15071 
See also hashicorp/terraform-plugin-sdk#568

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
    resource_aws_api_gateway_rest_api_test.go:653: skipping test; Endpoint Configuration type EDGE is not supported in this partition (aws-us-gov)
--- SKIP: TestAccAWSAPIGatewayModel_basic (1.47s)
--- SKIP: TestAccAWSAPIGatewayModel_disappears (1.47s)
--- SKIP: TestAccAWSAPIGatewayRequestValidator_basic (1.35s)
--- SKIP: TestAccAWSAPIGatewayRequestValidator_disappears (1.35s)
--- SKIP: TestAccAWSAPIGatewayResource_update (1.35s)
--- SKIP: TestAccAWSAPIGatewayResource_disappears (1.35s)
--- SKIP: TestAccAWSAPIGatewayResource_basic (1.36s)
--- SKIP: TestAccAWSAPIGatewayStage_basic (1.52s)
--- SKIP: TestAccAWSAPIGatewayStage_disappears (1.53s)
--- SKIP: TestAccAWSAPIGatewayStage_disappears_ReferencingDeployment (1.53s)
--- SKIP: TestAccAWSAPIGatewayStage_accessLogSettings_kinesis (1.53s)
--- SKIP: TestAccAWSAPIGatewayStage_accessLogSettings (1.53s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSAPIGatewayModel_disappears (13.71s)
--- PASS: TestAccAWSAPIGatewayModel_basic (70.53s)
--- PASS: TestAccAWSAPIGatewayRequestValidator_disappears (13.46s)
--- PASS: TestAccAWSAPIGatewayRequestValidator_basic (52.27s)
--- PASS: TestAccAWSAPIGatewayResource_disappears (14.02s)
--- PASS: TestAccAWSAPIGatewayResource_basic (15.78s)
--- PASS: TestAccAWSAPIGatewayResource_update (49.59s)
--- PASS: TestAccAWSAPIGatewayStage_disappears (45.64s)
--- PASS: TestAccAWSAPIGatewayStage_disappears_ReferencingDeployment (53.66s)
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings (225.22s)
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings_kinesis (337.48s)
--- PASS: TestAccAWSAPIGatewayStage_basic (376.78s)
```