### PR TITLE
r/storagegateway_tape_pool - add new resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -899,6 +899,7 @@ func Provider() *schema.Provider {
 			"aws_storagegateway_nfs_file_share":                       resourceAwsStorageGatewayNfsFileShare(),
 			"aws_storagegateway_smb_file_share":                       resourceAwsStorageGatewaySmbFileShare(),
 			"aws_storagegateway_stored_iscsi_volume":                  resourceAwsStorageGatewayStoredIscsiVolume(),
+			"aws_storagegateway_tape_pool":                            resourceAwsStorageGatewayTapePool(),
 			"aws_storagegateway_upload_buffer":                        resourceAwsStorageGatewayUploadBuffer(),
 			"aws_storagegateway_working_storage":                      resourceAwsStorageGatewayWorkingStorage(),
 			"aws_spot_datafeed_subscription":                          resourceAwsSpotDataFeedSubscription(),

--- a/aws/resource_aws_storagegateway_tape_pool.go
+++ b/aws/resource_aws_storagegateway_tape_pool.go
@@ -1,0 +1,162 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+)
+
+func resourceAwsStorageGatewayTapePool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsStorageGatewayTapePoolCreate,
+		Read:   resourceAwsStorageGatewayTapePoolRead,
+		Update: resourceAwsStorageGatewayTapePoolUpdate,
+		Delete: resourceAwsStorageGatewayTapePoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pool_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+			"storage_class": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(storagegateway.TapeStorageClass_Values(), false),
+			},
+			"retention_look_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(storagegateway.RetentionLockType_Values(), false),
+			},
+			"retention_lock_time_in_days": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(0, 36500),
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsStorageGatewayTapePoolCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.CreateTapePoolInput{
+		PoolName:     aws.String(d.Get("pool_name").(string)),
+		StorageClass: aws.String(d.Get("storage_class").(string)),
+		Tags:         keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().StoragegatewayTags(),
+	}
+
+	if v, ok := d.GetOk("retention_look_type"); ok {
+		input.RetentionLockType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOkExists("retention_lock_time_in_days"); ok {
+		input.RetentionLockTimeInDays = aws.Int64(int64(v.(int)))
+	}
+
+	log.Printf("[DEBUG] Creating Storage Gateway Tape Pool: %s", input)
+	output, err := conn.CreateTapePool(input)
+	if err != nil {
+		return fmt.Errorf("error creating Storage Gateway Tape Pool: %w", err)
+	}
+
+	d.SetId(aws.StringValue(output.PoolARN))
+
+	return resourceAwsStorageGatewayTapePoolRead(d, meta)
+}
+
+func resourceAwsStorageGatewayTapePoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+		if err := keyvaluetags.StoragegatewayUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %w", err)
+		}
+	}
+
+	return resourceAwsStorageGatewayTapePoolRead(d, meta)
+}
+
+func resourceAwsStorageGatewayTapePoolRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
+	input := &storagegateway.ListTapePoolsInput{
+		PoolARNs: []*string{aws.String(d.Id())},
+	}
+
+	log.Printf("[DEBUG] Reading Storage Gateway Tape Pool: %s", input)
+	output, err := conn.ListTapePools(input)
+
+	if err != nil {
+		if isAWSErr(err, storagegateway.ErrorCodeVolumeNotFound, "") || isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified pool was not found") {
+			log.Printf("[WARN] Storage Gateway Tape Pool %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Storage Gateway Tape Pool %q: %w", d.Id(), err)
+	}
+
+	if output == nil || len(output.PoolInfos) == 0 || output.PoolInfos[0] == nil || aws.StringValue(output.PoolInfos[0].PoolARN) != d.Id() {
+		log.Printf("[WARN] Storage Gateway Tape Pool %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	pool := output.PoolInfos[0]
+
+	poolArn := aws.StringValue(pool.PoolARN)
+	d.Set("arn", poolArn)
+	d.Set("pool_name", aws.StringValue(pool.PoolName))
+	d.Set("retention_lock_time_in_days", aws.Int64Value(pool.RetentionLockTimeInDays))
+	d.Set("retention_look_type", aws.StringValue(pool.RetentionLockType))
+	d.Set("storage_class", aws.StringValue(pool.StorageClass))
+
+	tags, err := keyvaluetags.StoragegatewayListTags(conn, poolArn)
+	if err != nil {
+		return fmt.Errorf("error listing tags for resource (%s): %w", poolArn, err)
+	}
+	if err := d.Set("tags", tags.IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	return nil
+}
+
+func resourceAwsStorageGatewayTapePoolDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.DeleteTapePoolInput{
+		PoolARN: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting Storage Gateway Tape Pool: %s", input)
+	_, err := conn.DeleteTapePool(input)
+	if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified volume was not found") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error deleting Storage Gateway Tape Pool %q: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_storagegateway_tape_pool.go
+++ b/aws/resource_aws_storagegateway_tape_pool.go
@@ -103,6 +103,10 @@ func resourceAwsStorageGatewayTapePoolRead(d *schema.ResourceData, meta interfac
 	log.Printf("[DEBUG] Reading Storage Gateway Tape Pool: %s", input)
 	output, err := conn.ListTapePools(input)
 
+	if err != nil {
+		return fmt.Errorf("[ERROR] Listing Storage Gateway Tape Pools %w", err)
+	}
+
 	if output == nil || len(output.PoolInfos) == 0 || output.PoolInfos[0] == nil || aws.StringValue(output.PoolInfos[0].PoolARN) != d.Id() {
 		log.Printf("[WARN] Storage Gateway Tape Pool %q not found, removing from state", d.Id())
 		d.SetId("")

--- a/aws/resource_aws_storagegateway_tape_pool.go
+++ b/aws/resource_aws_storagegateway_tape_pool.go
@@ -38,7 +38,7 @@ func resourceAwsStorageGatewayTapePool() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(storagegateway.TapeStorageClass_Values(), false),
 			},
-			"retention_look_type": {
+			"retention_lock_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      storagegateway.RetentionLockTypeNone,
@@ -63,7 +63,7 @@ func resourceAwsStorageGatewayTapePoolCreate(d *schema.ResourceData, meta interf
 	input := &storagegateway.CreateTapePoolInput{
 		PoolName:                aws.String(d.Get("pool_name").(string)),
 		StorageClass:            aws.String(d.Get("storage_class").(string)),
-		RetentionLockType:       aws.String(d.Get("retention_look_type").(string)),
+		RetentionLockType:       aws.String(d.Get("retention_lock_type").(string)),
 		RetentionLockTimeInDays: aws.Int64(int64(d.Get("retention_lock_time_in_days").(int))),
 		Tags:                    keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().StoragegatewayTags(),
 	}
@@ -119,7 +119,7 @@ func resourceAwsStorageGatewayTapePoolRead(d *schema.ResourceData, meta interfac
 	d.Set("arn", poolArn)
 	d.Set("pool_name", aws.StringValue(pool.PoolName))
 	d.Set("retention_lock_time_in_days", aws.Int64Value(pool.RetentionLockTimeInDays))
-	d.Set("retention_look_type", aws.StringValue(pool.RetentionLockType))
+	d.Set("retention_lock_type", aws.StringValue(pool.RetentionLockType))
 	d.Set("storage_class", aws.StringValue(pool.StorageClass))
 
 	tags, err := keyvaluetags.StoragegatewayListTags(conn, poolArn)

--- a/aws/resource_aws_storagegateway_tape_pool_test.go
+++ b/aws/resource_aws_storagegateway_tape_pool_test.go
@@ -1,0 +1,200 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAWSStorageGatewayTapePool_basic(t *testing.T) {
+	var TapePool storagegateway.PoolInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_tape_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayTapePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayTapePoolBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayTapePoolExists(resourceName, &TapePool),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "storagegateway", regexp.MustCompile(`tapepool/pool-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "pool_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "GLACIER"),
+					resource.TestCheckResourceAttr(resourceName, "retention_look_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "retention_lock_time_in_days", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayTapePool_tags(t *testing.T) {
+	var TapePool storagegateway.PoolInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_tape_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayTapePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayTapePoolConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayTapePoolExists(resourceName, &TapePool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSStorageGatewayTapePoolConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayTapePoolExists(resourceName, &TapePool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayTapePoolConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayTapePoolExists(resourceName, &TapePool),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayTapePool_disappears(t *testing.T) {
+	var storedIscsiVolume storagegateway.PoolInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_tape_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayTapePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayTapePoolBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayTapePoolExists(resourceName, &storedIscsiVolume),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsStorageGatewayTapePool(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSStorageGatewayTapePoolExists(resourceName string, TapePool *storagegateway.PoolInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
+
+		input := &storagegateway.ListTapePoolsInput{
+			PoolARNs: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.ListTapePools(input)
+
+		if err != nil {
+			return fmt.Errorf("error reading Storage Gateway Tape Pool: %s", err)
+		}
+
+		if output == nil || len(output.PoolInfos) == 0 || output.PoolInfos[0] == nil || aws.StringValue(output.PoolInfos[0].PoolARN) != rs.Primary.ID {
+			return fmt.Errorf("Storage Gateway Tape Pool %q not found", rs.Primary.ID)
+		}
+
+		*TapePool = *output.PoolInfos[0]
+
+		return nil
+	}
+}
+
+func testAccCheckAWSStorageGatewayTapePoolDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_storagegateway_tape_pool" {
+			continue
+		}
+
+		input := &storagegateway.ListTapePoolsInput{
+			PoolARNs: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.ListTapePools(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || len(output.PoolInfos) == 0 || output.PoolInfos[0] == nil || aws.StringValue(output.PoolInfos[0].PoolARN) != rs.Primary.ID {
+			return fmt.Errorf("Storage Gateway Tape Pool %q not found", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSStorageGatewayTapePoolBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_storagegateway_tape_pool" "test" {
+  pool_name     = %[1]q
+  storage_class = "GLACIER"
+}
+`, rName)
+}
+
+func testAccAWSStorageGatewayTapePoolConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_storagegateway_tape_pool" "test" {
+  pool_name     = %[1]q
+  storage_class = "GLACIER"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccAWSStorageGatewayTapePoolConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_storagegateway_tape_pool" "test" {
+  pool_name     = %[1]q
+  storage_class = "GLACIER"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/aws/resource_aws_storagegateway_tape_pool_test.go
+++ b/aws/resource_aws_storagegateway_tape_pool_test.go
@@ -185,7 +185,7 @@ func testAccCheckAWSStorageGatewayTapePoolDestroy(s *terraform.State) error {
 			return err
 		}
 
-		if output == nil || len(output.PoolInfos) == 0 || output.PoolInfos[0] == nil || aws.StringValue(output.PoolInfos[0].PoolARN) != rs.Primary.ID {
+		if len(output.PoolInfos) != 0 {
 			return fmt.Errorf("Storage Gateway Tape Pool %q not found", rs.Primary.ID)
 		}
 	}

--- a/aws/resource_aws_storagegateway_tape_pool_test.go
+++ b/aws/resource_aws_storagegateway_tape_pool_test.go
@@ -29,7 +29,7 @@ func TestAccAWSStorageGatewayTapePool_basic(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "storagegateway", regexp.MustCompile(`tapepool/pool-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "pool_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "GLACIER"),
-					resource.TestCheckResourceAttr(resourceName, "retention_look_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "retention_lock_type", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "retention_lock_time_in_days", "0"),
 				),
 			},
@@ -59,7 +59,7 @@ func TestAccAWSStorageGatewayTapePool_retention(t *testing.T) {
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "storagegateway", regexp.MustCompile(`tapepool/pool-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "pool_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "GLACIER"),
-					resource.TestCheckResourceAttr(resourceName, "retention_look_type", "GOVERNANCE"),
+					resource.TestCheckResourceAttr(resourceName, "retention_lock_type", "GOVERNANCE"),
 					resource.TestCheckResourceAttr(resourceName, "retention_lock_time_in_days", "1"),
 				),
 			},
@@ -207,7 +207,7 @@ func testAccAWSStorageGatewayTapePoolRetentionConfig(rName string) string {
 resource "aws_storagegateway_tape_pool" "test" {
   pool_name                   = %[1]q
   storage_class               = "GLACIER"
-  retention_look_type         = "GOVERNANCE"
+  retention_lock_type         = "GOVERNANCE"
   retention_lock_time_in_days = 1
 }
 `, rName)

--- a/website/docs/r/storagegateway_tape_pool.html.markdown
+++ b/website/docs/r/storagegateway_tape_pool.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Storage Gateway"
+layout: "aws"
+page_title: "AWS: aws_storagegateway_tape_pool"
+description: |-
+  Manages an AWS Storage Gateway Tape Pool
+---
+
+# Resource: aws_storagegateway_tape_pool
+
+Manages an AWS Storage Gateway Tape Pool.
+
+## Example Usage
+
+```hcl
+resource "aws_storagegateway_tape_pool" "example" {
+  pool_name     = "example"
+  storage_class = "GLACIER"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `pool_name` - (Required) The name of the new custom tape pool.
+* `storage_class` - (Required) The storage class that is associated with the new custom pool. When you use your backup application to eject the tape, the tape is archived directly into the storage class that corresponds to the pool. Possible values are `DEEP_ARCHIVE` or `GLACIER`.
+* `retention_look_type` - (Required) Tape retention lock can be configured in two modes. When configured in governance mode, AWS accounts with specific IAM permissions are authorized to remove the tape retention lock from archived virtual tapes. When configured in compliance mode, the tape retention lock cannot be removed by any user, including the root AWS account. Possible values are `COMPLIANCE`, `GOVERNANCE`, and `NONE`. Default value is `NONE`.
+* `retention_lock_time_in_days` - (Optional) Tape retention lock time is set in days. Tape retention lock can be enabled for up to 100 years (36,500 days). Default value is 0.
+* `tags` - (Optional) Key-value map of resource tags
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Volume Amazon Resource Name (ARN), e.g. `aws_storagegateway_tape_pool.example arn:aws:storagegateway:us-east-1:123456789012:tapepool/pool-12345678`.
+
+## Import
+
+`aws_storagegateway_tape_pool` can be imported by using the volume Amazon Resource Name (ARN), e.g.
+
+```
+$ terraform import aws_storagegateway_tape_pool.example arn:aws:storagegateway:us-east-1:123456789012:tapepool/pool-12345678
+```

--- a/website/docs/r/storagegateway_tape_pool.html.markdown
+++ b/website/docs/r/storagegateway_tape_pool.html.markdown
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `pool_name` - (Required) The name of the new custom tape pool.
 * `storage_class` - (Required) The storage class that is associated with the new custom pool. When you use your backup application to eject the tape, the tape is archived directly into the storage class that corresponds to the pool. Possible values are `DEEP_ARCHIVE` or `GLACIER`.
-* `retention_look_type` - (Required) Tape retention lock can be configured in two modes. When configured in governance mode, AWS accounts with specific IAM permissions are authorized to remove the tape retention lock from archived virtual tapes. When configured in compliance mode, the tape retention lock cannot be removed by any user, including the root AWS account. Possible values are `COMPLIANCE`, `GOVERNANCE`, and `NONE`. Default value is `NONE`.
+* `retention_lock_type` - (Required) Tape retention lock can be configured in two modes. When configured in governance mode, AWS accounts with specific IAM permissions are authorized to remove the tape retention lock from archived virtual tapes. When configured in compliance mode, the tape retention lock cannot be removed by any user, including the root AWS account. Possible values are `COMPLIANCE`, `GOVERNANCE`, and `NONE`. Default value is `NONE`.
 * `retention_lock_time_in_days` - (Optional) Tape retention lock time is set in days. Tape retention lock can be enabled for up to 100 years (36,500 days). Default value is 0.
 * `tags` - (Optional) Key-value map of resource tags
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10723

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_storagegateway_tape_pool: add new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSStorageGatewayTapePool_'
--- PASS: TestAccAWSStorageGatewayTapePool_basic (40.65s)
--- PASS: TestAccAWSStorageGatewayTapePool_retention (39.87s)
--- PASS: TestAccAWSStorageGatewayTapePool_tags (99.66s)
--- PASS: TestAccAWSStorageGatewayTapePool_disappears (29.18s)
```
