### PR TITLE
tests/resource/aws_ses_active_receipt_rule_set: Serialize testing

### DIFF
--- a/aws/resource_aws_ses_active_receipt_rule_set_test.go
+++ b/aws/resource_aws_ses_active_receipt_rule_set_test.go
@@ -2,20 +2,37 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAWSSESActiveReceiptRuleSet_basic(t *testing.T) {
+// Only one SES Receipt RuleSet can be active at a time, so run serially
+// locally and in TeamCity.
+func TestAccAWSSESActiveReceiptRuleSet_serial(t *testing.T) {
+	testFuncs := map[string]func(t *testing.T){
+		"basic":      testAccAWSSESActiveReceiptRuleSet_basic,
+		"disappears": testAccAWSSESActiveReceiptRuleSet_disappears,
+	}
+
+	for name, testFunc := range testFuncs {
+		testFunc := testFunc
+
+		t.Run(name, func(t *testing.T) {
+			testFunc(t)
+		})
+	}
+}
+
+func testAccAWSSESActiveReceiptRuleSet_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_active_receipt_rule_set.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
@@ -33,11 +50,11 @@ func TestAccAWSSESActiveReceiptRuleSet_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSSESActiveReceiptRuleSet_disappears(t *testing.T) {
+func testAccAWSSESActiveReceiptRuleSet_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ses_active_receipt_rule_set.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Since there can only be one active Receipt Rule Set, previously received these types of errors when ran in parallel:

```
=== CONT  TestAccAWSSESActiveReceiptRuleSet_basic
TestAccAWSSESActiveReceiptRuleSet_basic: resource_aws_ses_active_receipt_rule_set_test.go:18: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# aws_ses_active_receipt_rule_set.test will be updated in-place
~ resource "aws_ses_active_receipt_rule_set" "test" {
id            = "tf-acc-test-200923444865777778"
~ rule_set_name = "tf-acc-test-3328795909966366230" -> "tf-acc-test-200923444865777778"
}
Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAWSSESActiveReceiptRuleSet_basic (28.83s)

=== CONT  TestAccAWSSESActiveReceiptRuleSet_basic
TestAccAWSSESActiveReceiptRuleSet_basic: resource_aws_ses_active_receipt_rule_set_test.go:18: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
+ create
Terraform will perform the following actions:
# aws_ses_active_receipt_rule_set.test will be created
+ resource "aws_ses_active_receipt_rule_set" "test" {
+ id            = (known after apply)
+ rule_set_name = "tf-acc-test-4001499284644559282"
}
Plan: 1 to add, 0 to change, 0 to destroy.
--- FAIL: TestAccAWSSESActiveReceiptRuleSet_basic (34.83s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSESActiveReceiptRuleSet_serial (27.75s)
    --- PASS: TestAccAWSSESActiveReceiptRuleSet_serial/basic (14.81s)
    --- PASS: TestAccAWSSESActiveReceiptRuleSet_serial/disappears (12.94s)
```
