### PR TITLE
d/neptune_engine_version: New data source

### DIFF
--- a/aws/data_source_aws_neptune_engine_version.go
+++ b/aws/data_source_aws_neptune_engine_version.go
@@ -1,0 +1,191 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/neptune"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsNeptuneEngineVersion() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsNeptuneEngineVersionRead,
+		Schema: map[string]*schema.Schema{
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "neptune",
+			},
+
+			"engine_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"exportable_log_types": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
+			"parameter_group_family": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+
+			"preferred_versions": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"version"},
+			},
+
+			"supported_timezones": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"supports_log_exports_to_cloudwatch": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"supports_read_replica": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"valid_upgrade_targets": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"version": {
+				Type:          schema.TypeString,
+				Computed:      true,
+				Optional:      true,
+				ConflictsWith: []string{"preferred_versions"},
+			},
+
+			"version_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsNeptuneEngineVersionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	input := &neptune.DescribeDBEngineVersionsInput{}
+
+	if v, ok := d.GetOk("engine"); ok {
+		input.Engine = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("parameter_group_family"); ok {
+		input.DBParameterGroupFamily = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("version"); ok {
+		input.EngineVersion = aws.String(v.(string))
+	}
+
+	if _, ok := d.GetOk("version"); !ok {
+		if _, ok := d.GetOk("preferred_versions"); !ok {
+			input.DefaultOnly = aws.Bool(true)
+		}
+	}
+
+	log.Printf("[DEBUG] Reading Neptune engine versions: %v", input)
+	var engineVersions []*neptune.DBEngineVersion
+
+	err := conn.DescribeDBEngineVersionsPages(input, func(resp *neptune.DescribeDBEngineVersionsOutput, lastPage bool) bool {
+		for _, engineVersion := range resp.DBEngineVersions {
+			if engineVersion == nil {
+				continue
+			}
+
+			engineVersions = append(engineVersions, engineVersion)
+		}
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("error reading Neptune engine versions: %w", err)
+	}
+
+	if len(engineVersions) == 0 {
+		return fmt.Errorf("no Neptune engine versions found")
+	}
+
+	// preferred versions
+	var found *neptune.DBEngineVersion
+	if l := d.Get("preferred_versions").([]interface{}); len(l) > 0 {
+		for _, elem := range l {
+			preferredVersion, ok := elem.(string)
+
+			if !ok {
+				continue
+			}
+
+			for _, engineVersion := range engineVersions {
+				if preferredVersion == aws.StringValue(engineVersion.EngineVersion) {
+					found = engineVersion
+					break
+				}
+			}
+
+			if found != nil {
+				break
+			}
+		}
+	}
+
+	if found == nil && len(engineVersions) > 1 {
+		return fmt.Errorf("multiple Neptune engine versions (%v) match the criteria", engineVersions)
+	}
+
+	if found == nil && len(engineVersions) == 1 {
+		found = engineVersions[0]
+	}
+
+	if found == nil {
+		return fmt.Errorf("no Neptune engine versions match the criteria")
+	}
+
+	d.SetId(aws.StringValue(found.EngineVersion))
+
+	d.Set("engine", found.Engine)
+	d.Set("engine_description", found.DBEngineDescription)
+	d.Set("exportable_log_types", found.ExportableLogTypes)
+	d.Set("parameter_group_family", found.DBParameterGroupFamily)
+
+	var timezones []string
+	for _, tz := range found.SupportedTimezones {
+		timezones = append(timezones, aws.StringValue(tz.TimezoneName))
+	}
+	d.Set("supported_timezones", timezones)
+
+	d.Set("supports_log_exports_to_cloudwatch", found.SupportsLogExportsToCloudwatchLogs)
+	d.Set("supports_read_replica", found.SupportsReadReplica)
+
+	var upgradeTargets []string
+	for _, ut := range found.ValidUpgradeTarget {
+		upgradeTargets = append(upgradeTargets, aws.StringValue(ut.EngineVersion))
+	}
+	d.Set("valid_upgrade_targets", upgradeTargets)
+
+	d.Set("version", found.EngineVersion)
+	d.Set("version_description", found.DBEngineVersionDescription)
+
+	return nil
+}

--- a/aws/data_source_aws_neptune_engine_version_test.go
+++ b/aws/data_source_aws_neptune_engine_version_test.go
@@ -1,0 +1,119 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/neptune"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSNeptuneEngineVersionDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_neptune_engine_version.test"
+	version := "1.0.1.0"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSNeptuneEngineVersionPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneEngineVersionDataSourceBasicConfig(version),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "neptune"),
+					resource.TestCheckResourceAttr(dataSourceName, "version", version),
+					resource.TestCheckResourceAttrSet(dataSourceName, "engine_description"),
+					resource.TestMatchResourceAttr(dataSourceName, "exportable_log_types.#", regexp.MustCompile(`^[1-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "parameter_group_family"),
+					resource.TestMatchResourceAttr(dataSourceName, "supported_timezones.#", regexp.MustCompile(`^[0-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "supports_log_exports_to_cloudwatch"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "supports_read_replica"),
+					resource.TestMatchResourceAttr(dataSourceName, "valid_upgrade_targets.#", regexp.MustCompile(`^[1-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version_description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNeptuneEngineVersionDataSource_preferred(t *testing.T) {
+	dataSourceName := "data.aws_neptune_engine_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSNeptuneEngineVersionPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneEngineVersionDataSourcePreferredConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "neptune"),
+					resource.TestCheckResourceAttr(dataSourceName, "version", "1.0.3.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNeptuneEngineVersionDataSource_defaultOnly(t *testing.T) {
+	dataSourceName := "data.aws_neptune_engine_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccAWSNeptuneEngineVersionPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNeptuneEngineVersionDataSourceDefaultOnlyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "neptune"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSNeptuneEngineVersionPreCheck(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).neptuneconn
+
+	input := &neptune.DescribeDBEngineVersionsInput{
+		Engine:      aws.String("neptune"),
+		DefaultOnly: aws.Bool(true),
+	}
+
+	_, err := conn.DescribeDBEngineVersions(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAWSNeptuneEngineVersionDataSourceBasicConfig(version string) string {
+	return fmt.Sprintf(`
+data "aws_neptune_engine_version" "test" {
+  engine  = "neptune"
+  version = %q
+}
+`, version)
+}
+
+func testAccAWSNeptuneEngineVersionDataSourcePreferredConfig() string {
+	return fmt.Sprintf(`
+data "aws_neptune_engine_version" "test" {
+  preferred_versions = ["85.9.12", "1.0.3.0", "1.0.2.2"]
+}
+`)
+}
+
+func testAccAWSNeptuneEngineVersionDataSourceDefaultOnlyConfig() string {
+	return fmt.Sprintf(`
+data "aws_neptune_engine_version" "test" {}
+`)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -287,6 +287,7 @@ func Provider() *schema.Provider {
 			"aws_msk_configuration":                          dataSourceAwsMskConfiguration(),
 			"aws_nat_gateway":                                dataSourceAwsNatGateway(),
 			"aws_neptune_orderable_db_instance":              dataSourceAwsNeptuneOrderableDbInstance(),
+			"aws_neptune_engine_version":                     dataSourceAwsNeptuneEngineVersion(),
 			"aws_network_acls":                               dataSourceAwsNetworkAcls(),
 			"aws_network_interface":                          dataSourceAwsNetworkInterface(),
 			"aws_network_interfaces":                         dataSourceAwsNetworkInterfaces(),

--- a/website/docs/d/neptune_engine_version.markdown
+++ b/website/docs/d/neptune_engine_version.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "Neptune"
+layout: "aws"
+page_title: "AWS: aws_neptune_engine_version"
+description: |-
+  Information about a Neptune engine version.
+---
+
+# Data Source: aws_neptune_engine_version
+
+Information about a Neptune engine version.
+
+## Example Usage
+
+```hcl
+data "aws_neptune_engine_version" "test" {
+  preferred_versions = ["1.0.3.0", "1.0.2.2", "1.0.2.1"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `engine` - (Optional) DB engine. (Default: `neptune`)
+* `parameter_group_family` - (Optional) The name of a specific DB parameter group family. An example parameter group family is `neptune1`.
+* `preferred_versions` - (Optional) Ordered list of preferred engine versions. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned. If both the `version` and `preferred_versions` arguments are not configured, the data source will return the default version for the engine.
+* `version` - (Optional) Version of the DB engine. For example, `1.0.1.0`, `1.0.2.2`, and `1.0.3.0`. If both the `version` and `preferred_versions` arguments are not configured, the data source will return the default version for the engine.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `engine_description` - The description of the database engine.
+* `exportable_log_types` - Set of log types that the database engine has available for export to CloudWatch Logs.
+* `supported_timezones` - Set of the time zones supported by this engine.
+* `supports_log_exports_to_cloudwatch` - Indicates whether the engine version supports exporting the log types specified by `exportable_log_types` to CloudWatch Logs.
+* `supports_read_replica` - Indicates whether the database engine version supports read replicas.
+* `valid_upgrade_targets` - Set of engine versions that this database engine version can be upgraded to.
+* `version_description` - The description of the database engine version.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15257
Relates #15228, #15253

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
d/neptune_engine_version: New data source
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSNeptuneEngineVersionDataSource_basic (16.39s)
--- PASS: TestAccAWSNeptuneEngineVersionDataSource_defaultOnly (17.58s)
--- PASS: TestAccAWSNeptuneEngineVersionDataSource_preferred (18.74s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSNeptuneEngineVersionDataSource_basic (11.06s)
--- PASS: TestAccAWSNeptuneEngineVersionDataSource_defaultOnly (12.57s)
--- PASS: TestAccAWSNeptuneEngineVersionDataSource_preferred (13.10s)
```