### PR TITLE
fsx_lustre_file_system - add `auto_import_policy`  argument

### DIFF
--- a/aws/resource_aws_fsx_lustre_file_system.go
+++ b/aws/resource_aws_fsx_lustre_file_system.go
@@ -171,8 +171,8 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 			"auto_import_policy": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      fsx.AutoImportPolicyTypeNone,
-				ValidateFunc: validation.StringInSlice(fsx.LustreDeploymentType_Values(), false),
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(fsx.AutoImportPolicyType_Values(), false),
 			},
 		},
 	}

--- a/aws/resource_aws_fsx_lustre_file_system.go
+++ b/aws/resource_aws_fsx_lustre_file_system.go
@@ -115,15 +115,11 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 				),
 			},
 			"deployment_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  fsx.LustreDeploymentTypeScratch1,
-				ValidateFunc: validation.StringInSlice([]string{
-					fsx.LustreDeploymentTypeScratch1,
-					fsx.LustreDeploymentTypeScratch2,
-					fsx.LustreDeploymentTypePersistent1,
-				}, false),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      fsx.LustreDeploymentTypeScratch1,
+				ValidateFunc: validation.StringInSlice(fsx.LustreDeploymentType_Values(), false),
 			},
 			"kms_key_id": {
 				Type:         schema.TypeString,
@@ -171,6 +167,12 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(fsx.DriveCacheType_Values(), false),
+			},
+			"auto_import_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      fsx.AutoImportPolicyTypeNone,
+				ValidateFunc: validation.StringInSlice(fsx.LustreDeploymentType_Values(), false),
 			},
 		},
 	}
@@ -235,6 +237,10 @@ func resourceAwsFsxLustreFileSystemCreate(d *schema.ResourceData, meta interface
 		input.LustreConfiguration.DriveCacheType = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("auto_import_policy"); ok {
+		input.LustreConfiguration.AutoImportPolicy = aws.String(v.(string))
+	}
+
 	result, err := conn.CreateFileSystem(input)
 	if err != nil {
 		return fmt.Errorf("Error creating FSx Lustre filesystem: %w", err)
@@ -281,6 +287,11 @@ func resourceAwsFsxLustreFileSystemUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChange("daily_automatic_backup_start_time") {
 		input.LustreConfiguration.DailyAutomaticBackupStartTime = aws.String(d.Get("daily_automatic_backup_start_time").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("auto_import_policy") {
+		input.LustreConfiguration.AutoImportPolicy = aws.String(d.Get("auto_import_policy").(string))
 		requestUpdate = true
 	}
 
@@ -341,6 +352,7 @@ func resourceAwsFsxLustreFileSystemRead(d *schema.ResourceData, meta interface{}
 	d.Set("dns_name", filesystem.DNSName)
 	d.Set("export_path", lustreConfig.DataRepositoryConfiguration.ExportPath)
 	d.Set("import_path", lustreConfig.DataRepositoryConfiguration.ImportPath)
+	d.Set("auto_import_policy", lustreConfig.DataRepositoryConfiguration.AutoImportPolicy)
 	d.Set("imported_file_chunk_size", lustreConfig.DataRepositoryConfiguration.ImportedFileChunkSize)
 	d.Set("deployment_type", lustreConfig.DeploymentType)
 	if lustreConfig.PerUnitStorageThroughput != nil {

--- a/aws/resource_aws_fsx_lustre_file_system.go
+++ b/aws/resource_aws_fsx_lustre_file_system.go
@@ -56,6 +56,7 @@ func resourceAwsFsxLustreFileSystem() *schema.Resource {
 					validation.StringLenBetween(3, 900),
 					validation.StringMatch(regexp.MustCompile(`^s3://`), "must begin with s3://"),
 				),
+				RequiredWith: []string{"auto_import_policy"},
 			},
 			"imported_file_chunk_size": {
 				Type:         schema.TypeInt,

--- a/aws/resource_aws_fsx_lustre_file_system_test.go
+++ b/aws/resource_aws_fsx_lustre_file_system_test.go
@@ -626,7 +626,7 @@ func TestAccAWSFsxLustreFileSystem_autoImportPolicy(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("fsx", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckFsxLustreFileSystemDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_fsx_lustre_file_system_test.go
+++ b/aws/resource_aws_fsx_lustre_file_system_test.go
@@ -98,7 +98,6 @@ func TestAccAWSFsxLustreFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deployment_type", fsx.LustreDeploymentTypeScratch1),
 					resource.TestCheckResourceAttr(resourceName, "automatic_backup_retention_days", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_type", fsx.StorageTypeSsd),
-					resource.TestCheckResourceAttr(resourceName, "auto_import_policy", "NONE"),
 				),
 			},
 			{

--- a/website/docs/r/fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/fsx_lustre_file_system.html.markdown
@@ -39,6 +39,7 @@ The following arguments are supported:
 * `storage_type` - (Optional) - The filesystem storage type. Either `SSD` or `HDD`, defaults to `SSD`. `HDD` is only supported on `PERSISTENT_1` deployment types.
 * `drive_cache_type` - (Optional) - The type of drive cache used by `PERSISTENT_1` filesystems that are provisioned with `HDD` storage_type. Required for `HDD` storage_type, set to either `READ` or `NONE`.
 * `daily_automatic_backup_start_time` - (Optional) A recurring daily time, in the format HH:MM. HH is the zero-padded hour of the day (0-23), and MM is the zero-padded minute of the hour. For example, 05:00 specifies 5 AM daily. only valid for `PERSISTENT_1` deployment_type. Requires `automatic_backup_retention_days` to be set.
+* `auto_import_policy` - (Optional) How Amazon FSx keeps your file and directory listings up to date as you add or modify objects in your linked S3 bucket. see [Auto Import Data Repo](https://docs.aws.amazon.com/fsx/latest/LustreGuide/autoimport-data-repo.html) for more details.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14406

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resoruce_aws_fsx_lustre_file_system - add `auto_import_policy`  argument
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSFsxLustreFileSystem_'
--- PASS: TestAccAWSFsxLustreFileSystem_basic (596.06s)
--- PASS: TestAccAWSFsxLustreFileSystem_ExportPath (1396.45s)
--- PASS: TestAccAWSFsxLustreFileSystem_autoImportPolicy (1373.40s)
```
