### PR TITLE
tests/provider: Fix hardcoded (Config Config Aggregator)

### DIFF
--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -76,7 +76,7 @@ func TestAccAWSConfigConfigurationAggregator_account(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.account_ids.#", "1"),
 					testAccCheckResourceAttrAccountID(resourceName, "account_aggregation_source.0.account_ids.0"),
 					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.regions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "account_aggregation_source.0.regions.0", "us-west-2"),
+					resource.TestCheckResourceAttrPair(resourceName, "account_aggregation_source.0.regions.0", "data.aws_region.current", "name"),
 				),
 			},
 			{
@@ -261,12 +261,14 @@ func testAccCheckAWSConfigConfigurationAggregatorDestroy(s *terraform.State) err
 
 func testAccAWSConfigConfigurationAggregatorConfig_account(rName string) string {
 	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
 resource "aws_config_configuration_aggregator" "example" {
   name = %[1]q
 
   account_aggregation_source {
     account_ids = [data.aws_caller_identity.current.account_id]
-    regions     = ["us-west-2"]
+    regions     = [data.aws_region.current.name]
   }
 }
 
@@ -320,12 +322,14 @@ resource "aws_iam_role_policy_attachment" "example" {
 
 func testAccAWSConfigConfigurationAggregatorConfig_tags(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
 resource "aws_config_configuration_aggregator" "example" {
   name = %[1]q
 
   account_aggregation_source {
     account_ids = [data.aws_caller_identity.current.account_id]
-    regions     = ["us-west-2"]
+    regions     = [data.aws_region.current.name]
   }
 
   tags = {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSConfigConfigurationAggregator_account (22.16s)
--- PASS: TestAccAWSConfigConfigurationAggregator_tags (52.94s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSConfigConfigurationAggregator_account (15.76s)
--- PASS: TestAccAWSConfigConfigurationAggregator_tags (39.99s)
```
