### PR TITLE
resource/aws_cloudformation_stack_set_instance: Handle IAM eventual consistency retries during creation

### DIFF
--- a/aws/resource_aws_cloudformation_stack_set_instance.go
+++ b/aws/resource_aws_cloudformation_stack_set_instance.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
 func resourceAwsCloudFormationStackSetInstance() *schema.Resource {
@@ -95,16 +96,76 @@ func resourceAwsCloudFormationStackSetInstanceCreate(d *schema.ResourceData, met
 	}
 
 	log.Printf("[DEBUG] Creating CloudFormation StackSet Instance: %s", input)
-	output, err := conn.CreateStackInstances(input)
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		output, err := conn.CreateStackInstances(input)
 
-	if err != nil {
-		return fmt.Errorf("error creating CloudFormation StackSet Instance: %s", err)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("error creating CloudFormation StackSet Instance: %w", err))
+		}
+
+		d.SetId(fmt.Sprintf("%s,%s,%s", stackSetName, accountID, region))
+
+		err = waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutCreate))
+
+		if err != nil {
+			// IAM eventual consistency
+			if strings.Contains(err.Error(), "AccountGate check failed") {
+				input.OperationId = aws.String(resource.UniqueId())
+				return resource.RetryableError(err)
+			}
+
+			// IAM eventual consistency
+			// User: XXX is not authorized to perform: cloudformation:CreateStack on resource: YYY
+			if strings.Contains(err.Error(), "is not authorized") {
+				input.OperationId = aws.String(resource.UniqueId())
+				return resource.RetryableError(err)
+			}
+
+			// IAM eventual consistency
+			// XXX role has insufficient YYY permissions
+			if strings.Contains(err.Error(), "role has insufficient") {
+				input.OperationId = aws.String(resource.UniqueId())
+				return resource.RetryableError(err)
+			}
+
+			// IAM eventual consistency
+			// Account XXX should have YYY role with trust relationship to Role ZZZ
+			if strings.Contains(err.Error(), "role with trust relationship") {
+				input.OperationId = aws.String(resource.UniqueId())
+				return resource.RetryableError(err)
+			}
+
+			// IAM eventual consistency
+			if strings.Contains(err.Error(), "The security token included in the request is invalid") {
+				input.OperationId = aws.String(resource.UniqueId())
+				return resource.RetryableError(err)
+			}
+
+			return resource.NonRetryableError(fmt.Errorf("error waiting for CloudFormation StackSet Instance (%s) creation: %w", d.Id(), err))
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		var output *cloudformation.CreateStackInstancesOutput
+		output, err = conn.CreateStackInstances(input)
+
+		if err != nil {
+			return fmt.Errorf("error creating CloudFormation StackSet Instance: %w", err)
+		}
+
+		d.SetId(fmt.Sprintf("%s,%s,%s", stackSetName, accountID, region))
+
+		err = waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutCreate))
+
+		if err != nil {
+			return fmt.Errorf("error waiting for CloudFormation StackSet Instance (%s) creation: %w", d.Id(), err)
+		}
 	}
 
-	d.SetId(fmt.Sprintf("%s,%s,%s", stackSetName, accountID, region))
-
-	if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("error waiting for CloudFormation StackSet Instance (%s) creation: %s", d.Id(), err)
+	if err != nil {
+		return err
 	}
 
 	return resourceAwsCloudFormationStackSetInstanceRead(d, meta)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15165

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cloudformation_stack_set_instance: Handle IAM eventual consistency retries during creation
```

The setup for this retry handling is a little different than usual since the creation verification process happens post-creation API call while waiting for the operation to complete and the errors are not actual errors but operation response elements. The API returns a few different messages depending on the propagation state of the administration and execution IAM Roles and their permissions:

```
        Error: Operation (terraform-20200916123554140800000010) Results:
        Account (XXX) Region (us-west-2) Status (FAILED) Status Reason: Account XXX should have 'tf-acc-test-1067459111164387071-Execution' role with trust relationship to Role 'tf-acc-test-1067459111164387071-Administration'.

        Error: error waiting for CloudFormation StackSet Instance (tf-acc-test-4841473769601677612,187416307283,us-west-2) creation: Operation (terraform-20200916123226496600000010) Results:
        Account (XXX) Region (us-west-2) Status (FAILED) Status Reason: AccountGate check failed

        Error: error waiting for CloudFormation StackSet Instance (tf-acc-test-7048012082312792452,187416307283,us-west-2) creation: Operation (terraform-20200916123554655900000012) Results:
        Account (XXX) Region (us-west-2) Status (FAILED) Status Reason: User: arn:aws:sts::XXX:assumed-role/tf-acc-test-7048012082312792452-Execution/1653d549-0b76-48bc-afed-fdea2aa80583 is not authorized to perform: cloudformation:CreateStack on resource: arn:aws:cloudformation:us-west-2:XXX:stack/StackSet-tf-acc-test-7048012082312792452-6104a9a5-c4c2-48cf-98d6-511ae5bc6634/*

        Error: error waiting for CloudFormation StackSet Instance (tf-acc-test-9168173463114734219,187416307283,us-west-2) creation: Operation (terraform-20200916123226642200000011) Results:
        Account (XXX) Region (us-west-2) Status (FAILED) Status Reason: The security token included in the request is invalid. (Service: AmazonSNS; Status Code: 403; Error Code: InvalidClientTokenId; Request ID: 6c15a76a-70f5-5f0d-a661-f0b678d40743; Proxy: null)

                Error: error waiting for CloudFormation StackSet Instance (tf-acc-test-2459978012487741689,187416307283,us-west-2) creation: Operation (terraform-20200916131141578400000088) Results:
        Account (XXX) Region (us-west-2) Status (FAILED) Status Reason: AWSCloudFormationStackSetsExecution role has insufficient SNS permissions
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (123.68s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears (125.72s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (130.11s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (165.48s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (222.90s)
```
