### PR TITLE
Implement WAF Regional regex match set sweeper

### DIFF
--- a/aws/internal/service/wafregional/finder/finder.go
+++ b/aws/internal/service/wafregional/finder/finder.go
@@ -1,0 +1,15 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+)
+
+func RegexMatchSetByID(conn *wafregional.WAFRegional, id string) (*waf.RegexMatchSet, error) {
+	result, err := conn.GetRegexMatchSet(&waf.GetRegexMatchSetInput{
+		RegexMatchSetId: aws.String(id),
+	})
+
+	return result.RegexMatchSet, err
+}

--- a/aws/waf_helpers.go
+++ b/aws/waf_helpers.go
@@ -310,6 +310,15 @@ func flattenWafRegexMatchTuples(tuples []*waf.RegexMatchTuple) []interface{} {
 	return out
 }
 
+func expandWafRegexMatchTuple(tuple map[string]interface{}) *waf.RegexMatchTuple {
+	ftm := tuple["field_to_match"].([]interface{})
+	return &waf.RegexMatchTuple{
+		FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]interface{})),
+		RegexPatternSetId:  aws.String(tuple["regex_pattern_set_id"].(string)),
+		TextTransformation: aws.String(tuple["text_transformation"].(string)),
+	}
+}
+
 func diffWafRegexMatchSetTuples(oldT, newT []interface{}) []*waf.RegexMatchSetUpdate {
 	updates := make([]*waf.RegexMatchSetUpdate, 0)
 
@@ -321,28 +330,18 @@ func diffWafRegexMatchSetTuples(oldT, newT []interface{}) []*waf.RegexMatchSetUp
 			continue
 		}
 
-		ftm := tuple["field_to_match"].([]interface{})
 		updates = append(updates, &waf.RegexMatchSetUpdate{
-			Action: aws.String(waf.ChangeActionDelete),
-			RegexMatchTuple: &waf.RegexMatchTuple{
-				FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]interface{})),
-				RegexPatternSetId:  aws.String(tuple["regex_pattern_set_id"].(string)),
-				TextTransformation: aws.String(tuple["text_transformation"].(string)),
-			},
+			Action:          aws.String(waf.ChangeActionDelete),
+			RegexMatchTuple: expandWafRegexMatchTuple(tuple),
 		})
 	}
 
 	for _, nt := range newT {
 		tuple := nt.(map[string]interface{})
 
-		ftm := tuple["field_to_match"].([]interface{})
 		updates = append(updates, &waf.RegexMatchSetUpdate{
-			Action: aws.String(waf.ChangeActionInsert),
-			RegexMatchTuple: &waf.RegexMatchTuple{
-				FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]interface{})),
-				RegexPatternSetId:  aws.String(tuple["regex_pattern_set_id"].(string)),
-				TextTransformation: aws.String(tuple["text_transformation"].(string)),
-			},
+			Action:          aws.String(waf.ChangeActionInsert),
+			RegexMatchTuple: expandWafRegexMatchTuple(tuple),
 		})
 	}
 	return updates

--- a/aws/waf_token_handlers.go
+++ b/aws/waf_token_handlers.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -25,13 +25,12 @@ func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
 		var err error
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Failed to acquire change token: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("Failed to acquire change token: %w", err))
 		}
 
 		out, err = f(tokenOut.ChangeToken)
 		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "WAFStaleDataException" {
+			if tfawserr.ErrCodeEquals(err, waf.ErrCodeStaleDataException) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -42,7 +41,7 @@ func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 
 		if err != nil {
-			return nil, fmt.Errorf("error getting WAF change token: %s", err)
+			return nil, fmt.Errorf("error getting WAF change token: %w", err)
 		}
 
 		out, err = f(tokenOut.ChangeToken)

--- a/aws/wafregional_token_handlers.go
+++ b/aws/wafregional_token_handlers.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -28,13 +28,12 @@ func (t *WafRegionalRetryer) RetryWithToken(f withRegionalTokenFunc) (interface{
 
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Failed to acquire change token: %s", err))
+			return resource.NonRetryableError(fmt.Errorf("Failed to acquire change token: %w", err))
 		}
 
 		out, err = f(tokenOut.ChangeToken)
 		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "WAFStaleDataException" {
+			if tfawserr.ErrCodeEquals(err, waf.ErrCodeStaleDataException) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -45,7 +44,7 @@ func (t *WafRegionalRetryer) RetryWithToken(f withRegionalTokenFunc) (interface{
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 
 		if err != nil {
-			return nil, fmt.Errorf("error getting WAF Regional change token: %s", err)
+			return nil, fmt.Errorf("error getting WAF Regional change token: %w", err)
 		}
 
 		out, err = f(tokenOut.ChangeToken)


### PR DESCRIPTION
Implements sweeper for WAF Regional regex match set.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15122

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TESTARGS='-run=TestAccAWSWafRegionalRegexMatchSet'

--- PASS: TestAccAWSWafRegionalRegexMatchSet_serial (66.45s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/disappears (13.97s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/basic (15.14s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/changePatterns (24.67s)
    --- PASS: TestAccAWSWafRegionalRegexMatchSet_serial/noPatterns (12.66s)
```
