### PR TITLE
tests/provider: Ensure CHANGELOG.md changes properly comment on forked pull requests

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,30 +7,53 @@ on:
   pull_request:
     paths:
       - CHANGELOG.md
+  pull_request_target:
 
 env:
   GO_VERSION: "1.14"
   GO111MODULE: on
 
 jobs:
+  changes:
+    if: github.event_name == 'pull_request_target' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "gdavison", "maryelizbeth", "YakDriver"]'), github.actor)
+    name: Filter Changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            changed:
+              - CHANGELOG.md
   comment:
-    if: github.event_name == 'pull_request' && !contains(fromJSON('["bflad", "breathingdust", "ewbankkit", "gdavison", "maryelizbeth"]'), github.actor)
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' }}
     name: Comment
     runs-on: ubuntu-latest
     steps:
+      - name: Find Existing PR Comment
+        id: prc
+        uses: peter-evans/find-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "Please note that the `CHANGELOG.md` file contents are handled by the maintainers during merge"
+      - run: echo ${{ steps.prc.outputs.comment-id }}
       - name: PR Comment
-        uses: unsplash/comment-on-pr@v1.2.0
+        if: ${{ steps.prc.outputs.comment-id == '' }}
+        uses: peter-evans/create-or-update-comment@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: |-
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |-
             Thank you for your contribution! :rocket:
 
-            Please note that the `CHANGELOG.md` file contents are handled by the maintainers during merge. This is to prevent pull request merge conflicts, especially for contributions which may not be merged immediately. Please see the [Contributing Guide](https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md) for additional pull request review items.
+            Please note that the `CHANGELOG.md` file contents are handled by the maintainers during merge. This is to prevent pull request merge conflicts, especially for contributions which may not be merged immediately. Please see the [Contributing Guide](https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md) for additional pull request review items.
 
             Remove any changes to the `CHANGELOG.md` file and commit them in this pull request to prevent delays with reviewing and potentially merging this pull request.
-      - name: Fail the check
-        run: exit 1
   misspell:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Follows similar updates to dependencies.yml which switched to the `pull_request_target` event for correct permissions.

Output from acceptance testing: N/A (CI update)