### PR TITLE
d/docdb_orderable_db_instance: Add defaults for arguments

### DIFF
--- a/aws/data_source_aws_docdb_orderable_db_instance.go
+++ b/aws/data_source_aws_docdb_orderable_db_instance.go
@@ -19,15 +19,10 @@ func dataSourceAwsDocdbOrderableDbInstance() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"instance_class": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"engine": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "docdb",
 			},
 
 			"engine_version": {
@@ -36,16 +31,24 @@ func dataSourceAwsDocdbOrderableDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"instance_class": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"preferred_instance_classes"},
+			},
+
 			"license_model": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  "na",
 			},
 
 			"preferred_instance_classes": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"instance_class"},
 			},
 
 			"vpc": {
@@ -82,7 +85,7 @@ func dataSourceAwsDocdbOrderableDbInstanceRead(d *schema.ResourceData, meta inte
 		input.Vpc = aws.Bool(v.(bool))
 	}
 
-	log.Printf("[DEBUG] Reading DocDB Orderable DB Instance Options: %v", input)
+	log.Printf("[DEBUG] Reading DocDB Orderable DB Instance Classes: %v", input)
 	var instanceClassResults []*docdb.OrderableDBInstanceOption
 
 	err := conn.DescribeOrderableDBInstanceOptionsPages(input, func(resp *docdb.DescribeOrderableDBInstanceOptionsOutput, lastPage bool) bool {

--- a/website/docs/d/docdb_orderable_db_instance.markdown
+++ b/website/docs/d/docdb_orderable_db_instance.markdown
@@ -26,12 +26,12 @@ data "aws_docdb_orderable_db_instance" "test" {
 
 The following arguments are supported:
 
-* `engine` - (Required) DB engine. Engine values include `docdb`.
-* `instance_class` - (Optional) DB instance class. Examples of classes are `db.r5.12xlarge`, `db.r5.24xlarge`, `db.r5.2xlarge`, `db.r5.4xlarge`, `db.r5.large`, `db.r5.xlarge`, and `db.t3.medium`.
-* `engine_version` - (Optional) Version of the DB engine. For example, `3.6.0`.
-* `license_model` - (Optional) License model. Examples of license models are `general-public-license`, `na`, `bring-your-own-license`, and `amazon-license`.
-* `preferred_instance_classes` - (Optional) Ordered list of preferred DocumentDB DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned.
-* `vpc` - (Optional) Boolean that indicates whether to show only VPC or non-VPC offerings.
+* `engine` - (Optional) DB engine. Default: `docdb`
+* `engine_version` - (Optional) Version of the DB engine.
+* `instance_class` - (Optional) DB instance class. Examples of classes are `db.r5.12xlarge`, `db.r5.24xlarge`, `db.r5.2xlarge`, `db.r5.4xlarge`, `db.r5.large`, `db.r5.xlarge`, and `db.t3.medium`. (Conflicts with `preferred_instance_classes`.)
+* `license_model` - (Optional) License model. Default: `na`
+* `preferred_instance_classes` - (Optional) Ordered list of preferred DocumentDB DB instance classes. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned. (Conflicts with `instance_class`.)
+* `vpc` - (Optional) Enable to show only VPC.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15208

This PR has been gutted in favor of a new data source. A few useful items remain:

1. Defaults for `engine` and `license_model` when there are no options at present
2. Alphabetize arguments (code and docs).

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
d/docdb_orderable_db_instance: Add default `engine` and `license_model`
```

The output from acceptance testing on GovCloud:

```
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_basic (17.36s)
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_preferred (17.40s)
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_defaultOnly (19.43s)
```

The output from acceptance testing on commercial:

```
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_basic (12.55s)
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_preferred (13.02s)
--- PASS: TestAccAWSDocdbOrderableDbInstanceDataSource_defaultOnly (15.12s)
```