### PR TITLE
Update plan output to reflect publish(version, qualified_arn) when config changes

### DIFF
--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1953,7 +1953,6 @@ resource "aws_efs_access_point" "access_point_1" {
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
-  publish       = true
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   runtime       = "nodejs12.x"
@@ -2009,7 +2008,6 @@ resource "aws_efs_access_point" "access_point_2" {
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%s"
-  publish       = true
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   runtime       = "nodejs12.x"


### PR DESCRIPTION
When config changes, such as environment variables, a publish is triggered
and the state is updated with the new version, however as the values of
version and qualified_arn were not showing as computed any dependent resource,
such as aws_lambda_alias, would not be triggered to update.

I'm not too sure if the approach I've taken here is the best so I'll welcome any suggestions to improve this. I also couldn't find any test coverage around this area, if I've missed it please point me in the correct place. 

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #14934

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update plan output to reflect the changes to version and qualified_arn on config changes.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=TestAccAWSLambdaFunction_' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 15 -run=TestAccAWSLambdaFunction_ -timeout 120m
=== RUN   TestAccAWSLambdaFunction_basic
=== PAUSE TestAccAWSLambdaFunction_basic
=== RUN   TestAccAWSLambdaFunction_disappears
=== PAUSE TestAccAWSLambdaFunction_disappears
=== RUN   TestAccAWSLambdaFunction_concurrency
=== PAUSE TestAccAWSLambdaFunction_concurrency
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
=== PAUSE TestAccAWSLambdaFunction_concurrencyCycle
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccAWSLambdaFunction_encryptedEnvVariables
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_nilDeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_FileSystemConfig
=== PAUSE TestAccAWSLambdaFunction_FileSystemConfig
=== RUN   TestAccAWSLambdaFunction_tracingConfig
=== PAUSE TestAccAWSLambdaFunction_tracingConfig
=== RUN   TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== PAUSE TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== RUN   TestAccAWSLambdaFunction_Layers
=== PAUSE TestAccAWSLambdaFunction_Layers
=== RUN   TestAccAWSLambdaFunction_LayersUpdate
=== PAUSE TestAccAWSLambdaFunction_LayersUpdate
=== RUN   TestAccAWSLambdaFunction_VPC
=== PAUSE TestAccAWSLambdaFunction_VPC
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
=== PAUSE TestAccAWSLambdaFunction_VPCUpdate
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== RUN   TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== PAUSE TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
=== RUN   TestAccAWSLambdaFunction_EmptyVpcConfig
=== PAUSE TestAccAWSLambdaFunction_EmptyVpcConfig
=== RUN   TestAccAWSLambdaFunction_s3
=== PAUSE TestAccAWSLambdaFunction_s3
=== RUN   TestAccAWSLambdaFunction_localUpdate
=== PAUSE TestAccAWSLambdaFunction_localUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
=== PAUSE TestAccAWSLambdaFunction_s3Update_basic
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== RUN   TestAccAWSLambdaFunction_tags
=== PAUSE TestAccAWSLambdaFunction_tags
=== RUN   TestAccAWSLambdaFunction_runtimes
=== PAUSE TestAccAWSLambdaFunction_runtimes
=== CONT  TestAccAWSLambdaFunction_basic
=== CONT  TestAccAWSLambdaFunction_LayersUpdate
=== CONT  TestAccAWSLambdaFunction_localUpdate
=== CONT  TestAccAWSLambdaFunction_runtimes
=== CONT  TestAccAWSLambdaFunction_tags
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
=== CONT  TestAccAWSLambdaFunction_s3Update_basic
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
=== CONT  TestAccAWSLambdaFunction_Layers
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
=== CONT  TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables
=== CONT  TestAccAWSLambdaFunction_tracingConfig
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
=== CONT  TestAccAWSLambdaFunction_FileSystemConfig
=== CONT  TestAccAWSLambdaFunction_s3
2020/09/11 18:58:30 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/09/11 18:58:30 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/09/11 18:58:30 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
2020/09/11 18:58:30 [WARN] Truncating attribute path of 0 diagnostics for TypeSet
--- PASS: TestAccAWSLambdaFunction_s3 (63.39s)
=== CONT  TestAccAWSLambdaFunction_nilDeadLetterConfig
    TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables: resource_aws_lambda_function_test.go:686: [INFO] Got non-empty plan, as expected
2020/09/11 18:59:28 [DEBUG] Trying to get account information via sts:GetCallerIdentity
    TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables: resource_aws_lambda_function_test.go:686: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSLambdaFunction_basic (89.47s)
=== CONT  TestAccAWSLambdaFunction_EmptyVpcConfig
--- PASS: TestAccAWSLambdaFunction_KmsKeyArn_NoEnvironmentVariables (94.39s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (95.62s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (95.95s)
=== CONT  TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies
--- PASS: TestAccAWSLambdaFunction_Layers (117.34s)
=== CONT  TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_tracingConfig (128.85s)
=== CONT  TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_tags (132.00s)
=== CONT  TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (18.43s)
=== CONT  TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (171.39s)
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
--- PASS: TestAccAWSLambdaFunction_localUpdate (250.44s)
=== CONT  TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (250.76s)
=== CONT  TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (174.97s)
=== CONT  TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (286.15s)
=== CONT  TestAccAWSLambdaFunction_disappears
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (291.52s)
=== CONT  TestAccAWSLambdaFunction_concurrencyCycle
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (204.19s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (205.53s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (434.76s)
--- PASS: TestAccAWSLambdaFunction_runtimes (502.46s)
--- PASS: TestAccAWSLambdaFunction_VpcConfig_ProperIamDependencies (562.41s)
--- PASS: TestAccAWSLambdaFunction_versioned (650.41s)
--- PASS: TestAccAWSLambdaFunction_VPC (680.04s)
    TestAccAWSLambdaFunction_disappears: resource_aws_lambda_function_test.go:105: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSLambdaFunction_disappears (662.49s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (722.36s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (712.64s)
--- PASS: TestAccAWSLambdaFunction_concurrency (706.63s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (710.59s)
--- PASS: TestAccAWSLambdaFunction_envVariables (769.69s)



--- PASS: TestAccAWSLambdaFunction_FileSystemConfig (2008.68s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (2061.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2180.108s


...
```
