### PR TITLE
.github/dependencies: add support for forked repos

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,29 +5,50 @@ on:
     branches:
       - master
       - 'release/**'
-  pull_request:
-    paths:
-      - awsproviderlint/** # go/analysis/analysistest requires vendoring
-      - go.mod
-      - go.sum
-      - vendor/**
+  pull_request_target:
 
 env:
   GO_VERSION: "1.14"
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request_target' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "maryelizbeth", "YakDriver", "renovate[bot]"]'), github.actor)
+    name: Filter Changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            changed:
+              - awsproviderlint/**
+              - go.mod
+              - go.sum
+              - vendor/**
   comment:
-    if: github.event_name == 'pull_request' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "maryelizbeth", "YakDriver", "renovate[bot]"]'), github.actor)
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     name: Comment
     runs-on: ubuntu-latest
     steps:
+      - name: Find Existing PR Comment
+        id: prc
+        uses: peter-evans/find-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "Please note that typically Go dependency changes"
+      - run: echo ${{ steps.prc.outputs.comment-id }}
       - name: PR Comment
-        uses: unsplash/comment-on-pr@v1.2.0
+        if: ${{ steps.prc.outputs.comment-id == '' }}
+        uses: peter-evans/create-or-update-comment@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          check_duplicate_msg: true
-          msg: |-
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |-
             Thank you for your contribution! :rocket:
 
             Please note that typically Go dependency changes are handled in this repository by Renovate Bot or the maintainers. This is to prevent pull request merge conflicts and further delay reviews of contributions. Remove any changes to the `go.mod`, `go.sum`, and `vendor/` files and commit them into this pull request.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates:
* Previous Error in Checks:  https://github.com/terraform-providers/terraform-provider-aws/pull/15256/checks?check_run_id=1146283692

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
github-actions/dependencies: add support for forked repos
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
Use Github Actions Output
```

Notes:
* replaces `pull_request` even type to `pull_request_target` 
* uses `dorny/paths-filter@v2` Github Action to filter file paths as not feasible w/new event type and `paths`
* uses `peter-evans/find-comment@v1` to ensure we don't create duplicate comments on PR updates
* uses `peter-evans/create-or-update-comment@v1` to create comment on forked repo as previous Github Action did not support listening on `pull_request_target`

Example:
* https://github.com/terraform-providers/terraform-provider-aws/pull/15313