### PR TITLE
tests/provider: Fix hardcoded (Codepipeline)

### DIFF
--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -1365,7 +1365,7 @@ func TestResourceAWSCodePipelineExpandArtifactStoresValidation(t *testing.T) {
 					"location":       "",
 					"type":           "",
 					"encryption_key": []interface{}{},
-					"region":         "us-west-2",
+					"region":         "us-west-2", //lintignore:AWSAT003
 				},
 			},
 			ExpectedError: "region cannot be set for a single-region CodePipeline",
@@ -1377,13 +1377,13 @@ func TestResourceAWSCodePipelineExpandArtifactStoresValidation(t *testing.T) {
 					"location":       "",
 					"type":           "",
 					"encryption_key": []interface{}{},
-					"region":         "us-west-2",
+					"region":         "us-west-2", //lintignore:AWSAT003
 				},
 				map[string]interface{}{
 					"location":       "",
 					"type":           "",
 					"encryption_key": []interface{}{},
-					"region":         "us-east-1",
+					"region":         "us-east-1", //lintignore:AWSAT003
 				},
 			},
 		},
@@ -1412,7 +1412,7 @@ func TestResourceAWSCodePipelineExpandArtifactStoresValidation(t *testing.T) {
 					"location":       "",
 					"type":           "",
 					"encryption_key": []interface{}{},
-					"region":         "us-west-2",
+					"region":         "us-west-2", //lintignore:AWSAT003
 				},
 				map[string]interface{}{
 					"location":       "",
@@ -1430,13 +1430,13 @@ func TestResourceAWSCodePipelineExpandArtifactStoresValidation(t *testing.T) {
 					"location":       "",
 					"type":           "",
 					"encryption_key": []interface{}{},
-					"region":         "us-west-2",
+					"region":         "us-west-2", //lintignore:AWSAT003
 				},
 				map[string]interface{}{
 					"location":       "",
 					"type":           "",
 					"encryption_key": []interface{}{},
-					"region":         "us-west-2",
+					"region":         "us-west-2", //lintignore:AWSAT003
 				},
 			},
 			ExpectedError: "only one Artifact Store can be defined per region for a cross-region CodePipeline",
@@ -1444,6 +1444,7 @@ func TestResourceAWSCodePipelineExpandArtifactStoresValidation(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		_, err := expandAwsCodePipelineArtifactStores(tc.Input)
 		if tc.ExpectedError == "" {
 			if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Only one test modified: `TestResourceAWSCodePipelineExpandArtifactStoresValidation`

The output from acceptance testing (GovCloud):

```
--- PASS: TestResourceAWSCodePipelineExpandArtifactStoresValidation (0.00s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestResourceAWSCodePipelineExpandArtifactStoresValidation (0.00s)
```
