### PR TITLE
Change "upload to ECS" to "upload to ECR"

### DIFF
--- a/examples/sagemaker/README.md
+++ b/examples/sagemaker/README.md
@@ -4,7 +4,7 @@ This example takes the [example model provided by AWS](https://github.com/awslab
 to show how to deploy your own machine learning algorithm into a SageMaker container using Terraform.
 
 
-### Wrap model in Docker container and upload to [ECS](https://aws.amazon.com/ecs/)
+### Wrap model in Docker container and upload to [ECR](https://aws.amazon.com/ecr/)
 
 Get the SageMaker example model from AWS:
 


### PR DESCRIPTION
The `build_and_push.sh` script uploads the container to ECR, not ECS. 

- Change "ECS" to "ECR"
- Change link to point to ECR homepage

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

