### PR TITLE
resource/aws_gamelift_fleet: Check resource.TimeoutError on creation

### DIFF
--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -8,10 +8,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
+	iamwaiter "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/iam/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 func resourceAwsGameliftFleet() *schema.Resource {
@@ -232,19 +235,27 @@ func resourceAwsGameliftFleetCreate(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[INFO] Creating Gamelift Fleet: %s", input)
 	var out *gamelift.CreateFleetOutput
-	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(iamwaiter.PropagationTimeout, func() *resource.RetryError {
 		var err error
 		out, err = conn.CreateFleet(&input)
-		if isAWSErr(err, gamelift.ErrCodeInvalidRequestException, "GameLift is not authorized to perform") {
+
+		if tfawserr.ErrMessageContains(err, gamelift.ErrCodeInvalidRequestException, "GameLift is not authorized to perform") {
 			return resource.RetryableError(err)
 		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
+
 		return nil
 	})
+
+	if tfresource.TimedOut(err) {
+		out, err = conn.CreateFleet(&input)
+	}
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating GameLift Fleet (%s): %w", d.Get("name").(string), err)
 	}
 
 	d.SetId(*out.FleetAttributes.FleetId)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12985

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_gamelift_fleet: Prevent unexpected timeout error on creation due to API throttling
```

Output from acceptance testing:

```
--- PASS: TestAccAWSGameliftFleet_tags (1703.23s)
--- PASS: TestAccAWSGameliftFleet_basic (1707.75s)
--- PASS: TestAccAWSGameliftFleet_disappears (1725.93s)
--- PASS: TestAccAWSGameliftFleet_allFields (1763.86s)
```
