### PR TITLE
provider: Stabilization of singular data source id attributes with clear identifiers

### DIFF
--- a/aws/data_source_aws_acm_certificate.go
+++ b/aws/data_source_aws_acm_certificate.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
@@ -169,7 +168,7 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("No certificate for domain %q found in this region", target)
 	}
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(aws.StringValue(matchedCertificate.CertificateArn))
 	d.Set("arn", matchedCertificate.CertificateArn)
 
 	tags, err := keyvaluetags.AcmListTags(conn, aws.StringValue(matchedCertificate.CertificateArn))

--- a/aws/data_source_aws_autoscaling_group.go
+++ b/aws/data_source_aws_autoscaling_group.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -105,7 +104,6 @@ func dataSourceAwsAutoscalingGroup() *schema.Resource {
 
 func dataSourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).autoscalingconn
-	d.SetId(time.Now().UTC().String())
 
 	groupName := d.Get("name").(string)
 
@@ -142,13 +140,7 @@ func dataSourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[DEBUG] aws_autoscaling_group - Single Auto Scaling Group found: %s", *group.AutoScalingGroupName)
 
-	err1 := groupDescriptionAttributes(d, group)
-	return err1
-}
-
-// Populate group attribute fields with the returned group
-func groupDescriptionAttributes(d *schema.ResourceData, group *autoscaling.Group) error {
-	log.Printf("[DEBUG] Setting attributes: %s", group)
+	d.SetId(aws.StringValue(group.AutoScalingGroupName))
 	d.Set("name", group.AutoScalingGroupName)
 	d.Set("arn", group.AutoScalingGroupARN)
 	if err := d.Set("availability_zones", aws.StringValueSlice(group.AvailabilityZones)); err != nil {

--- a/aws/data_source_aws_availability_zones.go
+++ b/aws/data_source_aws_availability_zones.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"sort"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -65,7 +64,6 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[DEBUG] Reading Availability Zones.")
-	d.SetId(time.Now().UTC().String())
 
 	request := &ec2.DescribeAvailabilityZonesInput{}
 
@@ -129,6 +127,8 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 		names = append(names, name)
 		zoneIds = append(zoneIds, zoneID)
 	}
+
+	d.SetId(meta.(*AWSClient).region)
 
 	if err := d.Set("group_names", groupNames); err != nil {
 		return fmt.Errorf("error setting group_names: %s", err)

--- a/aws/data_source_aws_db_event_categories.go
+++ b/aws/data_source_aws_db_event_categories.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -56,7 +55,7 @@ func dataSourceAwsDbEventCategoriesRead(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(meta.(*AWSClient).region)
 	if err := d.Set("event_categories", eventCategories); err != nil {
 		return fmt.Errorf("Error setting Event Categories: %s", err)
 	}

--- a/aws/data_source_aws_ebs_default_kms_key.go
+++ b/aws/data_source_aws_ebs_default_kms_key.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -28,7 +27,7 @@ func dataSourceAwsEbsDefaultKmsKeyRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error reading EBS default KMS key: %q", err)
 	}
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(meta.(*AWSClient).region)
 	d.Set("key_arn", res.KmsKeyId)
 
 	return nil

--- a/aws/data_source_aws_ebs_encryption_by_default.go
+++ b/aws/data_source_aws_ebs_encryption_by_default.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -28,7 +27,7 @@ func dataSourceAwsEbsEncryptionByDefaultRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error reading default EBS encryption toggle: %q", err)
 	}
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(meta.(*AWSClient).region)
 	d.Set("enabled", res.EbsEncryptionByDefault)
 
 	return nil

--- a/aws/data_source_aws_ec2_instance_type_offering.go
+++ b/aws/data_source_aws_ec2_instance_type_offering.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -122,7 +121,7 @@ func dataSourceAwsEc2InstanceTypeOfferingRead(d *schema.ResourceData, meta inter
 
 	d.Set("instance_type", resultInstanceType)
 
-	d.SetId(resource.UniqueId())
+	d.SetId(resultInstanceType)
 
 	return nil
 }

--- a/aws/data_source_aws_ecr_authorization_token.go
+++ b/aws/data_source_aws_ecr_authorization_token.go
@@ -74,7 +74,7 @@ func dataSourceAwsEcrAuthorizationTokenRead(d *schema.ResourceData, meta interfa
 	}
 	userName := basicAuthorization[0]
 	password := basicAuthorization[1]
-	d.SetId(time.Now().UTC().String())
+	d.SetId(meta.(*AWSClient).region)
 	d.Set("authorization_token", authorizationToken)
 	d.Set("proxy_endpoint", proxyEndpoint)
 	d.Set("expires_at", expiresAt)

--- a/aws/data_source_aws_ecr_image.go
+++ b/aws/data_source_aws_ecr_image.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
@@ -98,7 +97,7 @@ func dataSourceAwsEcrImageRead(d *schema.ResourceData, meta interface{}) error {
 
 	image := imageDetails[0]
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(aws.StringValue(image.ImageDigest))
 	if err = d.Set("registry_id", aws.StringValue(image.RegistryId)); err != nil {
 		return fmt.Errorf("failed to set registry_id: %s", err)
 	}

--- a/aws/data_source_aws_eks_cluster_auth.go
+++ b/aws/data_source_aws_eks_cluster_auth.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -41,7 +40,7 @@ func dataSourceAwsEksClusterAuthRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error getting token: %v", err)
 	}
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(name)
 	d.Set("token", token.Token)
 
 	return nil

--- a/aws/data_source_aws_iam_account_alias.go
+++ b/aws/data_source_aws_iam_account_alias.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -27,7 +26,6 @@ func dataSourceAwsIamAccountAliasRead(d *schema.ResourceData, meta interface{}) 
 	conn := meta.(*AWSClient).iamconn
 
 	log.Printf("[DEBUG] Reading IAM Account Aliases.")
-	d.SetId(time.Now().UTC().String())
 
 	req := &iam.ListAccountAliasesInput{}
 	resp, err := conn.ListAccountAliases(req)
@@ -41,6 +39,7 @@ func dataSourceAwsIamAccountAliasRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	alias := aws.StringValue(resp.AccountAliases[0])
+	d.SetId(alias)
 	log.Printf("[DEBUG] Setting AWS IAM Account Alias to %s.", alias)
 	d.Set("account_alias", alias)
 

--- a/aws/data_source_aws_kms_alias.go
+++ b/aws/data_source_aws_kms_alias.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -60,7 +59,7 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("No alias with name %q found in this region.", target)
 	}
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(aws.StringValue(alias.AliasArn))
 	d.Set("arn", alias.AliasArn)
 
 	// ListAliases can return an alias for an AWS service key (e.g.

--- a/aws/data_source_aws_partition.go
+++ b/aws/data_source_aws_partition.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"log"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -28,7 +27,7 @@ func dataSourceAwsPartitionRead(d *schema.ResourceData, meta interface{}) error 
 	client := meta.(*AWSClient)
 
 	log.Printf("[DEBUG] Reading Partition.")
-	d.SetId(time.Now().UTC().String())
+	d.SetId(meta.(*AWSClient).partition)
 
 	log.Printf("[DEBUG] Setting AWS Partition to %s.", client.partition)
 	d.Set("partition", meta.(*AWSClient).partition)

--- a/aws/data_source_aws_regions.go
+++ b/aws/data_source_aws_regions.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -53,7 +52,7 @@ func dataSourceAwsRegionsRead(d *schema.ResourceData, meta interface{}) error {
 		names = append(names, aws.StringValue(v.RegionName))
 	}
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(meta.(*AWSClient).partition)
 	if err := d.Set("names", names); err != nil {
 		return fmt.Errorf("error setting names: %s", err)
 	}

--- a/aws/data_source_aws_sns.go
+++ b/aws/data_source_aws_sns.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -65,7 +64,7 @@ func dataSourceAwsSnsTopicsRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Multiple topics with name %q found in this region.", target)
 	}
 
-	d.SetId(time.Now().UTC().String())
+	d.SetId(arns[0])
 	d.Set("arn", arns[0])
 
 	return nil

--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -47,6 +47,7 @@ data "aws_acm_certificate" "rsa_4096" {
 
 ## Attributes Reference
 
-* `arn` - Set to the ARN of the found certificate, suitable for referencing in other resources that support ACM certificates.
+* `arn` - Amazon Resource Name (ARN) of the found certificate, suitable for referencing in other resources that support ACM certificates.
+* `id` - Amazon Resource Name (ARN) of the found certificate, suitable for referencing in other resources that support ACM certificates.
 * `tags` - A mapping of tags for the resource.
 

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -28,16 +28,17 @@ data "aws_autoscaling_group" "foo" {
 interpolation.
 
 * `arn` - The Amazon Resource Name (ARN) of the Auto Scaling group.
-* `name` - The name of the Auto Scaling group.
 * `availability_zones` - One or more Availability Zones for the group.
 * `default_cool_down` - The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
 * `desired_capacity` - The desired size of the group.
 * `health_check_grace_period` - The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before checking the health status of an EC2 instance that has come into service.
 * `health_check_type` - The service to use for the health checks. The valid values are EC2 and ELB.
+* `id` - Name of the Auto Scaling Group.
 * `launch_configuration` - The name of the associated launch configuration.
 * `load_balancers` - One or more load balancers associated with the group.
 * `max_size` - The maximum size of the group.
 * `min_size` - The minimum size of the group.
+* `name` - Name of the Auto Scaling Group.
 * `placement_group` - The name of the placement group into which to launch your instances, if any. For more information, see Placement Groups (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html) in the Amazon Elastic Compute Cloud User Guide.
 * `service_linked_role_arn` - The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling group uses to call other AWS services on your behalf.
 * `status` - The current state of the group when DeleteAutoScalingGroup is in progress.

--- a/website/docs/d/availability_zones.html.markdown
+++ b/website/docs/d/availability_zones.html.markdown
@@ -93,6 +93,7 @@ The following arguments are supported by the `filter` configuration block:
 In addition to all arguments above, the following attributes are exported:
 
 * `group_names` A set of the Availability Zone Group names. For Availability Zones, this is the same value as the Region name. For Local Zones, the name of the associated group, for example `us-west-2-lax-1`.
+* `id` - Region of the Availability Zones.
 * `names` - A list of the Availability Zone names available to the account.
 * `zone_ids` - A list of the Availability Zone IDs available to the account.
 

--- a/website/docs/d/db_event_categories.html.markdown
+++ b/website/docs/d/db_event_categories.html.markdown
@@ -43,3 +43,4 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `event_categories` - A list of the event categories.
+* `id` - Region of the event categories.

--- a/website/docs/d/ebs_default_kms_key.html.markdown
+++ b/website/docs/d/ebs_default_kms_key.html.markdown
@@ -28,3 +28,4 @@ resource "aws_ebs_volume" "example" {
 The following attributes are exported:
 
 * `key_arn` - Amazon Resource Name (ARN) of the default KMS key uses to encrypt an EBS volume in this region when no key is specified in an API call that creates the volume and encryption by default is enabled.
+* `id` - Region of the default KMS Key.

--- a/website/docs/d/ebs_encryption_by_default.html.markdown
+++ b/website/docs/d/ebs_encryption_by_default.html.markdown
@@ -21,3 +21,4 @@ data "aws_ebs_encryption_by_default" "current" {}
 The following attributes are exported:
 
 * `enabled` - Whether or not default EBS encryption is enabled. Returns as `true` or `false`.
+* `id` - Region of default EBS encryption.

--- a/website/docs/d/ec2_instance_type_offering.html.markdown
+++ b/website/docs/d/ec2_instance_type_offering.html.markdown
@@ -40,4 +40,5 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - EC2 Instance Type.
 * `instance_type` - EC2 Instance Type.

--- a/website/docs/d/ecr_authorization_token.html.markdown
+++ b/website/docs/d/ecr_authorization_token.html.markdown
@@ -28,7 +28,8 @@ The following arguments are supported:
 In addition to the argument above, the following attributes are exported:
 
 * `authorization_token` - Temporary IAM authentication credentials to access the ECR repository encoded in base64 in the form of `user_name:password`.
-* `proxy_endpoint` - The registry URL to use in the docker login command.
 * `expires_at` - The time in UTC RFC3339 format when the authorization token expires.
-* `user_name` - User name decoded from the authorization token.
+* `id` - Region of the authorization token.
 * `password` - Password decoded from the authorization token.
+* `proxy_endpoint` - The registry URL to use in the docker login command.
+* `user_name` - User name decoded from the authorization token.

--- a/website/docs/d/ecr_image.html.markdown
+++ b/website/docs/d/ecr_image.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - SHA256 digest of the image manifest.
 * `image_pushed_at` - The date and time, expressed as a unix timestamp, at which the current image was pushed to the repository.
 * `image_size_in_bytes` - The size, in bytes, of the image in the repository.
 * `image_tags` - The list of tags associated with this image.

--- a/website/docs/d/eks_cluster_auth.html.markdown
+++ b/website/docs/d/eks_cluster_auth.html.markdown
@@ -40,4 +40,5 @@ provider "kubernetes" {
 
 ## Attributes Reference
 
+* `id` - Name of the cluster.
 * `token` - The token to use to authenticate with the cluster.

--- a/website/docs/d/iam_account_alias.html.markdown
+++ b/website/docs/d/iam_account_alias.html.markdown
@@ -31,3 +31,4 @@ There are no arguments available for this data source.
 In addition to all arguments above, the following attributes are exported:
 
 * `account_alias` - The alias associated with the AWS account.
+* `id` - The alias associated with the AWS account.

--- a/website/docs/d/kms_alias.html.markdown
+++ b/website/docs/d/kms_alias.html.markdown
@@ -27,5 +27,6 @@ data "aws_kms_alias" "s3" {
 ## Attributes Reference
 
 * `arn` - The Amazon Resource Name(ARN) of the key alias.
+* `id` - The Amazon Resource Name(ARN) of the key alias.
 * `target_key_id` - Key identifier pointed to by the alias.
 * `target_key_arn` - ARN pointed to by the alias.

--- a/website/docs/d/partition.html.markdown
+++ b/website/docs/d/partition.html.markdown
@@ -37,5 +37,6 @@ There are no arguments available for this data source.
 
 ## Attributes Reference
 
-* `partition` is set to the identifier of the current partition.
-* `dns_suffix` is set to the base DNS domain name for the current partition (e.g. `amazonaws.com` in AWS Commercial, `amazonaws.com.cn` in AWS China).
+* `dns_suffix` - Base DNS domain name for the current partition (e.g. `amazonaws.com` in AWS Commercial, `amazonaws.com.cn` in AWS China).
+* `id` - Identifier of the current partition (e.g. `aws` in AWS Commercial, `aws-cn` in AWS China).
+* `partition` - Identifier of the current partition (e.g. `aws` in AWS Commercial, `aws-cn` in AWS China).

--- a/website/docs/d/regions.html.markdown
+++ b/website/docs/d/regions.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported by the `filter` configuration block:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - Identifier of the current partition (e.g. `aws` in AWS Commercial, `aws-cn` in AWS China).
 * `names` - Names of regions that meets the criteria.
 
 [1]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-regions.html

--- a/website/docs/d/sns_topic.html.markdown
+++ b/website/docs/d/sns_topic.html.markdown
@@ -26,4 +26,7 @@ data "aws_sns_topic" "example" {
 
 ## Attributes Reference
 
-* `arn` - Set to the ARN of the found topic, suitable for referencing in other resources that support SNS topics.
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the found topic, suitable for referencing in other resources that support SNS topics.
+* `id` - Amazon Resource Name (ARN) of the found topic, suitable for referencing in other resources that support SNS topics.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/14579
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/15199
Reference: https://github.com/hashicorp/terraform-provider-google/pull/7375
Reference: https://github.com/bflad/tfproviderlint/tree/master/passes/R015
Reference: https://github.com/bflad/tfproviderlint/tree/master/passes/R016
Reference: https://github.com/bflad/tfproviderlint/tree/master/passes/R017
Reference: https://www.terraform.io/docs/extend/best-practices/versioning.html#example-major-number-increments
Reference: https://registry.terraform.io/providers/hashicorp/random/
Reference: https://registry.terraform.io/providers/hashicorp/time/

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* data-source/aws_acm_certificate: The `id` attribute has changed to the ARN of the ACM Certificate. The first apply of this updated data source may show this difference.
* data-source/aws_autoscaling_group: The `id` attribute has changed to the name of the Auto Scaling Group. The first apply of this updated data source may show this difference.
* data-source/aws_availability_zones: The `id` attribute has changed to the name of the AWS Region. The first apply of this updated data source may show this difference.
* data-source/aws_db_event_categories: The `id` attribute has changed to the name of the AWS Region. The first apply of this updated data source may show this difference.
* data-source/aws_ebs_default_kms_key: The `id` attribute has changed to the name of the AWS Region. The first apply of this updated data source may show this difference.
* data-source/aws_ebs_encryption_by_default: The `id` attribute has changed to the name of the AWS Region. The first apply of this updated data source may show this difference.
* data-source/aws_ec2_instance_type_offering: The `id` attribute has changed to the EC2 Instance Type. The first apply of this updated data source may show this difference.
* data-source/aws_ecr_authorization_token: The `id` attribute has changed to the AWS Region. The first apply of this updated data source may show this difference.
* data-source/aws_ecr_image: The `id` attribute has changed to the SHA256 digest of the ECR Image. The first apply of this updated data source may show this difference.
* data-source/aws_eks_cluster_auth: The `id` attribute has changed to the name of the EKS Cluster. The first apply of this updated data source may show this difference.
* data-source/aws_iam_account_alias: The `id` attribute has changed to the AWS Account Alias. The first apply of this updated data source may show this difference.
* data-source/aws_kms_alias: The `id` attribute has changed to the ARN of the KMS Alias. The first apply of this updated data source may show this difference.
* data-source/aws_partition: The `id` attribute has changed to the identifier of the AWS Partition. The first apply of this updated data source may show this difference.
* data-source/aws_regions: The `id` attribute has changed to the identifier of the AWS Partition. The first apply of this updated data source may show this difference.
* data-source/aws_sns_topic: The `id` attribute has changed to the ARN of the SNS Topic. The first apply of this updated data source may show this difference.

FIXES:

* data-source/aws_acm_certificate: Prevent plan differences with the `id` attribute
* data-source/aws_autoscaling_group: Prevent plan differences with the `id` attribute
* data-source/aws_availability_zones: Prevent plan differences with the `id` attribute
* data-source/aws_db_event_categories: Prevent plan differences with the `id` attribute
* data-source/aws_ebs_default_kms_key: Prevent plan differences with the `id` attribute
* data-source/aws_ebs_encryption_by_default: Prevent plan differences with the `id` attribute
* data-source/aws_ec2_instance_type_offering: Prevent plan differences with the `id` attribute
* data-source/aws_ecr_authorization_token: Prevent plan differences with the `id` attribute
* data-source/aws_ecr_image: Prevent plan differences with the `id` attribute
* data-source/aws_eks_cluster_auth: Prevent plan differences with the `id` attribute
* data-source/aws_iam_account_alias: Prevent plan differences with the `id` attribute
* data-source/aws_kms_alias: Prevent plan differences with the `id` attribute
* data-source/aws_partition: Prevent plan differences with the `id` attribute
* data-source/aws_regions: Prevent plan differences with the `id` attribute
* data-source/aws_sns_topic: Prevent plan differences with the `id` attribute
```

Terraform 0.13 reworked data source reads into the plan graph, which had some unintentional consequences with Terraform Plugin SDK and provider behaviors that were previously ignored when displaying plan differences. While some of these differences  dealing with empty and missing blocks could be addressed with extra graph logic, there remains problematic behaviors that will not be addressable in the near future in core or the SDK.

This change set uses the `tfproviderlint` R015, R016, and R017 checks to find `(*schema.ResourceData).SetId()` usage with unstable values such as the current time and per-execution random identifiers and where the identifier can be stablized based on the data source purpose and surrounding context. For example, singular data sources that represent an analogous managed resource can use the same identifier (e.g. `aws_acm_certificate`, `aws_autoscaling_group`). Other cases where the data source represents information from an AWS Partition or AWS Region are stabilized with those as identifiers (e.g. `aws_regions`).

Importantly, its worth noting that while the unstable `id` attribute is the most visible in the plan difference output, it does not necessarily represent the underlying issue that is causing the output to show. There are two known cases, first with providers unexpectedly writing values to unconfigured and uncomputed attributes and second with Default usage in data source schemas, that are the real triggers of the unexpected difference output. Additional upstream bug reports to properly show difference sigils in the plan difference output are likely necessary, since in many of the real world cases of this particular issue they are missing. Potential future bug reports containing these data sources may help guide those.

Another important note here is that per the Extending Terraform documentation for versioning, that resource identifier changes typically fall under a best practice of a major version increment for Terraform Providers. Given the widespread reports of unexpected behavior as practitioners are upgrading to Terraform 0.13 and since the old identifiers did not represent meaningful information for the lookup context, these changes are not lightly being considered a bug fix. If the usage of a changing time stamp is necessary, the `timestamp()` function and Terraform Time Provider are recommended methodologies for this information. If the usage of a changing random identifier is necessary, the Terraform Random Provider is the recommended methodology.

There still remains other data sources and resources that suffer from known unstable identifiers, such as many plural data sources. Determination of the path forward for these is still undetermined, since ideally Terraform Providers should no longer need to set an `id` attribute after Terraform 0.12, however the Terraform Plugin SDK does not provide functionality to avoid this yet. Future changes may involve a standardized pattern for these within the provider itself.

In the future, Terraform core is moving towards the direction of always outputting any data source attributes changes between runs. There is no timeframe for this functionality, however fixing these here and now is a positive step should that upstream change be implemented.

Output from acceptance testing:

```
--- PASS: TestAccAwsAutoScalingGroupDataSource_basic (38.65s)

--- PASS: TestAccAWSAvailabilityZones_AllAvailabilityZones (23.55s)
--- PASS: TestAccAWSAvailabilityZones_basic (23.40s)
--- PASS: TestAccAWSAvailabilityZones_ExcludeNames (14.32s)
--- PASS: TestAccAWSAvailabilityZones_ExcludeZoneIds (24.34s)
--- PASS: TestAccAWSAvailabilityZones_Filter (23.32s)
--- PASS: TestAccAWSAvailabilityZones_stateFilter (23.23s)

--- PASS: TestAccAWSDbEventCategories_basic (15.76s)
--- PASS: TestAccAWSDbEventCategories_sourceType (14.71s)

--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_Filter (23.91s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_LocationType (24.65s)
--- PASS: TestAccAWSEc2InstanceTypeOfferingDataSource_PreferredInstanceTypes (23.58s)

--- PASS: TestAccAWSEcrAuthorizationTokenDataSource_basic (23.96s)

--- PASS: TestAccAWSEcrDataSource_ecrImage (24.22s)

--- PASS: TestAccAWSEksClusterAuthDataSource_basic (19.59s)

--- PASS: TestAccDataSourceAwsEBSDefaultKmsKey_basic (20.11s)

--- PASS: TestAccDataSourceAwsEBSEncryptionByDefault_basic (23.26s)

--- PASS: TestAccDataSourceAwsKmsAlias_AwsService (24.27s)
--- PASS: TestAccDataSourceAwsKmsAlias_CMK (28.03s)

--- PASS: TestAccDataSourceAwsRegions_AllRegions (23.30s)
--- PASS: TestAccDataSourceAwsRegions_basic (23.44s)
--- PASS: TestAccDataSourceAwsRegions_Filter (22.16s)

--- PASS: TestAccDataSourceAwsSnsTopic_basic (26.41s)
```