### PR TITLE
service/batch: Support resource tagging and prevent differences with new secrets support in container properties

### DIFF
--- a/aws/data_source_aws_batch_compute_environment.go
+++ b/aws/data_source_aws_batch_compute_environment.go
@@ -94,7 +94,7 @@ func dataSourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta inter
 	d.Set("state", computeEnvironment.State)
 
 	if err := d.Set("tags", keyvaluetags.BatchKeyValueTags(computeEnvironment.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %s", err)
+		return fmt.Errorf("error setting tags: %w", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_batch_compute_environment.go
+++ b/aws/data_source_aws_batch_compute_environment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsBatchComputeEnvironment() *schema.Resource {
@@ -34,6 +35,8 @@ func dataSourceAwsBatchComputeEnvironment() *schema.Resource {
 				Computed: true,
 			},
 
+			"tags": tagsSchemaComputed(),
+
 			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -59,6 +62,7 @@ func dataSourceAwsBatchComputeEnvironment() *schema.Resource {
 
 func dataSourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).batchconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	params := &batch.DescribeComputeEnvironmentsInput{
 		ComputeEnvironments: []*string{aws.String(d.Get("compute_environment_name").(string))},
@@ -88,5 +92,10 @@ func dataSourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta inter
 	d.Set("status", computeEnvironment.Status)
 	d.Set("status_reason", computeEnvironment.StatusReason)
 	d.Set("state", computeEnvironment.State)
+
+	if err := d.Set("tags", keyvaluetags.BatchKeyValueTags(computeEnvironment.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }

--- a/aws/data_source_aws_batch_job_queue.go
+++ b/aws/data_source_aws_batch_job_queue.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsBatchJobQueue() *schema.Resource {
@@ -39,6 +40,8 @@ func dataSourceAwsBatchJobQueue() *schema.Resource {
 				Computed: true,
 			},
 
+			"tags": tagsSchemaComputed(),
+
 			"priority": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -66,6 +69,7 @@ func dataSourceAwsBatchJobQueue() *schema.Resource {
 
 func dataSourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).batchconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	params := &batch.DescribeJobQueuesInput{
 		JobQueues: []*string{aws.String(d.Get("name").(string))},
@@ -103,6 +107,10 @@ func dataSourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) er
 	}
 	if err := d.Set("compute_environment_order", ceos); err != nil {
 		return fmt.Errorf("error setting compute_environment_order: %s", err)
+	}
+
+	if err := d.Set("tags", keyvaluetags.BatchKeyValueTags(jobQueue.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_batch_job_queue_test.go
+++ b/aws/data_source_aws_batch_job_queue_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceAwsBatchJobQueue_basic(t *testing.T) {
@@ -21,49 +20,22 @@ func TestAccDataSourceAwsBatchJobQueue_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsBatchJobQueueConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsBatchJobQueueCheck(datasourceName, resourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "compute_environment_order.#", resourceName, "compute_environments.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "priority", resourceName, "priority"),
+					resource.TestCheckResourceAttrPair(datasourceName, "state", resourceName, "state"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsBatchJobQueueCheck(datasourceName, resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		ds, ok := s.RootModule().Resources[datasourceName]
-		if !ok {
-			return fmt.Errorf("root module has no data source called %s", datasourceName)
-		}
-
-		jobQueueRs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", resourceName)
-		}
-
-		attrNames := []string{
-			"arn",
-			"name",
-			"state",
-			"priority",
-		}
-
-		for _, attrName := range attrNames {
-			if ds.Primary.Attributes[attrName] != jobQueueRs.Primary.Attributes[attrName] {
-				return fmt.Errorf(
-					"%s is %s; want %s",
-					attrName,
-					ds.Primary.Attributes[attrName],
-					jobQueueRs.Primary.Attributes[attrName],
-				)
-			}
-		}
-
-		return nil
-	}
-}
-
 func testAccDataSourceAwsBatchJobQueueConfig(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "ecs_instance_role" {
   name = "ecs_%[1]s"
 
@@ -75,7 +47,7 @@ resource "aws_iam_role" "ecs_instance_role" {
       "Action": "sts:AssumeRole",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
       }
     }
   ]
@@ -85,7 +57,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
   role       = aws_iam_role.ecs_instance_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_instance_profile" "ecs_instance_role" {
@@ -104,7 +76,7 @@ resource "aws_iam_role" "aws_batch_service_role" {
       "Action": "sts:AssumeRole",
       "Effect": "Allow",
       "Principal": {
-        "Service": "batch.amazonaws.com"
+        "Service": "batch.${data.aws_partition.current.dns_suffix}"
       }
     }
   ]
@@ -114,7 +86,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "aws_batch_service_role" {
   role       = aws_iam_role.aws_batch_service_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
 
 resource "aws_security_group" "sample" {

--- a/aws/internal/keyvaluetags/generators/gettag/main.go
+++ b/aws/internal/keyvaluetags/generators/gettag/main.go
@@ -18,6 +18,7 @@ const filename = `get_tag_gen.go`
 
 var serviceNames = []string{
 	"autoscaling",
+	"batch",
 	"dynamodb",
 	"ec2",
 	"ecs",

--- a/aws/internal/keyvaluetags/generators/listtags/main.go
+++ b/aws/internal/keyvaluetags/generators/listtags/main.go
@@ -28,6 +28,7 @@ var serviceNames = []string{
 	"athena",
 	"autoscaling",
 	"backup",
+	"batch",
 	"cloud9",
 	"cloudfront",
 	"cloudhsmv2",

--- a/aws/internal/keyvaluetags/generators/updatetags/main.go
+++ b/aws/internal/keyvaluetags/generators/updatetags/main.go
@@ -29,6 +29,7 @@ var serviceNames = []string{
 	"athena",
 	"autoscaling",
 	"backup",
+	"batch",
 	"cloud9",
 	"cloudfront",
 	"cloudhsmv2",

--- a/aws/internal/keyvaluetags/get_tag_gen.go
+++ b/aws/internal/keyvaluetags/get_tag_gen.go
@@ -5,6 +5,7 @@ package keyvaluetags
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -39,6 +40,21 @@ func AutoscalingGetTag(conn *autoscaling.AutoScaling, identifier string, resourc
 	listTags := AutoscalingKeyValueTags(output.Tags, identifier, resourceType)
 
 	return listTags.KeyExists(key), listTags.KeyTagData(key), nil
+}
+
+// BatchGetTag fetches an individual batch service tag for a resource.
+// Returns whether the key exists, the key value, and any errors.
+// This function will optimise the handling over BatchListTags, if possible.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func BatchGetTag(conn *batch.Batch, identifier string, key string) (bool, *string, error) {
+	listTags, err := BatchListTags(conn, identifier)
+
+	if err != nil {
+		return false, nil, err
+	}
+
+	return listTags.KeyExists(key), listTags.KeyValue(key), nil
 }
 
 // DynamodbGetTag fetches an individual dynamodb service tag for a resource.

--- a/aws/internal/keyvaluetags/list_tags_gen.go
+++ b/aws/internal/keyvaluetags/list_tags_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/aws/aws-sdk-go/service/cloud9"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
@@ -295,6 +296,23 @@ func BackupListTags(conn *backup.Backup, identifier string) (KeyValueTags, error
 	}
 
 	return BackupKeyValueTags(output.Tags), nil
+}
+
+// BatchListTags lists batch service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func BatchListTags(conn *batch.Batch, identifier string) (KeyValueTags, error) {
+	input := &batch.ListTagsForResourceInput{
+		ResourceArn: aws.String(identifier),
+	}
+
+	output, err := conn.ListTagsForResource(input)
+
+	if err != nil {
+		return New(nil), err
+	}
+
+	return BatchKeyValueTags(output.Tags), nil
 }
 
 // Cloud9ListTags lists cloud9 service tags.

--- a/aws/internal/keyvaluetags/service_generation_customizations.go
+++ b/aws/internal/keyvaluetags/service_generation_customizations.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/aws/aws-sdk-go/service/cloud9"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
@@ -147,6 +148,8 @@ func ServiceClientType(serviceName string) string {
 		funcType = reflect.TypeOf(autoscaling.New)
 	case "backup":
 		funcType = reflect.TypeOf(backup.New)
+	case "batch":
+		funcType = reflect.TypeOf(batch.New)
 	case "cloud9":
 		funcType = reflect.TypeOf(cloud9.New)
 	case "cloudfront":

--- a/aws/internal/keyvaluetags/update_tags_gen.go
+++ b/aws/internal/keyvaluetags/update_tags_gen.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/aws/aws-sdk-go/service/cloud9"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
@@ -532,6 +533,42 @@ func BackupUpdateTags(conn *backup.Backup, identifier string, oldTagsMap interfa
 		input := &backup.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        updatedTags.IgnoreAws().BackupTags(),
+		}
+
+		_, err := conn.TagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error tagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	return nil
+}
+
+// BatchUpdateTags updates batch service tags.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func BatchUpdateTags(conn *batch.Batch, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+	oldTags := New(oldTagsMap)
+	newTags := New(newTagsMap)
+
+	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+		input := &batch.UntagResourceInput{
+			ResourceArn: aws.String(identifier),
+			TagKeys:     aws.StringSlice(removedTags.IgnoreAws().Keys()),
+		}
+
+		_, err := conn.UntagResource(input)
+
+		if err != nil {
+			return fmt.Errorf("error untagging resource (%s): %w", identifier, err)
+		}
+	}
+
+	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+		input := &batch.TagResourceInput{
+			ResourceArn: aws.String(identifier),
+			Tags:        updatedTags.IgnoreAws().BatchTags(),
 		}
 
 		_, err := conn.TagResource(input)

--- a/aws/internal/service/batch/equivalency/container_properties.go
+++ b/aws/internal/service/batch/equivalency/container_properties.go
@@ -40,6 +40,11 @@ func (cp *containerProperties) Reduce() error {
 	}
 
 	// Prevent difference of API response that adds an empty array when not configured during the request
+	if len(cp.Secrets) == 0 {
+		cp.Secrets = nil
+	}
+
+	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.Ulimits) == 0 {
 		cp.Ulimits = nil
 	}

--- a/aws/internal/service/batch/equivalency/container_properties_test.go
+++ b/aws/internal/service/batch/equivalency/container_properties_test.go
@@ -209,7 +209,7 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
 			ExpectEquivalent: true,
 		},
 		{
-			Name: "empty command, mountPoints, resourceRequirements, ulimits, volumes",
+			Name: "empty command, mountPoints, resourceRequirements, secrets, ulimits, volumes",
 			ApiJson: `
 {
 	"image": "123.dkr.ecr.us-east-1.amazonaws.com/my-app",
@@ -221,7 +221,8 @@ func TestEquivalentBatchContainerPropertiesJSON(t *testing.T) {
 	"environment": [{"name":"ENVIRONMENT","value":"test"}],
 	"mountPoints": [],
 	"ulimits": [],
-	"resourceRequirements": []
+	"resourceRequirements": [],
+	"secrets": []
 }
 `,
 			ConfigurationJson: `

--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -164,6 +164,7 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{batch.CEStateEnabled, batch.CEStateDisabled}, true),
 				Default:      batch.CEStateEnabled,
 			},
+			"tags": tagsSchema(),
 			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -215,6 +216,10 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 
 	if v, ok := d.GetOk("state"); ok {
 		input.State = aws.String(v.(string))
+	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().BatchTags()
 	}
 
 	if computeEnvironmentType == batch.CETypeManaged {
@@ -315,6 +320,7 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 
 func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).batchconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	computeEnvironmentName := d.Get("compute_environment_name").(string)
 
@@ -342,6 +348,11 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 
 	d.Set("service_role", computeEnvironment.ServiceRole)
 	d.Set("state", computeEnvironment.State)
+
+	if err := d.Set("tags", keyvaluetags.BatchKeyValueTags(computeEnvironment.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	d.Set("type", computeEnvironment.Type)
 
 	if aws.StringValue(computeEnvironment.Type) == batch.CETypeManaged {
@@ -411,51 +422,61 @@ func resourceAwsBatchComputeEnvironmentDelete(d *schema.ResourceData, meta inter
 func resourceAwsBatchComputeEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).batchconn
 
-	computeEnvironmentName := d.Get("compute_environment_name").(string)
+	if d.HasChanges("compute_resources", "service_role", "state") {
+		computeEnvironmentName := d.Get("compute_environment_name").(string)
 
-	input := &batch.UpdateComputeEnvironmentInput{
-		ComputeEnvironment: aws.String(computeEnvironmentName),
-		ComputeResources:   &batch.ComputeResourceUpdate{},
-	}
-
-	if d.HasChange("service_role") {
-		input.ServiceRole = aws.String(d.Get("service_role").(string))
-	}
-	if d.HasChange("state") {
-		input.State = aws.String(d.Get("state").(string))
-	}
-
-	if d.HasChange("compute_resources") {
-		computeResources := d.Get("compute_resources").([]interface{})
-		if len(computeResources) == 0 {
-			return fmt.Errorf("One compute environment is expected, but no compute environments are set")
-		}
-		computeResource := computeResources[0].(map[string]interface{})
-
-		if d.HasChange("compute_resources.0.desired_vcpus") {
-			input.ComputeResources.DesiredvCpus = aws.Int64(int64(computeResource["desired_vcpus"].(int)))
+		input := &batch.UpdateComputeEnvironmentInput{
+			ComputeEnvironment: aws.String(computeEnvironmentName),
+			ComputeResources:   &batch.ComputeResourceUpdate{},
 		}
 
-		input.ComputeResources.MaxvCpus = aws.Int64(int64(computeResource["max_vcpus"].(int)))
-		input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
+		if d.HasChange("service_role") {
+			input.ServiceRole = aws.String(d.Get("service_role").(string))
+		}
+		if d.HasChange("state") {
+			input.State = aws.String(d.Get("state").(string))
+		}
+
+		if d.HasChange("compute_resources") {
+			computeResources := d.Get("compute_resources").([]interface{})
+			if len(computeResources) == 0 {
+				return fmt.Errorf("One compute environment is expected, but no compute environments are set")
+			}
+			computeResource := computeResources[0].(map[string]interface{})
+
+			if d.HasChange("compute_resources.0.desired_vcpus") {
+				input.ComputeResources.DesiredvCpus = aws.Int64(int64(computeResource["desired_vcpus"].(int)))
+			}
+
+			input.ComputeResources.MaxvCpus = aws.Int64(int64(computeResource["max_vcpus"].(int)))
+			input.ComputeResources.MinvCpus = aws.Int64(int64(computeResource["min_vcpus"].(int)))
+		}
+
+		log.Printf("[DEBUG] Update compute environment %s.\n", input)
+
+		if _, err := conn.UpdateComputeEnvironment(input); err != nil {
+			return fmt.Errorf("error updating Batch Compute Environment (%s): %w", d.Id(), err)
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{batch.CEStatusUpdating},
+			Target:     []string{batch.CEStatusValid},
+			Refresh:    resourceAwsBatchComputeEnvironmentStatusRefreshFunc(computeEnvironmentName, conn),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			MinTimeout: 5 * time.Second,
+		}
+
+		if _, err := stateConf.WaitForState(); err != nil {
+			return fmt.Errorf("error waiting for Batch Compute Environment (%s) update: %w", d.Id(), err)
+		}
 	}
 
-	log.Printf("[DEBUG] Update compute environment %s.\n", input)
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
 
-	if _, err := conn.UpdateComputeEnvironment(input); err != nil {
-		return fmt.Errorf("error updating Batch Compute Environment (%s): %w", d.Id(), err)
-	}
-
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{batch.CEStatusUpdating},
-		Target:     []string{batch.CEStatusValid},
-		Refresh:    resourceAwsBatchComputeEnvironmentStatusRefreshFunc(computeEnvironmentName, conn),
-		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		MinTimeout: 5 * time.Second,
-	}
-
-	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("error waiting for Batch Compute Environment (%s) update: %w", d.Id(), err)
+		if err := keyvaluetags.BatchUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
 	}
 
 	return resourceAwsBatchComputeEnvironmentRead(d, meta)

--- a/aws/resource_aws_batch_job_definition.go
+++ b/aws/resource_aws_batch_job_definition.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch/equivalency"
 )
 
@@ -18,6 +19,7 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsBatchJobDefinitionCreate,
 		Read:   resourceAwsBatchJobDefinitionRead,
+		Update: resourceAwsBatchJobDefinitionUpdate,
 		Delete: resourceAwsBatchJobDefinitionDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -71,6 +73,7 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 			"timeout": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -130,6 +133,10 @@ func resourceAwsBatchJobDefinitionCreate(d *schema.ResourceData, meta interface{
 		input.RetryStrategy = expandJobDefinitionRetryStrategy(v.([]interface{}))
 	}
 
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().BatchTags()
+	}
+
 	if v, ok := d.GetOk("timeout"); ok {
 		input.Timeout = expandJobDefinitionTimeout(v.([]interface{}))
 	}
@@ -145,6 +152,8 @@ func resourceAwsBatchJobDefinitionCreate(d *schema.ResourceData, meta interface{
 
 func resourceAwsBatchJobDefinitionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).batchconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
+
 	arn := d.Get("arn").(string)
 	job, err := getJobDefinition(conn, arn)
 	if err != nil {
@@ -174,12 +183,30 @@ func resourceAwsBatchJobDefinitionRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error setting retry_strategy: %s", err)
 	}
 
+	if err := d.Set("tags", keyvaluetags.BatchKeyValueTags(job.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	if err := d.Set("timeout", flattenBatchJobTimeout(job.Timeout)); err != nil {
 		return fmt.Errorf("error setting timeout: %s", err)
 	}
 
 	d.Set("revision", job.Revision)
 	d.Set("type", job.Type)
+	return nil
+}
+
+func resourceAwsBatchJobDefinitionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).batchconn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.BatchUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
+
 	return nil
 }
 

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -82,6 +82,7 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 				Config: testAccBatchJobDefinitionConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -117,6 +118,7 @@ func TestAccAWSBatchJobDefinition_ContainerProperties_Advanced(t *testing.T) {
 				{ContainerPath: aws.String("/tmp"), ReadOnly: aws.Bool(false), SourceVolume: aws.String("tmp")},
 			},
 			ResourceRequirements: []*batch.ResourceRequirement{},
+			Secrets:              []*batch.Secret{},
 			Ulimits: []*batch.Ulimit{
 				{HardLimit: aws.Int64(int64(1024)), Name: aws.String("nofile"), SoftLimit: aws.Int64(int64(1024))},
 			},
@@ -181,6 +183,50 @@ func TestAccAWSBatchJobDefinition_updateForcesNewResource(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchJobDefinition_Tags(t *testing.T) {
+	var jd batch.JobDefinition
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_batch_job_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchJobDefinitionConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBatchJobDefinitionConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccBatchJobDefinitionConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobDefinitionExists(resourceName, &jd),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -373,4 +419,43 @@ resource "aws_batch_job_definition" "test" {
   type = "container"
 }
 `, rName)
+}
+
+func testAccBatchJobDefinitionConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_batch_job_definition" "test" {
+  container_properties = jsonencode({
+    command = ["echo", "test"]
+    image   = "busybox"
+    memory  = 128
+    vcpus   = 1
+  })
+  name = %[1]q
+  type = "container"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccBatchJobDefinitionConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_batch_job_definition" "test" {
+  container_properties = jsonencode({
+    command = ["echo", "test"]
+    image   = "busybox"
+    memory  = 128
+    vcpus   = 1
+  })
+  name = %[1]q
+  type = "container"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func resourceAwsBatchJobQueue() *schema.Resource {
@@ -48,6 +49,7 @@ func resourceAwsBatchJobQueue() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{batch.JQStateDisabled, batch.JQStateEnabled}, true),
 			},
+			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -64,6 +66,11 @@ func resourceAwsBatchJobQueueCreate(d *schema.ResourceData, meta interface{}) er
 		Priority:                aws.Int64(int64(d.Get("priority").(int))),
 		State:                   aws.String(d.Get("state").(string)),
 	}
+
+	if v := d.Get("tags").(map[string]interface{}); len(v) > 0 {
+		input.Tags = keyvaluetags.New(v).IgnoreAws().BatchTags()
+	}
+
 	name := d.Get("name").(string)
 	out, err := conn.CreateJobQueue(&input)
 	if err != nil {
@@ -93,6 +100,7 @@ func resourceAwsBatchJobQueueCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).batchconn
+	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
 	jq, err := getJobQueue(conn, d.Id())
 	if err != nil {
@@ -124,36 +132,51 @@ func resourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("priority", jq.Priority)
 	d.Set("state", jq.State)
 
+	if err := d.Set("tags", keyvaluetags.BatchKeyValueTags(jq.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 
 func resourceAwsBatchJobQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).batchconn
 
-	name := d.Get("name").(string)
-	updateInput := &batch.UpdateJobQueueInput{
-		ComputeEnvironmentOrder: createComputeEnvironmentOrder(d.Get("compute_environments").([]interface{})),
-		JobQueue:                aws.String(name),
-		Priority:                aws.Int64(int64(d.Get("priority").(int))),
-		State:                   aws.String(d.Get("state").(string)),
-	}
-	_, err := conn.UpdateJobQueue(updateInput)
-	if err != nil {
-		return err
-	}
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{batch.JQStatusUpdating},
-		Target:     []string{batch.JQStatusValid},
-		Refresh:    batchJobQueueRefreshStatusFunc(conn, name),
-		Timeout:    10 * time.Minute,
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+	if d.HasChanges("compute_environments", "priority", "state") {
+		name := d.Get("name").(string)
+		updateInput := &batch.UpdateJobQueueInput{
+			ComputeEnvironmentOrder: createComputeEnvironmentOrder(d.Get("compute_environments").([]interface{})),
+			JobQueue:                aws.String(name),
+			Priority:                aws.Int64(int64(d.Get("priority").(int))),
+			State:                   aws.String(d.Get("state").(string)),
+		}
+		_, err := conn.UpdateJobQueue(updateInput)
+		if err != nil {
+			return err
+		}
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{batch.JQStatusUpdating},
+			Target:     []string{batch.JQStatusValid},
+			Refresh:    batchJobQueueRefreshStatusFunc(conn, name),
+			Timeout:    10 * time.Minute,
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = stateConf.WaitForState()
-	if err != nil {
-		return err
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := keyvaluetags.BatchUpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
 	}
+
 	return resourceAwsBatchJobQueueRead(d, meta)
 }
 

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -73,6 +73,7 @@ func TestAccAWSBatchJobQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
 					resource.TestCheckResourceAttr(resourceName, "state", batch.JQStateEnabled),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -194,6 +195,50 @@ func TestAccAWSBatchJobQueue_State(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSBatchJobQueue_Tags(t *testing.T) {
+	var jobQueue batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBatchJobQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchJobQueueConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBatchJobQueueConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccBatchJobQueueConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchJobQueueExists(resourceName, &jobQueue),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -384,4 +429,39 @@ resource "aws_batch_job_queue" "test" {
   state                = %[2]q
 }
 `, rName, state))
+}
+
+func testAccBatchJobQueueConfigTags1(rName, tagKey1, tagValue1 string) string {
+	return composeConfig(
+		testAccBatchJobQueueConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
+  compute_environments = [aws_batch_compute_environment.test.arn]
+  name                 = %[1]q
+  priority             = 1
+  state                = "DISABLED"
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccBatchJobQueueConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return composeConfig(
+		testAccBatchJobQueueConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_batch_job_queue" "test" {
+  compute_environments = [aws_batch_compute_environment.test.arn]
+  name                 = %[1]q
+  priority             = 1
+  state                = "DISABLED"
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/website/docs/d/batch_compute_environment.html.markdown
+++ b/website/docs/d/batch_compute_environment.html.markdown
@@ -36,3 +36,4 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The current status of the compute environment (for example, `CREATING` or `VALID`).
 * `status_reason` - A short, human-readable string to provide additional details about the current status of the compute environment.
 * `state` - The state of the compute environment (for example, `ENABLED` or `DISABLED`). If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues.
+* `tags` - Key-value map of resource tags

--- a/website/docs/d/batch_job_queue.html.markdown
+++ b/website/docs/d/batch_job_queue.html.markdown
@@ -34,6 +34,7 @@ In addition to all arguments above, the following attributes are exported:
 * `status_reason` - A short, human-readable string to provide additional details about the current status
     of the job queue.
 * `state` - Describes the ability of the queue to accept new jobs (for example, `ENABLED` or `DISABLED`).
+* `tags` - Key-value map of resource tags
 * `priority` - The priority of the job queue. Job queues with a higher priority are evaluated first when
     associated with the same compute environment.
 * `compute_environment_order` - The compute environments that are attached to the job queue and the order in

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -129,6 +129,7 @@ resource "aws_batch_compute_environment" "sample" {
 * `compute_resources` - (Optional) Details of the compute resources managed by the compute environment. This parameter is required for managed compute environments. See details below.
 * `service_role` - (Required) The full Amazon Resource Name (ARN) of the IAM role that allows AWS Batch to make calls to other AWS services on your behalf.
 * `state` - (Optional) The state of the compute environment. If the state is `ENABLED`, then the compute environment accepts jobs from a queue and can scale out automatically based on queues. Valid items are `ENABLED` or `DISABLED`. Defaults to `ENABLED`.
+* `tags` - (Optional) Key-value map of resource tags
 * `type` - (Required) The type of the compute environment. Valid items are `MANAGED` or `UNMANAGED`.
 
 **compute_resources** is a child block with a single argument:

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 * `parameters` - (Optional) Specifies the parameter substitution placeholders to set in the job definition.
 * `retry_strategy` - (Optional) Specifies the retry strategy to use for failed jobs that are submitted with this job definition.
     Maximum number of `retry_strategy` is `1`.  Defined below.
+* `tags` - (Optional) Key-value map of resource tags
 * `timeout` - (Optional) Specifies the timeout for jobs so that if a job runs longer, AWS Batch terminates the job. Maximum number of `timeout` is `1`. Defined below.
 * `type` - (Required) The type of job definition.  Must be `container`
 

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `priority` - (Required) The priority of the job queue. Job queues with a higher priority
     are evaluated first when associated with the same compute environment.
 * `state` - (Required) The state of the job queue. Must be one of: `ENABLED` or `DISABLED`
+* `tags` - (Optional) Key-value map of resource tags
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15469
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12997
Reference: https://aws.amazon.com/about-aws/whats-new/2020/10/aws-batch-now-supports-custom-logging-configurations-swap-space-and-shared-memory/

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS

* data-source/aws_batch_compute_environment: Add `tags` attribute
* data-source/aws_batch_job_queue: Add `tags` attribute
* resource/aws_batch_compute_environment: Add `tags` argument
* resource/aws_batch_job_definition: Add `tags` argument
* resource/aws_batch_job_queue: Add `tags` argument

BUG FIXES

* resource/aws_batch_job_definition: Prevent unexpected plan difference for `container_properties` argument value with new secrets support
```

With the recent Batch service updates, the new secrets support in container properties would show as a confusing plan difference:

```
              ~ container_properties = jsonencode(
                  ~ {
                        command              = [
                            "echo",
                            "test",
                        ]
                      - environment          = [] -> null
                        image                = "busybox"
                        memory               = 128
                      - mountPoints          = [] -> null
                      - resourceRequirements = [] -> null
                      - secrets              = [] -> null
                      - ulimits              = [] -> null
                        vcpus                = 1
                      - volumes              = [] -> null
                    }
                )
```

This augments the Batch equivalency to ensure the canonicalized API response of an empty secrets array matches no secrets configuration.

While verifying the updates, this fixes the following two AWS GovCloud (US) test failures due to hardcoded partition handling:

```
=== CONT  TestAccDataSourceAwsBatchJobQueue_basic
    data_source_aws_batch_job_queue_test.go:16: Step 1/1 error: terraform failed: exit status 1

        stderr:

        Error: Provider produced inconsistent result after apply

        When applying changes to aws_iam_role_policy_attachment.ecs_instance_role,
        provider "registry.terraform.io/-/aws" produced an unexpected new value for
        was present, but now absent.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

        Error: Provider produced inconsistent result after apply

        When applying changes to
        aws_iam_role_policy_attachment.aws_batch_service_role, provider
        "registry.terraform.io/-/aws" produced an unexpected new value for was
        present, but now absent.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

=== CONT  TestAccDataSourceAwsBatchComputeEnvironment_basic
    data_source_aws_batch_compute_environment_test.go:16: Step 1/1 error: terraform failed: exit status 1

        stderr:

        Error: Provider produced inconsistent result after apply

        When applying changes to aws_iam_role_policy_attachment.ecs_instance_role,
        provider "registry.terraform.io/-/aws" produced an unexpected new value for
        was present, but now absent.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

        Error: Provider produced inconsistent result after apply

        When applying changes to
        aws_iam_role_policy_attachment.aws_batch_service_role, provider
        "registry.terraform.io/-/aws" produced an unexpected new value for was
        present, but now absent.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_DesiredVcpus_Computed (224.88s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus (105.82s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus (213.34s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (51.12s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (32.16s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (46.93s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (54.38s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy (54.66s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (22.83s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (46.86s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (54.73s)
--- PASS: TestAccAWSBatchComputeEnvironment_createWithNamePrefix (54.19s)
--- PASS: TestAccAWSBatchComputeEnvironment_disappears (49.79s)
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (62.07s)
--- PASS: TestAccAWSBatchComputeEnvironment_Tags (107.51s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (97.15s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (96.17s)
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate (110.14s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (92.78s)

--- PASS: TestAccAWSBatchJobDefinition_basic (31.33s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (30.82s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (51.78s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (36.03s)

--- PASS: TestAccAWSBatchJobQueue_basic (142.93s)
--- PASS: TestAccAWSBatchJobQueue_ComputeEnvironments_ExternalOrderUpdate (146.15s)
--- PASS: TestAccAWSBatchJobQueue_disappears (159.82s)
--- PASS: TestAccAWSBatchJobQueue_Priority (182.59s)
--- PASS: TestAccAWSBatchJobQueue_State (146.39s)
--- PASS: TestAccAWSBatchJobQueue_Tags (210.84s)

--- PASS: TestAccDataSourceAwsBatchComputeEnvironment_basic (58.52s)

--- PASS: TestAccDataSourceAwsBatchJobQueue_basic (145.37s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_DesiredVcpus_Computed (246.11s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MaxVcpus (143.57s)
--- PASS: TestAccAWSBatchComputeEnvironment_ComputeResources_MinVcpus (271.07s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (52.91s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (24.92s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (58.91s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (62.24s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithAllocationStrategy (57.05s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (22.58s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (51.34s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (64.74s)
--- PASS: TestAccAWSBatchComputeEnvironment_createWithNamePrefix (51.71s)
--- PASS: TestAccAWSBatchComputeEnvironment_disappears (60.41s)
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (77.36s)
--- PASS: TestAccAWSBatchComputeEnvironment_Tags (121.87s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (108.52s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (125.32s)
--- PASS: TestAccAWSBatchComputeEnvironment_UpdateLaunchTemplate (110.03s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (91.09s)

--- PASS: TestAccAWSBatchJobDefinition_basic (24.22s)
--- PASS: TestAccAWSBatchJobDefinition_ContainerProperties_Advanced (24.59s)
--- PASS: TestAccAWSBatchJobDefinition_Tags (67.28s)
--- PASS: TestAccAWSBatchJobDefinition_updateForcesNewResource (36.09s)

--- PASS: TestAccAWSBatchJobQueue_basic (150.57s)
--- PASS: TestAccAWSBatchJobQueue_ComputeEnvironments_ExternalOrderUpdate (160.87s)
--- PASS: TestAccAWSBatchJobQueue_disappears (139.57s)
--- PASS: TestAccAWSBatchJobQueue_Priority (155.30s)
--- PASS: TestAccAWSBatchJobQueue_State (182.97s)
--- PASS: TestAccAWSBatchJobQueue_Tags (159.11s)

--- PASS: TestAccDataSourceAwsBatchComputeEnvironment_basic (54.23s)

--- PASS: TestAccDataSourceAwsBatchJobQueue_basic (139.32s)
```
