### PR TITLE
d/rds_orderable_db_instance: Add documentation for argument

### DIFF
--- a/aws/data_source_aws_rds_orderable_db_instance.go
+++ b/aws/data_source_aws_rds_orderable_db_instance.go
@@ -25,18 +25,18 @@ func dataSourceAwsRdsOrderableDbInstance() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"instance_class": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"engine": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
 			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"instance_class": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -88,13 +88,13 @@ func dataSourceAwsRdsOrderableDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
-			"preferred_engine_versions": {
+			"preferred_instance_classes": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"preferred_instance_classes": {
+			"preferred_engine_versions": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/aws/data_source_aws_rds_orderable_db_instance_test.go
+++ b/aws/data_source_aws_rds_orderable_db_instance_test.go
@@ -18,7 +18,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_basic(t *testing.T) {
 	storageType := "standard"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -41,7 +41,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_preferredClass(t *testing.T) {
 	preferredClass := "db.t2.micro"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_preferredVersion(t *testing.T) {
 	preferredVersion := "5.7.22"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -80,7 +80,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_preferredClassAndVersion(t *test
 	preferredVersion := "5.7.22"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -99,7 +99,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_supportsEnhancedMonitoring(t *te
 	dataSourceName := "data.aws_rds_orderable_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -117,7 +117,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_supportsIAMDatabaseAuthenticatio
 	dataSourceName := "data.aws_rds_orderable_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -135,7 +135,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_supportsIops(t *testing.T) {
 	dataSourceName := "data.aws_rds_orderable_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -153,7 +153,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_supportsKerberosAuthentication(t
 	dataSourceName := "data.aws_rds_orderable_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -173,8 +173,8 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_supportsPerformanceInsights(t *t
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckAWSRdsOrderableDbInstance(t)
-			testAccPreCheckAWSRdsOrderableDbInstanceStandardPartition(t)
+			testAccAWSRdsOrderableDbInstancePreCheck(t)
+			testAccRDSPerformanceInsightsDefaultVersionPreCheck(t, "mysql")
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
@@ -193,7 +193,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageAutoscaling(t *te
 	dataSourceName := "data.aws_rds_orderable_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -211,7 +211,7 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageEncryption(t *tes
 	dataSourceName := "data.aws_rds_orderable_db_instance.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsOrderableDbInstance(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSRdsOrderableDbInstancePreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
@@ -225,11 +225,13 @@ func TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageEncryption(t *tes
 	})
 }
 
-func testAccPreCheckAWSRdsOrderableDbInstance(t *testing.T) {
+func testAccAWSRdsOrderableDbInstancePreCheck(t *testing.T) {
 	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
 	input := &rds.DescribeOrderableDBInstanceOptionsInput{
-		Engine: aws.String("mysql"),
+		Engine:          aws.String("mysql"),
+		EngineVersion:   aws.String("8.0.20"),
+		DBInstanceClass: aws.String("db.m5.xlarge"),
 	}
 
 	_, err := conn.DescribeOrderableDBInstanceOptions(input)
@@ -240,12 +242,6 @@ func testAccPreCheckAWSRdsOrderableDbInstance(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-}
-
-func testAccPreCheckAWSRdsOrderableDbInstanceStandardPartition(t *testing.T) {
-	if testAccGetPartition() != "aws" {
-		t.Skipf("skipping acceptance testing, not in standard partition (partition: %s)", testAccGetPartition())
 	}
 }
 

--- a/website/docs/d/rds_orderable_db_instance.markdown
+++ b/website/docs/d/rds_orderable_db_instance.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_rds_orderable_db_instance
 
-Information about RDS orderable DB instances.
+Information about RDS orderable DB instances and valid parameter combinations.
 
 ## Example Usage
 
@@ -23,16 +23,30 @@ data "aws_rds_orderable_db_instance" "test" {
 }
 ```
 
+Valid parameter combinations can also be found with `preferred_engine_versions` and/or `preferred_instance_classes`.
+
+```hcl
+data "aws_rds_orderable_db_instance" "test" {
+  engine        = "mysql"
+  license_model = "general-public-license"
+
+  preferred_engine_versions  = ["5.6.35", "5.6.41", "5.6.44"]
+  preferred_instance_classes = ["db.t2.small", "db.t3.medium", "db.t3.large"]
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `engine` - (Required) DB engine. Engine values include `aurora`, `aurora-mysql`, `aurora-postgresql`, `docdb`, `mariadb`, `mysql`, `neptune`, `oracle-ee`, `oracle-se`, `oracle-se1`, `oracle-se2`, `postgres`, `sqlserver-ee`, `sqlserver-ex`, `sqlserver-se`, and `sqlserver-web`.
 * `availability_zone_group` - (Optional) Availability zone group.
+* `engine` - (Required) DB engine. Engine values include `aurora`, `aurora-mysql`, `aurora-postgresql`, `docdb`, `mariadb`, `mysql`, `neptune`, `oracle-ee`, `oracle-se`, `oracle-se1`, `oracle-se2`, `postgres`, `sqlserver-ee`, `sqlserver-ex`, `sqlserver-se`, and `sqlserver-web`.
+* `engine_version` - (Optional) Version of the DB engine. If none is provided, the AWS-defined default version will be used.
 * `instance_class` - (Optional) DB instance class. Examples of classes are `db.m3.2xlarge`, `db.t2.small`, and `db.m3.medium`.
-* `engine_version` - (Optional) Version of the DB engine.
 * `license_model` - (Optional) License model. Examples of license models are `general-public-license`, `bring-your-own-license`, and `amazon-license`.
 * `preferred_instance_classes` - (Optional) Ordered list of preferred RDS DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
+* `preferred_engine_versions` - (Optional) Ordered list of preferred RDS DB instance engine versions. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
 * `storage_type` - (Optional) Storage types. Examples of storage types are `standard`, `io1`, `gp2`, and `aurora`.
 * `supports_enhanced_monitoring` - (Optional) Enable this to ensure a DB instance supports Enhanced Monitoring at intervals from 1 to 60 seconds.
 * `supports_global_databases` - (Optional) Enable this to ensure a DB instance supports Aurora global databases with a specific combination of other DB engine attributes.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15203

This PR has been gutted in favor of a new data source (#15228). A few useful items remain:

1. Add documentation for `preferred_engine_versions` which was not included before (undocumented feature)
2. Alphabetize arguments (code and docs).
3. Rename precheck functions for convention conformity

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
NONE
```

The output from acceptance testing on GovCloud:

```
--- SKIP: TestAccAWSRdsOrderableDbInstanceDataSource_supportsPerformanceInsights (0.00s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_basic (21.69s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredClass (27.25s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsIAMDatabaseAuthentication (39.72s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageEncryption (42.38s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsEnhancedMonitoring (54.38s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredVersion (54.46s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_defaultOnly (59.58s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsIops (60.66s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageAutoscaling (78.02s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsKerberosAuthentication (96.30s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredClassAndVersion (102.25s)
```

The output from acceptance testing on commercial:

```
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_basic (15.47s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredClass (19.52s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_defaultOnly (203.34s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageAutoscaling (446.33s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredClassAndVersion (453.16s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsStorageEncryption (455.84s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsPerformanceInsights (456.21s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_preferredVersion (462.88s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsIops (469.54s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsIAMDatabaseAuthentication (482.06s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsEnhancedMonitoring (498.31s)
--- PASS: TestAccAWSRdsOrderableDbInstanceDataSource_supportsKerberosAuthentication (616.16s)
```