### PR TITLE
[WIP] r|d/aws_instance: Handle 'credit_specification' for T4g instance family.

### DIFF
--- a/aws/internal/service/ec2/finder/finder.go
+++ b/aws/internal/service/ec2/finder/finder.go
@@ -55,6 +55,25 @@ func ClientVpnRouteByID(conn *ec2.EC2, routeID string) (*ec2.DescribeClientVpnRo
 	return ClientVpnRoute(conn, endpointID, targetSubnetID, destinationCidr)
 }
 
+// InstanceTypeInfo returns the details of the specified instance type.
+// Returns nil if no instance type details are found.
+func InstanceTypeInfo(conn *ec2.EC2, instanceType string) (*ec2.InstanceTypeInfo, error) {
+	input := &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: aws.StringSlice([]string{instanceType}),
+	}
+
+	output, err := conn.DescribeInstanceTypes(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.InstanceTypes) == 0 {
+		return nil, nil
+	}
+
+	return output.InstanceTypes[0], nil
+}
+
 // SecurityGroupByID looks up a security group by ID. When not found, returns nil and potentially an API error.
 func SecurityGroupByID(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
 	req := &ec2.DescribeSecurityGroupsInput{

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -2981,6 +2981,173 @@ func TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint(t *t
 	})
 }
 
+func TestAccAWSInstance_creditSpecification_unknownCpuCredits_t4g(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_unknownCpuCredits_arm64(rName, "t4g.micro"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecificationT4g_unspecifiedDefaultsToUnlimited(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_unspecified_t4g(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecificationT4g_standardCpuCredits(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t4g(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "standard"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInstanceConfig_creditSpecification_unspecified_t4g(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "standard"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecificationT4g_unlimitedCpuCredits(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t4g(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInstanceConfig_creditSpecification_unspecified_t4g(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecificationT4g_updateCpuCredits(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t4g(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "standard"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t4g(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t4g(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "standard"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_disappears(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
@@ -4773,6 +4940,23 @@ resource "aws_instance" "test" {
 `
 }
 
+func testAccInstanceConfig_creditSpecification_unspecified_t4g(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinux2Arm64HvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(rName, false),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-arm64-ami-minimal-hvm-ebs.id
+  instance_type = "t4g.micro"
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
 func testAccInstanceConfig_creditSpecification_standardCpuCredits(rName string) string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + `
 resource "aws_instance" "test" {
@@ -4799,6 +4983,27 @@ resource "aws_instance" "test" {
   }
 }
 `
+}
+
+func testAccInstanceConfig_creditSpecification_standardCpuCredits_t4g(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinux2Arm64HvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(rName, false),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-arm64-ami-minimal-hvm-ebs.id
+  instance_type = "t4g.micro"
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
+}
+`, rName))
 }
 
 func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rName string) string {
@@ -4829,6 +5034,27 @@ resource "aws_instance" "test" {
 `
 }
 
+func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t4g(rName string) string {
+	return composeConfig(
+		testAccLatestAmazonLinux2Arm64HvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(rName, false),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-arm64-ami-minimal-hvm-ebs.id
+  instance_type = "t4g.micro"
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+}
+`, rName))
+}
+
 func testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rName string) string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + `
 resource "aws_instance" "test" {
@@ -4853,6 +5079,25 @@ resource "aws_instance" "test" {
   credit_specification {}
 }
 `, instanceType)
+}
+
+func testAccInstanceConfig_creditSpecification_unknownCpuCredits_arm64(rName, instanceType string) string {
+	return composeConfig(
+		testAccLatestAmazonLinux2Arm64HvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(rName, false),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-arm64-ami-minimal-hvm-ebs.id
+  instance_type = %[2]q
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+
+  credit_specification {}
+}
+`, rName, instanceType))
 }
 
 func testAccInstanceConfig_UserData_Unspecified(rName string) string {
@@ -4893,6 +5138,33 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
   filter {
     name   = "root-device-type"
     values = ["ebs"]
+  }
+}
+`
+}
+
+// testAccLatestAmazonLinux2Arm64HvmEbsAmiConfig returns the configuration for a data source that
+// describes the latest Amazon Linux 2 Arm64 AMI using HVM virtualization and an EBS root device.
+// The data source is named 'amzn2-arm64-ami-minimal-hvm-ebs'.
+func testAccLatestAmazonLinux2Arm64HvmEbsAmiConfig() string {
+	return `
+data "aws_ami" "amzn2-arm64-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
   }
 }
 `

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -197,7 +197,7 @@ Credit specification can be applied/modified to the EC2 Instance at any time.
 
 The `credit_specification` block supports the following:
 
-* `cpu_credits` - (Optional) The credit option for CPU usage. Can be `"standard"` or `"unlimited"`. T3 instances are launched as unlimited by default. T2 instances are launched as standard by default.
+* `cpu_credits` - (Optional) The credit option for CPU usage. Can be `"standard"` or `"unlimited"`. T3 and T4 instances are launched as unlimited by default. T2 instances are launched as standard by default.
 
 ### Metadata Options
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15156.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_instance: Handle `credit_specification` for the T4g instance family
data-source/aws_instance: Handle `credit_specification` for the T4g instance family
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSInstance_ -timeout 120m
=== RUN   TestAccAWSInstance_inDefaultVpcBySgName
=== PAUSE TestAccAWSInstance_inDefaultVpcBySgName
=== RUN   TestAccAWSInstance_inDefaultVpcBySgId
=== PAUSE TestAccAWSInstance_inDefaultVpcBySgId
=== RUN   TestAccAWSInstance_inEc2Classic
    resource_aws_instance_test.go:210: not running EC2-Classic test
--- SKIP: TestAccAWSInstance_inEc2Classic (0.00s)
=== RUN   TestAccAWSInstance_basic
=== PAUSE TestAccAWSInstance_basic
=== RUN   TestAccAWSInstance_atLeastOneOtherEbsVolume
=== PAUSE TestAccAWSInstance_atLeastOneOtherEbsVolume
=== RUN   TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
=== PAUSE TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
=== RUN   TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType
=== PAUSE TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType
=== RUN   TestAccAWSInstance_RootBlockDevice_KmsKeyArn
=== PAUSE TestAccAWSInstance_RootBlockDevice_KmsKeyArn
=== RUN   TestAccAWSInstance_userDataBase64
=== PAUSE TestAccAWSInstance_userDataBase64
=== RUN   TestAccAWSInstance_GP2IopsDevice
=== PAUSE TestAccAWSInstance_GP2IopsDevice
=== RUN   TestAccAWSInstance_GP2WithIopsValue
=== PAUSE TestAccAWSInstance_GP2WithIopsValue
=== RUN   TestAccAWSInstance_blockDevices
=== PAUSE TestAccAWSInstance_blockDevices
=== RUN   TestAccAWSInstance_rootInstanceStore
=== PAUSE TestAccAWSInstance_rootInstanceStore
=== RUN   TestAccAWSInstance_noAMIEphemeralDevices
=== PAUSE TestAccAWSInstance_noAMIEphemeralDevices
=== RUN   TestAccAWSInstance_sourceDestCheck
=== PAUSE TestAccAWSInstance_sourceDestCheck
=== RUN   TestAccAWSInstance_disableApiTermination
=== PAUSE TestAccAWSInstance_disableApiTermination
=== RUN   TestAccAWSInstance_vpc
=== PAUSE TestAccAWSInstance_vpc
=== RUN   TestAccAWSInstance_outpost
=== PAUSE TestAccAWSInstance_outpost
=== RUN   TestAccAWSInstance_placementGroup
=== PAUSE TestAccAWSInstance_placementGroup
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
=== PAUSE TestAccAWSInstance_ipv6_supportAddressCount
=== RUN   TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
=== PAUSE TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
=== RUN   TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
=== PAUSE TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
=== RUN   TestAccAWSInstance_multipleRegions
=== PAUSE TestAccAWSInstance_multipleRegions
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
=== PAUSE TestAccAWSInstance_NetworkInstanceSecurityGroups
=== RUN   TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
=== PAUSE TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
=== PAUSE TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
=== RUN   TestAccAWSInstance_tags
=== PAUSE TestAccAWSInstance_tags
=== RUN   TestAccAWSInstance_volumeTags
=== PAUSE TestAccAWSInstance_volumeTags
=== RUN   TestAccAWSInstance_volumeTagsComputed
=== PAUSE TestAccAWSInstance_volumeTagsComputed
=== RUN   TestAccAWSInstance_instanceProfileChange
=== PAUSE TestAccAWSInstance_instanceProfileChange
=== RUN   TestAccAWSInstance_withIamInstanceProfile
=== PAUSE TestAccAWSInstance_withIamInstanceProfile
=== RUN   TestAccAWSInstance_privateIP
=== PAUSE TestAccAWSInstance_privateIP
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
=== PAUSE TestAccAWSInstance_associatePublicIPAndPrivateIP
=== RUN   TestAccAWSInstance_Empty_PrivateIP
=== PAUSE TestAccAWSInstance_Empty_PrivateIP
=== RUN   TestAccAWSInstance_keyPairCheck
=== PAUSE TestAccAWSInstance_keyPairCheck
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
=== PAUSE TestAccAWSInstance_rootBlockDeviceMismatch
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
=== PAUSE TestAccAWSInstance_forceNewAndTagsDrift
=== RUN   TestAccAWSInstance_changeInstanceType
=== PAUSE TestAccAWSInstance_changeInstanceType
=== RUN   TestAccAWSInstance_EbsRootDevice_basic
=== PAUSE TestAccAWSInstance_EbsRootDevice_basic
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifySize
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifySize
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyType
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyType
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination
=== RUN   TestAccAWSInstance_EbsRootDevice_ModifyAll
=== PAUSE TestAccAWSInstance_EbsRootDevice_ModifyAll
=== RUN   TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize
=== PAUSE TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize
=== RUN   TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination
=== PAUSE TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination
=== RUN   TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices
=== PAUSE TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices
=== RUN   TestAccAWSInstance_primaryNetworkInterface
=== PAUSE TestAccAWSInstance_primaryNetworkInterface
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
=== PAUSE TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
=== RUN   TestAccAWSInstance_addSecondaryInterface
=== PAUSE TestAccAWSInstance_addSecondaryInterface
=== RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
=== PAUSE TestAccAWSInstance_addSecurityGroupNetworkInterface
=== RUN   TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs
=== PAUSE TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs
=== RUN   TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs
=== PAUSE TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs
=== RUN   TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate
=== PAUSE TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate
=== RUN   TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs
=== PAUSE TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs
=== RUN   TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate
=== PAUSE TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate
=== RUN   TestAccAWSInstance_associatePublic_defaultPrivate
=== PAUSE TestAccAWSInstance_associatePublic_defaultPrivate
=== RUN   TestAccAWSInstance_associatePublic_defaultPublic
=== PAUSE TestAccAWSInstance_associatePublic_defaultPublic
=== RUN   TestAccAWSInstance_associatePublic_explicitPublic
=== PAUSE TestAccAWSInstance_associatePublic_explicitPublic
=== RUN   TestAccAWSInstance_associatePublic_explicitPrivate
=== PAUSE TestAccAWSInstance_associatePublic_explicitPrivate
=== RUN   TestAccAWSInstance_associatePublic_overridePublic
=== PAUSE TestAccAWSInstance_associatePublic_overridePublic
=== RUN   TestAccAWSInstance_associatePublic_overridePrivate
=== PAUSE TestAccAWSInstance_associatePublic_overridePrivate
=== RUN   TestAccAWSInstance_getPasswordData_falseToTrue
=== PAUSE TestAccAWSInstance_getPasswordData_falseToTrue
=== RUN   TestAccAWSInstance_getPasswordData_trueToFalse
=== PAUSE TestAccAWSInstance_getPasswordData_trueToFalse
=== RUN   TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
=== PAUSE TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
=== RUN   TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
=== PAUSE TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
=== RUN   TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
=== PAUSE TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
=== RUN   TestAccAWSInstance_creditSpecification_standardCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_standardCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
=== PAUSE TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
=== RUN   TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
=== PAUSE TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
=== RUN   TestAccAWSInstance_creditSpecification_updateCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecification_updateCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
=== PAUSE TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
=== RUN   TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
=== PAUSE TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
=== RUN   TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
=== RUN   TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
=== RUN   TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
=== RUN   TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
=== PAUSE TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
=== RUN   TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
=== PAUSE TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
=== RUN   TestAccAWSInstance_creditSpecification_unknownCpuCredits_t4g
=== PAUSE TestAccAWSInstance_creditSpecification_unknownCpuCredits_t4g
=== RUN   TestAccAWSInstance_creditSpecificationT4g_unspecifiedDefaultsToUnlimited
=== PAUSE TestAccAWSInstance_creditSpecificationT4g_unspecifiedDefaultsToUnlimited
=== RUN   TestAccAWSInstance_creditSpecificationT4g_standardCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT4g_standardCpuCredits
=== RUN   TestAccAWSInstance_creditSpecificationT4g_unlimitedCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT4g_unlimitedCpuCredits
=== RUN   TestAccAWSInstance_creditSpecificationT4g_updateCpuCredits
=== PAUSE TestAccAWSInstance_creditSpecificationT4g_updateCpuCredits
=== RUN   TestAccAWSInstance_disappears
=== PAUSE TestAccAWSInstance_disappears
=== RUN   TestAccAWSInstance_UserData_EmptyStringToUnspecified
=== PAUSE TestAccAWSInstance_UserData_EmptyStringToUnspecified
=== RUN   TestAccAWSInstance_UserData_UnspecifiedToEmptyString
=== PAUSE TestAccAWSInstance_UserData_UnspecifiedToEmptyString
=== RUN   TestAccAWSInstance_hibernation
=== PAUSE TestAccAWSInstance_hibernation
=== RUN   TestAccAWSInstance_metadataOptions
=== PAUSE TestAccAWSInstance_metadataOptions
=== CONT  TestAccAWSInstance_inDefaultVpcBySgName
=== CONT  TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (118.31s)
=== CONT  TestAccAWSInstance_metadataOptions
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (131.98s)
=== CONT  TestAccAWSInstance_hibernation
--- PASS: TestAccAWSInstance_metadataOptions (169.20s)
=== CONT  TestAccAWSInstance_UserData_UnspecifiedToEmptyString
--- PASS: TestAccAWSInstance_hibernation (256.47s)
=== CONT  TestAccAWSInstance_UserData_EmptyStringToUnspecified
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (123.79s)
=== CONT  TestAccAWSInstance_disappears
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (125.92s)
=== CONT  TestAccAWSInstance_creditSpecificationT4g_updateCpuCredits
=== CONT  TestAccAWSInstance_disappears
    resource_aws_instance_test.go:3157: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSInstance_disappears (186.78s)
=== CONT  TestAccAWSInstance_creditSpecificationT4g_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT4g_updateCpuCredits (167.35s)
=== CONT  TestAccAWSInstance_creditSpecificationT4g_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT4g_unlimitedCpuCredits (138.51s)
=== CONT  TestAccAWSInstance_creditSpecificationT4g_unspecifiedDefaultsToUnlimited
--- PASS: TestAccAWSInstance_creditSpecificationT4g_standardCpuCredits (148.87s)
=== CONT  TestAccAWSInstance_creditSpecification_unknownCpuCredits_t4g
--- PASS: TestAccAWSInstance_creditSpecificationT4g_unspecifiedDefaultsToUnlimited (113.19s)
=== CONT  TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t4g (113.21s)
=== CONT  TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (165.30s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (162.39s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (97.69s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (414.68s)
=== CONT  TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (150.79s)
=== CONT  TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (115.64s)
=== CONT  TestAccAWSInstance_creditSpecification_updateCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (124.55s)
=== CONT  TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (152.36s)
=== CONT  TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (95.56s)
=== CONT  TestAccAWSInstance_creditSpecification_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (103.19s)
=== CONT  TestAccAWSInstance_creditSpecification_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (128.40s)
=== CONT  TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (130.60s)
=== CONT  TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (93.23s)
=== CONT  TestAccAWSInstance_CreditSpecification_Empty_NonBurstable
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (92.60s)
=== CONT  TestAccAWSInstance_getPasswordData_trueToFalse
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (131.01s)
=== CONT  TestAccAWSInstance_getPasswordData_falseToTrue
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (157.42s)
=== CONT  TestAccAWSInstance_associatePublic_overridePrivate
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (202.98s)
=== CONT  TestAccAWSInstance_associatePublic_overridePublic
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (103.21s)
=== CONT  TestAccAWSInstance_associatePublic_explicitPrivate
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (92.01s)
=== CONT  TestAccAWSInstance_associatePublic_explicitPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (92.07s)
=== CONT  TestAccAWSInstance_associatePublic_defaultPublic
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (103.18s)
=== CONT  TestAccAWSInstance_associatePublic_defaultPrivate
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (92.90s)
=== CONT  TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (113.77s)
=== CONT  TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs (104.09s)
=== CONT  TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate (176.61s)
=== CONT  TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate (144.03s)
=== CONT  TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs (114.55s)
=== CONT  TestAccAWSInstance_addSecurityGroupNetworkInterface
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (147.33s)
=== CONT  TestAccAWSInstance_addSecondaryInterface
--- PASS: TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs (198.87s)
=== CONT  TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (97.16s)
=== CONT  TestAccAWSInstance_primaryNetworkInterface
--- PASS: TestAccAWSInstance_addSecondaryInterface (156.03s)
=== CONT  TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices
--- PASS: TestAccAWSInstance_primaryNetworkInterface (96.75s)
=== CONT  TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (124.30s)
=== CONT  TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (215.94s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyAll
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (172.29s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (162.41s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (130.72s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2 (244.56s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifyType
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1 (150.89s)
=== CONT  TestAccAWSInstance_EbsRootDevice_ModifySize
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (139.19s)
=== CONT  TestAccAWSInstance_EbsRootDevice_basic
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (170.79s)
=== CONT  TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (127.51s)
=== CONT  TestAccAWSInstance_forceNewAndTagsDrift
    resource_aws_instance_test.go:1438: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSInstance_changeInstanceType (223.87s)
=== CONT  TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (167.99s)
=== CONT  TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (90.94s)
=== CONT  TestAccAWSInstance_Empty_PrivateIP
--- PASS: TestAccAWSInstance_keyPairCheck (74.97s)
=== CONT  TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_Empty_PrivateIP (97.94s)
=== CONT  TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (109.42s)
=== CONT  TestAccAWSInstance_withIamInstanceProfile
--- PASS: TestAccAWSInstance_privateIP (107.25s)
=== CONT  TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_withIamInstanceProfile (117.80s)
=== CONT  TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (139.88s)
=== CONT  TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_instanceProfileChange (228.30s)
=== CONT  TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_volumeTags (149.57s)
=== CONT  TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_tags (134.67s)
=== CONT  TestAccAWSInstance_noAMIEphemeralDevices
=== CONT  TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (98.90s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (112.72s)
=== CONT  TestAccAWSInstance_multipleRegions
2020/09/15 14:22:14 [DEBUG] Trying to get account information via sts:GetCallerIdentity
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (106.77s)
=== CONT  TestAccAWSInstance_ipv6_supportAddressCountWithIpv4
--- PASS: TestAccAWSInstance_multipleRegions (161.24s)
=== CONT  TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (16.53s)
=== CONT  TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (104.71s)
=== CONT  TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (92.85s)
=== CONT  TestAccAWSInstance_outpost
    data_source_aws_outposts_outposts_test.go:66: skipping since no Outposts found
--- SKIP: TestAccAWSInstance_outpost (1.77s)
=== CONT  TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_placementGroup (90.08s)
=== CONT  TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_vpc (117.12s)
=== CONT  TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_disableApiTermination (151.87s)
=== CONT  TestAccAWSInstance_RootBlockDevice_KmsKeyArn
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (106.92s)
=== CONT  TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_sourceDestCheck (186.80s)
=== CONT  TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_rootInstanceStore (105.22s)
=== CONT  TestAccAWSInstance_GP2WithIopsValue
--- PASS: TestAccAWSInstance_GP2WithIopsValue (7.86s)
=== CONT  TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_blockDevices (106.55s)
=== CONT  TestAccAWSInstance_userDataBase64
--- PASS: TestAccAWSInstance_GP2IopsDevice (106.68s)
=== CONT  TestAccAWSInstance_atLeastOneOtherEbsVolume
--- PASS: TestAccAWSInstance_userDataBase64 (138.11s)
=== CONT  TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType (8.07s)
=== CONT  TestAccAWSInstance_EbsBlockDevice_KmsKeyArn
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (110.81s)
=== CONT  TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_atLeastOneOtherEbsVolume (181.40s)
=== CONT  TestAccAWSInstance_inDefaultVpcBySgId
--- PASS: TestAccAWSInstance_basic (86.95s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (87.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	5867.433s
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstanceDataSource_' ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 2 -run=TestAccAWSInstanceDataSource_ -timeout 120m
=== RUN   TestAccAWSInstanceDataSource_basic
=== PAUSE TestAccAWSInstanceDataSource_basic
=== RUN   TestAccAWSInstanceDataSource_tags
=== PAUSE TestAccAWSInstanceDataSource_tags
=== RUN   TestAccAWSInstanceDataSource_AzUserData
=== PAUSE TestAccAWSInstanceDataSource_AzUserData
=== RUN   TestAccAWSInstanceDataSource_gp2IopsDevice
=== PAUSE TestAccAWSInstanceDataSource_gp2IopsDevice
=== RUN   TestAccAWSInstanceDataSource_blockDevices
=== PAUSE TestAccAWSInstanceDataSource_blockDevices
=== RUN   TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId
=== PAUSE TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId
=== RUN   TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId
=== PAUSE TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId
=== RUN   TestAccAWSInstanceDataSource_rootInstanceStore
=== PAUSE TestAccAWSInstanceDataSource_rootInstanceStore
=== RUN   TestAccAWSInstanceDataSource_privateIP
=== PAUSE TestAccAWSInstanceDataSource_privateIP
=== RUN   TestAccAWSInstanceDataSource_secondaryPrivateIPs
=== PAUSE TestAccAWSInstanceDataSource_secondaryPrivateIPs
=== RUN   TestAccAWSInstanceDataSource_keyPair
=== PAUSE TestAccAWSInstanceDataSource_keyPair
=== RUN   TestAccAWSInstanceDataSource_VPC
=== PAUSE TestAccAWSInstanceDataSource_VPC
=== RUN   TestAccAWSInstanceDataSource_PlacementGroup
=== PAUSE TestAccAWSInstanceDataSource_PlacementGroup
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
=== PAUSE TestAccAWSInstanceDataSource_SecurityGroups
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
=== PAUSE TestAccAWSInstanceDataSource_VPCSecurityGroups
=== RUN   TestAccAWSInstanceDataSource_getPasswordData_trueToFalse
=== PAUSE TestAccAWSInstanceDataSource_getPasswordData_trueToFalse
=== RUN   TestAccAWSInstanceDataSource_getPasswordData_falseToTrue
=== PAUSE TestAccAWSInstanceDataSource_getPasswordData_falseToTrue
=== RUN   TestAccAWSInstanceDataSource_GetUserData
=== PAUSE TestAccAWSInstanceDataSource_GetUserData
=== RUN   TestAccAWSInstanceDataSource_GetUserData_NoUserData
=== PAUSE TestAccAWSInstanceDataSource_GetUserData_NoUserData
=== RUN   TestAccAWSInstanceDataSource_creditSpecification
=== PAUSE TestAccAWSInstanceDataSource_creditSpecification
=== RUN   TestAccAWSInstanceDataSource_metadataOptions
=== PAUSE TestAccAWSInstanceDataSource_metadataOptions
=== CONT  TestAccAWSInstanceDataSource_basic
=== CONT  TestAccAWSInstanceDataSource_VPC
--- PASS: TestAccAWSInstanceDataSource_basic (92.59s)
=== CONT  TestAccAWSInstanceDataSource_metadataOptions
--- PASS: TestAccAWSInstanceDataSource_VPC (113.41s)
=== CONT  TestAccAWSInstanceDataSource_creditSpecification
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (92.29s)
=== CONT  TestAccAWSInstanceDataSource_GetUserData_NoUserData
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (91.82s)
=== CONT  TestAccAWSInstanceDataSource_GetUserData
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (153.03s)
=== CONT  TestAccAWSInstanceDataSource_getPasswordData_falseToTrue
--- PASS: TestAccAWSInstanceDataSource_GetUserData (152.54s)
=== CONT  TestAccAWSInstanceDataSource_getPasswordData_trueToFalse
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (167.89s)
=== CONT  TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (211.51s)
=== CONT  TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (105.06s)
=== CONT  TestAccAWSInstanceDataSource_PlacementGroup
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (85.65s)
=== CONT  TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (70.85s)
=== CONT  TestAccAWSInstanceDataSource_blockDevices
--- PASS: TestAccAWSInstanceDataSource_blockDevices (75.71s)
=== CONT  TestAccAWSInstanceDataSource_gp2IopsDevice
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (121.78s)
=== CONT  TestAccAWSInstanceDataSource_AzUserData
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (116.37s)
=== CONT  TestAccAWSInstanceDataSource_tags
--- PASS: TestAccAWSInstanceDataSource_AzUserData (101.22s)
=== CONT  TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId
--- PASS: TestAccAWSInstanceDataSource_tags (92.08s)
=== CONT  TestAccAWSInstanceDataSource_keyPair
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (127.27s)
=== CONT  TestAccAWSInstanceDataSource_secondaryPrivateIPs
--- PASS: TestAccAWSInstanceDataSource_keyPair (93.69s)
=== CONT  TestAccAWSInstanceDataSource_privateIP
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (103.54s)
=== CONT  TestAccAWSInstanceDataSource_rootInstanceStore
--- PASS: TestAccAWSInstanceDataSource_privateIP (113.55s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (128.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1237.215s
```
