### PR TITLE
f/aws_sagemaker_model: adding model attribute for container

### DIFF
--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
@@ -55,6 +56,13 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							Required:     true,
 							ForceNew:     true,
 							ValidateFunc: validateSagemakerImage,
+						},
+
+						"mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(sagemaker.ContainerMode_Values(), false),
 						},
 
 						"model_data_url": {
@@ -127,6 +135,13 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							Required:     true,
 							ForceNew:     true,
 							ValidateFunc: validateSagemakerImage,
+						},
+
+						"mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(sagemaker.ContainerMode_Values(), false),
 						},
 
 						"model_data_url": {
@@ -328,6 +343,10 @@ func expandContainer(m map[string]interface{}) *sagemaker.ContainerDefinition {
 		Image: aws.String(m["image"].(string)),
 	}
 
+	if v, ok := m["mode"]; ok && v.(string) != "" {
+		container.Mode = aws.String(v.(string))
+	}
+
 	if v, ok := m["container_hostname"]; ok && v.(string) != "" {
 		container.ContainerHostname = aws.String(v.(string))
 	}
@@ -359,6 +378,10 @@ func flattenContainer(container *sagemaker.ContainerDefinition) []interface{} {
 	cfg := make(map[string]interface{})
 
 	cfg["image"] = *container.Image
+
+	if container.Mode != nil {
+		cfg["mode"] = *container.Mode
+	}
 
 	if container.ContainerHostname != nil {
 		cfg["container_hostname"] = *container.ContainerHostname

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -62,6 +62,7 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
+							Default:      sagemaker.ContainerModeSingleModel,
 							ValidateFunc: validation.StringInSlice(sagemaker.ContainerMode_Values(), false),
 						},
 
@@ -141,6 +142,7 @@ func resourceAwsSagemakerModel() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
+							Default:      sagemaker.ContainerModeSingleModel,
 							ValidateFunc: validation.StringInSlice(sagemaker.ContainerMode_Values(), false),
 						},
 

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -198,6 +198,31 @@ func TestAccAWSSagemakerModel_primaryContainerEnvironment(t *testing.T) {
 	})
 }
 
+func TestAccAWSSagemakerModel_primaryContainerModeSingle(t *testing.T) {
+	rName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSagemakerModelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSagemakerPrimaryContainerModeSingle(rName, image),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSagemakerModelExists("aws_sagemaker_model.foo"),
+					resource.TestCheckResourceAttr("aws_sagemaker_model.foo",
+						"primary_container.0.mode", "SingleModel"),
+				),
+			},
+			{
+				ResourceName:      "aws_sagemaker_model.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSSagemakerModel_containers(t *testing.T) {
 	rName := acctest.RandString(10)
 
@@ -562,6 +587,38 @@ resource "aws_sagemaker_model" "foo" {
     environment = {
       foo = "bar"
     }
+  }
+}
+
+resource "aws_iam_role" "foo" {
+  name               = "terraform-testacc-sagemaker-model-%s"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.amazonaws.com"]
+    }
+  }
+}
+`, rName, image, rName)
+}
+
+func testAccSagemakerPrimaryContainerModeSingle(rName string, image string) string {
+	return fmt.Sprintf(`
+resource "aws_sagemaker_model" "foo" {
+  name               = "terraform-testacc-sagemaker-model-%s"
+  execution_role_arn = aws_iam_role.foo.arn
+
+  primary_container {
+    image = "%s"
+
+    mode = "SingleModel"
   }
 }
 

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 The `primary_container` and `container` block both support:
 
 * `image` - (Required) The registry path where the inference code image is stored in Amazon ECR.
+* `mode` - (Optional) The container hosts value `SingleModel/MultiModel`.
 * `model_data_url` - (Optional) The URL for the S3 location where model artifacts are stored.
 * `container_hostname` - (Optional) The DNS host name for the container.
 * `environment` - (Optional) Environment variables for the Docker container.

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 The `primary_container` and `container` block both support:
 
 * `image` - (Required) The registry path where the inference code image is stored in Amazon ECR.
-* `mode` - (Optional) The container hosts value `SingleModel/MultiModel`.
+* `mode` - (Optional) The container hosts value `SingleModel/MultiModel`. The default value is `SingleModel`.
 * `model_data_url` - (Optional) The URL for the S3 location where model artifacts are stored.
 * `container_hostname` - (Optional) The DNS host name for the container.
 * `environment` - (Optional) Environment variables for the Docker container.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #14891

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerModel_primaryContainerModeSingle'
--- PASS: TestAccAWSSagemakerModel_primaryContainerModeSingle (112.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	114.721s
...
```
