### PR TITLE
provider: Remove extraneous zero-value checking with (helper/schema.ResourceData).GetOk()

### DIFF
--- a/aws/data_source_aws_glue_script.go
+++ b/aws/data_source_aws_glue_script.go
@@ -109,7 +109,7 @@ func dataSourceAwsGlueScriptRead(d *schema.ResourceData, meta interface{}) error
 		DagNodes: expandGlueCodeGenNodes(dagNode),
 	}
 
-	if v, ok := d.GetOk("language"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("language"); ok {
 		input.Language = aws.String(v.(string))
 	}
 

--- a/aws/data_source_aws_vpc_dhcp_options.go
+++ b/aws/data_source_aws_vpc_dhcp_options.go
@@ -66,7 +66,7 @@ func dataSourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) e
 
 	input := &ec2.DescribeDhcpOptionsInput{}
 
-	if v, ok := d.GetOk("dhcp_options_id"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("dhcp_options_id"); ok {
 		input.DhcpOptionsIds = []*string{aws.String(v.(string))}
 	}
 

--- a/aws/resource_aws_api_gateway_domain_name.go
+++ b/aws/resource_aws_api_gateway_domain_name.go
@@ -181,15 +181,15 @@ func resourceAwsApiGatewayDomainNameCreate(d *schema.ResourceData, meta interfac
 		params.EndpointConfiguration = expandApiGatewayEndpointConfiguration(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("regional_certificate_arn"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("regional_certificate_arn"); ok {
 		params.RegionalCertificateArn = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("regional_certificate_name"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("regional_certificate_name"); ok {
 		params.RegionalCertificateName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("security_policy"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("security_policy"); ok {
 		params.SecurityPolicy = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -145,11 +145,11 @@ func resourceAwsApiGatewayRestApiCreate(d *schema.ResourceData, meta interface{}
 		params.EndpointConfiguration = expandApiGatewayEndpointConfiguration(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("api_key_source"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("api_key_source"); ok {
 		params.ApiKeySource = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("policy"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("policy"); ok {
 		params.Policy = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -613,7 +613,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 		createOpts.DefaultCooldown = aws.Int64(int64(v.(int)))
 	}
 
-	if v, ok := d.GetOk("health_check_type"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("health_check_type"); ok {
 		createOpts.HealthCheckType = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_dx_bgp_peer.go
+++ b/aws/resource_aws_dx_bgp_peer.go
@@ -88,13 +88,13 @@ func resourceAwsDxBgpPeerCreate(d *schema.ResourceData, meta interface{}) error 
 			Asn:           aws.Int64(asn),
 		},
 	}
-	if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("amazon_address"); ok {
 		req.NewBGPPeer.AmazonAddress = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("bgp_auth_key"); ok {
 		req.NewBGPPeer.AuthKey = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("customer_address"); ok {
 		req.NewBGPPeer.CustomerAddress = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_dx_hosted_private_virtual_interface.go
+++ b/aws/resource_aws_dx_hosted_private_virtual_interface.go
@@ -124,16 +124,16 @@ func resourceAwsDxHostedPrivateVirtualInterfaceCreate(d *schema.ResourceData, me
 		},
 		OwnerAccount: aws.String(d.Get("owner_account_id").(string)),
 	}
-	if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("amazon_address"); ok {
 		req.NewPrivateVirtualInterfaceAllocation.AmazonAddress = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("bgp_auth_key"); ok {
 		req.NewPrivateVirtualInterfaceAllocation.AuthKey = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("customer_address"); ok {
 		req.NewPrivateVirtualInterfaceAllocation.CustomerAddress = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("mtu"); ok && v.(int) != 0 {
+	if v, ok := d.GetOk("mtu"); ok {
 		req.NewPrivateVirtualInterfaceAllocation.Mtu = aws.Int64(int64(v.(int)))
 	}
 

--- a/aws/resource_aws_dx_hosted_public_virtual_interface.go
+++ b/aws/resource_aws_dx_hosted_public_virtual_interface.go
@@ -120,13 +120,13 @@ func resourceAwsDxHostedPublicVirtualInterfaceCreate(d *schema.ResourceData, met
 		},
 		OwnerAccount: aws.String(d.Get("owner_account_id").(string)),
 	}
-	if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("amazon_address"); ok {
 		req.NewPublicVirtualInterfaceAllocation.AmazonAddress = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("bgp_auth_key"); ok {
 		req.NewPublicVirtualInterfaceAllocation.AuthKey = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("customer_address"); ok {
 		req.NewPublicVirtualInterfaceAllocation.CustomerAddress = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("route_filter_prefixes"); ok {

--- a/aws/resource_aws_dx_hosted_transit_virtual_interface.go
+++ b/aws/resource_aws_dx_hosted_transit_virtual_interface.go
@@ -124,13 +124,13 @@ func resourceAwsDxHostedTransitVirtualInterfaceCreate(d *schema.ResourceData, me
 			Vlan:                 aws.Int64(int64(d.Get("vlan").(int))),
 		},
 	}
-	if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("amazon_address"); ok {
 		req.NewTransitVirtualInterfaceAllocation.AmazonAddress = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("bgp_auth_key"); ok {
 		req.NewTransitVirtualInterfaceAllocation.AuthKey = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("customer_address"); ok {
 		req.NewTransitVirtualInterfaceAllocation.CustomerAddress = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_dx_private_virtual_interface.go
+++ b/aws/resource_aws_dx_private_virtual_interface.go
@@ -144,13 +144,13 @@ func resourceAwsDxPrivateVirtualInterfaceCreate(d *schema.ResourceData, meta int
 	if dxgwOk && dxgwIdRaw.(string) != "" {
 		req.NewPrivateVirtualInterface.DirectConnectGatewayId = aws.String(dxgwIdRaw.(string))
 	}
-	if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("amazon_address"); ok {
 		req.NewPrivateVirtualInterface.AmazonAddress = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("bgp_auth_key"); ok {
 		req.NewPrivateVirtualInterface.AuthKey = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("customer_address"); ok {
 		req.NewPrivateVirtualInterface.CustomerAddress = aws.String(v.(string))
 	}
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {

--- a/aws/resource_aws_dx_public_virtual_interface.go
+++ b/aws/resource_aws_dx_public_virtual_interface.go
@@ -116,13 +116,13 @@ func resourceAwsDxPublicVirtualInterfaceCreate(d *schema.ResourceData, meta inte
 			Vlan:                 aws.Int64(int64(d.Get("vlan").(int))),
 		},
 	}
-	if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("amazon_address"); ok {
 		req.NewPublicVirtualInterface.AmazonAddress = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("bgp_auth_key"); ok {
 		req.NewPublicVirtualInterface.AuthKey = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("customer_address"); ok {
 		req.NewPublicVirtualInterface.CustomerAddress = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("route_filter_prefixes"); ok {

--- a/aws/resource_aws_dx_transit_virtual_interface.go
+++ b/aws/resource_aws_dx_transit_virtual_interface.go
@@ -125,13 +125,13 @@ func resourceAwsDxTransitVirtualInterfaceCreate(d *schema.ResourceData, meta int
 			Vlan:                   aws.Int64(int64(d.Get("vlan").(int))),
 		},
 	}
-	if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("amazon_address"); ok {
 		req.NewTransitVirtualInterface.AmazonAddress = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("bgp_auth_key"); ok {
 		req.NewTransitVirtualInterface.AuthKey = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("customer_address"); ok {
 		req.NewTransitVirtualInterface.CustomerAddress = aws.String(v.(string))
 	}
 	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {

--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -218,7 +218,7 @@ func resourceAwsEksClusterCreate(d *schema.ResourceData, meta interface{}) error
 		input.Tags = keyvaluetags.New(v).IgnoreAws().EksTags()
 	}
 
-	if v, ok := d.GetOk("version"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("version"); ok {
 		input.Version = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -202,7 +202,7 @@ func resourceAwsElasticTranscoderPipelineCreate(d *schema.ResourceData, meta int
 		ThumbnailConfig: expandETPiplineOutputConfig(d, "thumbnail_config"),
 	}
 
-	if v, ok := d.GetOk("output_bucket"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("output_bucket"); ok {
 		req.OutputBucket = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -285,7 +285,7 @@ func resourceAwsElbCreate(d *schema.ResourceData, meta interface{}) error {
 		elbOpts.Tags = tags
 	}
 
-	if scheme, ok := d.GetOk("internal"); ok && scheme.(bool) {
+	if _, ok := d.GetOk("internal"); ok {
 		elbOpts.Scheme = aws.String("internal")
 	}
 

--- a/aws/resource_aws_iam_service_linked_role.go
+++ b/aws/resource_aws_iam_service_linked_role.go
@@ -87,11 +87,11 @@ func resourceAwsIamServiceLinkedRoleCreate(d *schema.ResourceData, meta interfac
 		AWSServiceName: aws.String(serviceName),
 	}
 
-	if v, ok := d.GetOk("custom_suffix"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("custom_suffix"); ok {
 		params.CustomSuffix = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("description"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("description"); ok {
 		params.Description = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -81,7 +81,7 @@ func resourceAwsIamUserCreate(d *schema.ResourceData, meta interface{}) error {
 		UserName: aws.String(name),
 	}
 
-	if v, ok := d.GetOk("permissions_boundary"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("permissions_boundary"); ok {
 		request.PermissionsBoundary = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -565,7 +565,7 @@ func resourceAwsKinesisAnalyticsApplicationCreate(d *schema.ResourceData, meta i
 		ApplicationName: aws.String(name),
 	}
 
-	if v, ok := d.GetOk("code"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("code"); ok {
 		createOpts.ApplicationCode = aws.String(v.(string))
 	}
 
@@ -1086,7 +1086,7 @@ func createApplicationUpdateOpts(d *schema.ResourceData) *kinesisanalytics.Appli
 	applicationUpdate := &kinesisanalytics.ApplicationUpdate{}
 
 	if d.HasChange("code") {
-		if v, ok := d.GetOk("code"); ok && v.(string) != "" {
+		if v, ok := d.GetOk("code"); ok {
 			applicationUpdate.ApplicationCodeUpdate = aws.String(v.(string))
 		}
 	}

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -644,7 +644,7 @@ func resourceAwsLaunchTemplateCreate(d *schema.ResourceData, meta interface{}) e
 		TagSpecifications:  ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeLaunchTemplate),
 	}
 
-	if v, ok := d.GetOk("description"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("description"); ok {
 		launchTemplateOpts.VersionDescription = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -261,7 +261,7 @@ func resourceAwsLbCreate(d *schema.ResourceData, meta interface{}) error {
 		elbOpts.Tags = tags
 	}
 
-	if scheme, ok := d.GetOk("internal"); ok && scheme.(bool) {
+	if _, ok := d.GetOk("internal"); ok {
 		elbOpts.Scheme = aws.String("internal")
 	}
 

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -674,11 +674,11 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		// unless the cluster is a read-replica. This also applies to clusters
 		// within a global cluster. Providing a password and/or username for
 		// a replica will result in an InvalidParameterValue error.
-		if v, ok := d.GetOk("master_password"); ok && v.(string) != "" {
+		if v, ok := d.GetOk("master_password"); ok {
 			createOpts.MasterUserPassword = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("master_username"); ok && v.(string) != "" {
+		if v, ok := d.GetOk("master_username"); ok {
 			createOpts.MasterUsername = aws.String(v.(string))
 		}
 

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -512,7 +512,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	if logging, ok := d.GetOk("logging.0.enable"); ok && logging.(bool) {
+	if _, ok := d.GetOk("logging.0.enable"); ok {
 		if err := enableRedshiftClusterLogging(d, conn); err != nil {
 			return fmt.Errorf("error enabling Redshift Cluster (%s) logging: %s", d.Id(), err)
 		}

--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -122,7 +122,7 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 		input.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SecretsmanagerTags()
 	}
 
-	if v, ok := d.GetOk("kms_key_id"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("kms_key_id"); ok {
 		input.KmsKeyId = aws.String(v.(string))
 	}
 
@@ -278,7 +278,7 @@ func resourceAwsSecretsManagerSecretUpdate(d *schema.ResourceData, meta interfac
 			SecretId:    aws.String(d.Id()),
 		}
 
-		if v, ok := d.GetOk("kms_key_id"); ok && v.(string) != "" {
+		if v, ok := d.GetOk("kms_key_id"); ok {
 			input.KmsKeyId = aws.String(v.(string))
 		}
 

--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -639,7 +639,7 @@ func expandIPPerm(d *schema.ResourceData, sg *ec2.SecurityGroup) (*ec2.IpPermiss
 		groups[raw.(string)] = true
 	}
 
-	if v, ok := d.GetOk("self"); ok && v.(bool) {
+	if _, ok := d.GetOk("self"); ok {
 		if sg.VpcId != nil && *sg.VpcId != "" {
 			groups[*sg.GroupId] = true
 		} else {

--- a/aws/resource_aws_ses_identity_notification_topic.go
+++ b/aws/resource_aws_ses_identity_notification_topic.go
@@ -65,7 +65,7 @@ func resourceAwsSesNotificationTopicSet(d *schema.ResourceData, meta interface{}
 		NotificationType: aws.String(notification),
 	}
 
-	if v, ok := d.GetOk("topic_arn"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("topic_arn"); ok {
 		setOpts.SnsTopic = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -878,7 +878,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		spotFleetConfig.InstancePoolsToUseCount = aws.Int64(int64(v.(int)))
 	}
 
-	if v, ok := d.GetOk("spot_price"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("spot_price"); ok {
 		spotFleetConfig.SpotPrice = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_storagegateway_nfs_file_share.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share.go
@@ -188,7 +188,7 @@ func resourceAwsStorageGatewayNfsFileShareCreate(d *schema.ResourceData, meta in
 		Tags:                 keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().StoragegatewayTags(),
 	}
 
-	if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("kms_key_arn"); ok {
 		input.KMSKey = aws.String(v.(string))
 	}
 
@@ -311,7 +311,7 @@ func resourceAwsStorageGatewayNfsFileShareUpdate(d *schema.ResourceData, meta in
 			Squash:               aws.String(d.Get("squash").(string)),
 		}
 
-		if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
+		if v, ok := d.GetOk("kms_key_arn"); ok {
 			input.KMSKey = aws.String(v.(string))
 		}
 

--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -177,11 +177,11 @@ func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta in
 		Tags:                 keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().StoragegatewayTags(),
 	}
 
-	if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("kms_key_arn"); ok {
 		input.KMSKey = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("audit_destination_arn"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("audit_destination_arn"); ok {
 		input.AuditDestinationARN = aws.String(v.(string))
 	}
 
@@ -311,11 +311,11 @@ func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta in
 			CaseSensitivity:      aws.String(d.Get("case_sensitivity").(string)),
 		}
 
-		if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
+		if v, ok := d.GetOk("kms_key_arn"); ok {
 			input.KMSKey = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("audit_destination_arn"); ok && v.(string) != "" {
+		if v, ok := d.GetOk("audit_destination_arn"); ok {
 			input.AuditDestinationARN = aws.String(v.(string))
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/15014

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

`semgrep` rules present will only show new failures for pull requests, but the main branch will fail the GitHub Action until all reports are fixed. This is a broad sweep to clean out the existing reports so its no longer failing on the main branch, but the changes here can be split up if necessary.

Previously:

```console
$ semgrep
running 1 rules...
aws/data_source_aws_glue_script.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
112:  if v, ok := d.GetOk("language"); ok && v.(string) != "" {
113:    input.Language = aws.String(v.(string))
114:  }

aws/data_source_aws_vpc_dhcp_options.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
69: if v, ok := d.GetOk("dhcp_options_id"); ok && v.(string) != "" {
70:   input.DhcpOptionsIds = []*string{aws.String(v.(string))}
71: }

aws/resource_aws_api_gateway_domain_name.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
184:  if v, ok := d.GetOk("regional_certificate_arn"); ok && v.(string) != "" {
185:    params.RegionalCertificateArn = aws.String(v.(string))
186:  }
188:  if v, ok := d.GetOk("regional_certificate_name"); ok && v.(string) != "" {
189:    params.RegionalCertificateName = aws.String(v.(string))
190:  }
192:  if v, ok := d.GetOk("security_policy"); ok && v.(string) != "" {
193:    params.SecurityPolicy = aws.String(v.(string))
194:  }

aws/resource_aws_api_gateway_rest_api.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
148:  if v, ok := d.GetOk("api_key_source"); ok && v.(string) != "" {
149:    params.ApiKeySource = aws.String(v.(string))
150:  }
152:  if v, ok := d.GetOk("policy"); ok && v.(string) != "" {
153:    params.Policy = aws.String(v.(string))
154:  }

aws/resource_aws_autoscaling_group.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
616:  if v, ok := d.GetOk("health_check_type"); ok && v.(string) != "" {
617:    createOpts.HealthCheckType = aws.String(v.(string))
618:  }

aws/resource_aws_dx_bgp_peer.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
91: if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
92:   req.NewBGPPeer.AmazonAddress = aws.String(v.(string))
93: }
94: if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
95:   req.NewBGPPeer.AuthKey = aws.String(v.(string))
96: }
97: if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
98:   req.NewBGPPeer.CustomerAddress = aws.String(v.(string))
99: }

aws/resource_aws_dx_hosted_private_virtual_interface.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
127:  if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
128:    req.NewPrivateVirtualInterfaceAllocation.AmazonAddress = aws.String(v.(string))
129:  }
130:  if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
131:    req.NewPrivateVirtualInterfaceAllocation.AuthKey = aws.String(v.(string))
132:  }
133:  if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
134:    req.NewPrivateVirtualInterfaceAllocation.CustomerAddress = aws.String(v.(string))
135:  }
136:  if v, ok := d.GetOk("mtu"); ok && v.(int) != 0 {
137:    req.NewPrivateVirtualInterfaceAllocation.Mtu = aws.Int64(int64(v.(int)))
138:  }

aws/resource_aws_dx_hosted_public_virtual_interface.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
123:  if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
124:    req.NewPublicVirtualInterfaceAllocation.AmazonAddress = aws.String(v.(string))
125:  }
126:  if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
127:    req.NewPublicVirtualInterfaceAllocation.AuthKey = aws.String(v.(string))
128:  }
129:  if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
130:    req.NewPublicVirtualInterfaceAllocation.CustomerAddress = aws.String(v.(string))
131:  }

aws/resource_aws_dx_hosted_transit_virtual_interface.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
127:  if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
128:    req.NewTransitVirtualInterfaceAllocation.AmazonAddress = aws.String(v.(string))
129:  }
130:  if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
131:    req.NewTransitVirtualInterfaceAllocation.AuthKey = aws.String(v.(string))
132:  }
133:  if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
134:    req.NewTransitVirtualInterfaceAllocation.CustomerAddress = aws.String(v.(string))
135:  }

aws/resource_aws_dx_private_virtual_interface.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
147:  if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
148:    req.NewPrivateVirtualInterface.AmazonAddress = aws.String(v.(string))
149:  }
153:  if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
154:    req.NewPrivateVirtualInterface.CustomerAddress = aws.String(v.(string))
155:  }

aws/resource_aws_dx_public_virtual_interface.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
119:  if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
120:    req.NewPublicVirtualInterface.AmazonAddress = aws.String(v.(string))
121:  }
122:  if v, ok := d.GetOk("bgp_auth_key"); ok && v.(string) != "" {
123:    req.NewPublicVirtualInterface.AuthKey = aws.String(v.(string))
124:  }
125:  if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
126:    req.NewPublicVirtualInterface.CustomerAddress = aws.String(v.(string))
127:  }

aws/resource_aws_dx_transit_virtual_interface.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
128:  if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
129:    req.NewTransitVirtualInterface.AmazonAddress = aws.String(v.(string))
130:  }
134:  if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
135:    req.NewTransitVirtualInterface.CustomerAddress = aws.String(v.(string))
136:  }

aws/resource_aws_eks_cluster.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
221:  if v, ok := d.GetOk("version"); ok && v.(string) != "" {
222:    input.Version = aws.String(v.(string))
223:  }

aws/resource_aws_elastic_transcoder_pipeline.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
205:  if v, ok := d.GetOk("output_bucket"); ok && v.(string) != "" {
206:    req.OutputBucket = aws.String(v.(string))
207:  }

aws/resource_aws_elb.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
288:  if scheme, ok := d.GetOk("internal"); ok && scheme.(bool) {
289:    elbOpts.Scheme = aws.String("internal")
290:  }

aws/resource_aws_iam_service_linked_role.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
90: if v, ok := d.GetOk("custom_suffix"); ok && v.(string) != "" {
91:   params.CustomSuffix = aws.String(v.(string))
92: }
94: if v, ok := d.GetOk("description"); ok && v.(string) != "" {
95:   params.Description = aws.String(v.(string))
96: }

aws/resource_aws_iam_user.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
84: if v, ok := d.GetOk("permissions_boundary"); ok && v.(string) != "" {
85:   request.PermissionsBoundary = aws.String(v.(string))
86: }

aws/resource_aws_kinesis_analytics_application.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
568:  if v, ok := d.GetOk("code"); ok && v.(string) != "" {
569:    createOpts.ApplicationCode = aws.String(v.(string))
570:  }
1089:   if v, ok := d.GetOk("code"); ok && v.(string) != "" {
1090:     applicationUpdate.ApplicationCodeUpdate = aws.String(v.(string))
1091:   }

aws/resource_aws_launch_template.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
647:  if v, ok := d.GetOk("description"); ok && v.(string) != "" {
648:    launchTemplateOpts.VersionDescription = aws.String(v.(string))
649:  }

aws/resource_aws_lb.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
264:  if scheme, ok := d.GetOk("internal"); ok && scheme.(bool) {
265:    elbOpts.Scheme = aws.String("internal")
266:  }

aws/resource_aws_rds_cluster.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
677:    if v, ok := d.GetOk("master_password"); ok && v.(string) != "" {
678:      createOpts.MasterUserPassword = aws.String(v.(string))
679:    }
681:    if v, ok := d.GetOk("master_username"); ok && v.(string) != "" {
682:      createOpts.MasterUsername = aws.String(v.(string))
683:    }

aws/resource_aws_redshift_cluster.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
515:  if logging, ok := d.GetOk("logging.0.enable"); ok && logging.(bool) {
516:    if err := enableRedshiftClusterLogging(d, conn); err != nil {
517:      return fmt.Errorf("error enabling Redshift Cluster (%s) logging: %s", d.Id(), err)
518:    }
519:  }

aws/resource_aws_secretsmanager_secret.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
125:  if v, ok := d.GetOk("kms_key_id"); ok && v.(string) != "" {
126:    input.KmsKeyId = aws.String(v.(string))
127:  }
281:    if v, ok := d.GetOk("kms_key_id"); ok && v.(string) != "" {
282:      input.KmsKeyId = aws.String(v.(string))
283:    }

aws/resource_aws_security_group_rule.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
642:  if v, ok := d.GetOk("self"); ok && v.(bool) {
643:    if sg.VpcId != nil && *sg.VpcId != "" {
644:      groups[*sg.GroupId] = true
645:    } else {
646:      groups[*sg.GroupName] = true
647:    }
648:  }

aws/resource_aws_ses_identity_notification_topic.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
68: if v, ok := d.GetOk("topic_arn"); ok && v.(string) != "" {
69:   setOpts.SnsTopic = aws.String(v.(string))
70: }

aws/resource_aws_spot_fleet_request.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
881:  if v, ok := d.GetOk("spot_price"); ok && v.(string) != "" {
882:    spotFleetConfig.SpotPrice = aws.String(v.(string))
883:  }

aws/resource_aws_storagegateway_nfs_file_share.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
191:  if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
192:    input.KMSKey = aws.String(v.(string))
193:  }
314:    if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
315:      input.KMSKey = aws.String(v.(string))
316:    }

aws/resource_aws_storagegateway_smb_file_share.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
180:  if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
181:    input.KMSKey = aws.String(v.(string))
182:  }
184:  if v, ok := d.GetOk("audit_destination_arn"); ok && v.(string) != "" {
185:    input.AuditDestinationARN = aws.String(v.(string))
186:  }
314:    if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
315:      input.KMSKey = aws.String(v.(string))
316:    }
318:    if v, ok := d.GetOk("audit_destination_arn"); ok && v.(string) != "" {
319:      input.AuditDestinationARN = aws.String(v.(string))
320:    }
```

Now:

```console
$ semgrep
running 1 rules...
$
```

Output from acceptance testing (new failures at top are unrelated, other failures present on main branch):

```
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (148.25s)

TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned: resource_aws_rds_cluster_test.go:1591: Step 1/2 error: terraform failed: exit status 1
stderr:
Error: error creating RDS DB Cluster Snapshot: InvalidDBClusterSnapshotStateFault: Cannot create a snapshot because the database instance tf-acc-test-3666419845114088946-source already has a pending snapshot.

--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (158.93s)

TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow: resource_aws_rds_cluster_test.go:1872: Step 1/2 error: terraform failed: exit status 1
stderr:
Error: error creating RDS DB Cluster Snapshot: InvalidDBClusterSnapshotStateFault: Cannot create a snapshot because the database instance tf-acc-test-6680780650461000076-source already has a pending snapshot.

--- FAIL: TestAccAWSRedshiftCluster_iamRoles (271.01s)

TestAccAWSRedshiftCluster_iamRoles: resource_aws_redshift_cluster_test.go:290: Step 2/2 error: terraform failed: exit status 1
stderr:
Error: Error modifying Redshift Cluster IAM Roles (tf-redshift-cluster-6550992848935425938): InvalidClusterState: The Cluster is being modified by a concurrent operation. Please check the Cluster's status and try again.

--- FAIL: TestAccAWSRedshiftCluster_publiclyAccessible (292.64s)

TestAccAWSRedshiftCluster_publiclyAccessible: resource_aws_redshift_cluster_test.go:320: Step 2/2 error: terraform failed: exit status 1
stderr:
Error: Error modifying Redshift Cluster (tf-redshift-cluster-2433427977291724999): InvalidClusterState: The changes cannot be applied because the cluster is already pending other changes.

--- FAIL: TestAccAWSRedshiftCluster_changeEncryption1 (2708.45s)

TestAccAWSRedshiftCluster_changeEncryption1: resource_aws_redshift_cluster_test.go:526: Step 1/2 error: terraform failed: exit status 1
stderr:
Error: Error waiting for Redshift Cluster state to be "available": timeout while waiting for state to become 'available' (last state: 'creating', timeout: 30m0s)
TestAccAWSRedshiftCluster_changeEncryption1: testing_new.go:22: WARNING: destroy failed, so remote objects may still exist and be subject to billing
TestAccAWSRedshiftCluster_changeEncryption1: testing_new.go:22: failed to destroy: terraform failed: exit status 1
stderr:
Error: Error deleting Redshift Cluster (tf-redshift-cluster-3731357849043997978): InvalidClusterState: There is an operation running on the Cluster. Please try to delete it at a later time.


--- FAIL: TestAccAWSAPIGatewayDomainName_disappears (18.81s)
--- FAIL: TestAccAWSAPIGatewayDomainName_RegionalCertificateArn (19.32s)
--- FAIL: TestAccAWSAPIGatewayDomainName_SecurityPolicy (21.95s)
--- FAIL: TestAccAWSAPIGatewayDomainName_Tags (22.43s)
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateArn (0.00s)
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateName (0.00s)
--- SKIP: TestAccAWSAPIGatewayDomainName_RegionalCertificateName (0.00s)

--- PASS: TestAccAWSAPIGatewayRestApi_api_key_source (226.06s)
--- PASS: TestAccAWSAPIGatewayRestApi_basic (134.75s)
--- PASS: TestAccAWSAPIGatewayRestApi_disappears (53.04s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (368.31s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private (73.51s)
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_VPCEndpoint (389.12s)
--- PASS: TestAccAWSAPIGatewayRestApi_openapi (121.97s)
--- PASS: TestAccAWSAPIGatewayRestApi_policy (181.53s)
--- PASS: TestAccAWSAPIGatewayRestApi_tags (137.97s)

--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (142.25s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (298.54s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (89.29s)
--- PASS: TestAccAWSAutoScalingGroup_basic (273.88s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (169.49s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (219.75s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (201.13s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (85.85s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (73.49s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (113.74s)
--- PASS: TestAccAWSAutoScalingGroup_launchTempPartitionNum (64.54s)
--- PASS: TestAccAWSAutoScalingGroup_LoadBalancers (773.84s)
--- PASS: TestAccAWSAutoScalingGroup_MaxInstanceLifetime (79.98s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (56.19s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (31.21s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (117.53s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (90.58s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (56.65s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (111.78s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (119.08s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_UpdateToZeroOnDemandBaseCapacity (95.04s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (80.60s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (105.46s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (97.93s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_WeightedCapacity (141.89s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (90.00s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (66.75s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (212.95s)
--- PASS: TestAccAWSAutoScalingGroup_tags (252.94s)
--- PASS: TestAccAWSAutoScalingGroup_TargetGroupArns (190.42s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (165.48s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (132.14s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (246.14s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer_ToTargetGroup (389.00s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (101.85s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (182.85s)

--- SKIP: TestAccAwsDxBgpPeer_basic (0.00s)

--- SKIP: TestAccAwsDxHostedPrivateVirtualInterface_AccepterTags (0.00s)
--- SKIP: TestAccAwsDxHostedPrivateVirtualInterface_basic (0.00s)

--- SKIP: TestAccAwsDxHostedPublicVirtualInterface_AccepterTags (0.00s)
--- SKIP: TestAccAwsDxHostedPublicVirtualInterface_basic (0.00s)

--- PASS: TestAccAwsDxHostedTransitVirtualInterface_serial (0.00s)

--- SKIP: TestAccAwsDxPrivateVirtualInterface_basic (0.00s)
--- SKIP: TestAccAwsDxPrivateVirtualInterface_DxGateway (0.00s)
--- SKIP: TestAccAwsDxPrivateVirtualInterface_Tags (0.00s)

--- SKIP: TestAccAwsDxPublicVirtualInterface_basic (0.00s)
--- SKIP: TestAccAwsDxPublicVirtualInterface_Tags (0.00s)

--- PASS: TestAccAwsDxTransitVirtualInterface_serial (0.00s)

--- PASS: TestAccAWSEksCluster_basic (907.42s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig (742.39s)
--- PASS: TestAccAWSEksCluster_Logging (970.24s)
--- PASS: TestAccAWSEksCluster_Tags (757.03s)
--- PASS: TestAccAWSEksCluster_Version (2498.54s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2399.53s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1505.64s)
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (1149.43s)
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (741.46s)

--- PASS: TestAccAWSElasticTranscoderPipeline_basic (21.16s)
--- PASS: TestAccAWSElasticTranscoderPipeline_disappears (43.35s)
--- PASS: TestAccAWSElasticTranscoderPipeline_kmsKey (21.96s)
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (49.08s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (54.75s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (28.59s)

--- PASS: TestAccAWSELB_AccessLogs_disabled (67.79s)
--- PASS: TestAccAWSELB_AccessLogs_enabled (72.23s)
--- PASS: TestAccAWSELB_availabilityZones (47.27s)
--- PASS: TestAccAWSELB_basic (29.35s)
--- PASS: TestAccAWSELB_ConnectionDraining (38.71s)
--- PASS: TestAccAWSELB_disappears (20.03s)
--- PASS: TestAccAWSELB_fullCharacterRange (26.84s)
--- PASS: TestAccAWSELB_generatedName (84.00s)
--- PASS: TestAccAWSELB_generatesNameForZeroValue (34.63s)
--- PASS: TestAccAWSELB_HealthCheck (86.10s)
--- PASS: TestAccAWSELB_InstanceAttaching (230.59s)
--- PASS: TestAccAWSELB_listener (223.37s)
--- PASS: TestAccAWSELB_Listener_SSLCertificateID_IAMServerCertificate (46.21s)
--- PASS: TestAccAWSELB_namePrefix (26.56s)
--- PASS: TestAccAWSELB_SecurityGroups (43.59s)
--- PASS: TestAccAWSELB_swap_subnets (173.29s)
--- PASS: TestAccAWSELB_tags (61.74s)
--- PASS: TestAccAWSELB_Timeout (22.31s)

--- PASS: TestAccAWSIAMServiceLinkedRole_basic (34.01s)
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix (40.56s)
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix_DiffSuppressFunc (37.34s)
--- PASS: TestAccAWSIAMServiceLinkedRole_Description (63.21s)

--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (60.55s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (32.44s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (81.80s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (99.15s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (67.05s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (142.92s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (84.89s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (62.36s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (105.31s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (66.58s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (64.07s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (146.77s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (20.93s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (65.28s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_tags (101.12s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (55.87s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (59.26s)

--- PASS: TestAccAWSLaunchTemplate_associatePublicIPAddress (83.65s)
--- PASS: TestAccAWSLaunchTemplate_basic (31.68s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (63.05s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (83.29s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (31.33s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (34.04s)
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (29.53s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (33.67s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (33.60s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (33.21s)
--- PASS: TestAccAWSLaunchTemplate_data (31.82s)
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (59.31s)
--- PASS: TestAccAWSLaunchTemplate_description (57.56s)
--- PASS: TestAccAWSLaunchTemplate_disappears (21.16s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (134.72s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (58.64s)
--- PASS: TestAccAWSLaunchTemplate_hibernation (59.26s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (28.72s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (86.37s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (35.81s)
--- PASS: TestAccAWSLaunchTemplate_metadataOptions (35.11s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (39.58s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (35.50s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (34.29s)
--- PASS: TestAccAWSLaunchTemplate_networkInterfaceAddresses (37.08s)
--- PASS: TestAccAWSLaunchTemplate_NetworkInterfaces_DeleteOnTermination (100.66s)
--- PASS: TestAccAWSLaunchTemplate_placement_partitionNum (60.23s)
--- PASS: TestAccAWSLaunchTemplate_tags (59.25s)
--- PASS: TestAccAWSLaunchTemplate_update (83.71s)
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (73.05s)

--- PASS: TestAccAWSLB_ALB_AccessLogs (329.02s)
--- PASS: TestAccAWSLB_ALB_AccessLogs_Prefix (318.35s)
--- PASS: TestAccAWSLB_ALB_basic (185.38s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (261.39s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDropInvalidHeaderFields (264.97s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (332.68s)
--- PASS: TestAccAWSLB_BackwardsCompatibility (170.58s)
--- PASS: TestAccAWSLB_generatedName (171.46s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (240.32s)
--- PASS: TestAccAWSLB_namePrefix (192.64s)
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (258.04s)
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (303.58s)
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (269.48s)
--- PASS: TestAccAWSLB_NLB_AccessLogs (403.36s)
--- PASS: TestAccAWSLB_NLB_AccessLogs_Prefix (364.13s)
--- PASS: TestAccAWSLB_NLB_basic (200.62s)
--- PASS: TestAccAWSLB_NLB_privateipv4address (233.26s)
--- PASS: TestAccAWSLB_noSecurityGroup (180.63s)
--- PASS: TestAccAWSLB_tags (273.41s)
--- PASS: TestAccAWSLB_updatedIpAddressType (233.49s)
--- PASS: TestAccAWSLB_updatedSecurityGroups (210.78s)
--- PASS: TestAccAWSLB_updatedSubnets (208.57s)

--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add (117.65s)
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove (266.67s)
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update (125.01s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1534.93s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (129.02s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (172.59s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (196.28s)
--- PASS: TestAccAWSRDSCluster_basic (130.78s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (117.84s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (223.60s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (129.21s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (196.30s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (379.32s)
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (391.32s)
--- PASS: TestAccAWSRDSCluster_encrypted (144.10s)
--- PASS: TestAccAWSRDSCluster_EngineMode (491.64s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (175.70s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (150.85s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (175.69s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (431.40s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1113.84s)
--- PASS: TestAccAWSRDSCluster_generatedName (123.63s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global (161.01s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned (140.09s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters (1786.18s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier (1854.96s)
--- PASS: TestAccAWSRDSCluster_iamAuth (164.19s)
--- PASS: TestAccAWSRDSCluster_kmsKey (157.66s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (5.47s)
--- PASS: TestAccAWSRDSCluster_Port (260.34s)
--- PASS: TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId (1520.00s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (355.43s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity (371.66s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (375.44s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (395.57s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (364.98s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (396.10s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (355.82s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (355.20s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (353.90s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (357.90s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (359.99s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (385.53s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (397.09s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (345.87s)
--- PASS: TestAccAWSRDSCluster_Tags (170.64s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (171.46s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (185.85s)
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)

--- FAIL: TestAccAWSRedshiftCluster_updateNodeCount (3856.79s)
--- PASS: TestAccAWSRedshiftCluster_basic (1105.37s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (1829.04s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (2372.63s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (903.00s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (910.07s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (341.18s)
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (292.30s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (335.58s)
--- PASS: TestAccAWSRedshiftCluster_tags (2016.62s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (2674.92s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (1348.21s)

--- PASS: TestAccAwsSecretsManagerSecret_basic (13.36s)
--- PASS: TestAccAwsSecretsManagerSecret_Description (27.34s)
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (32.48s)
--- PASS: TestAccAwsSecretsManagerSecret_policy (71.69s)
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (29.76s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (58.13s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (52.78s)
--- PASS: TestAccAwsSecretsManagerSecret_Tags (46.49s)
--- PASS: TestAccAwsSecretsManagerSecret_withNamePrefix (12.95s)

--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts (34.34s)
--- PASS: TestAccAWSSecurityGroupRule_Description_AllPorts_NonZeroPorts (49.49s)
--- PASS: TestAccAWSSecurityGroupRule_Egress (17.94s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (15.96s)
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (33.48s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (2.14s)
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (1.51s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (18.65s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (18.79s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (17.46s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Source_With_Account_Id (16.70s)
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (15.84s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (16.51s)
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (29.98s)
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (17.06s)
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (71.89s)
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (19.01s)
--- PASS: TestAccAWSSecurityGroupRule_MultipleRuleSearching_AllProtocolCrash (24.36s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (24.96s)
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (20.32s)
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (27.96s)
--- PASS: TestAccAWSSecurityGroupRule_Race (91.65s)
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (19.28s)
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (18.38s)

--- PASS: TestAccAwsSESIdentityNotificationTopic_basic (48.49s)

--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (285.83s)
--- PASS: TestAccAWSSpotFleetRequest_basic (254.36s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (583.46s)
--- PASS: TestAccAWSSpotFleetRequest_disappears (256.35s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (270.52s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (276.37s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (308.18s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (305.64s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (119.72s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (113.98s)
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (556.65s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (274.32s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (254.83s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (518.58s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (225.65s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (337.73s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (287.75s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (230.22s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (366.20s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (290.54s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (227.81s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (280.65s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (63.09s)
--- PASS: TestAccAWSSpotFleetRequest_tags (318.77s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (566.78s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (806.47s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (297.78s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (287.56s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (270.32s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (267.50s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (374.50s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (370.25s)
--- PASS: TestAccAWSSpotFleetRequest_zero_capacity (387.77s)
--- SKIP: TestAccAWSSpotFleetRequest_WithInstanceStoreAmi (0.00s)

--- PASS: TestAccAWSStorageGatewayNfsFileShare_basic (218.79s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_cacheAttributes (362.77s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ClientList (341.93s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_DefaultStorageClass (286.42s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_disappears (234.81s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_GuessMIMETypeEnabled (308.46s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSEncrypted (202.22s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSKeyArn (343.61s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_NFSFileShareDefaults (288.16s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ObjectACL (271.99s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ReadOnly (279.40s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_RequesterPays (301.11s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_Squash (282.60s)
--- PASS: TestAccAWSStorageGatewayNfsFileShare_tags (291.95s)

--- PASS: TestAccAWSStorageGatewaySmbFileShare_audit (275.16s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory (784.21s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess (214.37s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_cacheAttributes (349.17s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_caseSensitivity (311.92s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass (299.73s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_disappears (236.16s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled (289.10s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_InvalidUserList (811.70s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted (218.27s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn (340.97s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ObjectACL (319.78s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ReadOnly (270.53s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_RequesterPays (278.23s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_smb_acl (873.55s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Tags (216.43s)
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ValidUserList (891.18s)

--- PASS: TestAccAWSUser_basic (55.20s)
--- PASS: TestAccAWSUser_disappears (19.48s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (38.16s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (40.87s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (40.57s)
--- PASS: TestAccAWSUser_ForceDestroy_SigningCertificate (36.93s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (37.16s)
--- PASS: TestAccAWSUser_nameChange (59.98s)
--- PASS: TestAccAWSUser_pathChange (56.68s)
--- PASS: TestAccAWSUser_permissionsBoundary (111.45s)
--- PASS: TestAccAWSUser_tags (58.03s)

--- PASS: TestAccDataSourceAWSGlueScript_Language_Python (63.24s)
--- PASS: TestAccDataSourceAWSGlueScript_Language_Scala (57.09s)

--- PASS: TestAccDataSourceAwsVpcDhcpOptions_basic (67.74s)
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_Filter (100.59s)
```
