### PR TITLE
service/directconnect: Replace EqSe2 location with EqSe2-EQ

### DIFF
--- a/aws/resource_aws_dx_connection_association_test.go
+++ b/aws/resource_aws_dx_connection_association_test.go
@@ -85,13 +85,13 @@ func testAccDxConnectionAssociationConfig(rName string) string {
 resource "aws_dx_connection" "test" {
   name      = "tf-dx-%s"
   bandwidth = "1Gbps"
-  location  = "EqSe2"
+  location  = "EqSe2-EQ"
 }
 
 resource "aws_dx_lag" "test" {
   name                  = "tf-dx-%s"
   connections_bandwidth = "1Gbps"
-  location              = "EqSe2"
+  location              = "EqSe2-EQ"
   force_destroy         = true
 }
 
@@ -107,19 +107,19 @@ func testAccDxConnectionAssociationConfig_multiConns(rName string) string {
 resource "aws_dx_connection" "test1" {
   name      = "tf-dxconn1-%s"
   bandwidth = "1Gbps"
-  location  = "EqSe2"
+  location  = "EqSe2-EQ"
 }
 
 resource "aws_dx_connection" "test2" {
   name      = "tf-dxconn2-%s"
   bandwidth = "1Gbps"
-  location  = "EqSe2"
+  location  = "EqSe2-EQ"
 }
 
 resource "aws_dx_lag" "test" {
   name                  = "tf-dx-%s"
   connections_bandwidth = "1Gbps"
-  location              = "EqSe2"
+  location              = "EqSe2-EQ"
   force_destroy         = true
 }
 

--- a/aws/resource_aws_dx_connection_test.go
+++ b/aws/resource_aws_dx_connection_test.go
@@ -26,7 +26,7 @@ func TestAccAWSDxConnection_basic(t *testing.T) {
 					testAccCheckAwsDxConnectionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", connectionName),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth", "1Gbps"),
-					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2"),
+					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2-EQ"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -116,7 +116,7 @@ func testAccDxConnectionConfig(n string) string {
 resource "aws_dx_connection" "test" {
   name      = "%s"
   bandwidth = "1Gbps"
-  location  = "EqSe2"
+  location  = "EqSe2-EQ"
 }
 `, n)
 }
@@ -126,7 +126,7 @@ func testAccDxConnectionConfig_tags(n string) string {
 resource "aws_dx_connection" "test" {
   name      = "%s"
   bandwidth = "1Gbps"
-  location  = "EqSe2"
+  location  = "EqSe2-EQ"
 
   tags = {
     Environment = "production"
@@ -141,7 +141,7 @@ func testAccDxConnectionConfig_tagsChanged(n string) string {
 resource "aws_dx_connection" "test" {
   name      = "%s"
   bandwidth = "1Gbps"
-  location  = "EqSe2"
+  location  = "EqSe2-EQ"
 
   tags = {
     Usage = "changed"

--- a/aws/resource_aws_dx_lag_test.go
+++ b/aws/resource_aws_dx_lag_test.go
@@ -27,7 +27,7 @@ func TestAccAWSDxLag_basic(t *testing.T) {
 					testAccCheckAwsDxLagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", lagName1),
 					resource.TestCheckResourceAttr(resourceName, "connections_bandwidth", "1Gbps"),
-					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2"),
+					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2-EQ"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -43,7 +43,7 @@ func TestAccAWSDxLag_basic(t *testing.T) {
 					testAccCheckAwsDxLagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", lagName2),
 					resource.TestCheckResourceAttr(resourceName, "connections_bandwidth", "1Gbps"),
-					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2"),
+					resource.TestCheckResourceAttr(resourceName, "location", "EqSe2-EQ"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
@@ -138,7 +138,7 @@ func testAccDxLagConfig(n string) string {
 resource "aws_dx_lag" "test" {
   name                  = "%s"
   connections_bandwidth = "1Gbps"
-  location              = "EqSe2"
+  location              = "EqSe2-EQ"
   force_destroy         = true
 }
 `, n)
@@ -149,7 +149,7 @@ func testAccDxLagConfig_tags(n string) string {
 resource "aws_dx_lag" "test" {
   name                  = "%s"
   connections_bandwidth = "1Gbps"
-  location              = "EqSe2"
+  location              = "EqSe2-EQ"
   force_destroy         = true
 
   tags = {
@@ -165,7 +165,7 @@ func testAccDxLagConfig_tagsChanged(n string) string {
 resource "aws_dx_lag" "test" {
   name                  = "%s"
   connections_bandwidth = "1Gbps"
-  location              = "EqSe2"
+  location              = "EqSe2-EQ"
   force_destroy         = true
 
   tags = {

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -536,7 +536,7 @@ For example, given this previous configuration:
 resource "aws_dx_lag" "example" {
   name                  = "example"
   connections_bandwidth = "1Gbps"
-  location              = "EqSe2"
+  location              = "EqSe2-EQ"
   number_of_connections = 1
 }
 ```
@@ -547,13 +547,13 @@ An updated configuration:
 resource "aws_dx_connection" "example" {
   name      = "example"
   bandwidth = "1Gbps"
-  location  = "EqSe2"
+  location  = "EqSe2-EQ"
 }
 
 resource "aws_dx_lag" "example" {
   name                  = "example"
   connections_bandwidth = "1Gbps"
-  location              = "EqSe2"
+  location              = "EqSe2-EQ"
 }
 
 resource "aws_dx_connection_association" "example" {

--- a/website/docs/r/dx_connection_association.html.markdown
+++ b/website/docs/r/dx_connection_association.html.markdown
@@ -16,13 +16,13 @@ Associates a Direct Connect Connection with a LAG.
 resource "aws_dx_connection" "example" {
   name      = "example"
   bandwidth = "1Gbps"
-  location  = "EqSe2"
+  location  = "EqSe2-EQ"
 }
 
 resource "aws_dx_lag" "example" {
   name                  = "example"
   connections_bandwidth = "1Gbps"
-  location              = "EqSe2"
+  location              = "EqSe2-EQ"
 }
 
 resource "aws_dx_connection_association" "example" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15151

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDxConnection_basic (24.77s)
--- PASS: TestAccAWSDxConnectionAssociation_basic (25.44s)
--- PASS: TestAccAWSDxConnectionAssociation_multiConns (25.67s)
--- PASS: TestAccAWSDxConnection_tags (34.96s)
--- PASS: TestAccAWSDxLag_basic (36.35s)
--- PASS: TestAccAWSDxLag_tags (47.70s)
```
