### PR TITLE
tests/provider: Fix hardcoded (app sticky cookie)

### DIFF
--- a/aws/resource_aws_app_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_app_cookie_stickiness_policy_test.go
@@ -189,10 +189,10 @@ func TestAccAWSAppCookieStickinessPolicy_drift(t *testing.T) {
 }
 
 func testAccAppCookieStickinessPolicyConfig(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 8000
@@ -208,15 +208,15 @@ resource "aws_app_cookie_stickiness_policy" "foo" {
   lb_port       = 80
   cookie_name   = "MyAppCookie"
 }
-`, rName)
+`, rName))
 }
 
 // Change the cookie_name to "MyOtherAppCookie".
 func testAccAppCookieStickinessPolicyConfigUpdate(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 8000
@@ -232,15 +232,15 @@ resource "aws_app_cookie_stickiness_policy" "foo" {
   lb_port       = 80
   cookie_name   = "MyOtherAppCookie"
 }
-`, rName)
+`, rName))
 }
 
 // attempt to destroy the policy, but we'll delete the LB in the PreConfig
 func testAccAppCookieStickinessPolicyConfigDestroy(rName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_elb" "lb" {
   name               = "%s"
-  availability_zones = ["us-west-2a"]
+  availability_zones = [data.aws_availability_zones.available.names[0]]
 
   listener {
     instance_port     = 8000
@@ -249,5 +249,5 @@ resource "aws_elb" "lb" {
     lb_protocol       = "http"
   }
 }
-`, rName)
+`, rName))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSAppCookieStickinessPolicy_drift (45.23s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_missingLB (45.25s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_basic (49.92s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSAppCookieStickinessPolicy_drift (40.84s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_missingLB (41.46s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_basic (42.09s)
```
