### PR TITLE
d/neptune_orderable_db_instance: Add defaults for arguments

### DIFF
--- a/aws/data_source_aws_neptune_orderable_db_instance.go
+++ b/aws/data_source_aws_neptune_orderable_db_instance.go
@@ -19,15 +19,10 @@ func dataSourceAwsNeptuneOrderableDbInstance() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"instance_class": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"engine": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "neptune",
 			},
 
 			"engine_version": {
@@ -36,10 +31,17 @@ func dataSourceAwsNeptuneOrderableDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"instance_class": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"preferred_instance_classes"},
+			},
+
 			"license_model": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  "amazon-license",
 			},
 
 			"max_iops_per_db_instance": {
@@ -78,9 +80,10 @@ func dataSourceAwsNeptuneOrderableDbInstance() *schema.Resource {
 			},
 
 			"preferred_instance_classes": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"instance_class"},
 			},
 
 			"read_replica_capable": {

--- a/website/docs/d/neptune_orderable_db_instance.markdown
+++ b/website/docs/d/neptune_orderable_db_instance.markdown
@@ -14,11 +14,7 @@ Information about Neptune orderable DB instances.
 
 ```hcl
 data "aws_neptune_orderable_db_instance" "test" {
-  engine         = "neptune"
-  engine_version = "1.0.3.0"
-  license_model  = "amazon-license"
-  storage_type   = "aurora"
-
+  engine_version             = "1.0.3.0"
   preferred_instance_classes = ["db.r5.large", "db.r4.large", "db.t3.medium"]
 }
 ```
@@ -27,12 +23,12 @@ data "aws_neptune_orderable_db_instance" "test" {
 
 The following arguments are supported:
 
-* `engine` - (Required) DB engine. Engine values include `neptune`.
-* `instance_class` - (Optional) DB instance class. Examples of classes are `db.r5.large`, `db.r5.xlarge`, `db.r4.large`, `db.r5.4xlarge`, `db.r5.12xlarge`, `db.r4.xlarge`, and `db.t3.medium`.
+* `engine` - (Optional) DB engine. (Default: `neptune`)
 * `engine_version` - (Optional) Version of the DB engine. For example, `1.0.1.0`, `1.0.1.2`, `1.0.2.2`, and `1.0.3.0`.
-* `license_model` - (Optional) License model. For example, `amazon-license`.
+* `instance_class` - (Optional) DB instance class. Examples of classes are `db.r5.large`, `db.r5.xlarge`, `db.r4.large`, `db.r5.4xlarge`, `db.r5.12xlarge`, `db.r4.xlarge`, and `db.t3.medium`.
+* `license_model` - (Optional) License model. (Default: `amazon-license`)
 * `preferred_instance_classes` - (Optional) Ordered list of preferred Neptune DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
-* `vpc` - (Optional) Boolean that indicates whether to show only VPC or non-VPC offerings.
+* `vpc` - (Optional) Enable to show only VPC offerings.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15206

This PR has been gutted in favor of a new data source. A few useful items remain:

1. Defaults for `engine` and `license_model` when there are no options at present
2. Alphabetize arguments (code and docs).

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
d/neptune_orderable_db_instance: Add defaults for arguments
```

The output from acceptance testing on GovCloud:

```
--- PASS: TestAccAWSNeptuneOrderableDbInstanceDataSource_basic (17.87s)
--- PASS: TestAccAWSNeptuneOrderableDbInstanceDataSource_preferred (17.96s)
--- PASS: TestAccAWSNeptuneOrderableDbInstanceDataSource_defaultOnly (20.11s)
```

The output from acceptance testing on commercial:

```
--- PASS: TestAccAWSNeptuneOrderableDbInstanceDataSource_basic (14.43s)
--- PASS: TestAccAWSNeptuneOrderableDbInstanceDataSource_preferred (14.86s)
--- PASS: TestAccAWSNeptuneOrderableDbInstanceDataSource_defaultOnly (17.24s)
```
