### PR TITLE
Adds missing text to aws_codepipeline v3 upgrade documentation

### DIFF
--- a/website/docs/guides/version-3-upgrade.html.md
+++ b/website/docs/guides/version-3-upgrade.html.md
@@ -771,6 +771,8 @@ resource "aws_codepipeline" "example" {
 }
 ```
 
+The configuration could be updated as follows:
+
 ```bash
 $ TF_VAR_github_token=<token> terraform apply
 ```


### PR DESCRIPTION
Makes the `aws_codepipeline` provider v3 upgrade documentation make sense.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
