### PR TITLE
Add configuring-enhanced-monitoring to Neptune instance pending states

### DIFF
--- a/aws/resource_aws_neptune_cluster_instance.go
+++ b/aws/resource_aws_neptune_cluster_instance.go
@@ -490,6 +490,7 @@ var resourceAwsNeptuneClusterInstanceCreateUpdatePendingStates = []string{
 	"starting",
 	"upgrading",
 	"configuring-log-exports",
+	"configuring-enhanced-monitoring",
 }
 
 var resourceAwsNeptuneClusterInstanceDeletePendingStates = []string{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15283

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add "configuring-enhanced-monitoring" to Neptune cluster instance create/update pending states
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSNeptuneClusterInstance'

--- PASS: TestAccAWSNeptuneClusterInstance_generatedName (697.19s)
--- PASS: TestAccAWSNeptuneClusterInstance_withSubnetGroup (756.74s)
--- PASS: TestAccAWSNeptuneClusterInstance_namePrefix (798.23s)
--- PASS: TestAccAWSNeptuneClusterInstance_kmsKey (825.04s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (887.08s)
--- PASS: TestAccAWSNeptuneClusterInstance_basic (887.68s)
```
