### PR TITLE
data-source/aws_vpc_endpoint_service: Accept service_type as argument

### DIFF
--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -67,6 +67,7 @@ func dataSourceAwsVpcEndpointService() *schema.Resource {
 			},
 			"service_type": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 			"tags": tagsSchemaComputed(),
@@ -133,11 +134,29 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("no matching VPC Endpoint Service found")
 	}
 
-	if len(resp.ServiceDetails) > 1 {
+	var serviceDetails []*ec2.ServiceDetail
+
+	// Client-side filtering. When the EC2 API supports this functionality
+	// server-side it should be moved.
+	for _, serviceDetail := range resp.ServiceDetails {
+		if serviceDetail == nil {
+			continue
+		}
+
+		if v, ok := d.GetOk("service_type"); ok {
+			if len(serviceDetail.ServiceType) > 0 && serviceDetail.ServiceType[0] != nil && v.(string) != aws.StringValue(serviceDetail.ServiceType[0].ServiceType) {
+				continue
+			}
+		}
+
+		serviceDetails = append(serviceDetails, serviceDetail)
+	}
+
+	if len(serviceDetails) > 1 {
 		return fmt.Errorf("multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service")
 	}
 
-	sd := resp.ServiceDetails[0]
+	sd := serviceDetails[0]
 	serviceId := aws.StringValue(sd.ServiceId)
 	serviceName = aws.StringValue(sd.ServiceName)
 

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -160,6 +161,28 @@ func testAccCheckResourceAttrRegionalHostname(resourceName, attributeName, servi
 		hostname := fmt.Sprintf("%s.%s.%s.%s", hostnamePrefix, serviceName, testAccGetRegion(), testAccGetPartitionDNSSuffix())
 
 		return resource.TestCheckResourceAttr(resourceName, attributeName, hostname)(s)
+	}
+}
+
+// testAccCheckResourceAttrRegionalHostnameService ensures the Terraform state exactly matches a service DNS hostname with region and partition DNS suffix
+//
+// For example: ec2.us-west-2.amazonaws.com
+func testAccCheckResourceAttrRegionalHostnameService(resourceName, attributeName, serviceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		hostname := fmt.Sprintf("%s.%s.%s", serviceName, testAccGetRegion(), testAccGetPartitionDNSSuffix())
+
+		return resource.TestCheckResourceAttr(resourceName, attributeName, hostname)(s)
+	}
+}
+
+// testAccCheckResourceAttrRegionalReverseDnsService ensures the Terraform state exactly matches a service reverse DNS hostname with region and partition DNS suffix
+//
+// For example: com.amazonaws.us-west-2.s3
+func testAccCheckResourceAttrRegionalReverseDnsService(resourceName, attributeName, serviceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		reverseDns := fmt.Sprintf("%s.%s.%s", testAccGetPartitionReverseDNSPrefix(), testAccGetRegion(), serviceName)
+
+		return resource.TestCheckResourceAttr(resourceName, attributeName, reverseDns)(s)
 	}
 }
 
@@ -448,6 +471,16 @@ func testAccGetPartitionDNSSuffix() string {
 		return partition.DNSSuffix()
 	}
 	return "amazonaws.com"
+}
+
+func testAccGetPartitionReverseDNSPrefix() string {
+	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), testAccGetRegion()); ok {
+		dnsParts := strings.Split(partition.DNSSuffix(), ".")
+		sort.Sort(sort.Reverse(sort.StringSlice(dnsParts)))
+		return strings.Join(dnsParts, ".")
+	}
+
+	return "com.amazonaws"
 }
 
 func testAccGetAlternateRegionPartition() string {

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -18,7 +18,8 @@ can be specified when creating a VPC endpoint within the region configured in th
 ```hcl
 # Declare the data source
 data "aws_vpc_endpoint_service" "s3" {
-  service = "s3"
+  service      = "s3"
+  service_type = "Gateway"
 }
 
 # Create a VPC
@@ -57,9 +58,10 @@ data "aws_vpc_endpoint_service" "test" {
 The arguments of this data source act as filters for querying the available VPC endpoint services.
 The given filters must match exactly one VPC endpoint service whose data will be exported as attributes.
 
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
 * `service` - (Optional) The common name of an AWS service (e.g. `s3`).
 * `service_name` - (Optional) The service name that is specified when creating a VPC endpoint. For AWS services the service name is usually in the form `com.amazonaws.<region>.<service>` (the SageMaker Notebook service is an exception to this rule, the service name is in the form `aws.sagemaker.<region>.notebook`).
-* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+* `service_type` - (Optional) The service type, `Gateway` or `Interface`.
 * `tags` - (Optional) A map of tags, each pair of which must exactly match a pair on the desired VPC Endpoint Service.
 
 ~> **NOTE:** Specifying `service` will not work for non-AWS services or AWS services that don't follow the standard `service_name` pattern of `com.amazonaws.<region>.<service>`.
@@ -83,6 +85,5 @@ In addition to all arguments above, the following attributes are exported:
 * `owner` - The AWS account ID of the service owner or `amazon`.
 * `private_dns_name` - The private DNS name for the service.
 * `service_id` - The ID of the endpoint service.
-* `service_type` - The service type, `Gateway` or `Interface`.
 * `tags` - A map of tags assigned to the resource.
 * `vpc_endpoint_policy_supported` - Whether or not the service supports endpoint policies - `true` or `false`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data-source/aws_vpc_endpoint_service: Accept `service_type` as argument
```

Allow practitioners to prevent the following error in certain environments:

```
Error: multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccDataSourceAwsVpcEndpointService_ServiceType_Interface (13.90s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (13.91s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_ServiceType_Gateway (14.00s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (14.69s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (243.09s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter_tags (243.14s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter (253.55s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccDataSourceAwsVpcEndpointService_ServiceType_Gateway (18.12s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_ServiceType_Interface (18.20s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (18.66s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (18.67s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (236.92s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter_tags (258.50s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom_filter (259.55s)
```
