### PR TITLE
tests/provider: Add precheck (CodeStar Notifications)

### DIFF
--- a/aws/resource_aws_codestarnotifications_notification_rule_test.go
+++ b/aws/resource_aws_codestarnotifications_notification_rule_test.go
@@ -17,7 +17,7 @@ func TestAccAWSCodeStarNotificationsNotificationRule_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("codestar", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodeStarNotificationsNotificationRuleDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccAWSCodeStarNotificationsNotificationRule_Status(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("codestar", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodeStarNotificationsNotificationRuleDestroy,
 		Steps: []resource.TestStep{
@@ -83,7 +83,7 @@ func TestAccAWSCodeStarNotificationsNotificationRule_Targets(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("codestar", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodeStarNotificationsNotificationRuleDestroy,
 		Steps: []resource.TestStep{
@@ -119,7 +119,7 @@ func TestAccAWSCodeStarNotificationsNotificationRule_Tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("codestar", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodeStarNotificationsNotificationRuleDestroy,
 		Steps: []resource.TestStep{
@@ -161,7 +161,7 @@ func TestAccAWSCodeStarNotificationsNotificationRule_EventTypeIds(t *testing.T) 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("codestar", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodeStarNotificationsNotificationRuleDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14188

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing in GovCloud:

```
    provider_test.go:511: skipping tests; partition aws-us-gov does not support codestar service
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_Status (1.61s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_EventTypeIds (1.61s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_Tags (1.61s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_basic (1.62s)
--- SKIP: TestAccAWSCodeStarNotificationsNotificationRule_Targets (1.63s)
```

The output from acceptance testing in commercial:

```
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_basic (18.75s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_EventTypeIds (42.52s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Status (43.65s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Tags (46.72s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Targets (51.71s)
```
