### PR TITLE
resource/aws_elastic_beanstalk_environment: Handle Terminated status on deletion, use IAM Instance Profile and custom service role in testing

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -779,8 +779,11 @@ func deleteElasticBeanstalkEnvironment(conn *elasticbeanstalk.ElasticBeanstalk, 
 
 func waitForElasticBeanstalkEnvironmentReady(conn *elasticbeanstalk.ElasticBeanstalk, id string, timeout, pollInterval time.Duration, startTime time.Time) error {
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"Launching", "Updating"},
-		Target:       []string{"Ready"},
+		Pending: []string{
+			elasticbeanstalk.EnvironmentStatusLaunching,
+			elasticbeanstalk.EnvironmentStatusUpdating,
+		},
+		Target:       []string{elasticbeanstalk.EnvironmentStatusReady},
 		Refresh:      elasticBeanstalkEnvironmentStateRefreshFunc(conn, id, startTime),
 		Timeout:      timeout,
 		Delay:        10 * time.Second,
@@ -794,8 +797,15 @@ func waitForElasticBeanstalkEnvironmentReady(conn *elasticbeanstalk.ElasticBeans
 
 func waitForElasticBeanstalkEnvironmentReadyIgnoreErrorEvents(conn *elasticbeanstalk.ElasticBeanstalk, id string, timeout, pollInterval time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"Launching", "Updating"},
-		Target:       []string{"Ready"},
+		Pending: []string{
+			elasticbeanstalk.EnvironmentStatusLaunching,
+			elasticbeanstalk.EnvironmentStatusTerminating,
+			elasticbeanstalk.EnvironmentStatusUpdating,
+		},
+		Target: []string{
+			elasticbeanstalk.EnvironmentStatusReady,
+			elasticbeanstalk.EnvironmentStatusTerminated,
+		},
 		Refresh:      elasticBeanstalkEnvironmentIgnoreErrorEventsStateRefreshFunc(conn, id),
 		Timeout:      timeout,
 		Delay:        10 * time.Second,

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -780,6 +780,76 @@ resource "aws_elastic_beanstalk_application" "test" {
   description = "tf-test-desc"
   name        = %[1]q
 }
+
+# Create custom service role per test to remove dependency on
+# Service-Linked Role existing.
+resource "aws_iam_role" "service_role" {
+  name = "%[1]s-service"
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "sts:ExternalId" = "elasticbeanstalk"
+        }
+      }
+      Effect = "Allow"
+      Principal = {
+        Service = "elasticbeanstalk.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "service_role-AWSElasticBeanstalkEnhancedHealth" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth"
+  role       = aws_iam_role.service_role.id
+}
+
+resource "aws_iam_role_policy_attachment" "service_role-AWSElasticBeanstalkService" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSElasticBeanstalkService"
+  role       = aws_iam_role.service_role.id
+}
+
+# Amazon Linux 2 environments require IAM Instance Profile.
+resource "aws_iam_role" "instance_profile" {
+  name = "%[1]s-instance"
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "instance_profile-AWSElasticBeanstalkWebTier" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSElasticBeanstalkWebTier"
+  role       = aws_iam_role.instance_profile.id
+}
+
+resource "aws_iam_role_policy_attachment" "instance_profile-AWSElasticBeanstalkWorkerTier" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSElasticBeanstalkWorkerTier"
+  role       = aws_iam_role.instance_profile.id
+}
+
+# Since the IAM Instance Profile is required anyways, also use it to
+# ensure IAM Role permissions for both roles are attached.
+resource "aws_iam_instance_profile" "test" {
+  depends_on = [
+    aws_iam_role_policy_attachment.instance_profile-AWSElasticBeanstalkWebTier,
+    aws_iam_role_policy_attachment.instance_profile-AWSElasticBeanstalkWorkerTier,
+    aws_iam_role_policy_attachment.service_role-AWSElasticBeanstalkEnhancedHealth,
+    aws_iam_role_policy_attachment.service_role-AWSElasticBeanstalkService,
+  ]
+
+  name = %[1]q
+  role = aws_iam_role.instance_profile.name
+}
 `, rName)
 }
 
@@ -812,6 +882,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
   }
 }
 `, rName)
@@ -847,6 +929,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
   }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
+  }
 }
 `, rName)
 }
@@ -880,6 +974,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
   }
 
   setting {
@@ -926,21 +1032,6 @@ resource "aws_elastic_beanstalk_environment" "test" {
 
 func testAccBeanstalkWorkerEnvConfig(rName string) string {
 	return testAccBeanstalkEnvConfigBase(rName) + fmt.Sprintf(`
-resource "aws_iam_instance_profile" "test" {
-  name = %[1]q
-  role = aws_iam_role.test.name
-}
-
-resource "aws_iam_role" "test" {
-  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"ec2.${data.aws_partition.current.dns_suffix}\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
-  name               = %[1]q
-}
-
-resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSElasticBeanstalkWorkerTier"
-  role       = aws_iam_role.test.id
-}
-
 resource "aws_elastic_beanstalk_environment" "test" {
   application         = aws_elastic_beanstalk_application.test.name
   name                = %[1]q
@@ -976,6 +1067,12 @@ resource "aws_elastic_beanstalk_environment" "test" {
     name      = "IamInstanceProfile"
     value     = aws_iam_instance_profile.test.name
   }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
+  }
 }
 `, rName)
 }
@@ -1010,6 +1107,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
   }
 }
 `, rName)
@@ -1053,6 +1162,18 @@ resource "aws_elastic_beanstalk_configuration_template" "test" {
   }
 
   setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
+  }
+
+  setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "TEMPLATE"
     value     = %[2]d
@@ -1090,6 +1211,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
   }
 
   setting {
@@ -1147,6 +1280,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     value     = aws_security_group.test.id
   }
 
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
+  }
+
   tags = {
     firstTag  = %[2]q
     secondTag = %[3]q
@@ -1184,6 +1329,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
   }
 }
 
@@ -1224,6 +1381,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
   }
 }
 
@@ -1283,6 +1452,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
   }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
+  }
 }
 `, rName)
 }
@@ -1335,6 +1516,18 @@ resource "aws_elastic_beanstalk_environment" "test" {
     name      = "SecurityGroups"
     value     = aws_security_group.test.id
   }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
+  }
 }
 `, rName)
 }
@@ -1348,36 +1541,6 @@ resource "aws_sqs_queue" "test" {
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
-}
-
-resource "aws_iam_instance_profile" "test" {
-  name = %[1]q
-  role = aws_iam_role.test.name
-}
-
-resource "aws_iam_role" "test" {
-  name = %[1]q
-
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-               "Service": "ec2.${data.aws_partition.current.dns_suffix}"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
-    ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSElasticBeanstalkWorkerTier"
-  role       = aws_iam_role.test.id
 }
 
 resource "aws_elastic_beanstalk_environment" "test" {
@@ -1478,12 +1641,6 @@ resource "aws_elastic_beanstalk_environment" "test" {
 
   setting {
     namespace = "aws:elasticbeanstalk:environment"
-    name      = "ServiceRole"
-    value     = "aws-elasticbeanstalk-service-role"
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:environment"
     name      = "EnvironmentType"
     value     = "LoadBalanced"
   }
@@ -1510,6 +1667,12 @@ resource "aws_elastic_beanstalk_environment" "test" {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "IamInstanceProfile"
     value     = aws_iam_instance_profile.test.name
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = aws_iam_role.service_role.name
   }
 
   setting {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15155

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_elastic_beanstalk_environment: Skip `Terminated` status errors on deletion
```

Previously:

```
=== CONT  TestAccAWSBeanstalkEnv_basic
TestAccAWSBeanstalkEnv_basic: resource_aws_elastic_beanstalk_environment_test.go:81: Step 1/2 error: terraform failed: exit status 1
stderr:
Error: Error waiting for Elastic Beanstalk Environment (e-scpzxse7ei) to become ready: 2 errors occurred:
  * 2020-09-15 07:48:42.231 +0000 UTC (e-scpzxse7ei) : Environment must have instance profile associated with it.
  * 2020-09-15 07:48:42.343 +0000 UTC (e-scpzxse7ei) : Failed to launch environment.
TestAccAWSBeanstalkEnv_basic: testing_new.go:22: WARNING: destroy failed, so remote objects may still exist and be subject to billing
TestAccAWSBeanstalkEnv_basic: testing_new.go:22: failed to destroy: terraform failed: exit status 1
stderr:
Error: error waiting for Elastic Beanstalk Environment "e-scpzxse7ei" to be ready before terminating: unexpected state 'Terminated', wanted target 'Ready'. last error: %!s(<nil>)
--- FAIL: TestAccAWSBeanstalkEnv_basic (31.41s)
```

After fixing the IAM Instance Profile error, received these two types of failures still:

```
=== CONT  TestAccAWSBeanstalkEnv_tier
    resource_aws_elastic_beanstalk_environment_test.go:118: Step 1/2 error: terraform failed: exit status 1

        stderr:

        Error: Error waiting for Elastic Beanstalk Environment (e-3tebzj5j3h) to become ready: 1 error occurred:
          * 2020-09-15 17:10:28.142 +0000 UTC (e-3tebzj5j3h) : Failed to launch environment.

    testing_new.go:22: WARNING: destroy failed, so remote objects may still exist and be subject to billing
    testing_new.go:22: failed to destroy: terraform failed: exit status 1

        stderr:

        Error: error waiting for Elastic Beanstalk Environment "e-3tebzj5j3h" to be ready before terminating: unexpected state 'Terminated', wanted target 'Ready'. last error: %!s(<nil>)
```

To handle the destroy error, added the `Terminating` and `Terminated` handling to the resource deletion polling. Looking in the console, the opaque `Failed to launch environment.` error details were found in this other `INFO` level event:

```
Operation failed because the environment needs a service role. You made the call without one, and you're missing the permission to create a service-linked role for this account. Repeat the call and provide a service role. Alternatively, ask your account administrator to create the account's service-linked role, and then repeat the call.
```

These test configurations were dependent on the Elastic Beanstalk IAM Service-Linked Role since they did not declare a custom IAM Role for the service role. While the credentials in use did have permissions, there was a delay before the EB created SLR was ready, introducing a few test failures until the rest would succeed once the SLR was propagated. This SLR is also challenging because the `TestAccAWSIAMServiceLinkedRole_basic` testing explicitly deletes it. Rather than keep reliance on this flaky shared resource, instead opted to customize the service role.

Output from acceptance testing:

```
--- PASS: TestAccAWSBeanstalkEnv_basic (462.19s)
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (632.10s)
--- PASS: TestAccAWSBeanstalkEnv_config (519.50s)
--- PASS: TestAccAWSBeanstalkEnv_platformArn (465.62s)
--- PASS: TestAccAWSBeanstalkEnv_resource (502.50s)
--- PASS: TestAccAWSBeanstalkEnv_settingWithJsonValue (381.12s)
--- PASS: TestAccAWSBeanstalkEnv_settings_update (716.57s)
--- PASS: TestAccAWSBeanstalkEnv_tags (694.50s)
--- PASS: TestAccAWSBeanstalkEnv_template_change (612.67s)
--- PASS: TestAccAWSBeanstalkEnv_tier (726.73s)
--- PASS: TestAccAWSBeanstalkEnv_version_label (534.55s)
```
