### PR TITLE
r/aws_backup_plan: Add support for AdvancedBackupSettings

### DIFF
--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -107,6 +107,23 @@ func resourceAwsBackupPlan() *schema.Resource {
 				},
 				Set: backupBackupPlanHash,
 			},
+			"advanced_backup_setting": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"backup_options": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"resource_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -125,8 +142,9 @@ func resourceAwsBackupPlanCreate(d *schema.ResourceData, meta interface{}) error
 
 	input := &backup.CreateBackupPlanInput{
 		BackupPlan: &backup.PlanInput{
-			BackupPlanName: aws.String(d.Get("name").(string)),
-			Rules:          expandBackupPlanRules(d.Get("rule").(*schema.Set)),
+			BackupPlanName:         aws.String(d.Get("name").(string)),
+			Rules:                  expandBackupPlanRules(d.Get("rule").(*schema.Set)),
+			AdvancedBackupSettings: expandBackupPlanAdvancedBackupSettings(d.Get("advanced_backup_setting").(*schema.Set)),
 		},
 		BackupPlanTags: keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().BackupTags(),
 	}
@@ -166,6 +184,12 @@ func resourceAwsBackupPlanRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting rule: %s", err)
 	}
 
+	// AdvancedBackupSettings being read direct from resp and not from under
+	// resp.BackupPlan is deliberate - the latter always contains null
+	if err := d.Set("advanced_backup_setting", flattenBackupPlanAdvancedBackupSettings(resp.AdvancedBackupSettings)); err != nil {
+		return fmt.Errorf("error setting advanced_backup_setting: %s", err)
+	}
+
 	tags, err := keyvaluetags.BackupListTags(conn, d.Get("arn").(string))
 	if err != nil {
 		return fmt.Errorf("error listing tags for Backup Plan (%s): %s", d.Id(), err)
@@ -180,12 +204,13 @@ func resourceAwsBackupPlanRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsBackupPlanUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).backupconn
 
-	if d.HasChange("rule") {
+	if d.HasChanges("rule", "advanced_backup_setting") {
 		input := &backup.UpdateBackupPlanInput{
 			BackupPlanId: aws.String(d.Id()),
 			BackupPlan: &backup.PlanInput{
-				BackupPlanName: aws.String(d.Get("name").(string)),
-				Rules:          expandBackupPlanRules(d.Get("rule").(*schema.Set)),
+				BackupPlanName:         aws.String(d.Get("name").(string)),
+				Rules:                  expandBackupPlanRules(d.Get("rule").(*schema.Set)),
+				AdvancedBackupSettings: expandBackupPlanAdvancedBackupSettings(d.Get("advanced_backup_setting").(*schema.Set)),
 			},
 		}
 
@@ -279,6 +304,27 @@ func expandBackupPlanRules(vRules *schema.Set) []*backup.RuleInput {
 	return rules
 }
 
+func expandBackupPlanAdvancedBackupSettings(vAdvancedBackupSettings *schema.Set) []*backup.AdvancedBackupSetting {
+	advancedBackupSettings := []*backup.AdvancedBackupSetting{}
+
+	for _, vAdvancedBackupSetting := range vAdvancedBackupSettings.List() {
+		advancedBackupSetting := &backup.AdvancedBackupSetting{}
+
+		mAdvancedBackupSetting := vAdvancedBackupSetting.(map[string]interface{})
+
+		if v, ok := mAdvancedBackupSetting["backup_options"].(map[string]interface{}); ok && v != nil {
+			advancedBackupSetting.BackupOptions = stringMapToPointers(v)
+		}
+		if v, ok := mAdvancedBackupSetting["resource_type"].(string); ok && v != "" {
+			advancedBackupSetting.ResourceType = aws.String(v)
+		}
+
+		advancedBackupSettings = append(advancedBackupSettings, advancedBackupSetting)
+	}
+
+	return advancedBackupSettings
+}
+
 func expandBackupPlanCopyActions(actionList []interface{}) []*backup.CopyAction {
 	actions := []*backup.CopyAction{}
 
@@ -339,6 +385,21 @@ func flattenBackupPlanRules(rules []*backup.Rule) *schema.Set {
 	}
 
 	return schema.NewSet(backupBackupPlanHash, vRules)
+}
+
+func flattenBackupPlanAdvancedBackupSettings(advancedBackupSettings []*backup.AdvancedBackupSetting) *schema.Set {
+	vAdvancedBackupSettings := []interface{}{}
+
+	for _, advancedBackupSetting := range advancedBackupSettings {
+		mAdvancedBackupSetting := map[string]interface{}{
+			"backup_options": aws.StringValueMap(advancedBackupSetting.BackupOptions),
+			"resource_type":  aws.StringValue(advancedBackupSetting.ResourceType),
+		}
+
+		vAdvancedBackupSettings = append(vAdvancedBackupSettings, mAdvancedBackupSetting)
+	}
+
+	return schema.NewSet(backupBackupPlanHash, vAdvancedBackupSettings)
 }
 
 func flattenBackupPlanCopyActions(copyActions []*backup.CopyAction) []interface{} {

--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -467,6 +467,38 @@ func TestAccAwsBackupPlan_Rule_CopyAction_CrossRegion(t *testing.T) {
 	})
 }
 
+func TestAccAwsBackupPlan_AdvancedBackupSetting(t *testing.T) {
+	var plan backup.GetBackupPlanOutput
+	resourceName := "aws_backup_plan.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsBackupPlanConfigAdvancedBackupSetting(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupPlanExists(resourceName, &plan),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "advanced_backup_setting.#", "1"),
+					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "advanced_backup_setting.*", map[string]string{
+						"backup_options.%":          "1",
+						"backup_options.WindowsVSS": "enabled",
+						"resource_type":             "EC2",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAwsBackupPlan_disappears(t *testing.T) {
 	var plan backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
@@ -886,6 +918,36 @@ resource "aws_backup_plan" "test" {
 
       destination_vault_arn = aws_backup_vault.test2.arn
     }
+  }
+}
+`, rName)
+}
+
+func testAccAwsBackupPlanConfigAdvancedBackupSetting(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+  name = "%[1]s-1"
+}
+
+resource "aws_backup_plan" "test" {
+  name = %[1]q
+
+  rule {
+    rule_name         = %[1]q
+    target_vault_name = aws_backup_vault.test.name
+    schedule          = "cron(0 12 * * ? *)"
+
+    lifecycle {
+      cold_storage_after = 30
+      delete_after       = 180
+    }
+  }
+
+  advanced_backup_setting {
+    backup_options = {
+      WindowsVSS = "enabled"
+    }
+    resource_type = "EC2"
   }
 }
 `, rName)

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -21,6 +21,13 @@ resource "aws_backup_plan" "example" {
     target_vault_name = aws_backup_vault.test.name
     schedule          = "cron(0 12 * * ? *)"
   }
+
+  advanced_backup_setting {
+    backup_options = {
+      WindowsVSS = "enabled"
+    }
+    resource_type = "EC2"
+  }
 }
 ```
 
@@ -30,6 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The display name of a backup plan.
 * `rule` - (Required) A rule object that specifies a scheduled task that is used to back up a selection of resources.
+* `advanced_backup_setting` - (Optional) An object that specifies backup options for each resource type.
 * `tags` - (Optional) Metadata that you can assign to help organize the plans you create.
 
 ### Rule Arguments
@@ -55,6 +63,12 @@ For **copy_action** the following attributes are supported:
 
 * `lifecycle` - (Optional) The lifecycle defines when a protected resource is copied over to a backup vault and when it expires.  Fields documented above.
 * `destination_vault_arn` - (Required) An Amazon Resource Name (ARN) that uniquely identifies the destination backup vault for the copied backup.
+
+### Advanced Backup Setting Arguments
+For `advanced_backup_setting` the following attibutes are supported:
+
+* `backup_options` - (Optional) Specifies the backup option for a selected resource. This option is only available for Windows VSS backup jobs. Set to `{ WindowsVSS = "enabled" }` to enable Windows VSS backup option and create a VSS Windows backup.
+* `resource_type` - (Optional) The type of AWS resource to be backed up. For VSS Windows backups, the only supported resource type is Amazon EC2. Valid values: `EC2`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15329

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_backup_plan: Add support for AdvancedBackupSettings ([#15341](https://github.com/terraform-providers/terraform-provider-aws/issues/15341))
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsBackupPlan_AdvancedBackupSetting'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsBackupPlan_AdvancedBackupSetting -timeout 120m
=== RUN   TestAccAwsBackupPlan_AdvancedBackupSetting
=== PAUSE TestAccAwsBackupPlan_AdvancedBackupSetting
=== CONT  TestAccAwsBackupPlan_AdvancedBackupSetting
--- PASS: TestAccAwsBackupPlan_AdvancedBackupSetting (30.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.427s
```
