### PR TITLE
Update data_source_aws_kms_secrets.go

### DIFF
--- a/aws/data_source_aws_kms_secrets.go
+++ b/aws/data_source_aws_kms_secrets.go
@@ -45,7 +45,7 @@ func dataSourceAwsKmsSecrets() *schema.Resource {
 			"plaintext": {
 				Type:      schema.TypeMap,
 				Computed:  true,
-				Sensitive: true
+				Sensitive: true,
 				Elem:      &schema.Schema{Type: schema.TypeString},
 			},
 		},

--- a/aws/data_source_aws_kms_secrets.go
+++ b/aws/data_source_aws_kms_secrets.go
@@ -43,12 +43,10 @@ func dataSourceAwsKmsSecrets() *schema.Resource {
 				},
 			},
 			"plaintext": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type:      schema.TypeString,
-					Sensitive: true,
-				},
+				Type:      schema.TypeMap,
+				Computed:  true,
+				Sensitive: true
+				Elem:      &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}


### PR DESCRIPTION
This commit will fix the fact that terraform display sensitive information in it's plan when using the data source for KMS Secrets. Plugin API ocmpatibility was not respected.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15157

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix: Stop displaying sensitive information for kms secrets datasources
```

