### PR TITLE
tests/resource/aws_s3_bucket_object: Fix etag and non-versions test configurations

### DIFF
--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -1226,15 +1226,15 @@ resource "aws_s3_bucket_object" "object" {
 func testAccAWSS3BucketObjectEtagEncryption(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket                 = aws_s3_bucket.object_bucket.bucket
   key                    = "test-key"
   server_side_encryption = "AES256"
-  source                 = %[1]q
-  etag                   = filemd5(%[1]q)
+  source                 = %[2]q
+  etag                   = filemd5(%[2]q)
 }
 `, randInt, source)
 }
@@ -1566,14 +1566,14 @@ func testAccAWSS3BucketObjectConfig_NonVersioned(randInt int, source string) str
 
 	return testAccProviderConfigAssumeRolePolicy(policy) + fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket_3" {
-  bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%[1]d"
 }
 
 resource "aws_s3_bucket_object" "object" {
   bucket = aws_s3_bucket.object_bucket_3.bucket
   key    = "updateable-key"
-  source = %[1]q
-  etag   = filemd5(%[1]q)
+  source = %[2]q
+  etag   = filemd5(%[2]q)
 }
 `, randInt, source)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
=== CONT  TestAccAWSS3BucketObject_etagEncryption
TestAccAWSS3BucketObject_etagEncryption: resource_aws_s3_bucket_object_test.go:199: Step 1/1 error: terraform failed: exit status 1
stderr:
Error: Invalid expression
on config027201552/terraform_plugin_test.tf line 10, in resource "aws_s3_bucket_object" "object":
10:   source                 = %!q(int=5634537717392942380)
Expected the start of an expression, but found an invalid expression token.
Error: Missing argument separator
on config027201552/terraform_plugin_test.tf line 11, in resource "aws_s3_bucket_object" "object":
11:   etag                   = filemd5(%!q(int=5634537717392942380))
A comma is required to separate each function argument from the next.
--- FAIL: TestAccAWSS3BucketObject_etagEncryption (1.67s)

=== CONT  TestAccAWSS3BucketObject_NonVersioned
TestAccAWSS3BucketObject_NonVersioned: resource_aws_s3_bucket_object_test.go:272: Step 1/1 error: terraform failed: exit status 1
stderr:
Error: Invalid expression
on config020903983/terraform_plugin_test.tf line 16, in resource "aws_s3_bucket_object" "object":
16:   source = %!q(int=1805044611502807977)
Expected the start of an expression, but found an invalid expression token.
Error: Missing argument separator
on config020903983/terraform_plugin_test.tf line 17, in resource "aws_s3_bucket_object" "object":
17:   etag   = filemd5(%!q(int=1805044611502807977))
A comma is required to separate each function argument from the next.
--- FAIL: TestAccAWSS3BucketObject_NonVersioned (2.34s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSS3BucketObject_etagEncryption (23.09s)
--- PASS: TestAccAWSS3BucketObject_NonVersioned (23.34s)
```
