### PR TITLE
Add stickiness support for NLB target_groups

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -450,11 +450,7 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 			})
 		}
 
-		// In CustomizeDiff we allow LB stickiness to be declared for TCP target
-		// groups, so long as it's not enabled. This allows for better support for
-		// modules, but also means we need to completely skip sending the data to the
-		// API if it's defined on a TCP target group.
-		if d.HasChange("stickiness") && d.Get("protocol") != elbv2.ProtocolEnumTcp {
+		if d.HasChange("stickiness") {
 			stickinessBlocks := d.Get("stickiness").([]interface{})
 			if len(stickinessBlocks) == 1 {
 				stickiness := stickinessBlocks[0].(map[string]interface{})
@@ -467,11 +463,15 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 					&elbv2.TargetGroupAttribute{
 						Key:   aws.String("stickiness.type"),
 						Value: aws.String(stickiness["type"].(string)),
-					},
-					&elbv2.TargetGroupAttribute{
-						Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
-						Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
 					})
+				if d.Get("protocol").(string) == elbv2.ProtocolEnumHttp ||
+					d.Get("protocol").(string) == elbv2.ProtocolEnumHttps {
+					attrs = append(attrs,
+						&elbv2.TargetGroupAttribute{
+							Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
+							Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+						})
+				}
 			} else if len(stickinessBlocks) == 0 {
 				attrs = append(attrs, &elbv2.TargetGroupAttribute{
 					Key:   aws.String("stickiness.enabled"),
@@ -670,23 +670,8 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 		}
 	}
 
-	// We only read in the stickiness attributes if the target group is not
-	// TCP-based. This ensures we don't end up causing a spurious diff if someone
-	// has defined the stickiness block on a TCP target group (albeit with
-	// false), for which this update would clobber the state coming from config
-	// for.
-	//
-	// This is a workaround to support module design where the module needs to
-	// support HTTP and TCP target groups.
-	switch {
-	case aws.StringValue(targetGroup.Protocol) != elbv2.ProtocolEnumTcp:
-		if err = flattenAwsLbTargetGroupStickiness(d, attrResp.Attributes); err != nil {
-			return err
-		}
-	case aws.StringValue(targetGroup.Protocol) == elbv2.ProtocolEnumTcp && len(d.Get("stickiness").([]interface{})) < 1:
-		if err = d.Set("stickiness", []interface{}{}); err != nil {
-			return fmt.Errorf("error setting stickiness: %s", err)
-		}
+	if err = flattenAwsLbTargetGroupStickiness(d, attrResp.Attributes); err != nil {
+		return err
 	}
 
 	tags, err := keyvaluetags.Elbv2ListTags(elbconn, d.Id())
@@ -741,15 +726,6 @@ func flattenAwsLbTargetGroupStickiness(d *schema.ResourceData, attributes []*elb
 
 func resourceAwsLbTargetGroupCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 	protocol := diff.Get("protocol").(string)
-	if protocol == elbv2.ProtocolEnumTcp {
-		// TCP load balancers do not support stickiness
-		if stickinessBlocks := diff.Get("stickiness").([]interface{}); len(stickinessBlocks) == 1 {
-			stickiness := stickinessBlocks[0].(map[string]interface{})
-			if val := stickiness["enabled"].(bool); val {
-				return fmt.Errorf("Network Load Balancers do not support Stickiness")
-			}
-		}
-	}
 
 	// Network Load Balancers have many special qwirks to them.
 	// See http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -150,6 +150,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"lb_cookie",
+								"source_ip",
 							}, false),
 						},
 						"cookie_duration": {

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -964,7 +964,7 @@ protocol = "TCP"
 	})
 }
 
-func TestAccAWSLBTargetGroup_defaultStickinessForNLB(t *testing.T) {
+func TestAccAWSLBTargetGroup_stickinessDefaultNLB(t *testing.T) {
 	var conf elbv2.TargetGroup
 	resourceName := "aws_lb_target_group.test"
 
@@ -975,7 +975,7 @@ func TestAccAWSLBTargetGroup_defaultStickinessForNLB(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_NLBdefaultStickiness("TCP"),
+				Config: testAccAWSLBTargetGroupConfig_stickinessDefault("TCP"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -984,7 +984,7 @@ func TestAccAWSLBTargetGroup_defaultStickinessForNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_NLBdefaultStickiness("UDP"),
+				Config: testAccAWSLBTargetGroupConfig_stickinessDefault("UDP"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -993,7 +993,7 @@ func TestAccAWSLBTargetGroup_defaultStickinessForNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_NLBdefaultStickiness("TCP_UDP"),
+				Config: testAccAWSLBTargetGroupConfig_stickinessDefault("TCP_UDP"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1005,7 +1005,7 @@ func TestAccAWSLBTargetGroup_defaultStickinessForNLB(t *testing.T) {
 	})
 }
 
-func TestAccAWSLBTargetGroup_validStickinessForNLB(t *testing.T) {
+func TestAccAWSLBTargetGroup_stickinessDefaultALB(t *testing.T) {
 	var conf elbv2.TargetGroup
 	resourceName := "aws_lb_target_group.test"
 
@@ -1016,7 +1016,30 @@ func TestAccAWSLBTargetGroup_validStickinessForNLB(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLBTargetGroupConfig_NLBvalidStickiness("TCP", false),
+				Config: testAccAWSLBTargetGroupConfig_stickinessDefault("HTTP"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "lb_cookie"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBTargetGroup_stickinessValidNLB(t *testing.T) {
+	var conf elbv2.TargetGroup
+	resourceName := "aws_lb_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "source_ip", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1025,7 +1048,7 @@ func TestAccAWSLBTargetGroup_validStickinessForNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_NLBvalidStickiness("TCP", true),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "source_ip", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1034,16 +1057,7 @@ func TestAccAWSLBTargetGroup_validStickinessForNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_NLBvalidStickiness("UDP", false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "source_ip"),
-				),
-			},
-			{
-				Config: testAccAWSLBTargetGroupConfig_NLBvalidStickiness("UDP", true),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("UDP", "source_ip", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1052,16 +1066,7 @@ func TestAccAWSLBTargetGroup_validStickinessForNLB(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSLBTargetGroupConfig_NLBvalidStickiness("TCP_UDP", false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "source_ip"),
-				),
-			},
-			{
-				Config: testAccAWSLBTargetGroupConfig_NLBvalidStickiness("TCP_UDP", true),
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "source_ip", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
@@ -1073,41 +1078,89 @@ func TestAccAWSLBTargetGroup_validStickinessForNLB(t *testing.T) {
 	})
 }
 
-func TestAccAWSLBTargetGroup_invalidStickinessForNLBShouldError(t *testing.T) {
+func TestAccAWSLBTargetGroup_stickinessValidALB(t *testing.T) {
+	var conf elbv2.TargetGroup
+	resourceName := "aws_lb_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("HTTP", "lb_cookie", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "86400"),
+				),
+			},
+			{
+				Config: testAccAWSLBTargetGroupConfig_stickinessValidity("HTTPS", "lb_cookie", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr(resourceName, "stickiness.0.cookie_duration", "86400"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBTargetGroup_stickinessInvalidNLB(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSLBTargetGroupConfig_NLBinvalidStickiness("TCP", true),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Network Load Balancers can only use \"source_ip\" stickiness."),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("TCP", "lb_cookie", true),
+				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_NLBinvalidStickiness("TCP", false),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Network Load Balancers can only use \"source_ip\" stickiness."),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("UDP", "lb_cookie", true),
+				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_NLBinvalidStickiness("UDP", true),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Network Load Balancers can only use \"source_ip\" stickiness."),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "lb_cookie", true),
+				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_NLBinvalidStickiness("UDP", false),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Network Load Balancers can only use \"source_ip\" stickiness."),
+				Config:             testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "lb_cookie", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSLBTargetGroup_stickinessInvalidALB(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("HTTP", "source_ip", true),
+				ExpectError: regexp.MustCompile("Stickiness type 'source_ip' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_NLBinvalidStickiness("TCP_UDP", true),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Network Load Balancers can only use \"source_ip\" stickiness."),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("HTTPS", "source_ip", true),
+				ExpectError: regexp.MustCompile("Stickiness type 'source_ip' is not supported for target groups with"),
 			},
 			{
-				Config:      testAccAWSLBTargetGroupConfig_NLBinvalidStickiness("TCP_UDP", false),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Network Load Balancers can only use \"source_ip\" stickiness."),
+				Config:      testAccAWSLBTargetGroupConfig_stickinessValidity("TLS", "lb_cookie", true),
+				ExpectError: regexp.MustCompile("Stickiness type 'lb_cookie' is not supported for target groups with"),
+			},
+			{
+				Config:             testAccAWSLBTargetGroupConfig_stickinessValidity("TCP_UDP", "lb_cookie", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -2033,12 +2086,12 @@ resource "aws_vpc" "test" {
 }
 `
 
-func testAccAWSLBTargetGroupConfig_NLBdefaultStickiness(protocol string) string {
+func testAccAWSLBTargetGroupConfig_stickinessDefault(protocol string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name_prefix = "tf-"
   port        = 25
-  protocol    = "%s"
+  protocol    = %q
   vpc_id      = aws_vpc.test.id
 }
 
@@ -2046,22 +2099,22 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "testAccAWSLBTargetGroupConfig_namePrefix"
+    Name = "testAccAWSLBTargetGroupConfig_stickinessDefault"
   }
 }
 `, protocol)
 }
 
-func testAccAWSLBTargetGroupConfig_NLBvalidStickiness(protocol string, enabled bool) string {
+func testAccAWSLBTargetGroupConfig_stickinessValidity(protocol, stickyType string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name_prefix = "tf-"
   port        = 25
-  protocol    = "%s"
+  protocol    = %q
   vpc_id      = aws_vpc.test.id
 
   stickiness {
-    type    = "source_ip"
+    type    = %q
     enabled = %t
   }
 }
@@ -2070,32 +2123,8 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "testAccAWSLBTargetGroupConfig_namePrefix"
+    Name = "testAccAWSLBTargetGroupConfig_stickinessValidity"
   }
 }
-`, protocol, enabled)
-}
-
-func testAccAWSLBTargetGroupConfig_NLBinvalidStickiness(protocol string, enabled bool) string {
-	return fmt.Sprintf(`
-resource "aws_lb_target_group" "test" {
-  name_prefix = "tf-"
-  port        = 25
-  protocol    = "%s"
-  vpc_id      = aws_vpc.test.id
-
-  stickiness {
-    type    = "lb_cookie"
-    enabled = %t
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "testAccAWSLBTargetGroupConfig_namePrefix"
-  }
-}
-`, protocol, enabled)
+`, protocol, stickyType, enabled)
 }

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -1829,6 +1829,8 @@ resource "aws_lb_target_group" "test" {
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
 
+  deregistration_delay = 200
+
   health_check {
     interval            = 10
     port                = "traffic-port"

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -1316,10 +1316,6 @@ resource "aws_lb_target_group" "test" {
   deregistration_delay = 200
   slow_start           = 0
 
-  stickiness {
-    type = "source_ip"
-  }
-
   health_check {
     %s
   }
@@ -1473,10 +1469,6 @@ resource "aws_lb_target_group" "test" {
   port     = 514
   protocol = "UDP"
   vpc_id   = aws_vpc.test.id
-
-  stickiness {
-    type = "source_ip"
-  }
 
   health_check {
     protocol = "TCP"
@@ -1772,10 +1764,6 @@ resource "aws_lb_target_group" "test" {
 
   deregistration_delay = 200
 
-  stickiness {
-    type = "source_ip"
-  }
-
   health_check {
     interval            = 10
     port                = "traffic-port"
@@ -1810,10 +1798,6 @@ resource "aws_lb_target_group" "test" {
   proxy_protocol_v2    = "true"
   deregistration_delay = 200
 
-  stickiness {
-    type = "source_ip"
-  }
-
   health_check {
     interval            = 10
     port                = "traffic-port"
@@ -1844,12 +1828,6 @@ resource "aws_lb_target_group" "test" {
   port     = 8082
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
-
-  deregistration_delay = 200
-
-  stickiness {
-    type = "source_ip"
-  }
 
   health_check {
     interval            = 10
@@ -1884,10 +1862,6 @@ resource "aws_lb_target_group" "test" {
 
   deregistration_delay = 200
 
-  stickiness {
-    type = "source_ip"
-  }
-
   health_check {
     interval            = 10
     port                = "traffic-port"
@@ -1921,10 +1895,6 @@ resource "aws_lb_target_group" "test" {
 
   deregistration_delay = 200
 
-  stickiness {
-    type = "source_ip"
-  }
-
   health_check {
     interval            = 30
     port                = "traffic-port"
@@ -1955,10 +1925,6 @@ resource "aws_lb_target_group" "test" {
   port     = 8082
   protocol = "TCP"
   vpc_id   = aws_vpc.test.id
-
-  stickiness {
-    type = "source_ip"
-  }
 
   health_check {
     healthy_threshold   = %[2]d

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -69,8 +69,8 @@ The following arguments are supported:
 * `load_balancing_algorithm_type` - (Optional) Determines how the load balancer selects targets when routing requests. Only applicable for Application Load Balancer Target Groups. The value is `round_robin` or `least_outstanding_requests`. The default is `round_robin`.
 * `lambda_multi_value_headers_enabled` - (Optional) Boolean whether the request and response headers exchanged between the load balancer and the Lambda function include arrays of values or strings. Only applies when `target_type` is `lambda`.
 * `proxy_protocol_v2` - (Optional) Boolean to enable / disable support for proxy protocol v2 on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol) for more information.
-* `stickiness` - (Optional) A Stickiness block. Stickiness blocks are documented below.
-* `health_check` - (Optional) A Health Check block. Health Check blocks are documented below.
+* `stickiness` - (Optional, Maximum of 1) A Stickiness block. Stickiness blocks are documented below.
+* `health_check` - (Optional, Maximum of 1) A Health Check block. Health Check blocks are documented below.
 * `target_type` - (Optional, Forces new resource) The type of target that you must specify when registering targets with this target group.
 The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address) or `lambda` (targets are specified by lambda arn).
 The default is `instance`. Note that you can't specify targets for a target group using both instance IDs and IP addresses.
@@ -82,7 +82,7 @@ You can't specify publicly routable IP addresses.
 Stickiness Blocks (`stickiness`) support the following:
 
 * `type` - (Required) The type of sticky sessions. The only current possible values are `lb_cookie` for ALBs and `source_ip` for NLBs.
-* `cookie_duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
+* `cookie_duration` - (Optional) Only used when the type is `lb_cookie`. The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
 * `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`
 
 ~> **NOTE:** To help facilitate the authoring of modules that support target groups of any protocol, you can define `stickiness` regardless of the protocol chosen. However, for `TCP` target groups, `enabled` must be `false`.

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -81,7 +81,7 @@ You can't specify publicly routable IP addresses.
 
 Stickiness Blocks (`stickiness`) support the following:
 
-* `type` - (Required) The type of sticky sessions. The only current possible value is `lb_cookie`.
+* `type` - (Required) The type of sticky sessions. The only current possible values are `lb_cookie` and `source_ip`.
 * `cookie_duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
 * `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 * `load_balancing_algorithm_type` - (Optional) Determines how the load balancer selects targets when routing requests. Only applicable for Application Load Balancer Target Groups. The value is `round_robin` or `least_outstanding_requests`. The default is `round_robin`.
 * `lambda_multi_value_headers_enabled` - (Optional) Boolean whether the request and response headers exchanged between the load balancer and the Lambda function include arrays of values or strings. Only applies when `target_type` is `lambda`.
 * `proxy_protocol_v2` - (Optional) Boolean to enable / disable support for proxy protocol v2 on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol) for more information.
-* `stickiness` - (Optional) A Stickiness block. Stickiness blocks are documented below. `stickiness` is only valid if used with Load Balancers of type `Application`
+* `stickiness` - (Optional) A Stickiness block. Stickiness blocks are documented below.
 * `health_check` - (Optional) A Health Check block. Health Check blocks are documented below.
 * `target_type` - (Optional, Forces new resource) The type of target that you must specify when registering targets with this target group.
 The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address) or `lambda` (targets are specified by lambda arn).
@@ -81,7 +81,7 @@ You can't specify publicly routable IP addresses.
 
 Stickiness Blocks (`stickiness`) support the following:
 
-* `type` - (Required) The type of sticky sessions. The only current possible values are `lb_cookie` and `source_ip`.
+* `type` - (Required) The type of sticky sessions. The only current possible values are `lb_cookie` for ALBs and `source_ip` for NLBs.
 * `cookie_duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
 * `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #9093 
Closes #13762

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Allow `stickiness` to be set for NLB `aws_lb_target_group` resources. 
Allow `source_ip` as only valid `stickiness` `type` for `aws_lb_target_group` resource.
```

This PR is meant to update the #13762, that has a minor syntax issue and no response from the author.