### PR TITLE
tests/provider: Fix hardcoded (DynamoDB Global Table)

### DIFF
--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,13 +15,19 @@ import (
 )
 
 func TestAccAWSDynamoDbGlobalTable_basic(t *testing.T) {
+	var providers []*schema.Provider
 	resourceName := "aws_dynamodb_global_table.test"
 	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDynamodbGlobalTable(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDynamoDbGlobalTableDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSDynamodbGlobalTable(t)
+			testAccAlternateRegionPreCheck(t)
+			testAccDynamoDBGlobalTablePreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsDynamoDbGlobalTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDynamoDbGlobalTableConfig_invalidName(acctest.RandString(2)),
@@ -63,6 +70,7 @@ func TestAccAWSDynamoDbGlobalTable_multipleRegions(t *testing.T) {
 			testAccPreCheckAWSDynamodbGlobalTable(t)
 			testAccMultipleRegionsPreCheck(t)
 			testAccAlternateRegionPreCheck(t)
+			testAccDynamoDBGlobalTablePreCheck(t)
 		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckAwsDynamoDbGlobalTableDestroy,
@@ -150,6 +158,15 @@ func testAccPreCheckAWSDynamodbGlobalTable(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+// testAccDynamoDBGlobalTablePreCheck checks if aws_dynamodb_global_table (version 2017.11.29) can be used and skips test if not.
+func testAccDynamoDBGlobalTablePreCheck(t *testing.T) {
+	supportRegionsSort := []string{"ap-northeast-1", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2", "eu-central-1", "eu-west-1", "eu-west-2", "us-east-1", "us-east-2", "us-west-1", "us-west-2"}
+
+	if testAccGetRegion() != supportRegionsSort[sort.SearchStrings(supportRegionsSort, testAccGetRegion())] {
+		t.Skipf("skipping test; aws_dynamodb_global_table (DynamoDB v2017.11.29) not supported in region %s", testAccGetRegion())
 	}
 }
 
@@ -255,13 +272,17 @@ resource "aws_dynamodb_global_table" "test" {
 }
 
 func testAccDynamoDbGlobalTableConfig_invalidName(tableName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAlternateRegionProviderConfig(), fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = "awsalternate"
+}
+
 resource "aws_dynamodb_global_table" "test" {
   name = "%s"
 
   replica {
-    region_name = "us-east-1"
+    region_name = data.aws_region.alternate.name
   }
 }
-`, tableName)
+`, tableName))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12995 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
    resource_aws_dynamodb_global_table_test.go:169: skipping test; aws_dynamodb_global_table (DynamoDB v2017.11.29) not supported in region us-gov-west-1
--- SKIP: TestAccAWSDynamoDbGlobalTable_basic (2.16s)
--- SKIP: TestAccAWSDynamoDbGlobalTable_multipleRegions (2.21s)
```

The output from acceptance testing (commercial):

```
kommer snart
```
