### PR TITLE
provider: Fix and prevent additional occurrences of extraneous conditionals after (helper/schema.ResourceData).GetOk() receiver method

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -9,5 +9,7 @@ rules:
       - pattern-either:
         - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(bool) { $BODY }
         - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(int) != 0 { $BODY }
+        - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(int) > 0 { $BODY }
         - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && $VALUE.(string) != "" { $BODY }
+        - pattern: if $VALUE, $OK := d.GetOk($KEY); $OK && len($VALUE.(string)) > 0 { $BODY }
     severity: WARNING

--- a/aws/data_source_aws_ecr_authorization_token.go
+++ b/aws/data_source_aws_ecr_authorization_token.go
@@ -50,7 +50,7 @@ func dataSourceAwsEcrAuthorizationToken() *schema.Resource {
 func dataSourceAwsEcrAuthorizationTokenRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecrconn
 	params := &ecr.GetAuthorizationTokenInput{}
-	if v, ok := d.GetOk("registry_id"); ok && len(v.(string)) > 0 {
+	if v, ok := d.GetOk("registry_id"); ok {
 		params.RegistryIds = []*string{aws.String(v.(string))}
 	}
 	log.Printf("[DEBUG] Getting ECR authorization token")

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -467,9 +467,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			opts.AvailabilityZones = expandStringList(attr.List())
 		}
 
-		// Need to check value > 0 due to:
-		// InvalidParameterValue: Backtrack is not enabled for the aurora-postgresql engine.
-		if v, ok := d.GetOk("backtrack_window"); ok && v.(int) > 0 {
+		if v, ok := d.GetOk("backtrack_window"); ok {
 			opts.BacktrackWindow = aws.Int64(int64(v.(int)))
 		}
 
@@ -569,9 +567,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			Tags:                tags,
 		}
 
-		// Need to check value > 0 due to:
-		// InvalidParameterValue: Backtrack is not enabled for the aurora-postgresql engine.
-		if v, ok := d.GetOk("backtrack_window"); ok && v.(int) > 0 {
+		if v, ok := d.GetOk("backtrack_window"); ok {
 			createOpts.BacktrackWindow = aws.Int64(int64(v.(int)))
 		}
 
@@ -690,9 +686,8 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		if v, ok := d.GetOk("enable_http_endpoint"); ok {
 			createOpts.EnableHttpEndpoint = aws.Bool(v.(bool))
 		}
-		// Need to check value > 0 due to:
-		// InvalidParameterValue: Backtrack is not enabled for the aurora-postgresql engine.
-		if v, ok := d.GetOk("backtrack_window"); ok && v.(int) > 0 {
+
+		if v, ok := d.GetOk("backtrack_window"); ok {
 			createOpts.BacktrackWindow = aws.Int64(int64(v.(int)))
 		}
 

--- a/aws/resource_aws_wafv2_ip_set.go
+++ b/aws/resource_aws_wafv2_ip_set.go
@@ -206,7 +206,7 @@ func resourceAwsWafv2IPSetUpdate(d *schema.ResourceData, meta interface{}) error
 		params.Addresses = expandStringSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("description"); ok && len(v.(string)) > 0 {
+	if v, ok := d.GetOk("description"); ok {
 		params.Description = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_wafv2_web_acl.go
+++ b/aws/resource_aws_wafv2_web_acl.go
@@ -256,7 +256,7 @@ func resourceAwsWafv2WebACLUpdate(d *schema.ResourceData, meta interface{}) erro
 			VisibilityConfig: expandWafv2VisibilityConfig(d.Get("visibility_config").([]interface{})),
 		}
 
-		if v, ok := d.GetOk("description"); ok && len(v.(string)) > 0 {
+		if v, ok := d.GetOk("description"); ok {
 			u.Description = aws.String(v.(string))
 		}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously (after adding new semgrep patterns):

```
aws/data_source_aws_ecr_authorization_token.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
53: if v, ok := d.GetOk("registry_id"); ok && len(v.(string)) > 0 {
54:   params.RegistryIds = []*string{aws.String(v.(string))}
55: }

aws/resource_aws_rds_cluster.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
472:    if v, ok := d.GetOk("backtrack_window"); ok && v.(int) > 0 {
473:      opts.BacktrackWindow = aws.Int64(int64(v.(int)))
474:    }
574:    if v, ok := d.GetOk("backtrack_window"); ok && v.(int) > 0 {
575:      createOpts.BacktrackWindow = aws.Int64(int64(v.(int)))
576:    }
695:    if v, ok := d.GetOk("backtrack_window"); ok && v.(int) > 0 {
696:      createOpts.BacktrackWindow = aws.Int64(int64(v.(int)))
697:    }

aws/resource_aws_wafv2_ip_set.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
209:  if v, ok := d.GetOk("description"); ok && len(v.(string)) > 0 {
210:    params.Description = aws.String(v.(string))
211:  }

aws/resource_aws_wafv2_web_acl.go
severity:warning rule:helper-schema-ResourceData-GetOk-with-extraneous-conditional: Zero value conditional check after `d.GetOk()` is extraneous
259:    if v, ok := d.GetOk("description"); ok && len(v.(string)) > 0 {
260:      u.Description = aws.String(v.(string))
261:    }
```

Output from accepance testing (failures present on main branch):

```
--- PASS: TestAccAWSEcrAuthorizationTokenDataSource_basic (25.71s)

--- FAIL: TestAccAWSRDSCluster_EngineMode_Global (139.05s)
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global (191.98s)
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Add (124.92s)
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Remove (132.04s)
--- FAIL: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Global_Update (142.51s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1513.68s)
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (330.61s)
--- PASS: TestAccAWSRDSCluster_AllowMajorVersionUpgrade (1375.71s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (123.91s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (168.95s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (230.35s)
--- PASS: TestAccAWSRDSCluster_basic (138.22s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (132.84s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (264.78s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (163.49s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (184.46s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_MySQL (249.61s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports_Postgresql (185.67s)
--- PASS: TestAccAWSRDSCluster_EnableHttpEndpoint (394.53s)
--- PASS: TestAccAWSRDSCluster_encrypted (122.17s)
--- PASS: TestAccAWSRDSCluster_EngineMode (459.48s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Multimaster (145.41s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (182.01s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (491.23s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1177.11s)
--- PASS: TestAccAWSRDSCluster_generatedName (185.87s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_EngineMode_Provisioned (129.06s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters (1687.15s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier (1853.66s)
--- PASS: TestAccAWSRDSCluster_iamAuth (203.57s)
--- PASS: TestAccAWSRDSCluster_kmsKey (238.84s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (9.76s)
--- PASS: TestAccAWSRDSCluster_Port (252.60s)
--- PASS: TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId (1675.19s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (406.51s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration_DefaultMinCapacity (352.61s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (376.83s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (439.21s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (366.53s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (415.75s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (385.94s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (386.58s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (374.41s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterPassword (376.11s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_MasterUsername (374.14s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (419.09s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (407.64s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (391.96s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (391.62s)
--- PASS: TestAccAWSRDSCluster_Tags (206.10s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (228.82s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (229.52s)
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)

--- PASS: TestAccAwsWafv2IPSet_basic (75.67s)
--- PASS: TestAccAwsWafv2IPSet_ChangeNameForceNew (68.69s)
--- PASS: TestAccAwsWafv2IPSet_Disappears (28.32s)
--- PASS: TestAccAwsWafv2IPSet_IPv6 (44.02s)
--- PASS: TestAccAwsWafv2IPSet_Large (40.23s)
--- PASS: TestAccAwsWafv2IPSet_Minimal (44.85s)
--- PASS: TestAccAwsWafv2IPSet_Tags (100.64s)

--- PASS: TestAccAwsWafv2WebACL_basic (763.70s)
--- PASS: TestAccAwsWafv2WebACL_ChangeNameForceNew (1308.83s)
--- PASS: TestAccAwsWafv2WebACL_Disappears (612.55s)
--- PASS: TestAccAwsWafv2WebACL_GeoMatchStatement (1685.53s)
--- PASS: TestAccAwsWafv2WebACL_GeoMatchStatement_ForwardedIPConfig (1714.34s)
--- PASS: TestAccAwsWafv2WebACL_IPSetReferenceStatement (1013.28s)
--- PASS: TestAccAwsWafv2WebACL_IPSetReferenceStatement_IPSetForwardedIPConfig (2244.84s)
--- PASS: TestAccAwsWafv2WebACL_ManagedRuleGroupStatement (1688.71s)
--- PASS: TestAccAwsWafv2WebACL_MaxNestedOperatorStatements (1042.74s)
--- PASS: TestAccAwsWafv2WebACL_MaxNestedRateBasedStatements (1030.27s)
--- PASS: TestAccAwsWafv2WebACL_Minimal (728.21s)
--- PASS: TestAccAwsWafv2WebACL_RateBasedStatement (1706.51s)
--- PASS: TestAccAwsWafv2WebACL_RateBasedStatement_ForwardedIPConfig (1698.23s)
--- PASS: TestAccAwsWafv2WebACL_RuleGroupReferenceStatement (1757.89s)
--- PASS: TestAccAwsWafv2WebACL_Tags (1736.54s)
--- PASS: TestAccAwsWafv2WebACL_updateRule (1786.31s)
--- PASS: TestAccAwsWafv2WebACL_UpdateRuleProperties (2177.52s)
```
