### PR TITLE
resource/aws_elasticsearch_domain: Future proof new log type values in order to support the new `AUDIT_LOGS` log type

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -364,13 +364,9 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"log_type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								elasticsearch.LogTypeIndexSlowLogs,
-								elasticsearch.LogTypeSearchSlowLogs,
-								elasticsearch.LogTypeEsApplicationLogs,
-							}, false),
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(elasticsearch.LogType_Values(), false),
 						},
 						"cloudwatch_log_group_arn": {
 							Type:         schema.TypeString,

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -296,7 +296,7 @@ Security Groups and Subnets referenced in these attributes must all be within th
 
 **log_publishing_options** supports the following attribute:
 
-* `log_type` - (Required) A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS
+* `log_type` - (Required) A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS, AUDIT_LOGS
 * `cloudwatch_log_group_arn` - (Required) ARN of the Cloudwatch log group to which log needs to be published.
 * `enabled` - (Optional, Default: true) Specifies whether given log publishing option is enabled or not.
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #15217

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
ENHANCEMENTS

* resource/aws_elasticsearch_domain: Add `AUDIT_LOGS` as a possible log type [GH-15218]
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSElasticSearchDomain_LogPublishingOptions'

... [unfortunately, don't have a set up testing environment for this]
```