### PR TITLE
f/resource_aws_glue_crawler:remove-table_prefix

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -297,9 +297,8 @@ func updateCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.Updat
 
 	crawlerInput.SchemaChangePolicy = expandGlueSchemaChangePolicy(d.Get("schema_change_policy").([]interface{}))
 
-	if tablePrefix, ok := d.GetOk("table_prefix"); ok {
-		crawlerInput.TablePrefix = aws.String(tablePrefix.(string))
-	}
+	crawlerInput.TablePrefix = aws.String(d.Get("table_prefix").(string))
+
 	if configuration, ok := d.GetOk("configuration"); ok {
 		crawlerInput.Configuration = aws.String(configuration.(string))
 	}

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -901,6 +901,39 @@ func TestAccAWSGlueCrawler_TablePrefix(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCrawler_RemoveTablePrefix(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerConfig_TablePrefix(rName, "prefix1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "table_prefix", "prefix1"),
+				),
+			},
+			{
+				Config: testAccGlueCrawlerConfig_TablePrefix(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "table_prefix", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueCrawler_Tags(t *testing.T) {
 	var crawler1, crawler2, crawler3 glue.Crawler
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -912,10 +912,10 @@ func TestAccAWSGlueCrawler_RemoveTablePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlueCrawlerConfig_TablePrefix(rName, "prefix1"),
+				Config: testAccGlueCrawlerConfig_TablePrefix(rName, "prefix"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
-					resource.TestCheckResourceAttr(resourceName, "table_prefix", "prefix1"),
+					resource.TestCheckResourceAttr(resourceName, "table_prefix", "prefix"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15300

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_glue_crawler: Allow removing `table_prefix`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSGlueCrawler_RemoveTablePrefix'
--- PASS: TestAccAWSGlueCrawler_RemoveTablePrefix (151.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       153.341s
...
```
