### PR TITLE
tech-debt/organizations_policy: add missing key/value block in copy_actions

### DIFF
--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -199,71 +199,74 @@ func testAccAwsOrganizationsPolicy_type_Backup(t *testing.T) {
 	resourceName := "aws_organizations_policy.test"
 	// Reference: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_backup_syntax.html
 	backupPolicyContent := `{
-  "plans": {
-    "PII_Backup_Plan": {
-      "regions": {
-        "@@assign": [
-          "ap-northeast-2",
-          "us-east-1",
-          "eu-north-1"
-        ]
-      },
-      "rules": {
-        "Hourly": {
-          "schedule_expression": {
-            "@@assign": "cron(0 5/1 ? * * *)"
-          },
-          "start_backup_window_minutes": {
-            "@@assign": "480"
-          },
-          "complete_backup_window_minutes": {
-            "@@assign": "10080"
-          },
-          "lifecycle": {
-            "move_to_cold_storage_after_days": {
-              "@@assign": "180"
-            },
-            "delete_after_days": {
-              "@@assign": "270"
+   "plans":{
+      "PII_Backup_Plan":{
+         "regions":{
+            "@@assign":[
+               "ap-northeast-2",
+               "us-east-1",
+               "eu-north-1"
+            ]
+         },
+         "rules":{
+            "Hourly":{
+               "schedule_expression":{
+                  "@@assign":"cron(0 5/1 ? * * *)"
+               },
+               "start_backup_window_minutes":{
+                  "@@assign":"480"
+               },
+               "complete_backup_window_minutes":{
+                  "@@assign":"10080"
+               },
+               "lifecycle":{
+                  "move_to_cold_storage_after_days":{
+                     "@@assign":"180"
+                  },
+                  "delete_after_days":{
+                     "@@assign":"270"
+                  }
+               },
+               "target_backup_vault_name":{
+                  "@@assign":"FortKnox"
+               },
+               "copy_actions":{
+                  "arn:aws:backup:us-east-1:$account:backup-vault:secondary_vault":{
+                     "target_backup_vault_arn":{
+                        "@@assign":"arn:aws:backup:us-east-1:$account:backup-vault:secondary_vault"
+                     },
+                     "lifecycle":{
+                        "delete_after_days":{
+                           "@@assign":"100"
+                        },
+                        "move_to_cold_storage_after_days":{
+                           "@@assign":"10"
+                        }
+                     }
+                  }
+               }
             }
-          },
-          "target_backup_vault_name": {
-            "@@assign": "FortKnox"
-          },
-          "copy_actions": {
-            "arn:aws:backup:us-east-1:$account:backup-vault:secondary_vault": {
-              "lifecycle": {
-                "delete_after_days": {
-                  "@@assign": "100"
-                },
-                "move_to_cold_storage_after_days": {
-                  "@@assign": "10"
-                }
-              }
+         },
+         "selections":{
+            "tags":{
+               "datatype":{
+                  "iam_role_arn":{
+                     "@@assign":"arn:aws:iam::$account:role/MyIamRole"
+                  },
+                  "tag_key":{
+                     "@@assign":"dataType"
+                  },
+                  "tag_value":{
+                     "@@assign":[
+                        "PII",
+                        "RED"
+                     ]
+                  }
+               }
             }
-          }
-        }
-      },
-      "selections": {
-        "tags": {
-          "datatype": {
-            "iam_role_arn": {
-              "@@assign": "arn:aws:iam::$account:role/MyIamRole"
-            },
-            "tag_key": {
-              "@@assign": "dataType"
-            },
-            "tag_value": {
-              "@@assign": [
-                "PII",
-                "RED"
-              ]
-            }
-          }
-        }
+         }
       }
-    }
-  }
+   }
 }`
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15335 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
tech-debt/organizations_policy: add missing key/value block in copy_actions
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
 --- PASS: TestAccAWSOrganizations_serial/Policy/Type_Backup (19.32s)
```
