### PR TITLE
resource/aws_s3_bucket_object: Ignore changes due to default bucket e…

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -139,6 +139,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			"kms_key_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validateArn,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// ignore diffs where the user hasn't specified a kms_key_id but the bucket has a default KMS key configured

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -140,6 +140,13 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateArn,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// ignore diffs where the user hasn't specified a kms_key_id but the bucket has a default KMS key configured
+					if new == "" && d.Get("server_side_encryption") == s3.ServerSideEncryptionAwsKms {
+						return true
+					}
+					return false
+				},
 			},
 
 			"etag": {

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -132,10 +132,9 @@ for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", "`ONEZONE_IA
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${filemd5("path/to/file")}` (Terraform 0.11.12 or later) or `${md5(file("path/to/file"))}` (Terraform 0.11.11 or earlier).
 This attribute is not compatible with KMS encryption, `kms_key_id` or `server_side_encryption = "aws:kms"`.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in S3. Valid values are "`AES256`" and "`aws:kms`".
-* `kms_key_id` - (Optional) Specifies the AWS KMS Key ARN to use for object encryption.
-This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,
-use the exported `arn` attribute:
-      `kms_key_id = "${aws_kms_key.foo.arn}"`
+* `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the
+`aws_kms_key` resource, use the `arn` attribute. If referencing the `aws_kms_alias` data source or resource, use the `target_key_arn` attribute. Terraform will only perform drift detection if a configuration value
+is provided.
 * `metadata` - (Optional) A map of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `tags` - (Optional) A map of tags to assign to the object.
 * `force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.


### PR DESCRIPTION
…ncryption (#10200)

When an object is uploaded to a bucket that has default encryption configured, the object inherits the kms_key_id from the bucket. We therefore need to ignore changes to that attribute, which the user won't have specified. Setting this attribute to "" has the effect of re-encrypting the object with the default `aws/s3` key, which is not what the user intended or expected.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #10200

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Prevent an object's encryption key changing from the bucket's default encryption key to the `aws/s3` key (#10200)
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSS3BucketObject'
--- FAIL: TestAccAWSS3BucketObject_etagEncryption (2.36s) # latent failure!
--- PASS: TestAccAWSS3BucketObject_noNameNoKey (6.97s)
--- PASS: TestAccAWSS3BucketObject_source (49.36s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (49.68s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (50.97s)
--- PASS: TestAccAWSS3BucketObject_sse (51.77s)
--- PASS: TestAccAWSS3BucketObject_kms (52.95s)
--- PASS: TestAccAWSS3BucketObject_empty (47.45s)
--- PASS: TestAccAWSS3BucketObject_defaultBucketSSE (61.72s)
--- PASS: TestAccAWSS3BucketObject_updateSameFile (94.87s)
--- PASS: TestAccAWSS3BucketObject_updates (95.25s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithOn (95.37s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (96.11s)
--- PASS: TestAccAWSS3BucketObject_content (59.72s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioningViaAccessPoint (109.58s)
--- PASS: TestAccAWSS3BucketObject_metadata (135.60s)
--- PASS: TestAccAWSS3BucketObject_acl (140.76s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithNone (138.73s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockLegalHoldStartWithNone (156.56s)
--- PASS: TestAccAWSS3BucketObject_ObjectLockRetentionStartWithSet (176.58s)
--- PASS: TestAccAWSS3BucketObject_tags (181.06s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (190.08s)
--- PASS: TestAccAWSS3BucketObject_storageClass (224.34s)
```
