### PR TITLE
Increase the efs_mount_target creation timeout to 30 minutes

### DIFF
--- a/aws/resource_aws_efs_mount_target.go
+++ b/aws/resource_aws_efs_mount_target.go
@@ -148,7 +148,7 @@ func resourceAwsEfsMountTargetCreate(d *schema.ResourceData, meta interface{}) e
 			log.Printf("[DEBUG] Current status of %q: %q", aws.StringValue(mt.MountTargetId), aws.StringValue(mt.LifeCycleState))
 			return mt, aws.StringValue(mt.LifeCycleState), nil
 		},
-		Timeout:    10 * time.Minute,
+		Timeout:    30 * time.Minute,
 		Delay:      2 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/15278

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSEFSMountTarget_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSEFSMountTarget_* -timeout 120m
=== RUN   TestAccAWSEFSMountTarget_basic
=== PAUSE TestAccAWSEFSMountTarget_basic
=== RUN   TestAccAWSEFSMountTarget_disappears
=== PAUSE TestAccAWSEFSMountTarget_disappears
=== RUN   TestAccAWSEFSMountTarget_IpAddress
=== PAUSE TestAccAWSEFSMountTarget_IpAddress
=== RUN   TestAccAWSEFSMountTarget_IpAddress_EmptyString
=== PAUSE TestAccAWSEFSMountTarget_IpAddress_EmptyString
=== CONT  TestAccAWSEFSMountTarget_basic
=== CONT  TestAccAWSEFSMountTarget_IpAddress
=== CONT  TestAccAWSEFSMountTarget_IpAddress_EmptyString
=== CONT  TestAccAWSEFSMountTarget_disappears
    TestAccAWSEFSMountTarget_disappears: resource_aws_efs_mount_target_test.go:138: [INFO] Got non-empty plan, as expected
--- PASS: TestAccAWSEFSMountTarget_IpAddress (159.13s)
--- PASS: TestAccAWSEFSMountTarget_disappears (159.33s)
--- PASS: TestAccAWSEFSMountTarget_IpAddress_EmptyString (164.62s)
--- PASS: TestAccAWSEFSMountTarget_basic (275.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	277.418s
```

Updated the timeout from 10 minutes to 30minutes. Thank you for your review!
