### PR TITLE
f/aws_organizations_policy:support for tags

### DIFF
--- a/aws/resource_aws_organizations_policy.go
+++ b/aws/resource_aws_organizations_policy.go
@@ -70,7 +70,7 @@ func resourceAwsOrganizationsPolicyCreate(d *schema.ResourceData, meta interface
 		Description: aws.String(d.Get("description").(string)),
 		Name:        aws.String(d.Get("name").(string)),
 		Type:        aws.String(d.Get("type").(string)),
-		Tags:    keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().OrganizationsTags(),
+		Tags:        keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().OrganizationsTags(),
 	}
 
 	log.Printf("[DEBUG] Creating Organizations Policy: %s", input)
@@ -135,7 +135,7 @@ func resourceAwsOrganizationsPolicyRead(d *schema.ResourceData, meta interface{}
 	d.Set("name", resp.Policy.PolicySummary.Name)
 	d.Set("type", resp.Policy.PolicySummary.Type)
 
-    tags, err := keyvaluetags.OrganizationsListTags(conn, d.Id())
+	tags, err := keyvaluetags.OrganizationsListTags(conn, d.Id())
 	if err != nil {
 		return fmt.Errorf("error listing tags: %s", err)
 	}
@@ -172,7 +172,7 @@ func resourceAwsOrganizationsPolicyUpdate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("error updating Organizations Policy: %s", err)
 	}
 
-    if d.HasChange("tags") {
+	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 		if err := keyvaluetags.OrganizationsUpdateTags(conn, d.Id(), o, n); err != nil {
 			return fmt.Errorf("error updating tags: %s", err)

--- a/aws/resource_aws_organizations_policy.go
+++ b/aws/resource_aws_organizations_policy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsOrganizationsPolicy() *schema.Resource {
@@ -53,6 +54,7 @@ func resourceAwsOrganizationsPolicy() *schema.Resource {
 					organizations.PolicyTypeTagPolicy,
 				}, false),
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -68,6 +70,7 @@ func resourceAwsOrganizationsPolicyCreate(d *schema.ResourceData, meta interface
 		Description: aws.String(d.Get("description").(string)),
 		Name:        aws.String(d.Get("name").(string)),
 		Type:        aws.String(d.Get("type").(string)),
+		Tags:    keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().OrganizationsTags(),
 	}
 
 	log.Printf("[DEBUG] Creating Organizations Policy: %s", input)
@@ -103,6 +106,7 @@ func resourceAwsOrganizationsPolicyCreate(d *schema.ResourceData, meta interface
 
 func resourceAwsOrganizationsPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).organizationsconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	input := &organizations.DescribePolicyInput{
 		PolicyId: aws.String(d.Id()),
@@ -130,6 +134,16 @@ func resourceAwsOrganizationsPolicyRead(d *schema.ResourceData, meta interface{}
 	d.Set("description", resp.Policy.PolicySummary.Description)
 	d.Set("name", resp.Policy.PolicySummary.Name)
 	d.Set("type", resp.Policy.PolicySummary.Type)
+
+    tags, err := keyvaluetags.OrganizationsListTags(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error listing tags: %s", err)
+	}
+
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 
@@ -156,6 +170,13 @@ func resourceAwsOrganizationsPolicyUpdate(d *schema.ResourceData, meta interface
 	_, err := conn.UpdatePolicy(input)
 	if err != nil {
 		return fmt.Errorf("error updating Organizations Policy: %s", err)
+	}
+
+    if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.OrganizationsUpdateTags(conn, d.Id(), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
 	}
 
 	return resourceAwsOrganizationsPolicyRead(d, meta)

--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -113,6 +113,51 @@ func testAccAwsOrganizationsPolicy_description(t *testing.T) {
 	})
 }
 
+func testAccAwsOrganizationsPolicy_tags(t *testing.T) {
+	var p1, p2, p3 organizations.Policy
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_organizations_policy.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOrganizationsPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsPolicyConfig_TagA(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsPolicyExists(resourceName, &p1),
+                    resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Alpha", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsOrganizationsPolicyConfig_TagB(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsPolicyExists(resourceName, &p2),
+                    resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Beta", "1"),
+				),
+			},
+			{
+				Config: testAccAwsOrganizationsPolicyConfig_TagC(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsPolicyExists(resourceName, &p3),
+                    resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAwsOrganizationsPolicy_type_AI_OPT_OUT(t *testing.T) {
 	var policy organizations.Policy
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -381,6 +426,89 @@ EOF
   depends_on = [aws_organizations_organization.test]
 }
 `, description, rName)
+}
+
+func testAccAwsOrganizationsPolicyConfig_TagA(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {}
+
+resource "aws_organizations_policy" "test" {
+  content = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+
+  name        = "%s"
+
+  depends_on = [aws_organizations_organization.test]
+
+  tags = {
+    TerraformProviderAwsTest = true
+    Alpha                    = 1
+  }
+}
+`, rName)
+}
+
+func testAccAwsOrganizationsPolicyConfig_TagB(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {}
+
+resource "aws_organizations_policy" "test" {
+  content = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+
+  name        = "%s"
+
+  depends_on = [aws_organizations_organization.test]
+
+  tags = {
+    TerraformProviderAwsTest = true
+    Beta                     = 1
+  }
+}
+`, rName)
+}
+
+func testAccAwsOrganizationsPolicyConfig_TagC(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {}
+
+resource "aws_organizations_policy" "test" {
+  content = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+
+  name        = "%s"
+
+  depends_on = [aws_organizations_organization.test]
+
+  tags = {
+    TerraformProviderAwsTest = true
+  }
+}
+`, rName)
 }
 
 func testAccAwsOrganizationsPolicyConfig_Required(rName, content string) string {

--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -114,7 +114,7 @@ func testAccAwsOrganizationsPolicy_description(t *testing.T) {
 }
 
 func testAccAwsOrganizationsPolicy_tags(t *testing.T) {
-	var p1, p2, p3 organizations.Policy
+	var p1, p2, p3, p4 organizations.Policy
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_organizations_policy.test"
 
@@ -127,7 +127,7 @@ func testAccAwsOrganizationsPolicy_tags(t *testing.T) {
 				Config: testAccAwsOrganizationsPolicyConfig_TagA(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsPolicyExists(resourceName, &p1),
-                    resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Alpha", "1"),
 				),
@@ -141,7 +141,7 @@ func testAccAwsOrganizationsPolicy_tags(t *testing.T) {
 				Config: testAccAwsOrganizationsPolicyConfig_TagB(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsPolicyExists(resourceName, &p2),
-                    resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Beta", "1"),
 				),
@@ -150,8 +150,15 @@ func testAccAwsOrganizationsPolicy_tags(t *testing.T) {
 				Config: testAccAwsOrganizationsPolicyConfig_TagC(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsPolicyExists(resourceName, &p3),
-                    resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.TerraformProviderAwsTest", "true"),
+				),
+			},
+			{
+				Config: testAccAwsOrganizationsPolicyConfig_NoTag(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsPolicyExists(resourceName, &p4),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -507,6 +514,29 @@ EOF
   tags = {
     TerraformProviderAwsTest = true
   }
+}
+`, rName)
+}
+
+func testAccAwsOrganizationsPolicyConfig_NoTag(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {}
+
+resource "aws_organizations_policy" "test" {
+  content = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+
+  name        = "%s"
+
+  depends_on = [aws_organizations_organization.test]
 }
 `, rName)
 }

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -29,6 +29,7 @@ func TestAccAWSOrganizations_serial(t *testing.T) {
 			"basic":           testAccAwsOrganizationsPolicy_basic,
 			"concurrent":      testAccAwsOrganizationsPolicy_concurrent,
 			"Description":     testAccAwsOrganizationsPolicy_description,
+			"Tags":            testAccAwsOrganizationsPolicy_tags,
 			"Type_AI_OPT_OUT": testAccAwsOrganizationsPolicy_type_AI_OPT_OUT,
 			"Type_Backup":     testAccAwsOrganizationsPolicy_type_Backup,
 			"Type_SCP":        testAccAwsOrganizationsPolicy_type_SCP,

--- a/website/docs/r/organizations_policy.html.markdown
+++ b/website/docs/r/organizations_policy.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `name` - (Required) The friendly name to assign to the policy.
 * `description` - (Optional) A description to assign to the policy.
 * `type` - (Optional) The type of policy to create. Valid values are `AISERVICES_OPT_OUT_POLICY`, `BACKUP_POLICY`, `SERVICE_CONTROL_POLICY` (SCP), and `TAG_POLICY`. Defaults to `SERVICE_CONTROL_POLICY`.
+* `tags` - (Optional) Key-value map of resource tags.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #15168

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=testAccAwsOrganizationsPolicy_tags'
--- PASS: TestAccAwsOrganizationsPolicy_tags (164.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       165.341s
...
```
