### PR TITLE
tests/provider: Add precheck (DS DS)

### DIFF
--- a/aws/data_source_aws_directory_service_directory_test.go
+++ b/aws/data_source_aws_directory_service_directory_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/directoryservice"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -30,13 +30,13 @@ func TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD(t *testing.T) {
 	dataSourceName := "data.aws_directory_service_directory.test-simple-ad"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSDirectoryServiceSimpleDirectory(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsDirectoryServiceDirectoryConfig_SimpleAD(alias),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "type", "SimpleAD"),
+					resource.TestCheckResourceAttr(dataSourceName, "type", directoryservice.DirectoryTypeSimpleAd),
 					resource.TestCheckResourceAttr(dataSourceName, "size", "Small"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", "tf-testacc-corp.neverland.com"),
 					resource.TestCheckResourceAttr(dataSourceName, "description", "tf-testacc SimpleAD"),
@@ -67,7 +67,7 @@ func TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsDirectoryServiceDirectoryConfig_MicrosoftAD(alias),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "type", "MicrosoftAD"),
+					resource.TestCheckResourceAttr(dataSourceName, "type", directoryservice.DirectoryTypeMicrosoftAd),
 					resource.TestCheckResourceAttr(dataSourceName, "edition", "Standard"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", "tf-testacc-corp.neverland.com"),
 					resource.TestCheckResourceAttr(dataSourceName, "description", "tf-testacc MicrosoftAD"),
@@ -99,7 +99,7 @@ func TestAccDataSourceAWSDirectoryServiceDirectory_connector(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceDirectoryServiceDirectoryConfig_connector,
+				Config: testAccDataSourceDirectoryServiceDirectoryConfig_connector(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "connect_settings.0.connect_ips", resourceName, "connect_settings.0.connect_ips"),
 				),
@@ -115,12 +115,12 @@ data "aws_directory_service_directory" "test" {
 `
 
 func testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites(adType string) string {
-	return testAccAvailableAZsNoOptInConfig() + fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "tf-testacc-%s"
+    Name = "tf-testacc-%[1]s"
   }
 }
 
@@ -130,7 +130,7 @@ resource "aws_subnet" "primary" {
   cidr_block        = "10.0.1.0/24"
 
   tags = {
-    Name = "tf-testacc-%s-primary"
+    Name = "tf-testacc-%[1]s-primary"
   }
 }
 
@@ -140,14 +140,14 @@ resource "aws_subnet" "secondary" {
   cidr_block        = "10.0.2.0/24"
 
   tags = {
-    Name = "tf-testacc-%s-secondary"
+    Name = "tf-testacc-%[1]s-secondary"
   }
 }
-`, adType, adType, adType)
+`, adType))
 }
 
 func testAccDataSourceAwsDirectoryServiceDirectoryConfig_SimpleAD(alias string) string {
-	return testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites("simple-ad") + fmt.Sprintf(`
+	return composeConfig(testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites("simple-ad"), fmt.Sprintf(`
 resource "aws_directory_service_directory" "test-simple-ad" {
   type        = "SimpleAD"
   size        = "Small"
@@ -168,11 +168,11 @@ resource "aws_directory_service_directory" "test-simple-ad" {
 data "aws_directory_service_directory" "test-simple-ad" {
   directory_id = aws_directory_service_directory.test-simple-ad.id
 }
-`, alias)
+`, alias))
 }
 
 func testAccDataSourceAwsDirectoryServiceDirectoryConfig_MicrosoftAD(alias string) string {
-	return testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites("microsoft-ad") + fmt.Sprintf(`
+	return composeConfig(testAccDataSourceAwsDirectoryServiceDirectoryConfig_Prerequisites("microsoft-ad"), fmt.Sprintf(`
 resource "aws_directory_service_directory" "test-microsoft-ad" {
   type        = "MicrosoftAD"
   edition     = "Standard"
@@ -193,10 +193,11 @@ resource "aws_directory_service_directory" "test-microsoft-ad" {
 data "aws_directory_service_directory" "test-microsoft-ad" {
   directory_id = aws_directory_service_directory.test-microsoft-ad.id
 }
-`, alias)
+`, alias))
 }
 
-var testAccDataSourceDirectoryServiceDirectoryConfig_connector = testAccAvailableAZsNoOptInConfig() + `
+func testAccDataSourceDirectoryServiceDirectoryConfig_connector() string {
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_directory_service_directory" "test" {
   name     = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -253,4 +254,5 @@ resource "aws_subnet" "test" {
 data "aws_directory_service_directory" "test-ad-connector" {
   directory_id = aws_directory_service_directory.connector.id
 }
-`
+`))
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13574

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing on GovCloud:

```
--- SKIP: TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD (2.01s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_NonExistent (3.93s)
--- FAIL: TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD (790.81s) (unrelated error: Error waiting for Directory Service (d-9867366502) to become available: unexpected state 'Deleting', wanted target 'Active'.)
```

The output from acceptance testing on commercial:

```
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_NonExistent (2.86s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_SimpleAD (598.70s)
--- PASS: TestAccDataSourceAwsDirectoryServiceDirectory_MicrosoftAD (1037.00s)
```