### PR TITLE
resource/aws_redshift_cluster: Increase default Update timeout to 75 minutes and remove arbitrary lower create timeout in testing

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -28,7 +28,7 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(75 * time.Minute),
-			Update: schema.DefaultTimeout(40 * time.Minute),
+			Update: schema.DefaultTimeout(75 * time.Minute),
 			Delete: schema.DefaultTimeout(40 * time.Minute),
 		},
 

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -765,10 +765,6 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
-
-  timeouts {
-    create = "30m"
-  }
 }
 `, rInt))
 }

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -79,7 +79,7 @@ string.
 [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
 - `create` - (Default `75 minutes`) Used for creating Clusters.
-- `update` - (Default `40 minutes`) Used for Cluster Argument changes.
+- `update` - (Default `75 minutes`) Used for updating Clusters.
 - `delete` - (Default `40 minutes`) Used for destroying Clusters.
 
 ### Nested Blocks


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #14754

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_redshift_cluster: Increase default update timeout to 75 minutes
```

Previously (inconsistently):

```
=== CONT  TestAccAWSRedshiftCluster_basic
TestAccAWSRedshiftCluster_basic: resource_aws_redshift_cluster_test.go:69: Step 1/2 error: terraform failed: exit status 1
stderr:
Error: Error waiting for Redshift Cluster state to be "available": timeout while waiting for state to become 'available' (last state: 'creating', timeout: 30m0s)

=== CONT  TestAccAWSRedshiftCluster_changeEncryption1
TestAccAWSRedshiftCluster_changeEncryption1: resource_aws_redshift_cluster_test.go:526: Step 1/2 error: terraform failed: exit status 1
stderr:
Error: Error waiting for Redshift Cluster state to be "available": timeout while waiting for state to become 'available' (last state: 'creating', timeout: 30m0s)

=== CONT  TestAccAWSRedshiftCluster_updateNodeCount
TestAccAWSRedshiftCluster_updateNodeCount: resource_aws_redshift_cluster_test.go:353: Step 1/2 error: terraform failed: exit status 1
stderr:
Error: Error waiting for Redshift Cluster state to be "available": timeout while waiting for state to become 'available' (last state: 'creating', timeout: 30m0s)

=== CONT  TestAccAWSRedshiftCluster_updateNodeType
TestAccAWSRedshiftCluster_updateNodeType: resource_aws_redshift_cluster_test.go:390: Step 1/2 error: terraform failed: exit status 1
stderr:
Error: Error waiting for Redshift Cluster state to be "available": timeout while waiting for state to become 'available' (last state: 'creating', timeout: 30m0s)

=== CONT  TestAccAWSRedshiftCluster_updateNodeCount
TestAccAWSRedshiftCluster_updateNodeCount: resource_aws_redshift_cluster_test.go:353: Step 2/2 error: terraform failed: exit status 1
stderr:
Error: Error Modifying Redshift Cluster (tf-redshift-cluster-7778138192916979662): timeout while waiting for state to become 'available' (last state: 'resizing', timeout: 40m0s)
```

The 75 minute update timeout value is chosen to match the create timeout value.

Output from acceptance testing:

```
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (373.42s)
--- PASS: TestAccAWSRedshiftCluster_basic (789.01s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (792.82s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (960.36s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (1111.85s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (1275.44s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (1290.59s)
--- PASS: TestAccAWSRedshiftCluster_iamRoles (1320.91s)
--- PASS: TestAccAWSRedshiftCluster_tags (1501.17s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (1502.53s)
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (1512.02s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (2246.61s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption1 (2506.37s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (3070.55s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (3251.04s)
```
