### PR TITLE
[WIP] Delta sync configuration for appsync dynamodb data source

### DIFF
--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -105,6 +105,14 @@ The following arguments are supported:
 * `region` - (Optional) AWS region of the DynamoDB table. Defaults to current region.
 * `use_caller_credentials` - (Optional) Set to `true` to use Amazon Cognito credentials with this data source.
 
+#### delta_sync_config
+
+Enable data source versioning, the following arguments are supported:
+
+* `base_table_ttl` - (Required) The amount of time (in minutes) items should be kept in the main table when deleted. Set to `0` to delete items in the main table immediately.
+* `delta_sync_table_name` - (Required) Delta sync table name
+* `delta_sync_table_ttl` - (Required) The amount of time (in minutes) the delta sync table will keep track of changes.
+
 ### elasticsearch_config
 
 The following arguments are supported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `delta_sync_config` block to `aws_appsync_datasource` `dynamodb_config` block to enable data source versioning
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAwsAppsyncDatasource_DynamoDBConfig_DeltaSync'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAwsAppsyncDatasource_DynamoDBConfig_DeltaSync -timeout 120m
=== RUN   TestAccAwsAppsyncDatasource_DynamoDBConfig_DeltaSync
=== PAUSE TestAccAwsAppsyncDatasource_DynamoDBConfig_DeltaSync
=== CONT  TestAccAwsAppsyncDatasource_DynamoDBConfig_DeltaSync
panic: interface conversion: interface {} is []interface {}, not map[string]interface {}

goroutine 478 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandAppsyncDynamodbDataSourceConfig(0xc001de86e0, 0x1, 0x1, 0xc000bdd0b3, 0x9, 0x500000000203001)
        /Users/ponti/developer/terraform-provider-aws/aws/resource_aws_appsync_datasource.go:350 +0x647
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsAppsyncDatasourceCreate(0xc00138aa00, 0x6b28d00, 0xc001650500, 0x0, 0xffffffffffffffff)
...
```


_The test isn't passing, but I'm not sure what exactly I'm missing. I'd like some guidance on how the test for this could be appropriately written/checked so as to pass and adequately validate the change_