### PR TITLE
tests/provider: Add prechecks (budgets)

### DIFF
--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -84,7 +84,7 @@ func TestAccAWSBudgetsBudget_basic(t *testing.T) {
 	configBasicUpdate := testAccAWSBudgetsBudgetConfigUpdate(name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBudgets(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("budgets", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAWSBudgetsBudgetDestroy,
 		Steps: []resource.TestStep{
@@ -136,7 +136,7 @@ func TestAccAWSBudgetsBudget_prefix(t *testing.T) {
 	configBasicUpdate := testAccAWSBudgetsBudgetConfigUpdate(name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBudgets(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("budgets", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAWSBudgetsBudgetDestroy,
 		Steps: []resource.TestStep{
@@ -198,7 +198,7 @@ func TestAccAWSBudgetsBudget_notification(t *testing.T) {
 	oneTopic := []string{"${aws_sns_topic.budget_notifications.arn}"}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBudgets(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("budgets", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAWSBudgetsBudgetDestroy,
 		Steps: []resource.TestStep{
@@ -394,24 +394,6 @@ func testAccAWSBudgetsBudgetDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccPreCheckAWSBudgets(t *testing.T) {
-	conn := testAccProvider.Meta().(*AWSClient).budgetconn
-
-	input := &budgets.DescribeBudgetsInput{
-		AccountId: aws.String(testAccProvider.Meta().(*AWSClient).accountid),
-	}
-
-	_, err := conn.DescribeBudgets(input)
-
-	if testAccPreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
 }
 
 func testAccAWSBudgetsBudgetConfigUpdate(name string) budgets.Budget {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14188

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
    provider_test.go:511: skipping tests; partition aws-us-gov does not support budgets service
--- SKIP: TestAccAWSBudgetsBudget_prefix (1.46s)
--- SKIP: TestAccAWSBudgetsBudget_notification (1.47s)
--- SKIP: TestAccAWSBudgetsBudget_basic (1.48s)
```

The output from acceptance testing (commercial):

```
--- FAIL: TestAccAWSBudgetsBudget_basic (13.61s)
--- PASS: TestAccAWSBudgetsBudget_prefix (20.89s)
--- PASS: TestAccAWSBudgetsBudget_notification (75.11s)
```

(Failure is preexisting and is tracked in #15507)