### PR TITLE
resource/aws_codestarnotifications_notification_rule: Check for resource.TimeoutError on target deletion

### DIFF
--- a/aws/resource_aws_codestarnotifications_notification_rule.go
+++ b/aws/resource_aws_codestarnotifications_notification_rule.go
@@ -12,6 +12,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
+)
+
+const (
+	// Maximum amount of time to wait for target subscriptions to propagate
+	codestarNotificationsTargetSubscriptionTimeout = 30 * time.Second
 )
 
 func resourceAwsCodeStarNotificationsNotificationRule() *schema.Resource {
@@ -197,41 +203,47 @@ func cleanupCodeStarNotificationsNotificationRuleTargets(conn *codestarnotificat
 		removedTargets = oldVal.Difference(newVal)
 	}
 
-	targets := removedTargets.List()
+	for _, targetRaw := range removedTargets.List() {
+		target, ok := targetRaw.(map[string]interface{})
 
-	err := resource.Retry(time.Duration(5)*time.Second, func() *resource.RetryError {
-		var (
-			reterr error
-			i      int
-		)
+		if !ok {
+			continue
+		}
 
-		for _, t := range targets {
-			target := t.(map[string]interface{})
-			_, err := conn.DeleteTarget(&codestarnotifications.DeleteTargetInput{
-				ForceUnsubscribeAll: aws.Bool(false),
-				TargetAddress:       aws.String(target["address"].(string)),
-			})
+		input := &codestarnotifications.DeleteTargetInput{
+			ForceUnsubscribeAll: aws.Bool(false),
+			TargetAddress:       aws.String(target["address"].(string)),
+		}
+
+		err := resource.Retry(codestarNotificationsTargetSubscriptionTimeout, func() *resource.RetryError {
+			_, err := conn.DeleteTarget(input)
+
 			if isAWSErr(err, codestarnotifications.ErrCodeValidationException, awsCodeStartNotificationsNotificationRuleErrorSubscribed) {
-				reterr = err
-				targets[i] = target
-				i++
-			} else if err != nil {
+				return resource.RetryableError(err)
+			}
+
+			if err != nil {
 				return resource.NonRetryableError(err)
 			}
-		}
-		targets = targets[:i]
 
-		if reterr != nil {
-			return resource.RetryableError(reterr)
-		}
-		return nil
-	})
+			return nil
+		})
 
-	if isAWSErr(err, codestarnotifications.ErrCodeValidationException, awsCodeStartNotificationsNotificationRuleErrorSubscribed) {
-		err = nil
+		if tfresource.TimedOut(err) {
+			_, err = conn.DeleteTarget(input)
+		}
+
+		// Treat target deletion as best effort
+		if isAWSErr(err, codestarnotifications.ErrCodeValidationException, awsCodeStartNotificationsNotificationRuleErrorSubscribed) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
 	}
 
-	return err
+	return nil
 }
 
 func resourceAwsCodeStarNotificationsNotificationRuleUpdate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12985

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_codestarnotifications_notification_rule: Prevent unexpected timeout error during target deletion due to API throttling
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_basic (21.33s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Status (48.06s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Tags (50.12s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_Targets (52.66s)
--- PASS: TestAccAWSCodeStarNotificationsNotificationRule_EventTypeIds (55.30s)
```
