### PR TITLE
Updates acceptance tests to use modern splat syntax instead of adding individual array elements to list

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -3331,7 +3331,7 @@ resource "aws_lb_target_group" "green" {
 resource "aws_lb" "test" {
   internal = true
   name     = %[1]q
-  subnets  = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnets  = aws_subnet.test[*].id
 }
 
 resource "aws_lb_listener" "test" {
@@ -3396,7 +3396,7 @@ resource "aws_ecs_service" "test" {
   network_configuration {
     assign_public_ip = true
     security_groups  = [aws_security_group.test.id]
-    subnets          = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+    subnets          = aws_subnet.test[*].id
   }
 }
 

--- a/aws/resource_aws_db_cluster_snapshot_test.go
+++ b/aws/resource_aws_db_cluster_snapshot_test.go
@@ -257,7 +257,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_db_subnet_group" "test" {
   name       = %[1]q
-  subnet_ids = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnet_ids = aws_subnet.test[*].id
 }
 
 resource "aws_rds_cluster" "test" {

--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -829,7 +829,7 @@ resource "aws_subnet" "test" {
 resource "aws_dms_replication_subnet_group" "test" {
   replication_subnet_group_description = %q
   replication_subnet_group_id          = %q
-  subnet_ids                           = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnet_ids                           = aws_subnet.test[*].id
 }
 
 resource "aws_dms_replication_instance" "test" {
@@ -916,7 +916,7 @@ resource "aws_subnet" "test" {
 resource "aws_dms_replication_subnet_group" "test" {
   replication_subnet_group_description = %q
   replication_subnet_group_id          = %q
-  subnet_ids                           = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnet_ids                           = aws_subnet.test[*].id
 }
 
 resource "aws_dms_replication_instance" "test" {

--- a/aws/resource_aws_docdb_cluster_snapshot_test.go
+++ b/aws/resource_aws_docdb_cluster_snapshot_test.go
@@ -141,7 +141,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_docdb_subnet_group" "test" {
   name       = %q
-  subnet_ids = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnet_ids = aws_subnet.test[*].id
 }
 
 resource "aws_docdb_cluster" "test" {

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -816,7 +816,7 @@ resource "aws_subnet" "test" {
 resource "aws_ec2_transit_gateway" "test" {}
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
-  subnet_ids         = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnet_ids         = aws_subnet.test[*].id
   transit_gateway_id = aws_ec2_transit_gateway.test.id
   vpc_id             = aws_vpc.test.id
 }

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -1862,7 +1862,7 @@ resource "aws_ecs_service" "main" {
 
   network_configuration {
     security_groups  = [aws_security_group.allow_all_a.id, aws_security_group.allow_all_b.id]
-    subnets          = [aws_subnet.main[0].id, aws_subnet.main[1].id]
+    subnets          = aws_subnet.main[*].id
     assign_public_ip = %s
   }
 }
@@ -1960,7 +1960,7 @@ resource "aws_ecs_service" "main" {
 
   network_configuration {
     security_groups  = [aws_security_group.allow_all_a.id, aws_security_group.allow_all_b.id]
-    subnets          = [aws_subnet.main[0].id, aws_subnet.main[1].id]
+    subnets          = aws_subnet.main[*].id
     assign_public_ip = false
   }
 }
@@ -2079,7 +2079,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_lb" "main" {
   name     = "%s"
   internal = true
-  subnets  = [aws_subnet.main[0].id, aws_subnet.main[1].id]
+  subnets  = aws_subnet.main[*].id
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -2214,7 +2214,7 @@ EOF
 
 resource "aws_elb" "main" {
   internal = true
-  subnets  = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnets  = aws_subnet.test[*].id
 
   listener {
     instance_port     = 8080
@@ -2376,7 +2376,7 @@ EOF
 
 resource "aws_elb" "main" {
   internal = true
-  subnets  = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnets  = aws_subnet.test[*].id
 
   listener {
     instance_port     = %[6]d
@@ -2649,7 +2649,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_lb" "main" {
   name     = "%s"
   internal = true
-  subnets  = [aws_subnet.main[0].id, aws_subnet.main[1].id]
+  subnets  = aws_subnet.main[*].id
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -2758,7 +2758,7 @@ resource "aws_lb_target_group" "static" {
 resource "aws_lb" "main" {
   name     = "%s"
   internal = true
-  subnets  = [aws_subnet.main[0].id, aws_subnet.main[1].id]
+  subnets  = aws_subnet.main[*].id
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -2903,7 +2903,7 @@ resource "aws_ecs_service" "main" {
   desired_count   = 1
   network_configuration {
     security_groups = [%s]
-    subnets         = [aws_subnet.main[0].id, aws_subnet.main[1].id]
+    subnets         = aws_subnet.main[*].id
   }
 }
 `, sg1Name, sg2Name, clusterName, tdName, svcName, securityGroups)
@@ -3004,7 +3004,7 @@ resource "aws_ecs_service" "test" {
 
   network_configuration {
     security_groups = [aws_security_group.test.id]
-    subnets         = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+    subnets         = aws_subnet.test[*].id
   }
 }
 `, rName, rName, rName, clusterName, tdName, svcName)
@@ -3211,7 +3211,7 @@ resource "aws_subnet" "test" {
 resource "aws_lb" "test" {
   internal = true
   name     = %[1]q
-  subnets  = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnets  = aws_subnet.test[*].id
 }
 
 resource "aws_lb_listener" "test" {

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -925,7 +925,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_elasticache_subnet_group" "test" {
   name       = %[1]q
-  subnet_ids = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnet_ids = aws_subnet.test[*].id
 }
 
 resource "aws_elasticache_replication_group" "test" {
@@ -1639,7 +1639,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_elasticache_subnet_group" "test" {
   name       = "%[1]s"
-  subnet_ids = [aws_subnet.test[0].id, aws_subnet.test[1].id]
+  subnet_ids = aws_subnet.test[*].id
 }
 
 resource "aws_elasticache_replication_group" "test" {


### PR DESCRIPTION
Updates acceptance tests to use modern splat syntax instead of adding individual array elements to list

Originally
```terraform
subnets  = [aws_subnet.test[0].id, aws_subnet.test[1].id]
```

After update
```terraform
 subnets  = aws_subnet.test[*].id
```
Relates #14722

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS="-run=TestResourceAWSElastiCacheReplicationGroupEngineValidation\|TestAccAWSCodeDeployDeploymentGroup\|TestAWSCodeDeployDeploymentGroup\|TestAccAWSDmsReplicationInstance\|TestAccAWSDocDBClusterSnapshot\|TestAccAWSEcsService\|TestAccAWSElasticacheReplicationGroup\|TestAccAWSDBClusterSnapshot\|TestAccAWSEc2TransitGatewayVpcAttachment"

--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (79.89s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (82.26s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (82.42s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (85.38s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (87.01s)
--- PASS: TestAccAWSEcsServiceDataSource_basic (101.97s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (104.17s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (107.52s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (109.64s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (110.50s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (113.75s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (121.38s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (122.18s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (123.25s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (124.43s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (127.95s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildAutoRollbackConfig (0.00s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (129.38s)
--- PASS: TestAWSCodeDeployDeploymentGroup_autoRollbackConfigToMap (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenDeploymentStyle (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandLoadBalancerInfo (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandDeploymentStyle (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenLoadBalancerInfo (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandBlueGreenDeploymentConfig (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenBlueGreenDeploymentConfig (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildAlarmConfig (0.00s)
--- PASS: TestAWSCodeDeployDeploymentGroup_alarmConfigToMap (0.00s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (63.58s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (68.90s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (155.02s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (57.28s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (104.99s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (99.49s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (103.04s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (97.96s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (99.92s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (94.58s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (87.30s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (88.25s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (88.75s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (180.40s)
--- PASS: TestAccAWSDBClusterSnapshot_basic (167.09s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic (1.06s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags (0.93s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation (1.10s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (192.37s)
--- PASS: TestAccAWSDBClusterSnapshot_Tags (195.13s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (363.39s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (365.89s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway (1.13s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (290.46s)
--- PASS: TestAccAWSDmsReplicationInstance_basic (326.82s)
--- PASS: TestAccAWSDocDBClusterSnapshot_basic (238.86s)
--- PASS: TestAccAWSDmsReplicationInstance_AvailabilityZone (375.27s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationSubnetGroupId (332.81s)
--- PASS: TestAccAWSDmsReplicationInstance_KmsKeyArn (428.48s)
--- PASS: TestAccAWSEcsService_withARN (91.34s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_disappears (351.92s)
--- PASS: TestAccAWSDmsReplicationInstance_PubliclyAccessible (473.23s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_basic (385.42s)
--- PASS: TestAccAWSEcsService_disappears (58.34s)
--- FAIL: TestAccAWSEcsService_basicImport (82.84s)
--- PASS: TestAccAWSDmsReplicationInstance_Tags (494.06s)
--- PASS: TestAccAWSDmsReplicationInstance_VpcSecurityGroupIds (494.49s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport (394.99s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (68.78s)
--- PASS: TestAccAWSDmsReplicationInstance_AutoMinorVersionUpgrade (581.65s)
--- PASS: TestAccAWSDmsReplicationInstance_PreferredMaintenanceWindow (536.79s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support (379.62s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (84.68s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_External (61.12s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled (313.92s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationInstanceClass (593.00s)
--- PASS: TestAccAWSEcsService_withMultipleCapacityProviderStrategies (114.77s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (69.02s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy_Type_Missing (1.49s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (81.10s)
--- PASS: TestAccAWSEcsService_withIamRole (123.63s)
--- PASS: TestAccAWSDmsReplicationInstance_EngineVersion (650.97s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (147.61s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Tags (429.98s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (78.98s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds (489.50s)
--- PASS: TestAccAWSEcsService_withCapacityProviderStrategy (191.16s)
--- PASS: TestAccAWSEcsService_withForceNewDeployment (81.62s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (73.73s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (71.00s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (92.29s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (58.14s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (51.99s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (81.76s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (111.65s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation (425.02s)
--- PASS: TestAccAWSEcsService_ManagedTags (82.15s)
--- PASS: TestAccAWSEcsService_withLbChanges (228.65s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (257.29s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (150.71s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (150.53s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (283.49s)
--- PASS: TestAccAWSEcsService_Tags (109.36s)
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (9.45s)
--- PASS: TestAccAWSEcsService_withAlb (232.24s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (153.30s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation (492.60s)
--- PASS: TestAccAWSEcsService_withMultipleTargetGroups (241.94s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (162.52s)
--- PASS: TestAccAWSEcsService_PropagateTags (195.20s)
--- PASS: TestAccAWSDmsReplicationInstance_AllocatedStorage (1043.00s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (544.27s)
--- PASS: TestResourceAWSElastiCacheReplicationGroupEngineValidation (0.00s)
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (680.87s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (702.24s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (753.35s)
--- PASS: TestAccAWSElasticacheReplicationGroup_useCmkKmsKeyId (816.03s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (945.75s)
--- PASS: TestAccAWSElasticacheReplicationGroup_tags (785.34s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1029.73s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (1049.99s)
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (1119.11s)
--- PASS: TestAccAWSDmsReplicationInstance_MultiAz (2002.04s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1254.04s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (1314.78s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1422.01s)
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (1473.45s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (1559.94s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (1564.73s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (1711.37s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (2823.10s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (3588.64s)
```

Failures are pre-existing:
* TestAccAWSEcsService_basicImport
* TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway
* TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic (1.06s)
* TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags (0.93s)
* TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagat