### PR TITLE
Add and use 'internal/tfresource' package

### DIFF
--- a/aws/internal/keyvaluetags/create_tags_gen.go
+++ b/aws/internal/keyvaluetags/create_tags_gen.go
@@ -10,16 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const EventualConsistencyTimeout = 5 * time.Minute
-
-// Copied from aws/utils.go
-// TODO: Export in shared package or add to Terraform Plugin SDK
-func isResourceTimeoutError(err error) bool {
-	timeoutErr, ok := err.(*resource.TimeoutError)
-	return ok && timeoutErr.LastError == nil
-}
 
 // Ec2CreateTags creates ec2 service tags for new resources.
 // The identifier is typically the Amazon Resource Name (ARN), although
@@ -45,7 +39,7 @@ func Ec2CreateTags(conn *ec2.EC2, identifier string, tagsMap interface{}) error 
 		return nil
 	})
 
-	if isResourceTimeoutError(err) {
+	if tfresource.TimedOut(err) {
 		_, err = conn.CreateTags(input)
 	}
 

--- a/aws/internal/keyvaluetags/generators/createtags/main.go
+++ b/aws/internal/keyvaluetags/generators/createtags/main.go
@@ -97,16 +97,10 @@ import (
 {{- end }}
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const EventualConsistencyTimeout = 5 * time.Minute
-
-// Copied from aws/utils.go
-// TODO: Export in shared package or add to Terraform Plugin SDK
-func isResourceTimeoutError(err error) bool {
-	timeoutErr, ok := err.(*resource.TimeoutError)
-	return ok && timeoutErr.LastError == nil
-}
 
 {{- range .ServiceNames }}
 
@@ -161,7 +155,7 @@ func {{ . | Title }}CreateTags(conn {{ . | ClientType }}, identifier string{{ if
 		return nil
 	})
 
-	if isResourceTimeoutError(err) {
+	if tfresource.TimedOut(err) {
 		_, err = conn.{{ . | TagFunction }}(input)
 	}
 	{{- else }}

--- a/aws/internal/tfresource/errors.go
+++ b/aws/internal/tfresource/errors.go
@@ -1,0 +1,21 @@
+package tfresource
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// NotFound returns true if the error represents a "resource not found" condition.
+// Specifically, NotFound returns true if the error is of type resource.NotFoundError.
+func NotFound(err error) bool {
+	_, ok := err.(*resource.NotFoundError)
+	return ok
+}
+
+// TimedOut returns true if the error represents a "wait timed out" condition.
+// Specifically, TimedOut returns true if the error matches all these conditions:
+//  * err is of type resource.TimeoutError
+//  * TimeoutError.LastError is nil
+func TimedOut(err error) bool {
+	timeoutErr, ok := err.(*resource.TimeoutError)
+	return ok && timeoutErr.LastError == nil
+}

--- a/aws/internal/tfresource/errors_test.go
+++ b/aws/internal/tfresource/errors_test.go
@@ -1,0 +1,97 @@
+package tfresource
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestNotFound(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name:     "not found error",
+			Err:      &resource.NotFoundError{LastError: errors.New("test")},
+			Expected: true,
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name: "wrapped not found error",
+			Err:  fmt.Errorf("test: %w", &resource.NotFoundError{LastError: errors.New("test")}),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := NotFound(testCase.Err)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestTimedOut(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name:     "timeout error",
+			Err:      &resource.TimeoutError{},
+			Expected: true,
+		},
+		{
+			Name: "timeout error non-nil last error",
+			Err:  &resource.TimeoutError{LastError: errors.New("test")},
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name: "wrapped timeout error",
+			Err:  fmt.Errorf("test: %w", &resource.TimeoutError{}),
+		},
+		{
+			Name: "wrapped timeout error non-nil last error",
+			Err:  fmt.Errorf("test: %w", &resource.TimeoutError{LastError: errors.New("test")}),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := TimedOut(testCase.Err)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/terraform-providers/terraform-provider-aws/pull/13036.

The changes in this PR have been separated from #13036 to simplify.

I've ended up naming the functions that act on `terraform-plugin-sdk/v2/helper/resource` errors based on the conditions that a `true` return value represents: `NotFound` and `TimedOut`.

Example usage:

```go
	log.Printf("[DEBUG] Waiting for EC2 Transit Gateway (%s) deletion", transitGatewayID)
	_, err := stateConf.WaitForState()

	if tfresource.NotFound(err) {
		return nil
	}
```

```go
	err := resource.Retry(EventualConsistencyTimeout, func() *resource.RetryError {
		_, err := conn.CreateTags(input)

		if tfawserr.ErrCodeContains(err, ".NotFound") {
			return resource.RetryableError(err)
		}

		if err != nil {
			return resource.NonRetryableError(err)
		}

		return nil
	})

	if tfresource.TimedOut(err) {
		_, err = conn.CreateTags(input)
	}
```

Once this is merged I will add a technical debt issue to replace the `isResource*` calls with calls in `utils.go` to these functions.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
n/a
```
