### PR TITLE
resource/dynamodb_table: re-add logic to expand non_key_attributes configured in a TypeList

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4247,6 +4247,10 @@ func expandDynamoDbProjection(data map[string]interface{}) *dynamodb.Projection 
 		ProjectionType: aws.String(data["projection_type"].(string)),
 	}
 
+	if v, ok := data["non_key_attributes"].([]interface{}); ok && len(v) > 0 {
+		projection.NonKeyAttributes = expandStringList(v)
+	}
+
 	if v, ok := data["non_key_attributes"].(*schema.Set); ok && v.Len() > 0 {
 		projection.NonKeyAttributes = expandStringList(v.List())
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15115

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_dynamodb_table: correctly expand local_seconday_index.non_key_attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccAWSDynamoDbTable_lsiNonKeyAttributes (26.20s)

--- PASS: TestDiffDynamoDbGSI (0.00s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (16.14s)
--- PASS: TestAccAWSDynamoDbTable_disappears (54.95s)
--- PASS: TestAccAWSDynamoDbTableItem_withMultipleItems (55.61s)
--- PASS: TestAccAWSDynamoDbTableItem_basic (64.31s)
--- PASS: TestAccAWSDynamoDbTableItem_rangeKey (65.84s)
--- PASS: TestAccAWSDynamoDbTable_basic (76.59s)
--- PASS: TestAccAWSDynamoDbTable_tags (81.49s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (18.65s)
--- PASS: TestAccAWSDynamoDbTableItem_updateWithRangeKey (104.31s)
--- PASS: TestAccAWSDynamoDbTableItem_update (105.96s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_PayPerRequestToProvisioned (109.80s)
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (113.14s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_Enabled (62.49s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (124.25s)
--- PASS: TestAccAWSDynamoDbTable_enablePitr (124.59s)
--- PASS: TestAccAWSDynamoDbTable_disappears_PayPerRequestWithGSI (129.60s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_PayPerRequestToProvisioned (130.37s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes_emptyPlan (75.35s)
--- PASS: TestAccAWSDynamoDbTable_Ttl_Disabled (70.50s)
--- PASS: TestAccAWSDynamoDbTable_encryption (141.96s)
--- PASS: TestAccAWSDynamoDbTable_extended (365.67s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (351.24s)
--- PASS: TestAccAWSDynamoDbTable_Replica_Single (511.33s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (700.15s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdate (637.15s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_GSI_ProvisionedToPayPerRequest (863.35s)
--- PASS: TestAccAWSDynamoDbTable_Replica_Multiple (880.79s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode_ProvisionedToPayPerRequest (1290.57s)
```
