### PR TITLE
tests/service/rds: Remove hardcoded instance classes from EC2-Classic tests and basic data source test

### DIFF
--- a/aws/data_source_aws_db_instance_test.go
+++ b/aws/data_source_aws_db_instance_test.go
@@ -64,12 +64,17 @@ func TestAccAWSDbInstanceDataSource_ec2Classic(t *testing.T) {
 
 func testAccAWSDBInstanceDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = "mariadb"
+  preferred_instance_classes = ["db.t3.micro", "db.t2.micro", "db.t3.small"]
+}
+
 resource "aws_db_instance" "bar" {
   identifier = "datasource-test-terraform-%d"
 
   allocated_storage = 10
-  engine            = "mariadb"
-  instance_class    = "db.t2.micro"
+  engine            = data.aws_rds_orderable_db_instance.test.engine
+  instance_class    = data.aws_rds_orderable_db_instance.test.instance_class
   name              = "baz"
   password          = "barbarbarbar"
   username          = "foo"
@@ -95,10 +100,29 @@ data "aws_db_instance" "bar" {
 
 func testAccAWSDBInstanceDataSourceConfig_ec2Classic(rInt int) string {
 	return fmt.Sprintf(`
-%s
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = "mysql"
+  engine_version             = "5.6.41"
+  preferred_instance_classes = ["db.m3.medium", "db.m3.large", "db.r3.large"]
+}
+
+resource "aws_db_instance" "bar" {
+  identifier           = "foobarbaz-test-terraform-%[1]d"
+  allocated_storage    = 10
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
+  name                 = "baz"
+  password             = "barbarbarbar"
+  username             = "foo"
+  publicly_accessible  = true
+  security_group_names = ["default"]
+  parameter_group_name = "default.mysql5.6"
+  skip_final_snapshot  = true
+}
 
 data "aws_db_instance" "bar" {
   db_instance_identifier = aws_db_instance.bar.identifier
 }
-`, testAccAWSDBInstanceConfigEc2Classic(rInt))
+`, rInt)
 }

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -4559,12 +4559,18 @@ resource "aws_db_instance" "bar" {
 
 func testAccAWSDBInstanceConfigEc2Classic(rInt int) string {
 	return fmt.Sprintf(`
+data "aws_rds_orderable_db_instance" "test" {
+  engine                     = "mysql"
+  engine_version             = "5.6.41"
+  preferred_instance_classes = ["db.m3.medium", "db.m3.large", "db.r3.large"]
+}
+
 resource "aws_db_instance" "bar" {
-  identifier           = "foobarbaz-test-terraform-%d"
+  identifier           = "foobarbaz-test-terraform-%[1]d"
   allocated_storage    = 10
-  engine               = "mysql"
-  engine_version       = "5.6"
-  instance_class       = "db.m5.large"
+  engine               = data.aws_rds_orderable_db_instance.test.engine
+  engine_version       = data.aws_rds_orderable_db_instance.test.engine_version
+  instance_class       = data.aws_rds_orderable_db_instance.test.instance_class
   name                 = "baz"
   password             = "barbarbarbar"
   username             = "foo"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15182

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
=== CONT  TestAccAWSDBInstance_ec2Classic
TestAccAWSDBInstance_ec2Classic: resource_aws_db_instance_test.go:2248: Step 1/1 error: terraform failed: exit status 1
stderr:
Error: Error creating DB Instance: InsufficientDBInstanceCapacity: Cannot create a db.m5.large database instance because there are no availability zones with sufficient capacity for non-VPC and storage type : gp2 for db.m5.large. Please try the request again at a later time.
  status code: 400, request id: 5bc39058-0571-4f63-bb80-c25533285646
--- FAIL: TestAccAWSDBInstance_ec2Classic (5.31s)

=== CONT  TestAccAWSDbInstanceDataSource_ec2Classic
TestAccAWSDbInstanceDataSource_ec2Classic: data_source_aws_db_instance_test.go:51: Step 1/1 error: terraform failed: exit status 1
stderr:
Error: Error creating DB Instance: InsufficientDBInstanceCapacity: Cannot create a db.m5.large database instance because there are no availability zones with sufficient capacity for non-VPC and storage type : gp2 for db.m5.large. Please try the request again at a later time.
  status code: 400, request id: 38414095-00df-4a5d-ba25-241b5c400ef6
--- FAIL: TestAccAWSDbInstanceDataSource_ec2Classic (15.24s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDbInstanceDataSource_basic (617.92s)
--- PASS: TestAccAWSDbInstanceDataSource_ec2Classic (456.35s)

--- PASS: TestAccAWSDBInstance_ec2Classic (406.18s)
```
