### PR TITLE
tests/provider: Lint AWSAT002 ignore (validators_test)

### DIFF
--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -1179,7 +1179,7 @@ func TestValidateEmrCustomAmiId(t *testing.T) {
 		ErrCount int
 	}{
 		{
-			Value:    "ami-dbcf88b1",
+			Value:    "ami-dbcf88b1", //lintignore:AWSAT002
 			ErrCount: 0,
 		},
 		{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #12994

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This is a unit-test change. Since it is a unit-test, it is okay to include a hardcoded AMI, which is not actually used. Thus, the lint finding is ignored.

```
% go test ./...
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	23.669s
```