### PR TITLE
Add url to aws_sqs_queue resource attributes

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -127,6 +127,10 @@ func resourceAwsSqsQueue() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -315,6 +319,7 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("receive_wait_time_seconds", 0)
 	d.Set("redrive_policy", "")
 	d.Set("visibility_timeout_seconds", 30)
+	d.Set("url", d.Id())
 
 	if attributeOutput != nil {
 		queueAttributes := aws.StringValueMap(attributeOutput.Attributes)

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -73,6 +73,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The URL for the created Amazon SQS queue.
 * `arn` - The ARN of the SQS queue
+* `url` - The URL of the queue.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11848

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add url to aws_sqs_queue resource attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSQSQueue_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSSQSQueue_ -timeout 120m
=== RUN   TestAccAWSSQSQueue_basic
=== PAUSE TestAccAWSSQSQueue_basic
=== RUN   TestAccAWSSQSQueue_tags
=== PAUSE TestAccAWSSQSQueue_tags
=== RUN   TestAccAWSSQSQueue_namePrefix
=== PAUSE TestAccAWSSQSQueue_namePrefix
=== RUN   TestAccAWSSQSQueue_namePrefix_fifo
=== PAUSE TestAccAWSSQSQueue_namePrefix_fifo
=== RUN   TestAccAWSSQSQueue_policy
=== PAUSE TestAccAWSSQSQueue_policy
=== RUN   TestAccAWSSQSQueue_queueDeletedRecently
=== PAUSE TestAccAWSSQSQueue_queueDeletedRecently
=== RUN   TestAccAWSSQSQueue_redrivePolicy
=== PAUSE TestAccAWSSQSQueue_redrivePolicy
=== RUN   TestAccAWSSQSQueue_Policybasic
=== PAUSE TestAccAWSSQSQueue_Policybasic
=== RUN   TestAccAWSSQSQueue_FIFO
=== PAUSE TestAccAWSSQSQueue_FIFO
=== RUN   TestAccAWSSQSQueue_FIFOExpectNameError
=== PAUSE TestAccAWSSQSQueue_FIFOExpectNameError
=== RUN   TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== PAUSE TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== RUN   TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== PAUSE TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== RUN   TestAccAWSSQSQueue_Encryption
=== PAUSE TestAccAWSSQSQueue_Encryption
=== CONT  TestAccAWSSQSQueue_basic
=== CONT  TestAccAWSSQSQueue_policy
=== CONT  TestAccAWSSQSQueue_redrivePolicy
=== CONT  TestAccAWSSQSQueue_queueDeletedRecently
=== CONT  TestAccAWSSQSQueue_Policybasic
=== CONT  TestAccAWSSQSQueue_Encryption
=== CONT  TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
=== CONT  TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
=== CONT  TestAccAWSSQSQueue_FIFOExpectNameError
=== CONT  TestAccAWSSQSQueue_FIFO
=== CONT  TestAccAWSSQSQueue_namePrefix
=== CONT  TestAccAWSSQSQueue_namePrefix_fifo
=== CONT  TestAccAWSSQSQueue_tags
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (14.11s)
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (14.17s)
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (46.44s)
--- PASS: TestAccAWSSQSQueue_Encryption (47.94s)
--- PASS: TestAccAWSSQSQueue_namePrefix (49.77s)
--- PASS: TestAccAWSSQSQueue_FIFO (51.34s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (51.73s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (52.29s)
--- PASS: TestAccAWSSQSQueue_policy (52.56s)
--- PASS: TestAccAWSSQSQueue_Policybasic (52.57s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (63.21s)
--- PASS: TestAccAWSSQSQueue_basic (82.86s)
--- PASS: TestAccAWSSQSQueue_tags (83.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       83.123s
```
