### PR TITLE
d/docdb_engine_version: New data source

### DIFF
--- a/aws/data_source_aws_docdb_engine_version.go
+++ b/aws/data_source_aws_docdb_engine_version.go
@@ -1,0 +1,174 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsDocdbEngineVersion() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsDocdbEngineVersionRead,
+		Schema: map[string]*schema.Schema{
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "docdb",
+			},
+
+			"engine_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"exportable_log_types": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"parameter_group_family": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+
+			"preferred_versions": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"version"},
+			},
+
+			"supports_log_exports_to_cloudwatch": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"valid_upgrade_targets": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"version": {
+				Type:          schema.TypeString,
+				Computed:      true,
+				Optional:      true,
+				ConflictsWith: []string{"preferred_versions"},
+			},
+
+			"version_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsDocdbEngineVersionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	input := &docdb.DescribeDBEngineVersionsInput{}
+
+	if v, ok := d.GetOk("engine"); ok {
+		input.Engine = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("parameter_group_family"); ok {
+		input.DBParameterGroupFamily = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("version"); ok {
+		input.EngineVersion = aws.String(v.(string))
+	}
+
+	if _, ok := d.GetOk("version"); !ok {
+		if _, ok := d.GetOk("preferred_versions"); !ok {
+			if _, ok := d.GetOk("parameter_group_family"); !ok {
+				input.DefaultOnly = aws.Bool(true)
+			}
+		}
+	}
+
+	log.Printf("[DEBUG] Reading DocumentDB engine versions: %v", input)
+	var engineVersions []*docdb.DBEngineVersion
+
+	err := conn.DescribeDBEngineVersionsPages(input, func(resp *docdb.DescribeDBEngineVersionsOutput, lastPage bool) bool {
+		for _, engineVersion := range resp.DBEngineVersions {
+			if engineVersion == nil {
+				continue
+			}
+
+			engineVersions = append(engineVersions, engineVersion)
+		}
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading DocumentDB engine versions: %w", err)
+	}
+
+	if len(engineVersions) == 0 {
+		return fmt.Errorf("no DocumentDB engine versions found")
+	}
+
+	// preferred versions
+	var found *docdb.DBEngineVersion
+	if l := d.Get("preferred_versions").([]interface{}); len(l) > 0 {
+		for _, elem := range l {
+			preferredVersion, ok := elem.(string)
+
+			if !ok {
+				continue
+			}
+
+			for _, engineVersion := range engineVersions {
+				if preferredVersion == aws.StringValue(engineVersion.EngineVersion) {
+					found = engineVersion
+					break
+				}
+			}
+
+			if found != nil {
+				break
+			}
+		}
+	}
+
+	if found == nil && len(engineVersions) > 1 {
+		return fmt.Errorf("multiple DocumentDB engine versions (%v) match the criteria", engineVersions)
+	}
+
+	if found == nil && len(engineVersions) == 1 {
+		found = engineVersions[0]
+	}
+
+	if found == nil {
+		return fmt.Errorf("no DocumentDB engine versions match the criteria")
+	}
+
+	d.SetId(aws.StringValue(found.EngineVersion))
+
+	d.Set("engine", found.Engine)
+	d.Set("engine_description", found.DBEngineDescription)
+	d.Set("exportable_log_types", found.ExportableLogTypes)
+	d.Set("parameter_group_family", found.DBParameterGroupFamily)
+	d.Set("supports_log_exports_to_cloudwatch", found.SupportsLogExportsToCloudwatchLogs)
+
+	var upgradeTargets []string
+	for _, ut := range found.ValidUpgradeTarget {
+		upgradeTargets = append(upgradeTargets, aws.StringValue(ut.EngineVersion))
+	}
+	d.Set("valid_upgrade_targets", upgradeTargets)
+
+	d.Set("version", found.EngineVersion)
+	d.Set("version_description", found.DBEngineVersionDescription)
+
+	return nil
+}

--- a/aws/data_source_aws_docdb_engine_version_test.go
+++ b/aws/data_source_aws_docdb_engine_version_test.go
@@ -1,0 +1,117 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSDocDBEngineVersionDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_docdb_engine_version.test"
+	engine := "docdb"
+	version := "3.6.0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSDocDBEngineVersionPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBEngineVersionDataSourceBasicConfig(engine, version),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "engine", engine),
+					resource.TestCheckResourceAttr(dataSourceName, "version", version),
+
+					resource.TestCheckResourceAttrSet(dataSourceName, "engine_description"),
+					resource.TestMatchResourceAttr(dataSourceName, "exportable_log_types.#", regexp.MustCompile(`^[1-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "parameter_group_family"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "supports_log_exports_to_cloudwatch"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version_description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBEngineVersionDataSource_preferred(t *testing.T) {
+	dataSourceName := "data.aws_docdb_engine_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSDocDBEngineVersionPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBEngineVersionDataSourcePreferredConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "version", "3.6.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBEngineVersionDataSource_defaultOnly(t *testing.T) {
+	dataSourceName := "data.aws_docdb_engine_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSDocDBEngineVersionPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBEngineVersionDataSourceDefaultOnlyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "docdb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSDocDBEngineVersionPreCheck(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).docdbconn
+
+	input := &docdb.DescribeDBEngineVersionsInput{
+		Engine:      aws.String("docdb"),
+		DefaultOnly: aws.Bool(true),
+	}
+
+	_, err := conn.DescribeDBEngineVersions(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAWSDocDBEngineVersionDataSourceBasicConfig(engine, version string) string {
+	return fmt.Sprintf(`
+data "aws_docdb_engine_version" "test" {
+  engine  = %q
+  version = %q
+}
+`, engine, version)
+}
+
+func testAccAWSDocDBEngineVersionDataSourcePreferredConfig() string {
+	return fmt.Sprintf(`
+data "aws_docdb_engine_version" "test" {
+  preferred_versions = ["34.6.1", "3.6.0", "2.6.0"]
+}
+`)
+}
+
+func testAccAWSDocDBEngineVersionDataSourceDefaultOnlyConfig() string {
+	return fmt.Sprintf(`
+data "aws_docdb_engine_version" "test" {}
+`)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -202,6 +202,7 @@ func Provider() *schema.Provider {
 			"aws_db_snapshot":                                dataSourceAwsDbSnapshot(),
 			"aws_db_subnet_group":                            dataSourceAwsDbSubnetGroup(),
 			"aws_directory_service_directory":                dataSourceAwsDirectoryServiceDirectory(),
+			"aws_docdb_engine_version":                       dataSourceAwsDocdbEngineVersion(),
 			"aws_docdb_orderable_db_instance":                dataSourceAwsDocdbOrderableDbInstance(),
 			"aws_dx_gateway":                                 dataSourceAwsDxGateway(),
 			"aws_dynamodb_table":                             dataSourceAwsDynamoDbTable(),

--- a/website/docs/d/docdb_engine_version.markdown
+++ b/website/docs/d/docdb_engine_version.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "DocumentDB"
+layout: "aws"
+page_title: "AWS: aws_docdb_engine_version"
+description: |-
+  Information about a DocumentDB engine version.
+---
+
+# Data Source: aws_docdb_engine_version
+
+Information about a DocumentDB engine version.
+
+## Example Usage
+
+```hcl
+data "aws_docdb_engine_version" "test" {
+  version = "3.6.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `engine` - (Optional) DB engine. (Default: `docdb`)
+* `parameter_group_family` - (Optional) The name of a specific DB parameter group family. An example parameter group family is `docdb3.6`.
+* `preferred_versions` - (Optional) Ordered list of preferred engine versions. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned. If both the `version` and `preferred_versions` arguments are not configured, the data source will return the default version for the engine.
+* `version` - (Optional) Version of the DB engine. For example, `3.6.0`. If `version` and `preferred_versions` are not set, the data source will provide information for the AWS-defined default version. If both the `version` and `preferred_versions` arguments are not configured, the data source will return the default version for the engine.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `engine_description` - The description of the database engine.
+* `exportable_log_types` - Set of log types that the database engine has available for export to CloudWatch Logs.
+* `supports_log_exports_to_cloudwatch` - Indicates whether the engine version supports exporting the log types specified by `exportable_log_types` to CloudWatch Logs.
+* `valid_upgrade_targets` - A set of engine versions that this database engine version can be upgraded to.
+* `version_description` - The description of the database engine version.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15255
Relates #15228, #15259 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
d/docdb_engine_version: New data source
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSDocDBEngineVersionDataSource_basic (15.96s)
--- PASS: TestAccAWSDocDBEngineVersionDataSource_preferred (17.53s)
--- PASS: TestAccAWSDocDBEngineVersionDataSource_defaultOnly (17.53s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSDocDBEngineVersionDataSource_basic (11.66s)
--- PASS: TestAccAWSDocDBEngineVersionDataSource_preferred (12.77s)
--- PASS: TestAccAWSDocDBEngineVersionDataSource_defaultOnly (12.77s)
```