### PR TITLE
Add Outpost and COIP support to aws_lb datasource and resource

### DIFF
--- a/aws/data_source_aws_lb.go
+++ b/aws/data_source_aws_lb.go
@@ -62,6 +62,10 @@ func dataSourceAwsLb() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"outpost_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"allocation_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -131,6 +135,11 @@ func dataSourceAwsLb() *schema.Resource {
 			},
 
 			"ip_address_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"customer_owned_ipv4_pool": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -55,6 +55,39 @@ func TestAccDataSourceAWSLB_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAWSLB_outpost(t *testing.T) {
+	lbName := fmt.Sprintf("testaccawslb-outpost-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	dataSourceName := "data.aws_lb.alb_test_with_arn"
+	resourceName := "aws_lb.alb_test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLBConfigOutpost(lbName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "internal", resourceName, "internal"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "subnets.#", resourceName, "subnets.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "security_groups.#", resourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.TestName", resourceName, "tags.TestName"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enable_deletion_protection", resourceName, "enable_deletion_protection"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "idle_timeout", resourceName, "idle_timeout"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpc_id", resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "zone_id", resourceName, "zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dns_name", resourceName, "dns_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ip_address_type", resourceName, "ip_address_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_mapping.#", resourceName, "subnet_mapping.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_mapping.0.outpost_id", resourceName, "subnet_mapping.0.outpost_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAWSLB_BackwardsCompatibility(t *testing.T) {
 	lbName := fmt.Sprintf("testaccawsalb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	dataSourceName1 := "data.aws_alb.alb_test_with_arn"
@@ -188,6 +221,77 @@ data "aws_lb" "alb_test_with_arn" {
 
 data "aws_lb" "alb_test_with_name" {
   name = aws_lb.alb_test.name
+}
+`, lbName)
+}
+
+func testAccDataSourceAWSLBConfigOutpost(lbName string) string {
+	return fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+resource "aws_lb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = [aws_security_group.alb_test.id]
+  subnets         = [aws_subnet.alb_test.id]
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    TestName = "TestAccAWSALB_outpost"
+  }
+}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-lb-data-source-outpost"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  vpc_id                  = aws_vpc.alb_test.id
+  cidr_block              = "10.0.0.0/24"
+  availability_zone       = data.aws_outposts_outpost.test.availability_zone
+  outpost_arn             = data.aws_outposts_outpost.test.arn
+
+  tags = {
+    Name = "tf-acc-lb-data-source-outpost"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = aws_vpc.alb_test.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    TestName = "TestAccAWSALB_outpost"
+  }
+}
+
+data "aws_lb" "alb_test_with_arn" {
+  arn = aws_lb.alb_test.arn
 }
 `, lbName)
 }

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -256,10 +256,10 @@ resource "aws_vpc" "alb_test" {
 }
 
 resource "aws_subnet" "alb_test" {
-  vpc_id                  = aws_vpc.alb_test.id
-  cidr_block              = "10.0.0.0/24"
-  availability_zone       = data.aws_outposts_outpost.test.availability_zone
-  outpost_arn             = data.aws_outposts_outpost.test.arn
+  vpc_id            = aws_vpc.alb_test.id
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = data.aws_outposts_outpost.test.availability_zone
+  outpost_arn       = data.aws_outposts_outpost.test.arn
 
   tags = {
     Name = "tf-acc-lb-data-source-outpost"

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -114,7 +114,6 @@ func resourceAwsLb() *schema.Resource {
 						"outpost_id": {
 							Type:     schema.TypeString,
 							Computed: true,
-							Optional: true,
 						},
 						"allocation_id": {
 							Type:     schema.TypeString,
@@ -133,7 +132,6 @@ func resourceAwsLb() *schema.Resource {
 					var buf bytes.Buffer
 					m := v.(map[string]interface{})
 					buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
-					buf.WriteString(fmt.Sprintf("%s-", m["outpost_id"].(string)))
 					if m["allocation_id"] != "" {
 						buf.WriteString(fmt.Sprintf("%s-", m["allocation_id"].(string)))
 					}

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -162,6 +162,45 @@ func TestAccAWSLB_NLB_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSLB_ALB_outpost(t *testing.T) {
+	var conf elbv2.LoadBalancer
+	lbName := fmt.Sprintf("testaccawslb-outpost-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	resourceName := "aws_lb.lb_test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSOutpostsOutposts(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBConfig_outpost(lbName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_logs.0.enabled", "false"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf("loadbalancer/app/%s/.+", lbName))),
+					resource.TestCheckResourceAttrSet(resourceName, "dns_name"),
+					resource.TestCheckResourceAttr(resourceName, "enable_deletion_protection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "idle_timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_type", "application"),
+					resource.TestCheckResourceAttr(resourceName, "name", lbName),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "TestAccAWSALB_outpost"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_mapping.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_mapping.0.outpost_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_owned_ipv4_pool"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "zone_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLB_networkLoadbalancerEIP(t *testing.T) {
 	var conf elbv2.LoadBalancer
 	resourceName := "aws_lb.lb_test"
@@ -1379,6 +1418,93 @@ resource "aws_security_group" "alb_test" {
 
   tags = {
     Name = "TestAccAWSALB_basic"
+  }
+}
+`, lbName))
+}
+
+func testAccAWSLBConfig_outpost(lbName string) string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
+data "aws_outposts_outposts" "test" {}
+
+data "aws_outposts_outpost" "test" {
+  id = tolist(data.aws_outposts_outposts.test.ids)[0]
+}
+
+data "aws_ec2_coip_pools" "test" {}
+
+data "aws_ec2_local_gateway_route_table" "test" {
+  outpost_arn = tolist(data.aws_outposts_outposts.test.arns)[0]
+}
+
+resource "aws_ec2_local_gateway_route_table_vpc_association" "test" {
+  local_gateway_route_table_id = data.aws_ec2_local_gateway_route_table.test.id
+  vpc_id                       = aws_vpc.alb_test.id
+}
+
+resource "aws_route_table" "test" {
+  vpc_id     = aws_vpc.alb_test.id
+  depends_on = [aws_ec2_local_gateway_route_table_vpc_association.test]
+}
+
+resource "aws_route_table_association" "a" {
+  subnet_id      = aws_subnet.alb_test.id
+  route_table_id = aws_route_table.test.id
+}
+
+resource "aws_lb" "lb_test" {
+  name                       = "%s"
+  security_groups            = [aws_security_group.alb_test.id]
+  customer_owned_ipv4_pool   = tolist(data.aws_ec2_coip_pools.test.pool_ids)[0]
+  idle_timeout               = 30
+  enable_deletion_protection = false
+  subnets                    = [aws_subnet.alb_test.id]
+
+  tags = {
+    Name = "TestAccAWSALB_outpost"
+  }
+}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-lb-outpost"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  vpc_id                  = aws_vpc.alb_test.id
+  cidr_block              = "10.0.0.0/24"
+  availability_zone       = data.aws_outposts_outpost.test.availability_zone
+  outpost_arn             = data.aws_outposts_outpost.test.arn
+
+  tags = {
+    Name = "tf-acc-lb-outpost"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = aws_vpc.alb_test.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "TestAccAWSALB_outpost"
   }
 }
 `, lbName))

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1474,10 +1474,10 @@ resource "aws_vpc" "alb_test" {
 }
 
 resource "aws_subnet" "alb_test" {
-  vpc_id                  = aws_vpc.alb_test.id
-  cidr_block              = "10.0.0.0/24"
-  availability_zone       = data.aws_outposts_outpost.test.availability_zone
-  outpost_arn             = data.aws_outposts_outpost.test.arn
+  vpc_id            = aws_vpc.alb_test.id
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = data.aws_outposts_outpost.test.availability_zone
+  outpost_arn       = data.aws_outposts_outpost.test.arn
 
   tags = {
     Name = "tf-acc-lb-outpost"

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -120,6 +120,7 @@ for load balancers of type `network` will force a recreation of the resource.
 * `enable_cross_zone_load_balancing` - (Optional) If true, cross-zone load balancing of the load balancer will be enabled.
    This is a `network` load balancer feature. Defaults to `false`.
 * `enable_http2` - (Optional) Indicates whether HTTP/2 is enabled in `application` load balancers. Defaults to `true`.
+* `customer_owned_ipv4_pool` - (Optional) The ID of the customer owned ipv4 pool to use for this load balancer.
 * `ip_address_type` - (Optional) The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`
 * `tags` - (Optional) A map of tags to assign to the resource.
 
@@ -144,6 +145,7 @@ The following attributes are exported in addition to the arguments listed above:
 * `arn_suffix` - The ARN suffix for use with CloudWatch Metrics.
 * `dns_name` - The DNS name of the load balancer.
 * `zone_id` - The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
+* `subnet_mapping.*.outpost_id` - ID of the Outpost containing the load balancer.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15147

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add aws_lb resource support for AWS Outpost
Add aws_lb resource support for customer owned IPv4 pools
Add aws_lb datasource support for AWS Outpost
Add aws_lb datasource support for customer owned IPv4 pools
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccDataSourceAWSLB_outpost'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccDataSourceAWSLB_outpost -timeout 120m
=== RUN   TestAccDataSourceAWSLB_outpost
=== PAUSE TestAccDataSourceAWSLB_outpost
=== CONT  TestAccDataSourceAWSLB_outpost
--- PASS: TestAccDataSourceAWSLB_outpost (284.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       284.548s

$ make testacc TESTARGS='-run=TestAccAWSLB_ALB_outpost'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSLB_ALB_outpost -timeout 120m
=== RUN   TestAccAWSLB_ALB_outpost
=== PAUSE TestAccAWSLB_ALB_outpost
=== CONT  TestAccAWSLB_ALB_outpost
--- PASS: TestAccAWSLB_ALB_outpost (303.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       303.550s
...
```
