### PR TITLE
tests/resource/aws_vpc_endpoint: Switch TestAccAWSVpcEndpoint_gatewayPolicy to dynamodb

### DIFF
--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -184,15 +184,14 @@ func TestAccAWSVpcEndpoint_gatewayPolicy(t *testing.T) {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "AmazonLinux2AMIRepositoryAccess",
+      "Sid": "ReadOnly",
       "Principal": "*",
       "Action": [
-        "s3:GetObject"
+        "dynamodb:DescribeTable",
+        "dynamodb:ListTables"
       ],
       "Effect": "Allow",
-      "Resource": [
-        "arn:aws:s3:::amazonlinux.*.amazonaws.com/*"
-      ]
+      "Resource": "*"
     }
   ]
 }
@@ -774,7 +773,7 @@ resource "aws_vpc_endpoint" "test" {
 func testAccVpcEndpointConfigGatewayPolicy(rName, policy string) string {
 	return fmt.Sprintf(`
 data "aws_vpc_endpoint_service" "test" {
-  service = "s3"
+  service = "dynamodb"
 }
 
 resource "aws_vpc" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

S3 VPC Endpoints now support both Gateway and Interface types. Did not see any feature requests to support additional client-side filtering for the type in the data source (since it is not available via server-side filtering), so just quickly fixed the test.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (58.65s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (70.65s)
```