### PR TITLE
Updates resource acceptance tests to Terraform 0.12 syntax, batch 4: IAM to KMS

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -9,12 +9,12 @@ on:
       - .github/workflows/acctest-terraform-lint.yml
       - aws/core_acceptance_test.go
       - aws/data_source_aws_*_test.go
-      - aws/resource_aws_[a-g]*_test.go
+      - aws/resource_aws_[a-k]*_test.go
 
 env:
   GO_VERSION: "1.14"
   GO111MODULE: on
-  TFLINT_VERSION: "v0.20.0" # Not yet available
+  TFLINT_VERSION: "v0.20.1"
 
 jobs:
   terrafmt:
@@ -47,12 +47,18 @@ jobs:
             -o -name 'resource_aws_e*_test.go' \
             -o -name 'resource_aws_f*_test.go' \
             -o -name 'resource_aws_g*_test.go' \
+            -o -name 'resource_aws_h*_test.go' \
+            -o -name 'resource_aws_i*_test.go' \
+            -o -name 'resource_aws_j*_test.go' \
+            -o -name 'resource_aws_k*_test.go' \
             \) \
             | sort -u \
             | grep -v resource_aws_apigatewayv2_domain_name_test.go \
             | grep -v resource_aws_dynamodb_table_test.go \
             | grep -v resource_aws_ecs_capacity_provider_test.go \
             | grep -v resource_aws_efs_file_system_test.go \
+            | grep -v resource_aws_kinesis_stream_test.go \
+            | grep -v resource_aws_kms_grant_test.go \
             | xargs -I {} terrafmt diff --check --quiet --fmtcompat {}
 
   validate-terraform:
@@ -73,12 +79,7 @@ jobs:
           git clone --branch tracking-main --single-branch https://github.com/gdavison/terrafmt terrafmt
           cd terrafmt
           go install
-      # - run: curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | sh
-      - run: |
-          git clone --no-checkout https://github.com/terraform-linters/tflint tflint
-          cd tflint
-          git checkout --recurse-submodules 5a002e926848899d4bfbb006f95c39285a5e9afa
-          go install
+      - run: curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | sh
       - run: |
           find ./aws -type f \( \
             -name 'core_acceptance_test.go' \
@@ -90,6 +91,10 @@ jobs:
             -o -name 'resource_aws_e*_test.go' \
             -o -name 'resource_aws_f*_test.go' \
             -o -name 'resource_aws_g*_test.go' \
+            -o -name 'resource_aws_h*_test.go' \
+            -o -name 'resource_aws_i*_test.go' \
+            -o -name 'resource_aws_j*_test.go' \
+            -o -name 'resource_aws_k*_test.go' \
             \) \
             | sort -u \
             | grep -v resource_aws_apigatewayv2_domain_name_test.go \
@@ -97,5 +102,7 @@ jobs:
             | grep -v resource_aws_ecs_capacity_provider_test.go \
             | grep -v resource_aws_efs_file_system_test.go \
             | grep -v resource_aws_elasticache_cluster_test.go \
+            | grep -v resource_aws_kinesis_stream_test.go \
+            | grep -v resource_aws_kms_grant_test.go \
             | ./scripts/validate-terraform.sh
           

--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -399,7 +399,7 @@ func testAccIAMUserPolicyConfig_name(rInt int, policy string) string {
 resource "aws_iam_user_policy" "foo" {
   name   = "foo_policy_%d"
   user   = aws_iam_user.user.name
-  policy = %v
+  policy = %s
 }
 `, testAccAWSUserConfig(fmt.Sprintf("test_user_%d", rInt), "/"), rInt, policy)
 }
@@ -411,7 +411,7 @@ func testAccIAMUserPolicyConfig_namePrefix(rInt int, policy string) string {
 resource "aws_iam_user_policy" "foo" {
   name_prefix = "foo_policy_"
   user        = aws_iam_user.user.name
-  policy      = %v
+  policy      = %s
 }
 `, testAccAWSUserConfig(fmt.Sprintf("test_user_%d", rInt), "/"), policy)
 }
@@ -422,7 +422,7 @@ func testAccIAMUserPolicyConfig_generatedName(rInt int, policy string) string {
 
 resource "aws_iam_user_policy" "foo" {
   user   = aws_iam_user.user.name
-  policy = %v
+  policy = %s
 }
 `, testAccAWSUserConfig(fmt.Sprintf("test_user_%d", rInt), "/"), policy)
 }
@@ -434,13 +434,13 @@ func testAccIAMUserPolicyConfig_multiplePolicies(rInt int, policy1, policy2 stri
 resource "aws_iam_user_policy" "foo" {
   name   = "foo_policy_%[2]d"
   user   = aws_iam_user.user.name
-  policy = %[3]v
+  policy = %[3]s
 }
 
 resource "aws_iam_user_policy" "bar" {
   name   = "bar_policy_%[2]d"
   user   = aws_iam_user.user.name
-  policy = %[4]v
+  policy = %[4]s
 }
 `, testAccAWSUserConfig(fmt.Sprintf("test_user_%d", rInt), "/"), rInt, policy1, policy2)
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -212,7 +212,7 @@ func TestAccAWSInstance_inEc2Classic(t *testing.T) {
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
@@ -769,7 +769,7 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 	})
 }
 
-func TestAccAWSInstance_vpc(t *testing.T) {
+func TestAccAWSInstance_dedicatedInstance(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
 	rName := fmt.Sprintf("tf-testacc-instance-%s", acctest.RandStringFromCharSet(12, acctest.CharSetAlphaNum))
@@ -782,9 +782,10 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigVPC(rName),
+				Config: testAccEc2InstanceConfigDedicatedInstance(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tenancy", "dedicated"),
 					resource.TestCheckResourceAttr(resourceName, "user_data", "562a3e32810edf6ff09994f050f12e799452379d"),
 				),
 			},
@@ -1453,6 +1454,7 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 				Config: testAccInstanceConfigWithSmallInstanceType(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.medium"),
 				),
 			},
 			{
@@ -1465,6 +1467,7 @@ func TestAccAWSInstance_changeInstanceType(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(resourceName, &after),
 					testAccCheckInstanceNotRecreated(t, &before, &after),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.large"),
 				),
 			},
 		},
@@ -3284,7 +3287,7 @@ func testAccAvailableAZsNoOptInDefaultExcludeConfig() string {
 func testAccAvailableAZsNoOptInExcludeConfig(excludeZoneIds ...string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
-  exclude_zone_ids = ["%[1]v"]
+  exclude_zone_ids = ["%[1]s"]
   state            = "available"
 
   filter {
@@ -3366,7 +3369,9 @@ resource "aws_security_group" "sg" {
 }
 
 resource "aws_instance" "test" {
-  ami             = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+
+  # tflint-ignore: aws_instance_previous_type
   instance_type   = "m3.medium"
   security_groups = [aws_security_group.sg.name]
 }
@@ -3401,7 +3406,9 @@ resource "aws_ebs_volume" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-hvm-instance-store.id
+  ami = data.aws_ami.amzn-ami-minimal-hvm-instance-store.id
+
+  # tflint-ignore: aws_instance_previous_type
   instance_type = "m1.small"
   subnet_id     = aws_subnet.test.id
   user_data     = "foo:-with-character's"
@@ -3421,7 +3428,7 @@ resource "aws_instance" "test" {
   ami       = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   subnet_id = aws_subnet.test.id
 
-  instance_type    = "m1.small"
+  instance_type    = "t2.small"
   user_data_base64 = base64encode("hello world")
 }
 `))
@@ -3433,7 +3440,7 @@ resource "aws_instance" "test" {
   ami       = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   subnet_id = aws_subnet.test.id
 
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 
   tags = {
     Name = "tf-acctest"
@@ -3448,7 +3455,7 @@ resource "aws_instance" "test" {
   ami       = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   subnet_id = aws_subnet.test.id
 
-  instance_type = "m3.large"
+  instance_type = "t2.large"
 
   tags = {
     Name = "tf-acctest"
@@ -3460,12 +3467,8 @@ resource "aws_instance" "test" {
 func testAccInstanceGP2IopsDevice() string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-
-  # In order to attach an encrypted volume to an instance you need to have an
-  # m3.medium or larger. See "Supported Instance Types" in:
-  # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
-  instance_type = "m3.medium"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = "t2.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -3478,12 +3481,8 @@ resource "aws_instance" "test" {
 func testAccInstanceGP2WithIopsValue() string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-
-  # In order to attach an encrypted volume to an instance you need to have an
-  # m3.medium or larger. See "Supported Instance Types" in:
-  # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
-  instance_type = "m3.medium"
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = "t2.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -3502,6 +3501,7 @@ resource "aws_instance" "test" {
 
   # Only certain instance types support ephemeral root instance stores.
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html
+  # tflint-ignore: aws_instance_previous_type
   instance_type = "m3.medium"
 }
 `))
@@ -3528,6 +3528,7 @@ data "aws_ami" "test" {
 resource "aws_instance" "test" {
   ami = data.aws_ami.test.id
 
+  # tflint-ignore: aws_instance_previous_type
   instance_type = "c3.large"
 
   root_block_device {
@@ -3553,7 +3554,7 @@ func testAccAwsEc2InstanceEbsRootDeviceBasic() string {
 resource "aws_instance" "test" {
   ami = data.aws_ami.ami.id
 
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 }
 `)
 }
@@ -3571,7 +3572,7 @@ func testAccAwsEc2InstanceRootBlockDeviceWithIOPS(size, delete, volumeType, iops
 resource "aws_instance" "test" {
   ami = data.aws_ami.ami.id
 
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 
   root_block_device {
     volume_size           = %[1]s
@@ -3618,10 +3619,7 @@ func testAccAwsEc2InstanceConfigBlockDevicesWithDeleteOnTerminate(size, delete s
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 
-  # In order to attach an encrypted volume to an instance you need to have an
-  # m3.medium or larger. See "Supported Instance Types" in:
-  # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 
   root_block_device {
     volume_type           = "gp2"
@@ -3661,7 +3659,7 @@ func testAccInstanceConfigSourceDestEnable(rName string) string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + `
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m1.small"
+  instance_type = "t2.small"
   subnet_id     = aws_subnet.test.id
 }
 `
@@ -3671,7 +3669,7 @@ func testAccInstanceConfigSourceDestDisable(rName string) string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + `
 resource "aws_instance" "test" {
   ami               = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type     = "m1.small"
+  instance_type     = "t2.small"
   subnet_id         = aws_subnet.test.id
   source_dest_check = false
 }
@@ -3682,17 +3680,19 @@ func testAccInstanceConfigDisableAPITermination(rName string, val bool) string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami                     = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type           = "m1.small"
+  instance_type           = "t2.small"
   subnet_id               = aws_subnet.test.id
   disable_api_termination = %[1]t
 }
 `, val)
 }
 
-func testAccInstanceConfigVPC(rName string) string {
+func testAccEc2InstanceConfigDedicatedInstance(rName string) string {
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + `
 resource "aws_instance" "test" {
-  ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+
+  # tflint-ignore: aws_instance_previous_type
   instance_type               = "m1.small"
   subnet_id                   = aws_subnet.test.id
   associate_public_ip_address = true
@@ -3751,7 +3751,7 @@ resource "aws_placement_group" "test" {
 # Limitations: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#concepts-placement-groups
 resource "aws_instance" "test" {
   ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type               = "c3.large"
+  instance_type               = "c5.large"
   subnet_id                   = aws_subnet.test.id
   associate_public_ip_address = true
   placement_group             = aws_placement_group.test.name
@@ -3813,7 +3813,7 @@ func testAccCheckInstanceConfigTags() string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m1.small"
+  instance_type = "t2.small"
 
   tags = {
     test = "test2"
@@ -3831,10 +3831,7 @@ resource "aws_kms_key" "test" {
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 
-  # In order to attach an encrypted volume to an instance you need to have an
-  # m3.medium or larger. See "Supported Instance Types" in:
-  # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -3913,7 +3910,7 @@ func testAccCheckInstanceConfigNoVolumeTags() string {
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -3946,12 +3943,11 @@ resource "aws_instance" "test" {
 `))
 }
 
-var testAccCheckInstanceConfigEBSBlockDeviceInvalidIops = composeConfig(testAccAwsEc2InstanceAmiWithEbsRootVolume,
-	`
+var testAccCheckInstanceConfigEBSBlockDeviceInvalidIops = composeConfig(testAccAwsEc2InstanceAmiWithEbsRootVolume, `
 resource "aws_instance" "test" {
   ami = data.aws_ami.ami.id
 
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 
   ebs_block_device {
     device_name = "/dev/sdc"
@@ -3967,7 +3963,7 @@ func testAccCheckInstanceConfigWithVolumeTags() string {
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -4009,7 +4005,7 @@ func testAccCheckInstanceConfigWithVolumeTagsUpdate() string {
 resource "aws_instance" "test" {
   ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
 
-  instance_type = "m3.medium"
+  instance_type = "t2.medium"
 
   root_block_device {
     volume_type = "gp2"
@@ -4051,7 +4047,7 @@ func testAccCheckInstanceConfigTagsUpdate() string {
 	return composeConfig(testAccLatestAmazonLinuxHvmEbsAmiConfig(), fmt.Sprintf(`
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m1.small"
+  instance_type = "t2.small"
 
   tags = {
     test2 = "test3"
@@ -4088,7 +4084,7 @@ EOF
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m1.small"
+  instance_type = "t2.small"
 
   tags = {
     Name = %[1]q
@@ -4129,7 +4125,9 @@ resource "aws_iam_instance_profile" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami                  = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+
+  # tflint-ignore: aws_instance_previous_type
   instance_type        = "m1.small"
   iam_instance_profile = aws_iam_instance_profile.test.name
 
@@ -4175,13 +4173,13 @@ resource "aws_instance" "test" {
 }
 
 func testAccInstanceNetworkInstanceSecurityGroups(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		testAccAwsInstanceVpcConfig(rName, false) +
-		testAccAwsInstanceVpcSecurityGroupConfig(rName) +
-		`
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(rName, false),
+		testAccAwsInstanceVpcSecurityGroupConfig(rName), `
 resource "aws_instance" "test" {
   ami                         = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type               = "t1.micro"
+  instance_type               = "t2.micro"
   vpc_security_group_ids      = [aws_security_group.test.id]
   subnet_id                   = aws_subnet.test.id
   associate_public_ip_address = true
@@ -4193,17 +4191,17 @@ resource "aws_eip" "test" {
   vpc        = true
   depends_on = [aws_internet_gateway.test]
 }
-`
+`)
 }
 
 func testAccInstanceNetworkInstanceVPCSecurityGroupIDs(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		testAccAwsInstanceVpcConfig(rName, false) +
-		testAccAwsInstanceVpcSecurityGroupConfig(rName) +
-		`
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(rName, false),
+		testAccAwsInstanceVpcSecurityGroupConfig(rName), `
 resource "aws_instance" "test" {
   ami                    = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type          = "t1.micro"
+  instance_type          = "t2.micro"
   vpc_security_group_ids = [aws_security_group.test.id]
   subnet_id              = aws_subnet.test.id
   depends_on             = [aws_internet_gateway.test]
@@ -4214,17 +4212,17 @@ resource "aws_eip" "test" {
   vpc        = true
   depends_on = [aws_internet_gateway.test]
 }
-`
+`)
 }
 
 func testAccInstanceNetworkInstanceVPCRemoveSecurityGroupIDs(rName string) string {
-	return testAccLatestAmazonLinuxHvmEbsAmiConfig() +
-		testAccAwsInstanceVpcConfig(rName, false) +
-		testAccAwsInstanceVpcSecurityGroupConfig(rName) +
-		`
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		testAccAwsInstanceVpcConfig(rName, false),
+		testAccAwsInstanceVpcSecurityGroupConfig(rName), `
 resource "aws_instance" "test" {
   ami                    = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type          = "t1.micro"
+  instance_type          = "t2.micro"
   vpc_security_group_ids = []
   subnet_id              = aws_subnet.test.id
   depends_on             = [aws_internet_gateway.test]
@@ -4235,7 +4233,7 @@ resource "aws_eip" "test" {
   vpc        = true
   depends_on = [aws_internet_gateway.test]
 }
-`
+`)
 }
 
 func testAccInstanceConfigKeyPair(rName string) string {
@@ -4247,7 +4245,7 @@ resource "aws_key_pair" "test" {
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "t1.micro"
+  instance_type = "t2.micro"
   key_name      = aws_key_pair.test.key_name
 
   tags = {
@@ -4261,7 +4259,9 @@ func testAccInstanceConfigRootBlockDeviceMismatch(rName string) string {
 	return testAccAwsInstanceVpcConfig(rName, false) + `
 resource "aws_instance" "test" {
   # This is an AMI in us-west-2 with RootDeviceName: "/dev/sda1"; actual root: "/dev/sda"
-  ami           = "ami-ef5b69df"
+  ami = "ami-ef5b69df"
+
+  # tflint-ignore: aws_instance_previous_type
   instance_type = "t1.micro"
   subnet_id     = aws_subnet.test.id
 
@@ -4382,7 +4382,7 @@ resource "aws_network_interface" "primary" {
   }
 }
 
-// Attach previously created network interface, observe no state diff on instance resource
+# Attach previously created network interface, observe no state diff on instance resource
 resource "aws_network_interface" "secondary" {
   subnet_id   = aws_subnet.test.id
   private_ips = ["10.1.1.43"]
@@ -4786,7 +4786,7 @@ func testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rName 
 	return testAccLatestAmazonLinuxHvmEbsAmiConfig() + testAccAwsInstanceVpcConfig(rName, false) + `
 resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-  instance_type = "m1.small"
+  instance_type = "t2.small"
   subnet_id     = aws_subnet.test.id
 
   credit_specification {
@@ -5046,22 +5046,9 @@ resource "aws_subnet" "test" {
 }
 
 func testAccInstanceConfigHibernation(hibernation bool) string {
-	return fmt.Sprintf(`
-data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-minimal-hvm-*"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
+	return composeConfig(
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -5091,7 +5078,7 @@ resource "aws_instance" "test" {
     volume_size = 20
   }
 }
-`, hibernation)
+`, hibernation))
 }
 
 func testAccInstanceConfigMetadataOptions(rName string) string {
@@ -5147,7 +5134,8 @@ resource "aws_instance" "test" {
 func testAccAwsEc2InstanceConfigDynamicEBSBlockDevices() string {
 	return composeConfig(testAccLatestAmazonLinuxPvEbsAmiConfig(), `
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn-ami-minimal-pv-ebs.id
+  ami = data.aws_ami.amzn-ami-minimal-pv-ebs.id
+  # tflint-ignore: aws_instance_previous_type
   instance_type = "m3.medium"
 
   dynamic "ebs_block_device" {
@@ -5172,10 +5160,10 @@ func testAccAvailableEc2InstanceTypeForRegion(preferredInstanceTypes ...string) 
 data "aws_ec2_instance_type_offering" "available" {
   filter {
     name   = "instance-type"
-    values = ["%[1]v"]
+    values = ["%[1]s"]
   }
 
-  preferred_instance_types = ["%[1]v"]
+  preferred_instance_types = ["%[1]s"]
 }
 `, strings.Join(preferredInstanceTypes, "\", \""))
 }
@@ -5196,7 +5184,7 @@ func testAccAvailableEc2InstanceTypeForAvailabilityZone(availabilityZoneName str
 data "aws_ec2_instance_type_offering" "available" {
   filter {
     name   = "instance-type"
-    values = ["%[2]v"]
+    values = ["%[2]s"]
   }
 
   filter {
@@ -5205,7 +5193,7 @@ data "aws_ec2_instance_type_offering" "available" {
   }
 
   location_type            = "availability-zone"
-  preferred_instance_types = ["%[2]v"]
+  preferred_instance_types = ["%[2]s"]
 }
 `, availabilityZoneName, strings.Join(preferredInstanceTypes, "\", \""))
 }

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1166,7 +1166,7 @@ func TestAccAWSInstance_instanceProfileChange(t *testing.T) {
 			{
 				Config: testAccInstanceConfigWithInstanceProfile(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStopInstance(&v), // GH-8262
+					testAccCheckStopInstance(&v), // GH-8262: Error on EC2 instance role change when stopped
 				),
 			},
 			{
@@ -4125,10 +4125,8 @@ resource "aws_iam_instance_profile" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-
-  # tflint-ignore: aws_instance_previous_type
-  instance_type        = "m1.small"
+  ami                  = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type        = "t2.small"
   iam_instance_profile = aws_iam_instance_profile.test.name
 
   tags = {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -2166,6 +2166,10 @@ func resourceAwsKinesisFirehoseDeliveryStreamCreate(d *schema.ResourceData, meta
 			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "is not authorized to") {
 				return resource.RetryableError(err)
 			}
+			// Retry for IAM eventual consistency
+			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Please make sure the role specified in VpcConfiguration has permissions") {
+				return resource.RetryableError(err)
+			}
 			// InvalidArgumentException: Verify that the IAM role has access to the ElasticSearch domain.
 			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Verify that the IAM role has access") {
 				return resource.RetryableError(err)
@@ -2296,6 +2300,10 @@ func resourceAwsKinesisFirehoseDeliveryStreamUpdate(d *schema.ResourceData, meta
 
 			// Retry for IAM eventual consistency
 			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "is not authorized to") {
+				return resource.RetryableError(err)
+			}
+			// Retry for IAM eventual consistency
+			if isAWSErr(err, firehose.ErrCodeInvalidArgumentException, "Please make sure the role specified in VpcConfiguration has permissions") {
 				return resource.RetryableError(err)
 			}
 			// InvalidArgumentException: Verify that the IAM role has access to the ElasticSearch domain.

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -2569,8 +2569,8 @@ resource "aws_elasticsearch_domain" "test_cluster" {
 }
 
 resource "aws_iam_role_policy" "firehose-elasticsearch" {
-  name = "tf-acc-test-%d"
-  role = aws_iam_role.firehose.id
+  name   = "tf-acc-test-%d"
+  role   = aws_iam_role.firehose.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -2594,74 +2594,74 @@ EOF
 // ElasticSearch associated with VPC
 var testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
 data "aws_availability_zones" "available" {
-	state = "available"
-  
-	filter {
-	  name   = "opt-in-status"
-	  values = ["opt-in-not-required"]
-	}
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
   }
-  
-  resource "aws_vpc" "elasticsearch_in_vpc" {
-	cidr_block = "192.168.0.0/22"
-  
-	tags = {
-	  Name = "terraform-testacc-elasticsearch-domain-in-vpc"
-	}
+}
+
+resource "aws_vpc" "elasticsearch_in_vpc" {
+  cidr_block = "192.168.0.0/22"
+
+  tags = {
+    Name = "terraform-testacc-elasticsearch-domain-in-vpc"
   }
-  
-  resource "aws_subnet" "first" {
-	vpc_id            = aws_vpc.elasticsearch_in_vpc.id
-	availability_zone = data.aws_availability_zones.available.names[0]
-	cidr_block        = "192.168.0.0/24"
-  
-	tags = {
-	  Name = "tf-acc-elasticsearch-domain-in-vpc-first"
-	}
+}
+
+resource "aws_subnet" "first" {
+  vpc_id            = aws_vpc.elasticsearch_in_vpc.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  cidr_block        = "192.168.0.0/24"
+
+  tags = {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-first"
   }
-  
-  resource "aws_subnet" "second" {
-	vpc_id            = aws_vpc.elasticsearch_in_vpc.id
-	availability_zone = data.aws_availability_zones.available.names[1]
-	cidr_block        = "192.168.1.0/24"
-  
-	tags = {
-	  Name = "tf-acc-elasticsearch-domain-in-vpc-second"
-	}
+}
+
+resource "aws_subnet" "second" {
+  vpc_id            = aws_vpc.elasticsearch_in_vpc.id
+  availability_zone = data.aws_availability_zones.available.names[1]
+  cidr_block        = "192.168.1.0/24"
+
+  tags = {
+    Name = "tf-acc-elasticsearch-domain-in-vpc-second"
   }
-  
-  resource "aws_security_group" "first" {
-	vpc_id = aws_vpc.elasticsearch_in_vpc.id
+}
+
+resource "aws_security_group" "first" {
+  vpc_id = aws_vpc.elasticsearch_in_vpc.id
+}
+
+resource "aws_security_group" "second" {
+  vpc_id = aws_vpc.elasticsearch_in_vpc.id
+}
+
+resource "aws_elasticsearch_domain" "test_cluster" {
+  domain_name = "es-test-%d"
+
+  cluster_config {
+    instance_count         = 2
+    zone_awareness_enabled = true
+    instance_type          = "t2.small.elasticsearch"
   }
-  
-  resource "aws_security_group" "second" {
-	vpc_id = aws_vpc.elasticsearch_in_vpc.id
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
   }
-  
-  resource "aws_elasticsearch_domain" "test_cluster" {
-	domain_name = "es-test-%d"
-  
-	cluster_config {
-	  instance_count         = 2
-	  zone_awareness_enabled = true
-	  instance_type          = "t2.small.elasticsearch"
-	}
-  
-	ebs_options {
-	  ebs_enabled = true
-	  volume_size = 10
-	}
-  
-	vpc_options {
-	  security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
-	  subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
-	}
+
+  vpc_options {
+    security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
+    subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
   }
-  
-  resource "aws_iam_role_policy" "firehose-elasticsearch" {
-	name   = "elasticsearch"
-	role   = aws_iam_role.firehose.id
-	policy = <<EOF
+}
+
+resource "aws_iam_role_policy" "firehose-elasticsearch" {
+  name   = "elasticsearch"
+  role   = aws_iam_role.firehose.id
+  policy = <<EOF
 {
 	"Version":"2012-10-17",
 	"Statement":[
@@ -2690,7 +2690,7 @@ data "aws_availability_zones" "available" {
 	]
 }
 EOF
-  }
+}
 `
 
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchBasic = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
@@ -2716,27 +2716,27 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchVpcBasic = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
-	depends_on = [aws_iam_role_policy.firehose-elasticsearch]
-  
-	name        = "terraform-kinesis-firehose-es-%d"
-	destination = "elasticsearch"
-	s3_configuration {
-	  role_arn   = aws_iam_role.firehose.arn
-	  bucket_arn = aws_s3_bucket.bucket.arn
-	}
-	elasticsearch_configuration {
-	  domain_arn = aws_elasticsearch_domain.test_cluster.arn
-	  role_arn   = aws_iam_role.firehose.arn
-	  index_name = "test"
-	  type_name  = "test"
-  
-	  vpc_config {
-		subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
-		security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
-		role_arn           = aws_iam_role.firehose.arn
-	  }
-	}
+  depends_on = [aws_iam_role_policy.firehose-elasticsearch]
+
+  name        = "terraform-kinesis-firehose-es-%d"
+  destination = "elasticsearch"
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
   }
+  elasticsearch_configuration {
+    domain_arn = aws_elasticsearch_domain.test_cluster.arn
+    role_arn   = aws_iam_role.firehose.arn
+    index_name = "test"
+    type_name  = "test"
+
+    vpc_config {
+      subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
+      security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
+      role_arn           = aws_iam_role.firehose.arn
+    }
+  }
+}
 `
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchUpdate = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
@@ -2775,37 +2775,37 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchVpcUpdate = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchVpcConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
-	depends_on = [aws_iam_role_policy.firehose-elasticsearch]
-  
-	name        = "terraform-kinesis-firehose-es-%d"
-	destination = "elasticsearch"
-	s3_configuration {
-	  role_arn   = aws_iam_role.firehose.arn
-	  bucket_arn = aws_s3_bucket.bucket.arn
-	}
-	elasticsearch_configuration {
-	  domain_arn         = aws_elasticsearch_domain.test_cluster.arn
-	  role_arn           = aws_iam_role.firehose.arn
-	  index_name         = "test"
-	  type_name          = "test"
-	  buffering_interval = 500
-	  vpc_config {
-		subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
-		security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
-		role_arn           = aws_iam_role.firehose.arn
-	  }
-	  processing_configuration {
-		enabled = false
-		processors {
-		  type = "Lambda"
-		  parameters {
-			parameter_name  = "LambdaArn"
-			parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-		  }
-		}
-	  }
-	}
-  }`
+  depends_on = [aws_iam_role_policy.firehose-elasticsearch]
+
+  name        = "terraform-kinesis-firehose-es-%d"
+  destination = "elasticsearch"
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
+  elasticsearch_configuration {
+    domain_arn         = aws_elasticsearch_domain.test_cluster.arn
+    role_arn           = aws_iam_role.firehose.arn
+    index_name         = "test"
+    type_name          = "test"
+    buffering_interval = 500
+    vpc_config {
+      subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
+      security_group_ids = [aws_security_group.first.id, aws_security_group.second.id]
+      role_arn           = aws_iam_role.firehose.arn
+    }
+    processing_configuration {
+      enabled = false
+      processors {
+        type = "Lambda"
+        parameters {
+          parameter_name  = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+      }
+    }
+  }
+}`
 
 var testAccKinesisFirehoseDeliveryStreamConfig_ElasticsearchEndpoint = testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig + `
 resource "aws_kinesis_firehose_delivery_stream" "test" {
@@ -2841,7 +2841,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   elasticsearch_configuration {
     cluster_endpoint   = "https://${aws_elasticsearch_domain.test_cluster.endpoint}"
-    role_arn           = "${aws_iam_role.firehose.arn}"
+    role_arn           = aws_iam_role.firehose.arn
     index_name         = "test"
     type_name          = "test"
     buffering_interval = 500

--- a/aws/resource_aws_kinesis_stream_test.go
+++ b/aws/resource_aws_kinesis_stream_test.go
@@ -553,15 +553,17 @@ func TestAccAWSKinesisStream_UpdateKmsKeyId(t *testing.T) {
 		CheckDestroy: testAccCheckKinesisStreamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKinesisStreamUpdateKmsKeyId(rInt, 1),
+				Config: testAccKinesisStreamUpdateKmsKeyId(rInt, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKinesisStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_kms_key.key.0", "id"),
 				),
 			},
 			{
-				Config: testAccKinesisStreamUpdateKmsKeyId(rInt, 2),
+				Config: testAccKinesisStreamUpdateKmsKeyId(rInt, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKinesisStreamExists(resourceName, &stream),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_kms_key.key.1", "id"),
 				),
 			},
 		},
@@ -765,22 +767,18 @@ resource "aws_kinesis_stream" "test" {
 
 func testAccKinesisStreamUpdateKmsKeyId(rInt int, key int) string {
 	return fmt.Sprintf(`
+resource "aws_kms_key" "key" {
+  count = 2
 
-resource "aws_kms_key" "key1" {
-  description             = "KMS key 1"
-  deletion_window_in_days = 10
-}
-
-resource "aws_kms_key" "key2" {
-  description             = "KMS key 2"
+  description             = "KMS key ${count.index+1}"
   deletion_window_in_days = 10
 }
 
 resource "aws_kinesis_stream" "test" {
-  name            = "test_stream-%d"
+  name            = "test_stream-%[1]d"
   shard_count     = 1
   encryption_type = "KMS"
-  kms_key_id      = aws_kms_key.key%d.id
+  kms_key_id      = aws_kms_key.key[%[2]d].id
 }
 `, rInt, key)
 }

--- a/scripts/validate-terraform.sh
+++ b/scripts/validate-terraform.sh
@@ -13,12 +13,14 @@ if [ -f ~/developer/terrafmt/terrafmt ]; then TERRAFMT_CMD="$HOME/developer/terr
 exit_code=0
 
 # Configure the rules for tflint.
-# The *_invalid_* rules disabled here prevent evaluation of expressions.
 rules=(
     # Syntax checks
     "--only=terraform_deprecated_interpolation"
     "--only=terraform_deprecated_index"
     "--only=terraform_comment_syntax"
+    # Ensure valid instance types
+    "--only=aws_db_instance_invalid_type"
+    "--only=aws_elasticache_cluster_invalid_type"
     # Ensure modern instance types
     "--only=aws_instance_previous_type"
     "--only=aws_db_instance_previous_type"


### PR DESCRIPTION
Updates resource acceptance tests to Terraform 0.12 syntax from IAM to KMS

Relates #14722

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestAccAWSInstance\|TestInstanceHostIDSchema\|TestInstanceCpuCoreCountSchema\|TestInstanceCpuThreadsPerCoreSchema\|TestAccAWSKinesisFirehoseDeliveryStream\|TestAccAWSKinesisStream\|TestAccAWSIAMUserPolicy\|TestFetchRootDevice"

--- PASS: TestAccAWSInstanceDataSource_keyPair (85.99s)
--- PASS: TestAccAWSInstanceDataSource_EbsBlockDevice_KmsKeyId (90.85s)
--- PASS: TestAccAWSInstanceDataSource_RootBlockDevice_KmsKeyId (95.35s)
--- PASS: TestAccAWSInstanceDataSource_tags (96.54s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (106.95s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (110.33s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (110.55s)
--- PASS: TestAccAWSInstanceDataSource_AzUserData (115.92s)
--- PASS: TestAccAWSInstanceDataSource_basic (117.20s)
--- PASS: TestAccAWSInstanceDataSource_secondaryPrivateIPs (118.65s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (118.51s)
--- PASS: TestFetchRootDevice (0.00s)
    --- PASS: TestFetchRootDevice/device_name_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/device_name_not_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/no_images (0.00s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (119.34s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (121.93s)
--- PASS: TestAccAWSInstanceDataSource_VPC (127.77s)
--- PASS: TestAccAWSIAMUserPolicy_disappears (19.81s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (139.17s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (147.11s)
--- PASS: TestAccAWSIAMUserPolicy_basic (46.60s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_InvalidIopsForVolumeType (11.79s)
--- PASS: TestAccAWSInstancesDataSource_basic (83.47s)
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (61.97s)
--- PASS: TestAccAWSInstancesDataSource_tags (83.35s)
--- PASS: TestAccAWSIAMUserPolicy_generatedName (64.03s)
--- PASS: TestAccAWSInstancesDataSource_instance_state_names (85.03s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (13.57s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (198.32s)
--- PASS: TestAccAWSIAMUserPolicy_multiplePolicies (92.57s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgId (97.56s)
--- SKIP: TestAccAWSInstance_outpost (1.80s)
--- PASS: TestAccAWSInstance_basic (93.94s)
--- PASS: TestAccAWSInstance_EbsBlockDevice_KmsKeyArn (82.43s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (225.15s)
--- PASS: TestAccAWSInstance_inDefaultVpcBySgName (108.03s)
--- PASS: TestAccAWSInstance_inEc2Classic (110.15s)
--- PASS: TestAccAWSKinesisStreamDataSource_basic (126.66s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (14.85s)
--- PASS: TestAccAWSInstance_userDataBase64 (94.18s)
--- PASS: TestAccAWSInstance_blockDevices (83.15s)
--- PASS: TestAccAWSInstance_RootBlockDevice_KmsKeyArn (120.03s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (95.97s)
--- PASS: TestAccAWSInstance_rootInstanceStore (101.59s)
--- PASS: TestAccAWSInstance_atLeastOneOtherEbsVolume (152.92s)
--- PASS: TestAccAWSInstance_placementGroup (69.07s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (294.85s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (122.59s)
--- PASS: TestAccAWSInstance_dedicatedInstance (107.93s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (100.35s)
--- PASS: TestAccAWSInstance_sourceDestCheck (138.85s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (106.30s)
--- PASS: TestAccAWSInstance_disableApiTermination (133.76s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (332.40s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (112.44s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (111.35s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (118.74s)
--- PASS: TestAccAWSInstance_tags (116.47s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (89.47s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (126.10s)
--- PASS: TestAccAWSInstance_privateIP (107.14s)
--- PASS: TestAccAWSInstance_keyPairCheck (97.44s)
--- PASS: TestAccAWSInstance_volumeTags (141.63s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (120.38s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (116.99s)
--- PASS: TestAccAWSInstanceDataSource_metadataOptions (322.83s)
--- FAIL: TestAccAWSInstance_instanceProfileChange (136.12s)
--- PASS: TestAccAWSInstance_Empty_PrivateIP (126.72s)
--- PASS: TestAccAWSInstance_EbsRootDevice_basic (94.89s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyDeleteOnTermination (97.21s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyType (124.86s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifySize (128.88s)
--- PASS: TestAccAWSInstance_changeInstanceType (157.95s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io2 (147.75s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyIOPS_Io1 (158.69s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (101.91s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (182.23s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (112.20s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifySize (151.95s)
--- PASS: TestAccAWSInstance_EbsRootDevice_ModifyAll (155.65s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPs (110.45s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleBlockDevices_ModifyDeleteOnTermination (137.35s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPsUpdate (109.80s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PrivateIPAndSecondaryPrivateIPs (125.70s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (84.16s)
--- PASS: TestAccAWSInstance_addSecondaryInterface (147.96s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (147.42s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (107.51s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (90.34s)
--- PASS: TestAccAWSInstance_CreditSpecification_Empty_NonBurstable (61.18s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (93.34s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (99.17s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_EmptyPrivateIPAndSecondaryPrivateIPsUpdate (173.66s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (85.48s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (103.18s)
--- PASS: TestAccAWSInstance_EbsRootDevice_MultipleDynamicEBSBlockDevices (216.99s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (104.57s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (79.12s)
--- PASS: TestInstanceHostIDSchema (0.00s)
--- PASS: TestInstanceCpuCoreCountSchema (0.00s)
--- PASS: TestInstanceCpuThreadsPerCoreSchema (0.00s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t2 (94.94s)
--- PASS: TestAccAWSInstance_CreditSpecification_UnspecifiedToEmpty_NonBurstable (126.71s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (111.47s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (151.71s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (107.08s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (154.85s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (106.43s)
--- PASS: TestAccAWSInstance_disappears (76.52s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (117.14s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (145.54s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (108.33s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (116.68s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (155.53s)
--- PASS: TestAccAWSInstance_metadataOptions (119.41s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (117.31s)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_basic (132.79s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (106.76s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (106.25s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_disappears (142.36s)
--- PASS: TestAccAWSInstance_NewNetworkInterface_PublicIPAndSecondaryPrivateIPs (376.25s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (125.69s)
--- PASS: TestAccAWSInstance_hibernation (191.50s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (112.42s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ExternalUpdate (118.75s)
--- PASS: TestAccAWSInstance_creditSpecification_unknownCpuCredits_t3 (302.46s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (114.22s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (138.09s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (159.94s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (102.79s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (201.33s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSEAndKeyType (220.03s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (121.81s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (113.66s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ProcessingConfiguration_Empty (110.20s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSEAndKeyArn (250.87s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_KinesisStreamSource (105.01s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (150.32s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (139.88s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (149.77s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithSSE (287.90s)
--- PASS: TestAccAWSKinesisStream_basic (61.10s)
--- PASS: TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError (69.79s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (150.34s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (395.79s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (102.50s)
--- PASS: TestAccAWSKinesisStream_enforceConsumerDeletion (61.85s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (404.34s)
--- PASS: TestAccAWSKinesisStream_createMultipleConcurrentStreams (133.50s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (162.49s)
--- PASS: TestAccAWSKinesisStream_retentionPeriod (111.24s)
--- PASS: TestAccAWSKinesisStream_shardCount (121.01s)
--- PASS: TestAccAWSKinesisStream_UpdateKmsKeyId (112.80s)
--- PASS: TestAccAWSKinesisStream_shardLevelMetrics (159.98s)
--- PASS: TestAccAWSKinesisStream_encryption (193.85s)
--- PASS: TestAccAWSKinesisStream_Tags (202.21s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (417.57s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigEndpointUpdates (910.12s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (994.91s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchWithVpcConfigUpdates (1492.23s)
```

The two failures are pre-existing:
* TestAccAWSKinesisFirehoseDeliveryStream_basic
* TestAccAWSInstance_instanceProfileChange