### PR TITLE
New service: TimestreamWrite service client with single database resource

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -548,6 +548,9 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     "service/synthetics" = [
       "aws_synthetics_",
     ],
+    "service/timestreamwrite" = [
+      "aws_timestreamwrite_",
+    ],
     "service/transfer" = [
       "aws_transfer_",
     ],
@@ -1427,6 +1430,11 @@ behavior "pull_request_path_labeler" "service_labels" {
       "aws/internal/service/synthetics/**/*",
       "**/*_synthetics_*",
       "**/synthetics_*"
+    ]
+    "service/timestreamwrite" = [
+      "aws/internal/service/timestreamwrite/**/*",
+      "**/*_timestreamwrite_*",
+      "**/timestreamwrite_*"
     ]
     "service/transfer" = [
       "aws/internal/service/transfer/**/*",

--- a/aws/config.go
+++ b/aws/config.go
@@ -146,6 +146,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/aws/aws-sdk-go/service/synthetics"
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 	"github.com/aws/aws-sdk-go/service/transfer"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
@@ -341,6 +342,7 @@ type AWSClient struct {
 	swfconn                             *swf.SWF
 	syntheticsconn                      *synthetics.Synthetics
 	terraformVersion                    string
+	timestreamwriteconn                 *timestreamwrite.TimestreamWrite
 	transferconn                        *transfer.Transfer
 	wafconn                             *waf.WAF
 	wafregionalconn                     *wafregional.WAFRegional
@@ -566,6 +568,7 @@ func (c *Config) Client() (interface{}, error) {
 		swfconn:                             swf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["swf"])})),
 		syntheticsconn:                      synthetics.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["synthetics"])})),
 		terraformVersion:                    c.terraformVersion,
+		timestreamwriteconn:                 timestreamwrite.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["timestreamwrite"])})),
 		transferconn:                        transfer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["transfer"])})),
 		wafconn:                             waf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["waf"])})),
 		wafregionalconn:                     wafregional.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints["wafregional"])})),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -1193,6 +1193,7 @@ func init() {
 		"sts",
 		"swf",
 		"synthetics",
+		"timestreamwrite",
 		"transfer",
 		"waf",
 		"wafregional",

--- a/infrastructure/repository/labels-service.tf
+++ b/infrastructure/repository/labels-service.tf
@@ -185,6 +185,7 @@ variable "service_labels" {
     "synthetics",
     "textract",
     "transcribeservice",
+    "timestreamwrite",
     "transfer",
     "translate",
     "waf",

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -110,6 +110,7 @@ SimpleDB
 Step Function (SFN)
 Storage Gateway
 Synthetics
+TimestreamWrite
 Transfer
 Transit Gateway Network Manager
 VPC

--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -189,6 +189,7 @@ The Terraform AWS Provider allows the following endpoints to be customized:
   <li><code>sts</code></li>
   <li><code>swf</code></li>
   <li><code>synthetics</code></li>
+  <li><code>timestreamwrite</code></li>
   <li><code>transfer</code></li>
   <li><code>waf</code></li>
   <li><code>wafregional</code></li>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15421

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:
- **New Resource:** `aws_timestreamwrite_database`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSTimestreamWriteDatabase_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSTimestreamWriteDatabase_ -timeout 120m
=== RUN   TestAccAWSTimestreamWriteDatabase_basic
=== PAUSE TestAccAWSTimestreamWriteDatabase_basic
=== RUN   TestAccAWSTimestreamWriteDatabase_kmsKey
=== PAUSE TestAccAWSTimestreamWriteDatabase_kmsKey
=== RUN   TestAccAWSTimestreamWriteDatabase_Tags
=== PAUSE TestAccAWSTimestreamWriteDatabase_Tags
=== CONT  TestAccAWSTimestreamWriteDatabase_basic
=== CONT  TestAccAWSTimestreamWriteDatabase_Tags
=== CONT  TestAccAWSTimestreamWriteDatabase_kmsKey
--- PASS: TestAccAWSTimestreamWriteDatabase_basic (16.37s)
--- PASS: TestAccAWSTimestreamWriteDatabase_kmsKey (18.24s)
--- PASS: TestAccAWSTimestreamWriteDatabase_Tags (40.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.707s
```
