### PR TITLE
tests/provider: Add precheck (Cloud9)

### DIFF
--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -21,7 +21,7 @@ func TestAccAWSCloud9EnvironmentEc2_basic(t *testing.T) {
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloud9", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
@@ -68,7 +68,7 @@ func TestAccAWSCloud9EnvironmentEc2_allFields(t *testing.T) {
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloud9", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
@@ -111,7 +111,7 @@ func TestAccAWSCloud9EnvironmentEc2_tags(t *testing.T) {
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloud9", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
@@ -157,7 +157,7 @@ func TestAccAWSCloud9EnvironmentEc2_disappears(t *testing.T) {
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloud9", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
@@ -271,22 +271,6 @@ func testAccCheckAWSCloud9EnvironmentEc2Destroy(s *terraform.State) error {
 		return fmt.Errorf("Cloud9 Environment EC2 %q still exists.", rs.Primary.ID)
 	}
 	return nil
-}
-
-func testAccPreCheckAWSCloud9(t *testing.T) {
-	conn := testAccProvider.Meta().(*AWSClient).cloud9conn
-
-	input := &cloud9.ListEnvironmentsInput{}
-
-	_, err := conn.ListEnvironments(input)
-
-	if testAccPreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
 }
 
 func testAccAWSCloud9EnvironmentEc2ConfigBase() string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #14188 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
    provider_test.go:511: skipping tests; partition aws-us-gov does not support cloud9 service
--- SKIP: TestAccAWSCloud9EnvironmentEc2_basic (1.57s)
--- SKIP: TestAccAWSCloud9EnvironmentEc2_allFields (1.57s)
--- SKIP: TestAccAWSCloud9EnvironmentEc2_tags (1.58s)
--- SKIP: TestAccAWSCloud9EnvironmentEc2_disappears (1.58s)
```
