### PR TITLE
tests/provider: Add prechecks (Workspaces)

### DIFF
--- a/aws/resource_aws_workspaces_directory_test.go
+++ b/aws/resource_aws_workspaces_directory_test.go
@@ -62,7 +62,12 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 	iamRoleDataSourceName := "data.aws_iam_role.workspaces-default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
@@ -78,7 +83,7 @@ func TestAccAwsWorkspacesDirectory_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.0.restart_workspace", "true"),
 					resource.TestCheckResourceAttr(resourceName, "self_service_permissions.0.switch_running_mode", "false"),
 					resource.TestCheckResourceAttr(resourceName, "dns_ip_addresses.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "directory_type", "SIMPLE_AD"),
+					resource.TestCheckResourceAttr(resourceName, "directory_type", workspaces.WorkspaceDirectoryTypeSimpleAd),
 					resource.TestCheckResourceAttrPair(resourceName, "directory_name", directoryResourceName, "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "alias", directoryResourceName, "alias"),
 					resource.TestCheckResourceAttrPair(resourceName, "directory_id", directoryResourceName, "id"),
@@ -128,7 +133,12 @@ func TestAccAwsWorkspacesDirectory_disappears(t *testing.T) {
 	resourceName := "aws_workspaces_directory.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
@@ -151,7 +161,12 @@ func TestAccAwsWorkspacesDirectory_subnetIds(t *testing.T) {
 	resourceName := "aws_workspaces_directory.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
@@ -178,7 +193,12 @@ func TestAccAwsWorkspacesDirectory_tags(t *testing.T) {
 	resourceName := "aws_workspaces_directory.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesDirectoryDestroy,
 		Steps: []resource.TestStep{
@@ -372,6 +392,22 @@ func TestFlattenSelfServicePermissions(t *testing.T) {
 		if !reflect.DeepEqual(actual, c.expected) {
 			t.Fatalf("expected\n\n%#+v\n\ngot\n\n%#+v", c.expected, actual)
 		}
+	}
+}
+
+func testAccPreCheckWorkspacesDirectory(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).workspacesconn
+
+	input := &workspaces.DescribeWorkspaceDirectoriesInput{}
+
+	_, err := conn.DescribeWorkspaceDirectories(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_workspaces_workspace_test.go
+++ b/aws/resource_aws_workspaces_workspace_test.go
@@ -61,7 +61,12 @@ func TestAccAwsWorkspacesWorkspace_basic(t *testing.T) {
 	bundleDataSourceName := "data.aws_workspaces_bundle.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{
@@ -102,7 +107,12 @@ func TestAccAwsWorkspacesWorkspace_tags(t *testing.T) {
 	resourceName := "aws_workspaces_workspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{
@@ -148,7 +158,12 @@ func TestAccAwsWorkspacesWorkspace_workspaceProperties(t *testing.T) {
 	resourceName := "aws_workspaces_workspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{
@@ -207,7 +222,12 @@ func TestAccAwsWorkspacesWorkspace_workspaceProperties_runningModeAlwaysOn(t *te
 	resourceName := "aws_workspaces_workspace.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole") },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWorkspacesDirectory(t)
+			testAccPreCheckAWSDirectoryServiceSimpleDirectory(t)
+			testAccPreCheckHasIAMRole(t, "workspaces_DefaultRole")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsWorkspacesWorkspaceDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15129

On GovCloud, the `workspaces` service _is_ supported and so the new precheck added here does not skip the workspaces tests. However, the workspaces tests listed here rely on creating a simple AD directory using the `directoryservice` service. GovCloud does _not_ support creating simple AD directories and so the existing precheck `testAccPreCheckAWSDirectoryServiceSimpleDirectory()` is also used to avoid these tests from failing.

Workspaces tests that rely on creating a simple AD directory:
```
TestAccAwsWorkspacesDirectory_basic
TestAccAwsWorkspacesDirectory_disappears
TestAccAwsWorkspacesDirectory_subnetIds
TestAccAwsWorkspacesDirectory_tags
TestAccAwsWorkspacesWorkspace_basic
TestAccAwsWorkspacesWorkspace_tags
TestAccAwsWorkspacesWorkspace_workspaceProperties
TestAccAwsWorkspacesWorkspace_workspaceProperties_runningModeAlwaysOn
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing on GovCloud:

```
    resource_aws_directory_service_directory_test.go:475: skipping acceptance testing: ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 961c4b52-375a-4688-8dfd-8630212023f2 : RequestId: 961c4b52-375a-4688-8dfd-8630212023f2
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "961c4b52-375a-4688-8dfd-8630212023f2"
          },
          Message_: "Simple AD directory creation is currently not supported in this region. : RequestId: 961c4b52-375a-4688-8dfd-8630212023f2 : RequestId: 961c4b52-375a-4688-8dfd-8630212023f2",
          RequestId: "961c4b52-375a-4688-8dfd-8630212023f2"
        }
--- SKIP: TestAccAwsWorkspacesDirectory_basic (2.70s)
--- SKIP: TestAccAwsWorkspacesDirectory_disappears (2.69s)
--- SKIP: TestAccAwsWorkspacesDirectory_subnetIds (2.22s)
--- SKIP: TestAccAwsWorkspacesDirectory_tags (2.19s)
--- SKIP: TestAccAwsWorkspacesWorkspace_basic (2.60s)
--- SKIP: TestAccAwsWorkspacesWorkspace_tags (2.20s)
--- SKIP: TestAccAwsWorkspacesWorkspace_workspaceProperties (2.23s)
--- SKIP: TestAccAwsWorkspacesWorkspace_workspaceProperties_runningModeAlwaysOn (2.24s)
```

The output from acceptance testing on commercial/standard partition:

```
kommer snart
```
