### PR TITLE
[WIP] r/aws_transfer_server: Support for VPC subnets/IP addresses

### DIFF
--- a/aws/resource_aws_transfer_server.go
+++ b/aws/resource_aws_transfer_server.go
@@ -582,6 +582,10 @@ func describeTransferServer(conn *transfer.Transfer, serverId string) (*transfer
 func waitForTransferServerVPCEndpointState(transferConn *transfer.Transfer, ec2Conn *ec2.EC2, serverId string, timeout time.Duration) error {
 	server, err := describeTransferServer(transferConn, serverId)
 
+	if err != nil {
+		return err
+	}
+
 	stateChangeConf := &resource.StateChangeConf{
 		Pending: []string{ec2.VpcStatePending},
 		Target:  []string{ec2.VpcStateAvailable},

--- a/aws/resource_aws_transfer_server.go
+++ b/aws/resource_aws_transfer_server.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -57,16 +56,6 @@ func resourceAwsTransferServer() *schema.Resource {
 							Type:          schema.TypeString,
 							Optional:      true,
 							ConflictsWith: []string{"endpoint_details.0.address_allocation_ids", "endpoint_details.0.subnet_ids", "endpoint_details.0.vpc_id"},
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								validNamePattern := "^vpce-[0-9a-f]{17}$"
-								validName, nameMatchErr := regexp.MatchString(validNamePattern, value)
-								if !validName || nameMatchErr != nil {
-									errors = append(errors, fmt.Errorf(
-										"%q must match regex '%v'", k, validNamePattern))
-								}
-								return
-							},
 							DiffSuppressFunc: func(k, o, n string, d *schema.ResourceData) bool {
 								if n == "" && d.Get("endpoint_type").(string) == transfer.EndpointTypeVpc {
 									return true
@@ -465,16 +454,16 @@ func flattenTransferServerEndpointDetails(endpointDetails *transfer.EndpointDeta
 
 	e := make(map[string]interface{})
 	if endpointDetails.VpcEndpointId != nil {
-		e["vpc_endpoint_id"] = *endpointDetails.VpcEndpointId
+		e["vpc_endpoint_id"] = aws.StringValue(endpointDetails.VpcEndpointId)
 	}
 	if endpointDetails.AddressAllocationIds != nil {
-		e["address_allocation_ids"] = endpointDetails.AddressAllocationIds
+		e["address_allocation_ids"] = flattenStringSet(endpointDetails.AddressAllocationIds)
 	}
 	if endpointDetails.SubnetIds != nil {
-		e["subnet_ids"] = endpointDetails.SubnetIds
+		e["subnet_ids"] = flattenStringSet(endpointDetails.SubnetIds)
 	}
 	if endpointDetails.VpcId != nil {
-		e["vpc_id"] = *endpointDetails.VpcId
+		e["vpc_id"] = aws.StringValue(endpointDetails.VpcId)
 	}
 
 	return []interface{}{e}

--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -67,28 +67,29 @@ func testSweepTransferServers(region string) error {
 
 func TestAccAWSTransferServer_basic(t *testing.T) {
 	var conf transfer.DescribedServer
+	resourceName := "aws_transfer_server.foo"
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		IDRefreshName: "aws_transfer_server.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &conf),
-					testAccMatchResourceAttrRegionalARN("aws_transfer_server.foo", "arn", "transfer", regexp.MustCompile(`server/.+`)),
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "transfer", regexp.MustCompile(`server/.+`)),
 					resource.TestMatchResourceAttr(
-						"aws_transfer_server.foo", "endpoint", regexp.MustCompile(fmt.Sprintf("^s-[a-z0-9]+.server.transfer.%s.amazonaws.com$", testAccGetRegion()))),
+						resourceName, "endpoint", regexp.MustCompile(fmt.Sprintf("^s-[a-z0-9]+.server.transfer.%s.amazonaws.com$", testAccGetRegion()))),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "identity_provider_type", "SERVICE_MANAGED"),
-					resource.TestCheckResourceAttr("aws_transfer_server.foo", "tags.%", "0"),
+						resourceName, "identity_provider_type", "SERVICE_MANAGED"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				ResourceName:            "aws_transfer_server.foo",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy"},
@@ -96,15 +97,15 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 			{
 				Config: testAccAWSTransferServerConfig_basicUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &conf),
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "tags.%", "2"),
+						resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "tags.NAME", "tf-acc-test-transfer-server"),
+						resourceName, "tags.NAME", "tf-acc-test-transfer-server"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "tags.ENV", "test"),
+						resourceName, "tags.ENV", "test"),
 					resource.TestCheckResourceAttrPair(
-						"aws_transfer_server.foo", "logging_role", "aws_iam_role.foo", "arn"),
+						resourceName, "logging_role", "aws_iam_role.foo", "arn"),
 				),
 			},
 		},
@@ -113,27 +114,28 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 
 func TestAccAWSTransferServer_Vpc(t *testing.T) {
 	var conf transfer.DescribedServer
+	resourceName := "aws_transfer_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		IDRefreshName: "aws_transfer_server.test",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_Vpc,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.test", &conf),
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.test", "endpoint_type", "VPC"),
+						resourceName, "endpoint_type", "VPC"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.test", "endpoint_details.0.subnet_ids.#", "1"),
+						resourceName, "endpoint_details.0.subnet_ids.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.test", "endpoint_details.0.address_allocation_ids.#", "1"),
+						resourceName, "endpoint_details.0.address_allocation_ids.#", "1"),
 				),
 			},
 			{
-				ResourceName:            "aws_transfer_server.test",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy"},
@@ -141,11 +143,11 @@ func TestAccAWSTransferServer_Vpc(t *testing.T) {
 			{
 				Config: testAccAWSTransferServerConfig_VpcUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.test", &conf),
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.test", "endpoint_type", "VPC"),
+						resourceName, "endpoint_type", "VPC"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.test", "endpoint_details.0.address_allocation_ids.#", "1"),
+						resourceName, "endpoint_details.0.address_allocation_ids.#", "1"),
 				),
 			},
 		},
@@ -154,28 +156,29 @@ func TestAccAWSTransferServer_Vpc(t *testing.T) {
 
 func TestAccAWSTransferServer_apigateway(t *testing.T) {
 	var conf transfer.DescribedServer
+	resourceName := "aws_transfer_server.foo"
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		IDRefreshName: "aws_transfer_server.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_apigateway(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &conf),
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "identity_provider_type", "API_GATEWAY"),
+						resourceName, "identity_provider_type", "API_GATEWAY"),
 					resource.TestCheckResourceAttrSet(
-						"aws_transfer_server.foo", "invocation_role"),
+						resourceName, "invocation_role"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "tags.%", "2"),
+						resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "tags.NAME", "tf-acc-test-transfer-server"),
+						resourceName, "tags.NAME", "tf-acc-test-transfer-server"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "tags.TYPE", "apigateway"),
+						resourceName, "tags.TYPE", "apigateway"),
 				),
 			},
 		},
@@ -184,6 +187,7 @@ func TestAccAWSTransferServer_apigateway(t *testing.T) {
 
 func TestAccAWSTransferServer_disappears(t *testing.T) {
 	var conf transfer.DescribedServer
+	resourceName := "aws_transfer_server.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
@@ -193,7 +197,7 @@ func TestAccAWSTransferServer_disappears(t *testing.T) {
 			{
 				Config: testAccAWSTransferServerConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &conf),
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					testAccCheckAWSTransferServerDisappears(&conf),
 				),
 				ExpectNonEmptyPlan: true,
@@ -205,29 +209,30 @@ func TestAccAWSTransferServer_disappears(t *testing.T) {
 func TestAccAWSTransferServer_forcedestroy(t *testing.T) {
 	var conf transfer.DescribedServer
 	var roleConf iam.GetRoleOutput
+	resourceName := "aws_transfer_server.foo"
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		IDRefreshName: "aws_transfer_server.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferServerConfig_forcedestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &conf),
+					testAccCheckAWSTransferServerExists(resourceName, &conf),
 					testAccCheckAWSRoleExists("aws_iam_role.foo", &roleConf),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "identity_provider_type", "SERVICE_MANAGED"),
+						resourceName, "identity_provider_type", "SERVICE_MANAGED"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_server.foo", "force_destroy", "true"),
+						resourceName, "force_destroy", "true"),
 					testAccCheckAWSTransferCreateUser(&conf, &roleConf, rName),
 					testAccCheckAWSTransferCreateSshKey(&conf, rName),
 				),
 			},
 			{
-				ResourceName:            "aws_transfer_server.foo",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy", "host_key"},

--- a/aws/resource_aws_transfer_user.go
+++ b/aws/resource_aws_transfer_user.go
@@ -339,8 +339,8 @@ func flattenTransferServerUserHomeDirectoryMappings(m []*transfer.HomeDirectoryM
 	for _, e := range m {
 		if e.Entry != nil && e.Target != nil {
 			m := make(map[string]interface{})
-			m["entry"] = *e.Entry
-			m["target"] = *e.Target
+			m["entry"] = aws.StringValue(e.Entry)
+			m["target"] = aws.StringValue(e.Target)
 
 			ms = append(ms, m)
 		}

--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -15,27 +15,28 @@ import (
 
 func TestAccAWSTransferUser_basic(t *testing.T) {
 	var conf transfer.DescribedUser
+	resourceName := "aws_transfer_user.foo"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		IDRefreshName: "aws_transfer_user.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &conf),
-					testAccMatchResourceAttrRegionalARN("aws_transfer_user.foo", "arn", "transfer", regexp.MustCompile(`user/.+`)),
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "transfer", regexp.MustCompile(`user/.+`)),
 					resource.TestCheckResourceAttrPair(
-						"aws_transfer_user.foo", "server_id", "aws_transfer_server.foo", "id"),
+						resourceName, "server_id", "aws_transfer_server.foo", "id"),
 					resource.TestCheckResourceAttrPair(
-						"aws_transfer_user.foo", "role", "aws_iam_role.foo", "arn"),
+						resourceName, "role", "aws_iam_role.foo", "arn"),
 				),
 			},
 			{
-				ResourceName:      "aws_transfer_user.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -45,29 +46,30 @@ func TestAccAWSTransferUser_basic(t *testing.T) {
 
 func TestAccAWSTransferUser_restricted(t *testing.T) {
 	var conf transfer.DescribedUser
+	resourceName := "aws_transfer_user.foo"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		IDRefreshName: "aws_transfer_user.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferUserConfig_restricted(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &conf),
-					testAccMatchResourceAttrRegionalARN("aws_transfer_user.foo", "arn", "transfer", regexp.MustCompile(`user/.+`)),
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "transfer", regexp.MustCompile(`user/.+`)),
 					resource.TestCheckResourceAttrPair(
-						"aws_transfer_user.foo", "server_id", "aws_transfer_server.foo", "id"),
+						resourceName, "server_id", "aws_transfer_server.foo", "id"),
 					resource.TestCheckResourceAttrPair(
-						"aws_transfer_user.foo", "role", "aws_iam_role.foo", "arn"),
+						resourceName, "role", "aws_iam_role.foo", "arn"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "home_directory_type", "LOGICAL"),
+						resourceName, "home_directory_type", "LOGICAL"),
 				),
 			},
 			{
-				ResourceName:      "aws_transfer_user.foo",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -77,57 +79,58 @@ func TestAccAWSTransferUser_restricted(t *testing.T) {
 
 func TestAccAWSTransferUser_modifyWithOptions(t *testing.T) {
 	var conf transfer.DescribedUser
+	resourceName := "aws_transfer_user.foo"
 	rName := acctest.RandString(10)
 	rName2 := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
-		IDRefreshName: "aws_transfer_user.foo",
+		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSTransferUserConfig_options(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &conf),
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "home_directory", "/home/tftestuser"),
+						resourceName, "home_directory", "/home/tftestuser"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "tags.%", "3"),
+						resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "tags.NAME", "tftestuser"),
+						resourceName, "tags.NAME", "tftestuser"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "tags.ENV", "test"),
+						resourceName, "tags.ENV", "test"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "tags.ADMIN", "test"),
+						resourceName, "tags.ADMIN", "test"),
 				),
 			},
 			{
 				Config: testAccAWSTransferUserConfig_modify(rName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &conf),
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
 					resource.TestCheckResourceAttrPair(
-						"aws_transfer_user.foo", "role", "aws_iam_role.foo", "arn"),
+						resourceName, "role", "aws_iam_role.foo", "arn"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "home_directory", "/test"),
+						resourceName, "home_directory", "/test"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "tags.%", "2"),
+						resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "tags.NAME", "tf-test-user"),
+						resourceName, "tags.NAME", "tf-test-user"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "tags.TEST", "test2"),
+						resourceName, "tags.TEST", "test2"),
 				),
 			},
 			{
 				Config: testAccAWSTransferUserConfig_forceNew(rName2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &conf),
+					testAccCheckAWSTransferUserExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "user_name", "tftestuser2"),
+						resourceName, "user_name", "tftestuser2"),
 					resource.TestCheckResourceAttrPair(
-						"aws_transfer_user.foo", "role", "aws_iam_role.foo", "arn"),
+						resourceName, "role", "aws_iam_role.foo", "arn"),
 					resource.TestCheckResourceAttr(
-						"aws_transfer_user.foo", "home_directory", "/home/tftestuser2"),
+						resourceName, "home_directory", "/home/tftestuser2"),
 				),
 			},
 		},
@@ -137,6 +140,7 @@ func TestAccAWSTransferUser_modifyWithOptions(t *testing.T) {
 func TestAccAWSTransferUser_disappears(t *testing.T) {
 	var serverConf transfer.DescribedServer
 	var userConf transfer.DescribedUser
+	resourceName := "aws_transfer_user.foo"
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -148,7 +152,7 @@ func TestAccAWSTransferUser_disappears(t *testing.T) {
 				Config: testAccAWSTransferUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &serverConf),
-					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &userConf),
+					testAccCheckAWSTransferUserExists(resourceName, &userConf),
 					testAccCheckAWSTransferUserDisappears(&serverConf, &userConf),
 				),
 				ExpectNonEmptyPlan: true,

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -79,7 +79,10 @@ The following arguments are supported:
 
 **endpoint_details** requires the following:
 
-* `vpc_endpoint_id` - (Required) The ID of the VPC endpoint.
+* `vpc_endpoint_id` - (Optional) The ID of the VPC endpoint. This property can only be used when `endpoint_type` is set to `VPC_ENDPOINT`
+* `address_allocation_ids` - (Optional) A list of address allocation IDs that are required to attach an Elastic IP address to your SFTP server's endpoint. This property can only be used when `endpoint_type` is set to `VPC`.
+* `subnet_ids` - (Optional) A list of subnet IDs that are required to host your SFTP server endpoint in your VPC. This property can only be used when `endpoint_type` is set to `VPC`.
+* `vpc_id` - (Optional) The VPC ID of the virtual private cloud in which the SFTP server's endpoint will be hosted. This property can only be used when `endpoint_type` is set to `VPC`.
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -75,8 +75,15 @@ The following arguments are supported:
 * `user_name` - (Requirement) The name used for log in to your SFTP server.
 * `home_directory` - (Optional) The landing directory (folder) for a user when they log in to the server using their SFTP client.  It should begin with a `/`.  The first item in the path is the name of the home bucket (accessible as `${Transfer:HomeBucket}` in the policy) and the rest is the home directory (accessible as `${Transfer:HomeDirectory}` in the policy). For example, `/example-bucket-1234/username` would set the home bucket to `example-bucket-1234` and the home directory to `username`.
 * `policy` - (Optional) An IAM JSON policy document that scopes down user access to portions of their Amazon S3 bucket. IAM variables you can use inside this policy include `${Transfer:UserName}`, `${Transfer:HomeDirectory}`, and `${Transfer:HomeBucket}`. Since the IAM variable syntax matches Terraform's interpolation syntax, they must be escaped inside Terraform configuration strings (`$${Transfer:UserName}`).  These are evaluated on-the-fly when navigating the bucket.
+* `home_directory_type` (Optional) The type of landing directory (folder) you want your users' home directory to be when they log into the SFTP server. If you set it to PATH, the user will see the absolute Amazon S3 bucket paths as is in their SFTP clients. If you set it `LOGICAL`, you will need to provide mappings in the `home_directory_mappings` for how you want to make S3 paths visible to your user. Allowed Values: `LOGICAL` | `PATH`.
+* `home_directory_mappings` (Optional) Logical directory mappings that specify what S3 paths and keys should be visible to your user and how you want to make them visible. You will need to specify the `entry` and `target` pair, where `entry` shows how the path is made visible and `target` is the actual S3 path. If you only specify a `target`, it will be displayed as is. You will need to also make sure that your AWS IAM Role provides access to paths in `target`. In most cases, you can use this value instead of the scope down policy to lock your user down to the designated home directory ("chroot"). To do this, you can set `entry` to `/` and set `target` to the `home_directory` parameter value.
 * `role` - (Requirement) Amazon Resource Name (ARN) of an IAM role that allows the service to controls your user’s access to your Amazon S3 bucket.
 * `tags` - (Optional) A map of tags to assign to the resource.
+
+#### Home Directory Mappings arguments
+
+* `entry` (Required) - Represents an entry for `home_directory_mappings`.
+* `target` (Required) - Represents a target for `home_directory_mappings`.
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
Based on the work in #12599. This rebases on top of master, addresses some review comments and removes the calls to modify security groups (this can potentially be addressed in a separate resource).

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
