### PR TITLE
r/aws_apigatewayv2_api: Add 'disable_execute_api_endpoint' attribute

### DIFF
--- a/aws/resource_aws_apigatewayv2_api_test.go
+++ b/aws/resource_aws_apigatewayv2_api_test.go
@@ -88,6 +88,7 @@ func TestAccAWSAPIGatewayV2Api_basicWebSocket(t *testing.T) {
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "false"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeWebsocket),
@@ -124,6 +125,7 @@ func TestAccAWSAPIGatewayV2Api_basicHttp(t *testing.T) {
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "false"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
@@ -155,7 +157,7 @@ func TestAccAWSAPIGatewayV2Api_disappears(t *testing.T) {
 				Config: testAccAWSAPIGatewayV2ApiConfig_basicWebSocket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
-					testAccCheckAWSAPIGatewayV2ApiDisappears(&v),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsApiGatewayV2Api(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -183,6 +185,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket(t *testing.T) {
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "true"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeWebsocket),
@@ -198,6 +201,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeWebsocket),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.body.action"),
@@ -212,6 +216,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$context.authorizer.usageIdentifierKey"),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.body.service"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -225,6 +230,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$context.authorizer.usageIdentifierKey"),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.body.service"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -260,6 +266,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "true"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(`.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
@@ -275,6 +282,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "protocol_type", apigatewayv2.ProtocolTypeHttp),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
@@ -289,6 +297,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -302,6 +311,7 @@ func TestAccAWSAPIGatewayV2Api_AllAttributesHttp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "api_key_selection_expression", "$request.header.x-api-key"),
 					resource.TestCheckResourceAttr(resourceName, "cors_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName1),
 					resource.TestCheckResourceAttr(resourceName, "route_selection_expression", "$request.method $request.path"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -333,6 +343,7 @@ func TestAccAWSAPIGatewayV2Api_Openapi(t *testing.T) {
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "version", ""),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
@@ -350,6 +361,7 @@ func TestAccAWSAPIGatewayV2Api_Openapi(t *testing.T) {
 				Config: testAccAWSAPIGatewayV2ApiConfig_UpdatedOpenAPIYaml(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "version", ""),
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
@@ -477,6 +489,7 @@ func TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields(t *testing.T) {
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "api_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "version", ""),
 					testAccMatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "apigateway", regexp.MustCompile(`/apis/.+`)),
@@ -494,6 +507,7 @@ func TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields(t *testing.T) {
 				Config: testAccAWSAPIGatewayV2ApiConfig_UpdatedOpenAPI2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", "description test"),
+					resource.TestCheckResourceAttr(resourceName, "disable_execute_api_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "version", "2017-04-21T04:08:08Z"),
 					testAccCheckAWSAPIGatewayV2ApiExists(resourceName, &v),
@@ -753,18 +767,6 @@ func testAccCheckAWSAPIGatewayV2ApiDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSAPIGatewayV2ApiDisappears(v *apigatewayv2.GetApiOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).apigatewayv2conn
-
-		_, err := conn.DeleteApi(&apigatewayv2.DeleteApiInput{
-			ApiId: v.ApiId,
-		})
-
-		return err
-	}
-}
-
 func testAccCheckAWSAPIGatewayV2ApiExists(n string, v *apigatewayv2.GetApiOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -914,6 +916,7 @@ func testAccAWSAPIGatewayV2ApiConfig_allAttributesWebSocket(rName string) string
 resource "aws_apigatewayv2_api" "test" {
   api_key_selection_expression = "$context.authorizer.usageIdentifierKey"
   description                  = "test description"
+  disable_execute_api_endpoint = true
   name                         = %[1]q
   protocol_type                = "WEBSOCKET"
   route_selection_expression   = "$request.body.service"
@@ -925,10 +928,11 @@ resource "aws_apigatewayv2_api" "test" {
 func testAccAWSAPIGatewayV2ApiConfig_allAttributesHttp(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_apigatewayv2_api" "test" {
-  description   = "test description"
-  name          = %[1]q
-  protocol_type = "HTTP"
-  version       = "v1"
+  description                  = "test description"
+  disable_execute_api_endpoint = true
+  name                         = %[1]q
+  protocol_type                = "HTTP"
+  version                      = "v1"
 }
 `, rName)
 }
@@ -1241,7 +1245,7 @@ resource "aws_apigatewayv2_api" "test" {
   "info": {
     "title": "%s_DIFFERENT",
     "version": "2.0",
-    "description": "description different" 
+    "description": "description different"
   },
   "paths": {
     "/update": {

--- a/website/docs/r/apigatewayv2_api.html.markdown
+++ b/website/docs/r/apigatewayv2_api.html.markdown
@@ -45,6 +45,9 @@ Applicable for WebSocket APIs.
 * `cors_configuration` - (Optional) The cross-origin resource sharing (CORS) [configuration](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html). Applicable for HTTP APIs.
 * `credentials_arn` - (Optional) Part of _quick create_. Specifies any credentials required for the integration. Applicable for HTTP APIs.
 * `description` - (Optional) The description of the API.
+* `disable_execute_api_endpoint` - (Optional) Whether clients can invoke the API by using the default `execute-api` endpoint.
+By default, clients can invoke the API with the default `{api_id}.execute-api.{region}.amazonaws.com endpoint`.
+To require that clients use a custom domain name to invoke the API, disable the default endpoint.
 * `route_key` - (Optional) Part of _quick create_. Specifies any [route key](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-routes.html). Applicable for HTTP APIs.
 * `route_selection_expression` - (Optional) The [route selection expression](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-route-selection-expressions) for the API.
 Defaults to `$request.method $request.path`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15220.
Relates #13527.
Relates #14601.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_api: Add `disable_execute_api_endpoint` attribute
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayV2Api_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Api_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Api_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Api_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Api_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Api_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Api_disappears
=== PAUSE TestAccAWSAPIGatewayV2Api_disappears
=== RUN   TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket
=== RUN   TestAccAWSAPIGatewayV2Api_AllAttributesHttp
=== PAUSE TestAccAWSAPIGatewayV2Api_AllAttributesHttp
=== RUN   TestAccAWSAPIGatewayV2Api_Openapi
=== PAUSE TestAccAWSAPIGatewayV2Api_Openapi
=== RUN   TestAccAWSAPIGatewayV2Api_Openapi_WithTags
=== PAUSE TestAccAWSAPIGatewayV2Api_Openapi_WithTags
=== RUN   TestAccAWSAPIGatewayV2Api_Openapi_WithCorsConfiguration
=== PAUSE TestAccAWSAPIGatewayV2Api_Openapi_WithCorsConfiguration
=== RUN   TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields
=== PAUSE TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields
=== RUN   TestAccAWSAPIGatewayV2Api_Tags
=== PAUSE TestAccAWSAPIGatewayV2Api_Tags
=== RUN   TestAccAWSAPIGatewayV2Api_CorsConfiguration
=== PAUSE TestAccAWSAPIGatewayV2Api_CorsConfiguration
=== RUN   TestAccAWSAPIGatewayV2Api_QuickCreate
=== PAUSE TestAccAWSAPIGatewayV2Api_QuickCreate
=== CONT  TestAccAWSAPIGatewayV2Api_basicWebSocket
=== CONT  TestAccAWSAPIGatewayV2Api_QuickCreate
=== CONT  TestAccAWSAPIGatewayV2Api_CorsConfiguration
=== CONT  TestAccAWSAPIGatewayV2Api_Tags
=== CONT  TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields
=== CONT  TestAccAWSAPIGatewayV2Api_AllAttributesHttp
=== CONT  TestAccAWSAPIGatewayV2Api_Openapi_WithTags
=== CONT  TestAccAWSAPIGatewayV2Api_Openapi
=== CONT  TestAccAWSAPIGatewayV2Api_disappears
=== CONT  TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket
=== CONT  TestAccAWSAPIGatewayV2Api_Openapi_WithCorsConfiguration
=== CONT  TestAccAWSAPIGatewayV2Api_basicHttp
=== CONT  TestAccAWSAPIGatewayV2Api_disappears
    resource_aws_apigatewayv2_api_test.go:151: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSAPIGatewayV2Api_disappears (35.17s)
--- PASS: TestAccAWSAPIGatewayV2Api_basicWebSocket (48.38s)
--- PASS: TestAccAWSAPIGatewayV2Api_QuickCreate (50.27s)y
--- PASS: TestAccAWSAPIGatewayV2Api_basicHttp (80.44s)
--- PASS: TestAccAWSAPIGatewayV2Api_Tags (81.27s)
--- PASS: TestAccAWSAPIGatewayV2Api_Openapi (85.63s)
--- PASS: TestAccAWSAPIGatewayV2Api_Openapi_WithTags (89.80s)
--- PASS: TestAccAWSAPIGatewayV2Api_OpenapiWithMoreFields (91.56s)
--- PASS: TestAccAWSAPIGatewayV2Api_Openapi_WithCorsConfiguration (117.17s)
--- PASS: TestAccAWSAPIGatewayV2Api_CorsConfiguration (117.81s)
--- PASS: TestAccAWSAPIGatewayV2Api_AllAttributesWebSocket (118.94s)
--- PASS: TestAccAWSAPIGatewayV2Api_AllAttributesHttp (130.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	130.934s
```
