### PR TITLE
Td/aws_ssm_maintenance_window_target:TestAccAWSSSMMaintenanceWindowTarget_resourceGroup

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -172,8 +172,7 @@ func TestAccAWSSSMMaintenanceWindowTarget_resourceGroup(t *testing.T) {
 					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
 					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "resource-groups:ResourceTypeFilters"),
 					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "AWS::EC2::INSTANCE"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.1", "AWS::EC2::VPC"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "AWS::EC2::Instance"),
 					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "resource-groups:Name"),
 					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "targets.1.values.0", "resource-group-name"),
@@ -345,7 +344,7 @@ resource "aws_ssm_maintenance_window_target" "test" {
 
   targets {
     key    = "resource-groups:ResourceTypeFilters"
-    values = ["AWS::EC2::INSTANCE", "AWS::EC2::VPC"]
+    values = ["AWS::EC2::Instance"]
   }
 
   targets {

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -171,7 +171,7 @@ func TestAccAWSSSMMaintenanceWindowTarget_resourceGroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTargetExists(resourceName, &maint),
 					resource.TestCheckResourceAttr(resourceName, "targets.0.key", "resource-groups:ResourceTypeFilters"),
-					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.values.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "targets.0.values.0", "AWS::EC2::Instance"),
 					resource.TestCheckResourceAttr(resourceName, "targets.1.key", "resource-groups:Name"),
 					resource.TestCheckResourceAttr(resourceName, "targets.1.values.#", "1"),

--- a/website/docs/r/ssm_maintenance_window_target.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_target.html.markdown
@@ -51,7 +51,7 @@ resource "aws_ssm_maintenance_window_target" "target1" {
 
   targets {
     key    = "resource-groups:ResourceTypeFilters"
-    values = ["AWS::EC2::INSTANCE", "AWS::EC2::VPC"]
+    values = ["AWS::EC2::Instance"]
   }
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #14511

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindowTarget_resourceGroup'
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_resourceGroup (65.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       65.702s
...
```
