### PR TITLE
tests/provider: Add precheck for ep config type edge (API Gateway Usage Plan)

### DIFF
--- a/aws/resource_aws_api_gateway_usage_plan_key_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_key_test.go
@@ -20,7 +20,7 @@ func TestAccAWSAPIGatewayUsagePlanKey_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan_key.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanKeyDestroy,
 		Steps: []resource.TestStep{
@@ -76,7 +76,7 @@ func TestAccAWSAPIGatewayUsagePlanKey_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan_key.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanKeyDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_api_gateway_usage_plan_test.go
+++ b/aws/resource_aws_api_gateway_usage_plan_test.go
@@ -19,7 +19,7 @@ func TestAccAWSAPIGatewayUsagePlan_basic(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
@@ -61,7 +61,7 @@ func TestAccAWSAPIGatewayUsagePlan_tags(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
@@ -107,7 +107,7 @@ func TestAccAWSAPIGatewayUsagePlan_description(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
@@ -160,7 +160,7 @@ func TestAccAWSAPIGatewayUsagePlan_productCode(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
@@ -213,7 +213,7 @@ func TestAccAWSAPIGatewayUsagePlan_throttling(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
@@ -267,7 +267,7 @@ func TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
@@ -293,7 +293,7 @@ func TestAccAWSAPIGatewayUsagePlan_quota(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
@@ -348,7 +348,7 @@ func TestAccAWSAPIGatewayUsagePlan_apiStages(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{
@@ -412,7 +412,7 @@ func TestAccAWSAPIGatewayUsagePlan_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_usage_plan.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAPIGatewayTypeEDGEPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayUsagePlanDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates #15071 
See also hashicorp/terraform-plugin-sdk#568

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
    resource_aws_api_gateway_rest_api_test.go:653: skipping test; Endpoint Configuration type EDGE is not supported in this partition (aws-us-gov)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_productCode (1.60s)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_apiStages (1.61s)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_disappears (1.61s)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_tags (1.61s)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_description (1.61s)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_throttling (1.61s)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (1.61s)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_quota (1.61s)
--- SKIP: TestAccAWSAPIGatewayUsagePlan_basic (1.62s)
--- SKIP: TestAccAWSAPIGatewayUsagePlanKey_disappears (1.34s)
--- SKIP: TestAccAWSAPIGatewayUsagePlanKey_basic (1.35s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSAPIGatewayUsagePlan_disappears (68.84s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_basic (109.97s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (131.25s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (169.42s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (219.59s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (265.57s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (330.10s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_tags (340.05s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (541.04s)
--- PASS: TestAccAWSAPIGatewayUsagePlanKey_disappears (38.78s)
--- PASS: TestAccAWSAPIGatewayUsagePlanKey_basic (127.72s)
```