### PR TITLE
tests/provider: Fix, Enable AWSAT002

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -99,6 +99,7 @@ awsproviderlint:
 		-AT007 \
 		-AT008 \
 		-AWSAT001 \
+		-AWSAT002 \
 		-AWSAT004 \
 		-AWSR001 \
 		-AWSR002 \

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -558,13 +558,6 @@ func testAccRegionPreCheck(t *testing.T, region string) {
 	}
 }
 
-// testAccPartitionPreCheck checks that the test partition is the specified partition.
-func testAccPartitionPreCheck(t *testing.T, partition string) {
-	if testAccGetPartition() != partition {
-		t.Skipf("skipping tests; partition (%s) does not equal %s", testAccGetPartition(), partition)
-	}
-}
-
 func testAccOrganizationsAccountPreCheck(t *testing.T) {
 	conn := testAccProvider.Meta().(*AWSClient).organizationsconn
 	input := &organizations.DescribeOrganizationInput{}

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -922,30 +922,6 @@ func TestAccAWSInstance_ipv6_supportAddressCountWithIpv4(t *testing.T) {
 	})
 }
 
-func TestAccAWSInstance_multipleRegions(t *testing.T) {
-	var v ec2.Instance
-	resourceName := "aws_instance.test"
-
-	// record the initialized providers so that we can use them to
-	// check for the instances in each region
-	var providers []*schema.Provider
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPartitionPreCheck(t, "aws") },
-		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckWithProviders(testAccCheckInstanceDestroyWithProvider, &providers),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstanceConfigMultipleRegions,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceExistsWithProvider(resourceName, &v, testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					testAccCheckInstanceExistsWithProvider("aws_instance.test2", &v, testAccAwsRegionProviderFunc("us-east-1", &providers)),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
@@ -1398,7 +1374,7 @@ func TestAccAWSInstance_rootBlockDeviceMismatch(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccRegionPreCheck(t, "us-west-2") },
+		PreCheck:     func() { testAccPreCheck(t); testAccRegionPreCheck(t, "us-west-2") }, //lintignore:AWSAT003
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -3833,29 +3809,6 @@ resource "aws_instance" "test" {
 `, rName)
 }
 
-const testAccInstanceConfigMultipleRegions = `
-provider "awswest" {
-  region = "us-west-2"
-}
-
-provider "awseast" {
-  region = "us-east-1"
-}
-resource "aws_instance" "test" {
-  # us-west-2
-  provider      = "awswest"
-  ami           = "ami-4fccb37f"
-  instance_type = "m1.small"
-}
-
-resource "aws_instance" "test2" {
-  # us-east-1
-  provider      = "awseast"
-  ami           = "ami-8c6ea9e4"
-  instance_type = "m1.small"
-}
-`
-
 func testAccCheckInstanceConfigTags() string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
@@ -4316,7 +4269,7 @@ resource "aws_instance" "test" {
     volume_size = 13
   }
 }
-`
+` //lintignore:AWSAT002
 }
 
 func testAccInstanceConfigForceNewAndTagsDrift(rName string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #12994 

In this PR:

1. ignore the `AWSAT002` and `AWSAT003` errors in a `us-west-2` specific regression (`TestAccAWSInstance_rootBlockDeviceMismatch`),
2. rework a test for either GovCloud or commercial partition (`TestAccAWSInstance_multipleRegions`),
3. remove `testAccPartitionPreCheck()` since it was only used in `TestAccAWSInstance_multipleRegions`, and
3. enable `AWSAT002`

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing on GovCloud:

```
    provider_test.go:557: skipping tests; AWS_DEFAULT_REGION (us-gov-west-1) does not equal us-west-2
--- SKIP: TestAccAWSInstance_rootBlockDeviceMismatch (1.50s)
--- PASS: TestAccAWSInstance_multipleRegions (111.71s)
```

The output from acceptance testing on commercial:

```
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (99.15s)
--- PASS: TestAccAWSInstance_multipleRegions (130.40s)
```
