### PR TITLE
r/aws_apigatewayv2_authorizer: Support Lambda authorization options for HTTP APIs

### DIFF
--- a/aws/internal/service/apigatewayv2/finder/finder.go
+++ b/aws/internal/service/apigatewayv2/finder/finder.go
@@ -1,0 +1,20 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+)
+
+// ApiByID returns the API corresponding to the specified ID.
+func ApiByID(conn *apigatewayv2.ApiGatewayV2, apiID string) (*apigatewayv2.GetApiOutput, error) {
+	input := &apigatewayv2.GetApiInput{
+		ApiId: aws.String(apiID),
+	}
+
+	output, err := conn.GetApi(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/aws/resource_aws_apigatewayv2_authorizer.go
+++ b/aws/resource_aws_apigatewayv2_authorizer.go
@@ -58,8 +58,7 @@ func resourceAwsApiGatewayV2Authorizer() *schema.Resource {
 			},
 			"identity_sources": {
 				Type:     schema.TypeSet,
-				Required: true,
-				MinItems: 1,
+				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"jwt_configuration": {

--- a/aws/resource_aws_apigatewayv2_authorizer.go
+++ b/aws/resource_aws_apigatewayv2_authorizer.go
@@ -117,7 +117,7 @@ func resourceAwsApiGatewayV2AuthorizerCreate(d *schema.ResourceData, meta interf
 	if v, ok := d.GetOk("authorizer_payload_format_version"); ok {
 		req.AuthorizerPayloadFormatVersion = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("authorizer_result_ttl_in_seconds"); ok {
+	if v, ok := d.GetOkExists("authorizer_result_ttl_in_seconds"); ok {
 		req.AuthorizerResultTtlInSeconds = aws.Int64(int64(v.(int)))
 	} else if protocolType == apigatewayv2.ProtocolTypeHttp && authorizerType == apigatewayv2.AuthorizerTypeRequest {
 		// Default in the AWS Console is 300 seconds.

--- a/aws/resource_aws_apigatewayv2_authorizer_test.go
+++ b/aws/resource_aws_apigatewayv2_authorizer_test.go
@@ -34,8 +34,7 @@ func TestAccAWSAPIGatewayV2Authorizer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "REQUEST"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
-					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "route.request.header.Auth"),
+					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
@@ -135,8 +134,7 @@ func TestAccAWSAPIGatewayV2Authorizer_Credentials(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
 					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
-					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "1"),
-					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "route.request.header.Auth"),
+					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
@@ -376,11 +374,10 @@ func testAccAWSAPIGatewayV2AuthorizerConfig_basic(rName string) string {
 		testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName),
 		fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
-  api_id           = aws_apigatewayv2_api.test.id
-  authorizer_type  = "REQUEST"
-  authorizer_uri   = aws_lambda_function.test.invoke_arn
-  identity_sources = ["route.request.header.Auth"]
-  name             = %[1]q
+  api_id          = aws_apigatewayv2_api.test.id
+  authorizer_type = "REQUEST"
+  authorizer_uri  = aws_lambda_function.test.invoke_arn
+  name            = %[1]q
 }
 `, rName))
 }

--- a/aws/resource_aws_apigatewayv2_authorizer_test.go
+++ b/aws/resource_aws_apigatewayv2_authorizer_test.go
@@ -29,8 +29,11 @@ func TestAccAWSAPIGatewayV2Authorizer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_payload_format_version", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "REQUEST"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
 					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "route.request.header.Auth"),
 					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "0"),
@@ -62,7 +65,7 @@ func TestAccAWSAPIGatewayV2Authorizer_disappears(t *testing.T) {
 				Config: testAccAWSAPIGatewayV2AuthorizerConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
-					testAccCheckAWSAPIGatewayV2AuthorizerDisappears(&apiId, &v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayV2Authorizer(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -88,8 +91,11 @@ func TestAccAWSAPIGatewayV2Authorizer_Credentials(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_payload_format_version", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "REQUEST"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
 					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "route.request.header.Auth"),
 					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "0"),
@@ -108,7 +114,10 @@ func TestAccAWSAPIGatewayV2Authorizer_Credentials(t *testing.T) {
 					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_credentials_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "REQUEST"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_payload_format_version", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
 					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "2"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "route.request.header.Auth"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "route.request.querystring.Name"),
@@ -122,7 +131,10 @@ func TestAccAWSAPIGatewayV2Authorizer_Credentials(t *testing.T) {
 					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_credentials_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "REQUEST"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_payload_format_version", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
 					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "route.request.header.Auth"),
 					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "0"),
@@ -149,8 +161,11 @@ func TestAccAWSAPIGatewayV2Authorizer_JWT(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_payload_format_version", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "JWT"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_uri", ""),
+					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
 					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "$request.header.Authorization"),
 					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "1"),
@@ -170,14 +185,72 @@ func TestAccAWSAPIGatewayV2Authorizer_JWT(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_payload_format_version", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "0"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "JWT"),
 					resource.TestCheckResourceAttr(resourceName, "authorizer_uri", ""),
+					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
 					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "1"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "$request.header.Authorization"),
 					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.0.audience.#", "2"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "jwt_configuration.0.audience.*", "test"),
 					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "jwt_configuration.0.audience.*", "testing"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayV2Authorizer_HttpApiLambdaRequestAuthorizer(t *testing.T) {
+	var apiId string
+	var v apigatewayv2.GetAuthorizerOutput
+	resourceName := "aws_apigatewayv2_authorizer.test"
+	lambdaResourceName := "aws_lambda_function.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayV2AuthorizerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayV2AuthorizerConfig_httpApiLambdaRequestAuthorizer(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_payload_format_version", "2.0"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "600"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "REQUEST"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "true"),
+					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "1"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "$request.header.Auth"),
+					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccAWSAPIGatewayV2AuthorizerImportStateIdFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSAPIGatewayV2AuthorizerConfig_httpApiLambdaRequestAuthorizerUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayV2AuthorizerExists(resourceName, &apiId, &v),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_credentials_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_payload_format_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_result_ttl_in_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "authorizer_type", "REQUEST"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorizer_uri", lambdaResourceName, "invoke_arn"),
+					resource.TestCheckResourceAttr(resourceName, "enable_simple_responses", "false"),
+					resource.TestCheckResourceAttr(resourceName, "identity_sources.#", "2"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "$request.querystring.User"),
+					tfawsresource.TestCheckTypeSetElemAttr(resourceName, "identity_sources.*", "$context.routeKey"),
+					resource.TestCheckResourceAttr(resourceName, "jwt_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
@@ -208,19 +281,6 @@ func testAccCheckAWSAPIGatewayV2AuthorizerDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckAWSAPIGatewayV2AuthorizerDisappears(apiId *string, v *apigatewayv2.GetAuthorizerOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
-
-		_, err := conn.DeleteAuthorizer(&apigatewayv2.DeleteAuthorizerInput{
-			ApiId:        apiId,
-			AuthorizerId: v.AuthorizerId,
-		})
-
-		return err
-	}
 }
 
 func testAccCheckAWSAPIGatewayV2AuthorizerExists(n string, vApiId *string, v *apigatewayv2.GetAuthorizerOutput) resource.TestCheckFunc {
@@ -263,20 +323,33 @@ func testAccAWSAPIGatewayV2AuthorizerImportStateIdFunc(resourceName string) reso
 	}
 }
 
-func testAccAWSAPIGatewayV2AuthorizerConfig_baseWebSocket(rName string) string {
-	return baseAccAWSLambdaConfig(rName, rName, rName) + fmt.Sprintf(`
+func testAccAWSAPIGatewayV2AuthorizerConfig_apiWebSocket(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name                       = %[1]q
+  protocol_type              = "WEBSOCKET"
+  route_selection_expression = "$request.body.action"
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2AuthorizerConfig_apiHttp(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+}
+`, rName)
+}
+
+func testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName string) string {
+	return composeConfig(baseAccAWSLambdaConfig(rName, rName, rName), fmt.Sprintf(`
 resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
   runtime       = "nodejs10.x"
-}
-
-resource "aws_apigatewayv2_api" "test" {
-  name                       = %[1]q
-  protocol_type              = "WEBSOCKET"
-  route_selection_expression = "$request.body.action"
 }
 
 resource "aws_iam_role" "test" {
@@ -294,24 +367,14 @@ resource "aws_iam_role" "test" {
 }
 EOF
 }
-`, rName)
-}
-
-func testAccAWSAPIGatewayV2AuthorizerConfig_baseHttp(rName string) string {
-	return baseAccAWSLambdaConfig(rName, rName, rName) + fmt.Sprintf(`
-resource "aws_apigatewayv2_api" "test" {
-  name          = %[1]q
-  protocol_type = "HTTP"
-}
-
-resource "aws_cognito_user_pool" "test" {
-  name = %[1]q
-}
-`, rName)
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2AuthorizerConfig_basic(rName string) string {
-	return testAccAWSAPIGatewayV2AuthorizerConfig_baseWebSocket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAPIGatewayV2AuthorizerConfig_apiWebSocket(rName),
+		testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName),
+		fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
   api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "REQUEST"
@@ -319,11 +382,14 @@ resource "aws_apigatewayv2_authorizer" "test" {
   identity_sources = ["route.request.header.Auth"]
   name             = %[1]q
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2AuthorizerConfig_credentials(rName string) string {
-	return testAccAWSAPIGatewayV2AuthorizerConfig_baseWebSocket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAPIGatewayV2AuthorizerConfig_apiWebSocket(rName),
+		testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName),
+		fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
   api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "REQUEST"
@@ -333,11 +399,14 @@ resource "aws_apigatewayv2_authorizer" "test" {
 
   authorizer_credentials_arn = aws_iam_role.test.arn
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2AuthorizerConfig_credentialsUpdated(rName string) string {
-	return testAccAWSAPIGatewayV2AuthorizerConfig_baseWebSocket(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAPIGatewayV2AuthorizerConfig_apiWebSocket(rName),
+		testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName),
+		fmt.Sprintf(`
 resource "aws_apigatewayv2_authorizer" "test" {
   api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "REQUEST"
@@ -347,11 +416,18 @@ resource "aws_apigatewayv2_authorizer" "test" {
 
   authorizer_credentials_arn = aws_iam_role.test.arn
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2AuthorizerConfig_jwt(rName string) string {
-	return testAccAWSAPIGatewayV2AuthorizerConfig_baseHttp(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAPIGatewayV2AuthorizerConfig_apiHttp(rName),
+		testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+}
+
 resource "aws_apigatewayv2_authorizer" "test" {
   api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "JWT"
@@ -363,11 +439,18 @@ resource "aws_apigatewayv2_authorizer" "test" {
     issuer   = "https://${aws_cognito_user_pool.test.endpoint}"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSAPIGatewayV2AuthorizerConfig_jwtUpdated(rName string) string {
-	return testAccAWSAPIGatewayV2AuthorizerConfig_baseHttp(rName) + fmt.Sprintf(`
+	return composeConfig(
+		testAccAWSAPIGatewayV2AuthorizerConfig_apiHttp(rName),
+		testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
+}
+
 resource "aws_apigatewayv2_authorizer" "test" {
   api_id           = aws_apigatewayv2_api.test.id
   authorizer_type  = "JWT"
@@ -379,5 +462,41 @@ resource "aws_apigatewayv2_authorizer" "test" {
     issuer   = "https://${aws_cognito_user_pool.test.endpoint}"
   }
 }
-`, rName)
+`, rName))
+}
+
+func testAccAWSAPIGatewayV2AuthorizerConfig_httpApiLambdaRequestAuthorizer(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2AuthorizerConfig_apiHttp(rName),
+		testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_authorizer" "test" {
+  api_id                            = aws_apigatewayv2_api.test.id
+  authorizer_payload_format_version = "2.0"
+  authorizer_result_ttl_in_seconds  = 600
+  authorizer_type                   = "REQUEST"
+  authorizer_uri                    = aws_lambda_function.test.invoke_arn
+  enable_simple_responses           = true
+  identity_sources                  = ["$request.header.Auth"]
+  name                              = %[1]q
+}
+`, rName))
+}
+
+func testAccAWSAPIGatewayV2AuthorizerConfig_httpApiLambdaRequestAuthorizerUpdated(rName string) string {
+	return composeConfig(
+		testAccAWSAPIGatewayV2AuthorizerConfig_apiHttp(rName),
+		testAccAWSAPIGatewayV2AuthorizerConfig_baseLambda(rName),
+		fmt.Sprintf(`
+resource "aws_apigatewayv2_authorizer" "test" {
+  api_id                            = aws_apigatewayv2_api.test.id
+  authorizer_payload_format_version = "1.0"
+  authorizer_result_ttl_in_seconds  = 3600
+  authorizer_type                   = "REQUEST"
+  authorizer_uri                    = aws_lambda_function.test.invoke_arn
+  enable_simple_responses           = false
+  identity_sources                  = ["$request.querystring.User", "$context.routeKey"]
+  name                              = %[1]q
+}
+`, rName))
 }

--- a/website/docs/r/apigatewayv2_authorizer.html.markdown
+++ b/website/docs/r/apigatewayv2_authorizer.html.markdown
@@ -55,7 +55,7 @@ Supported only for `REQUEST` authorizers.
 * `authorizer_payload_format_version` - (Optional) The format of the payload sent to an HTTP API Lambda authorizer. Required for HTTP API Lambda authorizers.
 Valid values: `1.0`, `2.0`.
 * `authorizer_result_ttl_in_seconds` - (Optional) The time to live (TTL) for cached authorizer results, in seconds. If it equals 0, authorization caching is disabled.
-If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour.
+If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour. Defaults to `300`.
 Supported only for HTTP API Lambda authorizers.
 * `authorizer_uri` - (Optional) The authorizer's Uniform Resource Identifier (URI).
 For `REQUEST` authorizers this must be a well-formed Lambda function URI, such as the `invoke_arn` attribute of the [`aws_lambda_function`](/docs/providers/aws/r/lambda_function.html) resource.

--- a/website/docs/r/apigatewayv2_authorizer.html.markdown
+++ b/website/docs/r/apigatewayv2_authorizer.html.markdown
@@ -49,9 +49,6 @@ The following arguments are supported:
 * `authorizer_type` - (Required) The authorizer type. Valid values: `JWT`, `REQUEST`.
 Specify `REQUEST` for a Lambda function using incoming request parameters.
 For HTTP APIs, specify `JWT` to use JSON Web Tokens.
-* `identity_sources` - (Required) The identity sources for which authorization is requested.
-For `REQUEST` authorizers the value is a list of one or more mapping expressions of the specified request parameters.
-For `JWT` authorizers the single entry specifies where to extract the JSON Web Token (JWT) from inbound requests.
 * `name` - (Required) The name of the authorizer.
 * `authorizer_credentials_arn` - (Optional) The required credentials as an IAM role for API Gateway to invoke the authorizer.
 Supported only for `REQUEST` authorizers.
@@ -65,6 +62,9 @@ For `REQUEST` authorizers this must be a well-formed Lambda function URI, such a
 Supported only for `REQUEST` authorizers.
 * `enable_simple_responses` - (Optional) Whether a Lambda authorizer returns a response in a simple format. If enabled, the Lambda authorizer can return a boolean value instead of an IAM policy.
 Supported only for HTTP APIs.
+* `identity_sources` - (Optional) The identity sources for which authorization is requested.
+For `REQUEST` authorizers the value is a list of one or more mapping expressions of the specified request parameters.
+For `JWT` authorizers the single entry specifies where to extract the JSON Web Token (JWT) from inbound requests.
 * `jwt_configuration` - (Optional) The configuration of a JWT authorizer. Required for the `JWT` authorizer type.
 Supported only for HTTP APIs.
 

--- a/website/docs/r/apigatewayv2_authorizer.html.markdown
+++ b/website/docs/r/apigatewayv2_authorizer.html.markdown
@@ -47,17 +47,24 @@ The following arguments are supported:
 
 * `api_id` - (Required) The API identifier.
 * `authorizer_type` - (Required) The authorizer type. Valid values: `JWT`, `REQUEST`.
-For WebSocket APIs, specify `REQUEST` for a Lambda function using incoming request parameters.
- For HTTP APIs, specify `JWT` to use JSON Web Tokens.
+Specify `REQUEST` for a Lambda function using incoming request parameters.
+For HTTP APIs, specify `JWT` to use JSON Web Tokens.
 * `identity_sources` - (Required) The identity sources for which authorization is requested.
 For `REQUEST` authorizers the value is a list of one or more mapping expressions of the specified request parameters.
 For `JWT` authorizers the single entry specifies where to extract the JSON Web Token (JWT) from inbound requests.
 * `name` - (Required) The name of the authorizer.
 * `authorizer_credentials_arn` - (Optional) The required credentials as an IAM role for API Gateway to invoke the authorizer.
 Supported only for `REQUEST` authorizers.
+* `authorizer_payload_format_version` - (Optional) The format of the payload sent to an HTTP API Lambda authorizer. Required for HTTP API Lambda authorizers.
+Valid values: `1.0`, `2.0`.
+* `authorizer_result_ttl_in_seconds` - (Optional) The time to live (TTL) for cached authorizer results, in seconds. If it equals 0, authorization caching is disabled.
+If it is greater than 0, API Gateway caches authorizer responses. The maximum value is 3600, or 1 hour.
+Supported only for HTTP API Lambda authorizers.
 * `authorizer_uri` - (Optional) The authorizer's Uniform Resource Identifier (URI).
 For `REQUEST` authorizers this must be a well-formed Lambda function URI, such as the `invoke_arn` attribute of the [`aws_lambda_function`](/docs/providers/aws/r/lambda_function.html) resource.
 Supported only for `REQUEST` authorizers.
+* `enable_simple_responses` - (Optional) Whether a Lambda authorizer returns a response in a simple format. If enabled, the Lambda authorizer can return a boolean value instead of an IAM policy.
+Supported only for HTTP APIs.
 * `jwt_configuration` - (Optional) The configuration of a JWT authorizer. Required for the `JWT` authorizer type.
 Supported only for HTTP APIs.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/15126.
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/15181.
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/13527.
Relates https://github.com/terraform-providers/terraform-provider-aws/issues/14601.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_authorizer: Add `authorizer_payload_format_version`, `authorizer_result_ttl_in_seconds` and `enable_simple_responses` attribute to support Lambda authorizers for HTTP APIs
resource/aws_apigatewayv2_authorizer: Change `identity_sources` to an optional attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayV2Authorizer_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Authorizer_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Authorizer_basic
=== PAUSE TestAccAWSAPIGatewayV2Authorizer_basic
=== RUN   TestAccAWSAPIGatewayV2Authorizer_disappears
=== PAUSE TestAccAWSAPIGatewayV2Authorizer_disappears
=== RUN   TestAccAWSAPIGatewayV2Authorizer_Credentials
=== PAUSE TestAccAWSAPIGatewayV2Authorizer_Credentials
=== RUN   TestAccAWSAPIGatewayV2Authorizer_JWT
=== PAUSE TestAccAWSAPIGatewayV2Authorizer_JWT
=== RUN   TestAccAWSAPIGatewayV2Authorizer_HttpApiLambdaRequestAuthorizer
=== PAUSE TestAccAWSAPIGatewayV2Authorizer_HttpApiLambdaRequestAuthorizer
=== CONT  TestAccAWSAPIGatewayV2Authorizer_basic
=== CONT  TestAccAWSAPIGatewayV2Authorizer_HttpApiLambdaRequestAuthorizer
=== CONT  TestAccAWSAPIGatewayV2Authorizer_JWT
=== CONT  TestAccAWSAPIGatewayV2Authorizer_Credentials
=== CONT  TestAccAWSAPIGatewayV2Authorizer_disappears
    resource_aws_apigatewayv2_authorizer_test.go:59: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSAPIGatewayV2Authorizer_disappears (50.06s)
--- PASS: TestAccAWSAPIGatewayV2Authorizer_basic (72.89s)
--- PASS: TestAccAWSAPIGatewayV2Authorizer_HttpApiLambdaRequestAuthorizer (87.77s)
--- PASS: TestAccAWSAPIGatewayV2Authorizer_JWT (100.85s)
--- PASS: TestAccAWSAPIGatewayV2Authorizer_Credentials (110.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	110.928s
```
