### PR TITLE
d/codeartifact_auth_token - new data source 

### DIFF
--- a/aws/data_source_aws_codeartifact_authorization_token.go
+++ b/aws/data_source_aws_codeartifact_authorization_token.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codeartifact"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceAwsCodeArtifactAuthorizationToken() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCodeArtifactAuthorizationTokenRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"domain_owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"duration_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ValidateFunc: validation.Any(
+					validation.IntBetween(900, 43200),
+					validation.IntInSlice([]int{0}),
+				),
+			},
+			"authorization_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expiration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCodeArtifactAuthorizationTokenRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codeartifactconn
+	domain := d.Get("domain").(string)
+	domainOwner := meta.(*AWSClient).accountid
+	params := &codeartifact.GetAuthorizationTokenInput{
+		Domain: aws.String(domain),
+	}
+
+	if v, ok := d.GetOk("domain_owner"); ok {
+		params.DomainOwner = aws.String(v.(string))
+		domainOwner = v.(string)
+	}
+
+	if v, ok := d.GetOkExists("duration_seconds"); ok {
+		params.DurationSeconds = aws.Int64(int64(v.(int)))
+	}
+
+	log.Printf("[DEBUG] Getting CodeArtifact authorization token")
+	out, err := conn.GetAuthorizationToken(params)
+	if err != nil {
+		return fmt.Errorf("error getting CodeArtifact authorization token: %w", err)
+	}
+
+	log.Printf("[DEBUG] CodeArtifact authorization token: %#v", out)
+	log.Printf(aws.StringValue(out.AuthorizationToken))
+
+	d.SetId(fmt.Sprintf("%s:%s", domainOwner, domain))
+	d.Set("authorization_token", aws.StringValue(out.AuthorizationToken))
+	d.Set("expiration", aws.TimeValue(out.Expiration).Format(time.RFC3339))
+	d.Set("domain_owner", domainOwner)
+
+	return nil
+}

--- a/aws/data_source_aws_codeartifact_authorization_token.go
+++ b/aws/data_source_aws_codeartifact_authorization_token.go
@@ -21,9 +21,10 @@ func dataSourceAwsCodeArtifactAuthorizationToken() *schema.Resource {
 				Required: true,
 			},
 			"domain_owner": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateAwsAccountId,
 			},
 			"duration_seconds": {
 				Type:     schema.TypeInt,

--- a/aws/data_source_aws_codeartifact_authorization_token.go
+++ b/aws/data_source_aws_codeartifact_authorization_token.go
@@ -68,9 +68,7 @@ func dataSourceAwsCodeArtifactAuthorizationTokenRead(d *schema.ResourceData, met
 	if err != nil {
 		return fmt.Errorf("error getting CodeArtifact authorization token: %w", err)
 	}
-
 	log.Printf("[DEBUG] CodeArtifact authorization token: %#v", out)
-	log.Printf(aws.StringValue(out.AuthorizationToken))
 
 	d.SetId(fmt.Sprintf("%s:%s", domainOwner, domain))
 	d.Set("authorization_token", aws.StringValue(out.AuthorizationToken))

--- a/aws/data_source_aws_codeartifact_authorization_token_test.go
+++ b/aws/data_source_aws_codeartifact_authorization_token_test.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSCodeArtifactAuthorizationTokenDataSource_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_codeartifact_authorization_token.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSCodeArtifactAuthorizationTokenBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorization_token"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeArtifactAuthorizationTokenDataSource_owner(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_codeartifact_authorization_token.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSCodeArtifactAuthorizationTokenOwnerConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorization_token"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeArtifactAuthorizationTokenDataSource_duration(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_codeartifact_authorization_token.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSCodeArtifactAuthorizationTokenDurationConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "authorization_token"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+					resource.TestCheckResourceAttr(dataSourceName, "duration_seconds", "900"),
+					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCodeArtifactAuthorizationTokenBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_codeartifact_domain" "test" {
+  domain         = %[1]q
+  encryption_key = aws_kms_key.test.arn
+}
+`, rName)
+}
+
+func testAccCheckAWSCodeArtifactAuthorizationTokenBasicConfig(rName string) string {
+	return testAccCheckAWSCodeArtifactAuthorizationTokenBaseConfig(rName) +
+		fmt.Sprintf(`
+data "aws_codeartifact_authorization_token" "test" {
+  domain = aws_codeartifact_domain.test.domain
+}
+`)
+}
+
+func testAccCheckAWSCodeArtifactAuthorizationTokenOwnerConfig(rName string) string {
+	return testAccCheckAWSCodeArtifactAuthorizationTokenBaseConfig(rName) +
+		fmt.Sprintf(`
+data "aws_codeartifact_authorization_token" "test" {
+  domain       = aws_codeartifact_domain.test.domain
+  domain_owner = aws_codeartifact_domain.test.owner
+}
+`)
+}
+
+func testAccCheckAWSCodeArtifactAuthorizationTokenDurationConfig(rName string) string {
+	return testAccCheckAWSCodeArtifactAuthorizationTokenBaseConfig(rName) +
+		fmt.Sprintf(`
+data "aws_codeartifact_authorization_token" "test" {
+  domain           = aws_codeartifact_domain.test.domain
+  duration_seconds = 900
+}
+`)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -193,6 +193,7 @@ func Provider() *schema.Provider {
 			"aws_cloudhsm_v2_cluster":                        dataSourceCloudHsmV2Cluster(),
 			"aws_cloudtrail_service_account":                 dataSourceAwsCloudTrailServiceAccount(),
 			"aws_cloudwatch_log_group":                       dataSourceAwsCloudwatchLogGroup(),
+			"aws_codeartifact_authorization_token":           dataSourceAwsCodeArtifactAuthorizationToken(),
 			"aws_cognito_user_pools":                         dataSourceAwsCognitoUserPools(),
 			"aws_codecommit_repository":                      dataSourceAwsCodeCommitRepository(),
 			"aws_cur_report_definition":                      dataSourceAwsCurReportDefinition(),

--- a/website/docs/d/codeartifact_authorization_token.html.markdown
+++ b/website/docs/d/codeartifact_authorization_token.html.markdown
@@ -31,5 +31,4 @@ The following arguments are supported:
 In addition to the argument above, the following attributes are exported:
 
 * `authorization_token` - Temporary authorization token.
-* `domain_owner` - The account number of the AWS account that owns the domain.
 * `expiration` - The time in UTC RFC3339 format when the authorization token expires.

--- a/website/docs/d/codeartifact_authorization_token.html.markdown
+++ b/website/docs/d/codeartifact_authorization_token.html.markdown
@@ -24,7 +24,7 @@ The following arguments are supported:
 
 * `domain` - (Required) The name of the domain that is in scope for the generated authorization token.
 * `domain_owner` - (Optional) The account number of the AWS account that owns the domain.
-* `duration_seconds` - (Optional) The time, in seconds, that the generated authorization token is valid. Valid values are `0` and between `900` and `43200`. 
+* `duration_seconds` - (Optional) The time, in seconds, that the generated authorization token is valid. Valid values are `0` and between `900` and `43200`.
 
 ## Attributes Reference
 

--- a/website/docs/d/codeartifact_authorization_token.html.markdown
+++ b/website/docs/d/codeartifact_authorization_token.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "CodeArtifact"
+layout: "aws"
+page_title: "AWS: aws_codeartifact_authorization_token"
+description: |-
+    Provides details about an CodeArtifact Authorization Token
+---
+
+# Data Source: aws_codeartifact_authorization_token
+
+The CodeArtifact Authorization Token data source allows the authorization token a CodeArtifact domain.
+
+## Example Usage
+
+```hcl
+data "aws_codeartifact_authorization_token" "test" {
+  domain = aws_codeartifact_domain.test.domain
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The name of the domain that is in scope for the generated authorization token.
+* `domain_owner` - (Optional) The account number of the AWS account that owns the domain.
+* `duration_seconds` - (Optional) The time, in seconds, that the generated authorization token is valid. Valid values are `0` and between `900` and `43200`. 
+
+## Attributes Reference
+
+In addition to the argument above, the following attributes are exported:
+
+* `authorization_token` - Temporary authorization token.
+* `domain_owner` - The account number of the AWS account that owns the domain.
+* `expiration` - The time in UTC RFC3339 format when the authorization token expires.

--- a/website/docs/d/codeartifact_authorization_token.html.markdown
+++ b/website/docs/d/codeartifact_authorization_token.html.markdown
@@ -3,12 +3,12 @@ subcategory: "CodeArtifact"
 layout: "aws"
 page_title: "AWS: aws_codeartifact_authorization_token"
 description: |-
-    Provides details about an CodeArtifact Authorization Token
+    Provides details about a CodeArtifact Authorization Token
 ---
 
 # Data Source: aws_codeartifact_authorization_token
 
-The CodeArtifact Authorization Token data source allows the authorization token a CodeArtifact domain.
+The CodeArtifact Authorization Token data source generates a temporary authentication token for accessing repositories in a CodeArtifact domain.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13714

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
datasource_codeartifact_authorization_token - new data source
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
