### PR TITLE
Add "AUDIT_LOGS" log_type for aws_elasticsearch_domain

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -370,6 +370,7 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 								elasticsearch.LogTypeIndexSlowLogs,
 								elasticsearch.LogTypeSearchSlowLogs,
 								elasticsearch.LogTypeEsApplicationLogs,
+								elasticsearch.LogTypeAuditLogs,
 							}, false),
 						},
 						"cloudwatch_log_group_arn": {

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -296,7 +296,7 @@ Security Groups and Subnets referenced in these attributes must all be within th
 
 **log_publishing_options** supports the following attribute:
 
-* `log_type` - (Required) A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS
+* `log_type` - (Required) A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS, AUDIT_LOGS
 * `cloudwatch_log_group_arn` - (Required) ARN of the Cloudwatch log group to which log needs to be published.
 * `enabled` - (Optional, Default: true) Specifies whether given log publishing option is enabled or not.
 


### PR DESCRIPTION
Similar to #5474 -- this is now supported, see https://godoc.org/github.com/aws/aws-sdk-go/service/elasticsearchservice.

Fixes #15243.