### PR TITLE
r/sagemaker_notebook_instance - `lifecycle_config_name`, `root_access`, and `default_code_repository` allow updating + refactor tests

### DIFF
--- a/aws/internal/service/sagemaker/waiter/status.go
+++ b/aws/internal/service/sagemaker/waiter/status.go
@@ -1,0 +1,27 @@
+package waiter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// NotebookInstanceStatus fetches the NotebookInstance and its Status
+func NotebookInstanceStatus(conn *sagemaker.SageMaker, notebookName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &sagemaker.DescribeNotebookInstanceInput{
+			NotebookInstanceName: aws.String(notebookName),
+		}
+
+		output, err := conn.DescribeNotebookInstance(input)
+		if err != nil {
+			return nil, sagemaker.NotebookInstanceStatusFailed, err
+		}
+
+		if output == nil {
+			return nil, "", nil
+		}
+
+		return output, aws.StringValue(output.NotebookInstanceStatus), nil
+	}
+}

--- a/aws/internal/service/sagemaker/waiter/waiter.go
+++ b/aws/internal/service/sagemaker/waiter/waiter.go
@@ -1,0 +1,77 @@
+package waiter
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	NotebookInstanceInServiceTimeout = 10 * time.Minute
+	NotebookInstanceStoppedTimeout   = 10 * time.Minute
+	NotebookInstanceDeletedTimeout   = 10 * time.Minute
+)
+
+// NotebookInstanceInService waits for a NotebookInstance to return InService
+func NotebookInstanceInService(conn *sagemaker.SageMaker, notebookName string) (*sagemaker.DescribeNotebookInstanceOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			sagemaker.NotebookInstanceStatusUpdating,
+			sagemaker.NotebookInstanceStatusPending,
+			sagemaker.NotebookInstanceStatusStopped,
+		},
+		Target:  []string{sagemaker.NotebookInstanceStatusInService},
+		Refresh: NotebookInstanceStatus(conn, notebookName),
+		Timeout: NotebookInstanceInServiceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeNotebookInstanceOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// NotebookInstanceStopped waits for a NotebookInstance to return Stopped
+func NotebookInstanceStopped(conn *sagemaker.SageMaker, notebookName string) (*sagemaker.DescribeNotebookInstanceOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			sagemaker.NotebookInstanceStatusUpdating,
+			sagemaker.NotebookInstanceStatusStopping,
+		},
+		Target:  []string{sagemaker.NotebookInstanceStatusStopped},
+		Refresh: NotebookInstanceStatus(conn, notebookName),
+		Timeout: NotebookInstanceStoppedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeNotebookInstanceOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+// NotebookInstanceDeleted waits for a NotebookInstance to return Deleted
+func NotebookInstanceDeleted(conn *sagemaker.SageMaker, notebookName string) (*sagemaker.DescribeNotebookInstanceOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			sagemaker.NotebookInstanceStatusDeleting,
+		},
+		Target:  []string{""},
+		Refresh: NotebookInstanceStatus(conn, notebookName),
+		Timeout: NotebookInstanceDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeNotebookInstanceOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/aws/internal/service/sagemaker/waiter/waiter.go
+++ b/aws/internal/service/sagemaker/waiter/waiter.go
@@ -17,6 +17,7 @@ const (
 func NotebookInstanceInService(conn *sagemaker.SageMaker, notebookName string) (*sagemaker.DescribeNotebookInstanceOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
+			SagemakerNotebookInstanceStatusNotFound,
 			sagemaker.NotebookInstanceStatusUpdating,
 			sagemaker.NotebookInstanceStatusPending,
 			sagemaker.NotebookInstanceStatusStopped,
@@ -62,7 +63,7 @@ func NotebookInstanceDeleted(conn *sagemaker.SageMaker, notebookName string) (*s
 		Pending: []string{
 			sagemaker.NotebookInstanceStatusDeleting,
 		},
-		Target:  []string{""},
+		Target:  []string{},
 		Refresh: NotebookInstanceStatus(conn, notebookName),
 		Timeout: NotebookInstanceDeletedTimeout,
 	}

--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -100,7 +100,6 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 			"default_code_repository": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"tags": tagsSchema(),
@@ -280,7 +279,15 @@ func resourceAwsSagemakerNotebookInstanceUpdate(d *schema.ResourceData, meta int
 		} else {
 			updateOpts.DisassociateLifecycleConfig = aws.Bool(true)
 		}
-		updateOpts.InstanceType = aws.String(d.Get("instance_type").(string))
+		hasChanged = true
+	}
+
+	if d.HasChange("default_code_repository") {
+		if v, ok := d.GetOk("default_code_repository"); ok {
+			updateOpts.DefaultCodeRepository = aws.String(v.(string))
+		} else {
+			updateOpts.DisassociateDefaultCodeRepository = aws.Bool(true)
+		}
 		hasChanged = true
 	}
 

--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -1,12 +1,14 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -23,6 +25,11 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		CustomizeDiff: customdiff.Sequence(
+			customdiff.ForceNewIfChange("volume_size", func(_ context.Context, old, new, meta interface{}) bool {
+				return new.(int) < old.(int)
+			}),
+		),
 
 		Schema: map[string]*schema.Schema{
 			"arn": {

--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -278,6 +278,7 @@ func resourceAwsSagemakerNotebookInstanceUpdate(d *schema.ResourceData, meta int
 
 	if d.HasChange("volume_size") {
 		updateOpts.VolumeSizeInGB = aws.Int64(int64(d.Get("volume_size").(int)))
+		hasChanged = true
 	}
 
 	if d.HasChange("lifecycle_config_name") {

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -618,10 +618,6 @@ resource "aws_subnet" "test" {
   }
 }
 
-// resource "aws_internet_gateway" "test" {
-//   vpc_id = aws_vpc.test.id
-// }
-
 resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -641,6 +641,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
   role_arn      = aws_iam_role.test.arn
   instance_type = "ml.t2.medium"
   volume_size   = 8
+}
   `, rName)
 }
 

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -538,7 +538,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 
   tags = {
     %[2]q = %[3]q
-    %[3]q = %[4]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -93,7 +93,7 @@ func TestAccAWSSagemakerNotebookInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t2.medium"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t3.medium"),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
 					resource.TestCheckResourceAttr(resourceName, "root_access", "Enabled"),
@@ -126,7 +126,7 @@ func TestAccAWSSagemakerNotebookInstance_update(t *testing.T) {
 				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
-					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t2.medium"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t3.medium"),
 				),
 			},
 
@@ -525,7 +525,7 @@ func testAccAWSSagemakerNotebookInstanceBasicConfig(rName string) string {
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t2.medium"
+  instance_type = "ml.t3.medium"
 }
 `, rName)
 }
@@ -547,7 +547,7 @@ resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
 }
 
 resource "aws_sagemaker_notebook_instance" "test" {
-  instance_type         = "ml.t2.medium"
+  instance_type         = "ml.t3.medium"
   lifecycle_config_name = aws_sagemaker_notebook_instance_lifecycle_configuration.test.name
   name                  = %[1]q
   role_arn              = aws_iam_role.test.arn
@@ -560,7 +560,7 @@ func testAccAWSSagemakerNotebookInstanceConfigTags1(rName, tagKey1, tagValue1 st
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t2.medium"
+  instance_type = "ml.t3.medium"
 
   tags = {
     %[2]q = %[3]q
@@ -574,7 +574,7 @@ func testAccAWSSagemakerNotebookInstanceConfigTags2(rName, tagKey1, tagValue1, t
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t2.medium"
+  instance_type = "ml.t3.medium"
 
   tags = {
     %[2]q = %[3]q
@@ -589,7 +589,7 @@ func testAccAWSSagemakerNotebookInstanceConfigRootAccess(rName string, rootAcces
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t2.medium"
+  instance_type = "ml.t3.medium"
   root_access   = %[2]q
 }
 `, rName, rootAccess)
@@ -601,7 +601,7 @@ func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(rName string,
 resource "aws_sagemaker_notebook_instance" "test" {
   name                   = %[1]q
   role_arn               = aws_iam_role.test.arn
-  instance_type          = "ml.t2.medium"
+  instance_type          = "ml.t3.medium"
   security_groups        = [aws_security_group.test.id]
   subnet_id              = aws_subnet.test.id
   direct_internet_access = %[2]q
@@ -643,7 +643,7 @@ func testAccAWSSagemakerNotebookInstanceConfigVolume(rName string) string {
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t2.medium"
+  instance_type = "ml.t3.medium"
   volume_size   = 8
 }
   `, rName)
@@ -654,7 +654,7 @@ func testAccAWSSagemakerNotebookInstanceConfigDefaultCodeRepository(rName string
 resource "aws_sagemaker_notebook_instance" "test" {
   name                    = %[1]q
   role_arn                = aws_iam_role.test.arn
-  instance_type           = "ml.t2.medium"
+  instance_type           = "ml.t3.medium"
   default_code_repository = %[2]q
 }
 `, rName, defaultCodeRepository)
@@ -687,7 +687,7 @@ POLICY
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t2.medium"
+  instance_type = "ml.t3.medium"
   kms_key_id    = aws_kms_key.test.id
 }
 `, rName)

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -401,7 +401,7 @@ func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Disabled"),
-					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 				),
 			},
@@ -415,7 +415,7 @@ func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
-					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 				),
 			},

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"testing"
@@ -146,7 +147,7 @@ func TestAccAWSSagemakerNotebookInstance_update(t *testing.T) {
 }
 
 func TestAccAWSSagemakerNotebookInstance_volumesize(t *testing.T) {
-	var notebook sagemaker.DescribeNotebookInstanceOutput
+	var notebook1, notebook2, notebook3 sagemaker.DescribeNotebookInstanceOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	var resourceName = "aws_sagemaker_notebook_instance.test"
 	resource.ParallelTest(t, resource.TestCase{
@@ -155,24 +156,32 @@ func TestAccAWSSagemakerNotebookInstance_volumesize(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerNotebookInstanceConfigVolume(rName),
+				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook1),
 					resource.TestCheckResourceAttr(resourceName, "volume_size", "5"),
 				),
 			},
-
 			{
-				Config: testAccAWSSagemakerNotebookInstanceUpdateConfig(rName),
+				Config: testAccAWSSagemakerNotebookInstanceConfigVolume(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook2),
 					resource.TestCheckResourceAttr(resourceName, "volume_size", "8"),
+					testAccCheckAWSSagemakerNotebookInstanceNotRecreated(&notebook1, &notebook2),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook3),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "5"),
+					testAccCheckAWSSagemakerNotebookInstanceRecreated(&notebook2, &notebook3),
+				),
 			},
 		},
 	})
@@ -356,6 +365,26 @@ func testAccCheckAWSSagemakerNotebookInstanceExists(n string, notebook *sagemake
 		}
 
 		*notebook = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAWSSagemakerNotebookInstanceNotRecreated(i, j *sagemaker.DescribeNotebookInstanceOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreationTime) != aws.TimeValue(j.CreationTime) {
+			return errors.New("Sagemaker Notebook Instance was recreated")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSSagemakerNotebookInstanceRecreated(i, j *sagemaker.DescribeNotebookInstanceOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreationTime) == aws.TimeValue(j.CreationTime) {
+			return errors.New("Sagemaker Notebook Instance was not recreated")
+		}
 
 		return nil
 	}

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -624,6 +624,10 @@ resource "aws_subnet" "test" {
   }
 }
 
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
 resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -546,7 +546,7 @@ resource "aws_sagemaker_notebook_instance" "test" {
 
 func testAccAWSSagemakerNotebookInstanceConfigRootAccess(rName string, rootAccess string) string {
 	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_notebook_instance" "foo" {
+resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
   instance_type = "ml.t2.medium"
@@ -558,7 +558,7 @@ resource "aws_sagemaker_notebook_instance" "foo" {
 func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(rName string, directInternetAccess string) string {
 	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) +
 		fmt.Sprintf(`
-resource "aws_sagemaker_notebook_instance" "foo" {
+resource "aws_sagemaker_notebook_instance" "test" {
   name                   = %[1]q
   role_arn               = aws_iam_role.test.arn
   instance_type          = "ml.t2.medium"

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -87,7 +87,7 @@ func TestAccAWSSagemakerNotebookInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t3.medium"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t2.medium"),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
 					resource.TestCheckResourceAttr(resourceName, "root_access", "Enabled"),
@@ -120,7 +120,7 @@ func TestAccAWSSagemakerNotebookInstance_update(t *testing.T) {
 				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
-					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t3.medium"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t2.medium"),
 				),
 			},
 
@@ -519,7 +519,7 @@ func testAccAWSSagemakerNotebookInstanceBasicConfig(rName string) string {
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t3.medium"
+  instance_type = "ml.t2.medium"
 }
 `, rName)
 }
@@ -541,7 +541,7 @@ resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
 }
 
 resource "aws_sagemaker_notebook_instance" "test" {
-  instance_type         = "ml.t3.medium"
+  instance_type         = "ml.t2.medium"
   lifecycle_config_name = aws_sagemaker_notebook_instance_lifecycle_configuration.test.name
   name                  = %[1]q
   role_arn              = aws_iam_role.test.arn
@@ -554,7 +554,7 @@ func testAccAWSSagemakerNotebookInstanceConfigTags1(rName, tagKey1, tagValue1 st
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t3.medium"
+  instance_type = "ml.t2.medium"
 
   tags = {
     %[2]q = %[3]q
@@ -568,7 +568,7 @@ func testAccAWSSagemakerNotebookInstanceConfigTags2(rName, tagKey1, tagValue1, t
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t3.medium"
+  instance_type = "ml.t2.medium"
 
   tags = {
     %[2]q = %[3]q
@@ -583,7 +583,7 @@ func testAccAWSSagemakerNotebookInstanceConfigRootAccess(rName string, rootAcces
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t3.medium"
+  instance_type = "ml.t2.medium"
   root_access   = %[2]q
 }
 `, rName, rootAccess)
@@ -595,7 +595,7 @@ func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(rName string,
 resource "aws_sagemaker_notebook_instance" "test" {
   name                   = %[1]q
   role_arn               = aws_iam_role.test.arn
-  instance_type          = "ml.t3.medium"
+  instance_type          = "ml.t2.medium"
   security_groups        = [aws_security_group.test.id]
   subnet_id              = aws_subnet.test.id
   direct_internet_access = %[2]q
@@ -633,7 +633,7 @@ func testAccAWSSagemakerNotebookInstanceConfigVolume(rName string) string {
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t3.medium"
+  instance_type = "ml.t2.medium"
   volume_size   = 8
 }
   `, rName)
@@ -644,7 +644,7 @@ func testAccAWSSagemakerNotebookInstanceConfigDefaultCodeRepository(rName string
 resource "aws_sagemaker_notebook_instance" "test" {
   name                    = %[1]q
   role_arn                = aws_iam_role.test.arn
-  instance_type           = "ml.t3.medium"
+  instance_type           = "ml.t2.medium"
   default_code_repository = %[2]q
 }
 `, rName, defaultCodeRepository)
@@ -677,7 +677,7 @@ POLICY
 resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
-  instance_type = "ml.t3.medium"
+  instance_type = "ml.t2.medium"
   kms_key_id    = aws_kms_key.test.id
 }
 `, rName)

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
-
-const sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix = "terraform-testacc-"
 
 func init() {
 	resource.AddTestSweepers("aws_sagemaker_notebook_instance", &resource.Sweeper{
@@ -81,23 +80,26 @@ func testSweepSagemakerNotebookInstances(region string) error {
 
 func TestAccAWSSagemakerNotebookInstance_basic(t *testing.T) {
 	var notebook sagemaker.DescribeNotebookInstanceOutput
-	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
-	var resourceName = "aws_sagemaker_notebook_instance.foo"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	var resourceName = "aws_sagemaker_notebook_instance.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerNotebookInstanceConfig(notebookName),
+				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
-					testAccCheckAWSSagemakerNotebookInstanceName(&notebook, notebookName),
-
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_notebook_instance.foo", "name", notebookName),
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_notebook_instance.foo", "volume_size", "5"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t2.medium"),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "root_access", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "5"),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -111,7 +113,7 @@ func TestAccAWSSagemakerNotebookInstance_basic(t *testing.T) {
 
 func TestAccAWSSagemakerNotebookInstance_update(t *testing.T) {
 	var notebook sagemaker.DescribeNotebookInstanceOutput
-	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	var resourceName = "aws_sagemaker_notebook_instance.foo"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -119,22 +121,18 @@ func TestAccAWSSagemakerNotebookInstance_update(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerNotebookInstanceConfig(notebookName),
+				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
-
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_notebook_instance.foo", "instance_type", "ml.t2.medium"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.t2.medium"),
 				),
 			},
 
 			{
-				Config: testAccAWSSagemakerNotebookInstanceUpdateConfig(notebookName),
+				Config: testAccAWSSagemakerNotebookInstanceUpdateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerNotebookInstanceExists("aws_sagemaker_notebook_instance.foo", &notebook),
-
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_notebook_instance.foo", "instance_type", "ml.m4.xlarge"),
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "ml.m4.xlarge"),
 				),
 			},
 			{
@@ -148,30 +146,26 @@ func TestAccAWSSagemakerNotebookInstance_update(t *testing.T) {
 
 func TestAccAWSSagemakerNotebookInstance_volumesize(t *testing.T) {
 	var notebook sagemaker.DescribeNotebookInstanceOutput
-	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
-	var resourceName = "aws_sagemaker_notebook_instance.foo"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	var resourceName = "aws_sagemaker_notebook_instance.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerNotebookInstanceConfigVolume(notebookName),
+				Config: testAccAWSSagemakerNotebookInstanceConfigVolume(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
-
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_notebook_instance.foo", "volume_size", "5"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "5"),
 				),
 			},
 
 			{
-				Config: testAccAWSSagemakerNotebookInstanceUpdateConfig(notebookName),
+				Config: testAccAWSSagemakerNotebookInstanceUpdateConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerNotebookInstanceExists("aws_sagemaker_notebook_instance.foo", &notebook),
-
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_notebook_instance.foo", "volume_size", "8"),
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "8"),
 				),
 			},
 			{
@@ -185,7 +179,7 @@ func TestAccAWSSagemakerNotebookInstance_volumesize(t *testing.T) {
 
 func TestAccAWSSagemakerNotebookInstance_LifecycleConfigName(t *testing.T) {
 	var notebook sagemaker.DescribeNotebookInstanceOutput
-	rName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_sagemaker_notebook_instance.test"
 	sagemakerLifecycleConfigResourceName := "aws_sagemaker_notebook_instance_lifecycle_configuration.test"
 
@@ -212,7 +206,7 @@ func TestAccAWSSagemakerNotebookInstance_LifecycleConfigName(t *testing.T) {
 
 func TestAccAWSSagemakerNotebookInstance_tags(t *testing.T) {
 	var notebook sagemaker.DescribeNotebookInstanceOutput
-	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -220,20 +214,16 @@ func TestAccAWSSagemakerNotebookInstance_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerNotebookInstanceTagsConfig(notebookName),
+				Config: testAccAWSSagemakerNotebookInstanceConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists("aws_sagemaker_notebook_instance.foo", &notebook),
-					testAccCheckAWSSagemakerNotebookInstanceTags(&notebook, "foo", "bar"),
-
-					resource.TestCheckResourceAttr(
-						"aws_sagemaker_notebook_instance.foo", "name", notebookName),
 					resource.TestCheckResourceAttr("aws_sagemaker_notebook_instance.foo", "tags.%", "1"),
 					resource.TestCheckResourceAttr("aws_sagemaker_notebook_instance.foo", "tags.foo", "bar"),
 				),
 			},
 
 			{
-				Config: testAccAWSSagemakerNotebookInstanceTagsUpdateConfig(notebookName),
+				Config: testAccAWSSagemakerNotebookInstanceConfigTags2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists("aws_sagemaker_notebook_instance.foo", &notebook),
 					testAccCheckAWSSagemakerNotebookInstanceTags(&notebook, "foo", ""),
@@ -249,18 +239,19 @@ func TestAccAWSSagemakerNotebookInstance_tags(t *testing.T) {
 
 func TestAccAWSSagemakerNotebookInstance_disappears(t *testing.T) {
 	var notebook sagemaker.DescribeNotebookInstanceOutput
-	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
-	var resourceName = "aws_sagemaker_notebook_instance.foo"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	var resourceName = "aws_sagemaker_notebook_instance.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSagemakerNotebookInstanceConfig(notebookName),
+				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
-					testAccCheckAWSSagemakerNotebookInstanceDisappears(&notebook),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerNotebookInstance(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -313,41 +304,6 @@ func testAccCheckAWSSagemakerNotebookInstanceExists(n string, notebook *sagemake
 		}
 
 		*notebook = *resp
-
-		return nil
-	}
-}
-
-func testAccCheckAWSSagemakerNotebookInstanceDisappears(instance *sagemaker.DescribeNotebookInstanceOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
-
-		if *instance.NotebookInstanceStatus != sagemaker.NotebookInstanceStatusFailed && *instance.NotebookInstanceStatus != sagemaker.NotebookInstanceStatusStopped {
-			if err := stopSagemakerNotebookInstance(conn, *instance.NotebookInstanceName); err != nil {
-				return err
-			}
-		}
-
-		deleteOpts := &sagemaker.DeleteNotebookInstanceInput{
-			NotebookInstanceName: instance.NotebookInstanceName,
-		}
-
-		if _, err := conn.DeleteNotebookInstance(deleteOpts); err != nil {
-			return fmt.Errorf("error trying to delete sagemaker notebook instance (%s): %s", aws.StringValue(instance.NotebookInstanceName), err)
-		}
-
-		stateConf := &resource.StateChangeConf{
-			Pending: []string{
-				sagemaker.NotebookInstanceStatusDeleting,
-			},
-			Target:  []string{""},
-			Refresh: sagemakerNotebookInstanceStateRefreshFunc(conn, *instance.NotebookInstanceName),
-			Timeout: 10 * time.Minute,
-		}
-		_, err := stateConf.WaitForState()
-		if err != nil {
-			return fmt.Errorf("error waiting for sagemaker notebook instance (%s) to delete: %s", aws.StringValue(instance.NotebookInstanceName), err)
-		}
 
 		return nil
 	}
@@ -514,21 +470,15 @@ func testAccCheckAWSSagemakerNotebookInstanceTags(notebook *sagemaker.DescribeNo
 	}
 }
 
-func testAccAWSSagemakerNotebookInstanceConfig(notebookName string) string {
+func testAccAWSSagemakerNotebookInstanceBaseConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_sagemaker_notebook_instance" "foo" {
-  name          = "%s"
-  role_arn      = aws_iam_role.foo.arn
-  instance_type = "ml.t2.medium"
-}
-
-resource "aws_iam_role" "foo" {
-  name               = "%s"
+resource "aws_iam_role" "test" {
+  name               = %[1]q
   path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.test.json
 }
 
-data "aws_iam_policy_document" "assume_role" {
+data "aws_iam_policy_document" "test" {
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -538,84 +488,31 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-`, notebookName, notebookName)
+`, rName)
 }
 
-func testAccAWSSagemakerNotebookInstanceConfigVolume(notebookName string) string {
-	return fmt.Sprintf(`
-resource "aws_sagemaker_notebook_instance" "foo" {
-  name          = "%s"
-  role_arn      = aws_iam_role.foo.arn
+func testAccAWSSagemakerNotebookInstanceBasicConfig(rName string) string {
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_notebook_instance" "test" {
+  name          = %[1]q
+  role_arn      = aws_iam_role.test.arn
   instance_type = "ml.t2.medium"
-  volume_size   = "5"
+}
+`, rName)
 }
 
-resource "aws_iam_role" "foo" {
-  name               = "%s"
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
-}
-`, notebookName, notebookName)
-}
-
-func testAccAWSSagemakerNotebookInstanceUpdateConfig(notebookName string) string {
-	return fmt.Sprintf(`
-resource "aws_sagemaker_notebook_instance" "foo" {
-  name          = "%s"
-  role_arn      = aws_iam_role.foo.arn
+func testAccAWSSagemakerNotebookInstanceUpdateConfig(rName string) string {
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_notebook_instance" "test" {
+  name          = %[1]q
+  role_arn      = aws_iam_role.test.arn
   instance_type = "ml.m4.xlarge"
-  volume_size   = "8"
 }
-
-resource "aws_iam_role" "foo" {
-  name               = "%s"
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
-}
-`, notebookName, notebookName)
+`, rName)
 }
 
 func testAccAWSSagemakerNotebookInstanceConfigLifecycleConfigName(rName string) string {
-	return fmt.Sprintf(`
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      identifiers = ["sagemaker.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}
-
-resource "aws_iam_role" "test" {
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-  name               = %[1]q
-  path               = "/"
-}
-
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "test" {
   name = %[1]q
 }
@@ -629,128 +526,62 @@ resource "aws_sagemaker_notebook_instance" "test" {
 `, rName)
 }
 
-func testAccAWSSagemakerNotebookInstanceTagsConfig(notebookName string) string {
-	return fmt.Sprintf(`
-resource "aws_sagemaker_notebook_instance" "foo" {
-  name          = "%s"
-  role_arn      = aws_iam_role.foo.arn
+func testAccAWSSagemakerNotebookInstanceConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_notebook_instance" "test" {
+  name          = %[1]q
+  role_arn      = aws_iam_role.test.arn
   instance_type = "ml.t2.medium"
 
   tags = {
-    foo = "bar"
+    %[2]q = %[3]q
   }
 }
-
-resource "aws_iam_role" "foo" {
-  name               = "%s"
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+`, rName, tagKey1, tagValue1)
 }
 
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
-}
-`, notebookName, notebookName)
-}
-
-func testAccAWSSagemakerNotebookInstanceTagsUpdateConfig(notebookName string) string {
-	return fmt.Sprintf(`
-resource "aws_sagemaker_notebook_instance" "foo" {
-  name          = "%s"
-  role_arn      = aws_iam_role.foo.arn
+func testAccAWSSagemakerNotebookInstanceConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_notebook_instance" "test" {
+  name          = %[1]q
+  role_arn      = aws_iam_role.test.arn
   instance_type = "ml.t2.medium"
 
   tags = {
-    bar = "baz"
+    %[2]q = %[3]q
+    %[3]q = %[4]q
   }
 }
-
-resource "aws_iam_role" "foo" {
-  name               = "%s"
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
-}
-`, notebookName, notebookName)
-}
-
-func testAccAWSSagemakerNotebookInstanceConfigRootAccess(notebookName string, rootAccess string) string {
-	return fmt.Sprintf(`
+func testAccAWSSagemakerNotebookInstanceConfigRootAccess(rName string, rootAccess string) string {
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
   name          = %[1]q
-  role_arn      = aws_iam_role.foo.arn
+  role_arn      = aws_iam_role.test.arn
   instance_type = "ml.t2.medium"
   root_access   = %[2]q
 }
-
-resource "aws_iam_role" "foo" {
-  name               = %[1]q
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+`, rName, rootAccess)
 }
 
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
-}
-`, notebookName, rootAccess)
-}
-
-func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(notebookName string, directInternetAccess string) string {
-	return fmt.Sprintf(`
+func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(rName string, directInternetAccess string) string {
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
   name                   = %[1]q
-  role_arn               = aws_iam_role.foo.arn
+  role_arn               = aws_iam_role.test.arn
   instance_type          = "ml.t2.medium"
   security_groups        = [aws_security_group.test.id]
-  subnet_id              = aws_subnet.sagemaker.id
+  subnet_id              = aws_subnet.test.id
   direct_internet_access = %[2]q
-}
-
-resource "aws_iam_role" "foo" {
-  name               = %[1]q
-  path               = "/"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["sagemaker.amazonaws.com"]
-    }
-  }
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "tf-acc-test-sagemaker-notebook-instance-direct-internet-access"
+    Name = %[1]q
   }
 }
 
@@ -758,15 +589,24 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-resource "aws_subnet" "sagemaker" {
+resource "aws_subnet" "test" {
   vpc_id     = aws_vpc.test.id
   cidr_block = "10.0.0.0/24"
 
   tags = {
-    Name = "tf-acc-test-sagemaker-notebook-instance-direct-internet-access"
+    Name = %[1]q
   }
 }
-`, notebookName, directInternetAccess)
+`, rName, directInternetAccess)
+}
+
+func testAccAWSSagemakerNotebookInstanceConfigVolume(rName string) string {
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
+  name          = %[1]q
+  role_arn      = aws_iam_role.test.arn
+  instance_type = "ml.t2.medium"
+  volume_size   = 8
+  `, rName)
 }
 
 func testAccAWSSagemakerNotebookInstanceConfigDefaultCodeRepository(notebookName string, defaultCodeRepository string) string {

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -200,6 +200,13 @@ func TestAccAWSSagemakerNotebookInstance_LifecycleConfigName(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_config_name", ""),
+				),
+			},
 		},
 	})
 }
@@ -217,7 +224,7 @@ func TestAccAWSSagemakerNotebookInstance_tags(t *testing.T) {
 			{
 				Config: testAccAWSSagemakerNotebookInstanceConfigTags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerNotebookInstanceExists("aws_sagemaker_notebook_instance.foo", &notebook),
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -243,6 +250,32 @@ func TestAccAWSSagemakerNotebookInstance_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerNotebookInstance_kms(t *testing.T) {
+	var notebook sagemaker.DescribeNotebookInstanceOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_notebook_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerNotebookInstanceKMSConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", "aws_kms_key.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -338,16 +371,16 @@ func TestAccAWSSagemakerNotebookInstance_root_access(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSSagemakerNotebookInstanceConfigRootAccess(rName, "Enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "root_access", "Enabled"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -368,19 +401,23 @@ func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Disabled"),
-				),
-			},
-			{
-				Config: testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(rName, "Enabled"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
-					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet", "id"),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(rName, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet", "id"),
+					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
+				),
 			},
 		},
 	})
@@ -519,7 +556,8 @@ resource "aws_sagemaker_notebook_instance" "foo" {
 }
 
 func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(rName string, directInternetAccess string) string {
-	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) +
+		fmt.Sprintf(`
 resource "aws_sagemaker_notebook_instance" "foo" {
   name                   = %[1]q
   role_arn               = aws_iam_role.test.arn
@@ -537,13 +575,17 @@ resource "aws_vpc" "test" {
   }
 }
 
-resource "aws_security_group" "test" {
-  vpc_id = aws_vpc.test.id
-}
-
 resource "aws_subnet" "test" {
   vpc_id     = aws_vpc.test.id
   cidr_block = "10.0.0.0/24"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
 
   tags = {
     Name = %[1]q
@@ -609,4 +651,37 @@ resource "aws_subnet" "sagemaker" {
   }
 }
 `, notebookName, defaultCodeRepository)
+}
+
+func testAccAWSSagemakerNotebookInstanceKMSConfig(rName string) string {
+	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = "Terraform acc test %[1]s"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "kms-tf-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_sagemaker_notebook_instance" "test" {
+  name          = %[1]q
+  role_arn      = aws_iam_role.test.arn
+  instance_type = "ml.t2.medium"
+  kms_key_id    = aws_kms_key.test.id
+}
+`, rName)
 }

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -607,6 +607,7 @@ resource "aws_security_group" "test" {
 
 func testAccAWSSagemakerNotebookInstanceConfigVolume(rName string) string {
 	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_notebook_instance" "test" {
   name          = %[1]q
   role_arn      = aws_iam_role.test.arn
   instance_type = "ml.t2.medium"

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -208,6 +208,13 @@ func TestAccAWSSagemakerNotebookInstance_LifecycleConfigName(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_config_name", ""),
 				),
 			},
+			{
+				Config: testAccAWSSagemakerNotebookInstanceConfigLifecycleConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					resource.TestCheckResourceAttrPair(resourceName, "lifecycle_config_name", sagemakerLifecycleConfigResourceName, "name"),
+				),
+			},
 		},
 	})
 }
@@ -445,6 +452,20 @@ func TestAccAWSSagemakerNotebookInstance_default_code_repository(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAWSSagemakerNotebookInstanceBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "default_code_repository", ""),
+				),
+			},
+			{
+				Config: testAccAWSSagemakerNotebookInstanceConfigDefaultCodeRepository(rName, "https://github.com/terraform-providers/terraform-provider-aws.git"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "default_code_repository", "https://github.com/terraform-providers/terraform-provider-aws.git"),
+				),
+			},
 		},
 	})
 }
@@ -595,14 +616,13 @@ func testAccAWSSagemakerNotebookInstanceConfigVolume(rName string) string {
 
 func testAccAWSSagemakerNotebookInstanceConfigDefaultCodeRepository(rName string, defaultCodeRepository string) string {
 	return testAccAWSSagemakerNotebookInstanceBaseConfig(rName) + fmt.Sprintf(`
-resource "aws_sagemaker_notebook_instance" "foo" {
+resource "aws_sagemaker_notebook_instance" "test" {
   name                    = %[1]q
   role_arn                = aws_iam_role.test.arn
   instance_type           = "ml.t2.medium"
-  security_groups         = [aws_security_group.test.id]
-  subnet_id               = aws_subnet.sagemaker.id
   default_code_repository = %[2]q
 }
+<<<<<<< HEAD
 
 resource "aws_iam_role" "foo" {
   name               = %[1]q
@@ -644,6 +664,8 @@ resource "aws_subnet" "sagemaker" {
     Name = %[1]q
   }
 }
+=======
+>>>>>>> 7cac2f614... allow updating default code repo
 `, rName, defaultCodeRepository)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #8880

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_notebook_instance:  `lifecycle_config_name` and `root_access`  are updateable.
resource_aws_sagemaker_notebook_instance: plan time validation for `role_arn`, `instance_type`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance_'
--- PASS: TestAccAWSSagemakerNotebookInstance_basic (353.11s)
--- PASS: TestAccAWSSagemakerNotebookInstance_update (728.56s)
--- PASS: TestAccAWSSagemakerNotebookInstance_LifecycleConfigName (721.73s)
--- PASS: TestAccAWSSagemakerNotebookInstance_kms (360.70s)
--- PASS: TestAccAWSSagemakerNotebookInstance_disappears (341.23s)
--- PASS: TestAccAWSSagemakerNotebookInstance_root_access (648.05s)
--- PASS: TestAccAWSSagemakerNotebookInstance_tags (428.07s)
--- PASS: TestAccAWSSagemakerNotebookInstance_direct_internet_access (811.45s)
```
