### PR TITLE
provider: Remove now duplicate security issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,6 +12,3 @@ contact_links:
   - name: Terraform Language or Workflow Questions
     url: https://discuss.hashicorp.com/c/terraform-core
     about: Please ask and answer language or workflow related questions through the Terraform Core Community Forum.
-  - name: Security Vulnerability
-    url: https://www.hashicorp.com/security.html
-    about: Please report security vulnerabilities responsibly.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The security policy (and issue template linking) is now automatically handled by the presence of an Organization-wide file: https://github.com/terraform-providers/.github/blob/master/SECURITY.md

This security policy is also present in the HashiCorp organization, for if/when the repository is transferred.

Output from acceptance testing: N/A