### PR TITLE
resource/aws_ecs_cluster: Retry CreateCluster for IAM Service Linked Role eventual consistency

### DIFF
--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -8,10 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
 )
 
 const (
@@ -114,25 +116,46 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	clusterName := d.Get("name").(string)
 	log.Printf("[DEBUG] Creating ECS cluster %s", clusterName)
 
-	input := ecs.CreateClusterInput{
-		ClusterName: aws.String(clusterName),
-		Tags:        keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().EcsTags(),
-	}
-
-	if v, ok := d.GetOk("setting"); ok {
-		input.Settings = expandEcsSettings(v.(*schema.Set))
+	input := &ecs.CreateClusterInput{
+		ClusterName:                     aws.String(clusterName),
+		DefaultCapacityProviderStrategy: expandEcsCapacityProviderStrategy(d.Get("default_capacity_provider_strategy").(*schema.Set)),
+		Tags:                            keyvaluetags.New(d.Get("tags").(map[string]interface{})).IgnoreAws().EcsTags(),
 	}
 
 	if v, ok := d.GetOk("capacity_providers"); ok {
 		input.CapacityProviders = expandStringSet(v.(*schema.Set))
 	}
 
-	input.DefaultCapacityProviderStrategy = expandEcsCapacityProviderStrategy(d.Get("default_capacity_provider_strategy").(*schema.Set))
-
-	out, err := conn.CreateCluster(&input)
-	if err != nil {
-		return err
+	if v, ok := d.GetOk("setting"); ok {
+		input.Settings = expandEcsSettings(v.(*schema.Set))
 	}
+
+	// CreateCluster will create the ECS IAM Service Linked Role on first ECS provision
+	// This process does not complete before the initial API call finishes.
+	var out *ecs.CreateClusterOutput
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
+		var err error
+		out, err = conn.CreateCluster(input)
+
+		if tfawserr.ErrMessageContains(err, ecs.ErrCodeInvalidParameterException, "Unable to assume the service linked role") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		out, err = conn.CreateCluster(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error creating ECS Cluster (%s): %w", clusterName, err)
+	}
+
 	log.Printf("[DEBUG] ECS cluster %s created", aws.StringValue(out.Cluster.ClusterArn))
 
 	d.SetId(aws.StringValue(out.Cluster.ClusterArn))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15452

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_ecs_cluster: Prevent IAM Service Linked Role error on first ECS provision
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEcsCluster_disappears (22.48s)
--- PASS: TestAccAWSEcsCluster_basic (27.36s)
--- PASS: TestAccAWSEcsCluster_Tags (46.73s)
--- PASS: TestAccAWSEcsCluster_CapacityProviders (49.40s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersNoStrategy (53.36s)
--- PASS: TestAccAWSEcsCluster_containerInsights (65.48s)
--- PASS: TestAccAWSEcsCluster_CapacityProvidersUpdate (83.87s)
--- PASS: TestAccAWSEcsCluster_SingleCapacityProvider (90.92s)
```
