### PR TITLE
service/lex: Check resource.TimeoutError on creation

### DIFF
--- a/aws/resource_aws_lex_bot.go
+++ b/aws/resource_aws_lex_bot.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -233,6 +234,11 @@ func resourceAwsLexBotCreate(d *schema.ResourceData, meta interface{}) error {
 
 		return nil
 	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.PutBot(input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating bot %s: %w", name, err)
 	}

--- a/aws/resource_aws_lex_bot_alias.go
+++ b/aws/resource_aws_lex_bot_alias.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -152,6 +153,11 @@ func resourceAwsLexBotAliasCreate(d *schema.ResourceData, meta interface{}) erro
 
 		return nil
 	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.PutBotAlias(input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating bot alias '%s': %w", id, err)
 	}

--- a/aws/resource_aws_lex_intent.go
+++ b/aws/resource_aws_lex_intent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -308,6 +309,11 @@ func resourceAwsLexIntentCreate(d *schema.ResourceData, meta interface{}) error 
 
 		return nil
 	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.PutIntent(input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating intent %s: %w", name, err)
 	}

--- a/aws/resource_aws_lex_slot_type.go
+++ b/aws/resource_aws_lex_slot_type.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/lex/waiter"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfresource"
 )
 
 const (
@@ -136,6 +137,11 @@ func resourceAwsLexSlotTypeCreate(d *schema.ResourceData, meta interface{}) erro
 
 		return nil
 	})
+
+	if tfresource.TimedOut(err) {
+		_, err = conn.PutSlotType(input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating slot type %s: %w", name, err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/12985

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_lex_bot: Prevent unexpected timeout error on creation due to API throttling
* resource/aws_lex_bot_alias: Prevent unexpected timeout error on creation due to API throttling
* resource/aws_lex_intent: Prevent unexpected timeout error on creation due to API throttling
* resource/aws_lex_slot_type: Prevent unexpected timeout error on creation due to API throttling
```

Output from acceptance testing:

```
--- PASS: TestAccAwsLexBot_abortStatement (73.59s)
--- PASS: TestAccAwsLexBot_basic (26.10s)
--- PASS: TestAccAwsLexBot_childDirected (62.70s)
--- PASS: TestAccAwsLexBot_clarificationPrompt (55.30s)
--- PASS: TestAccAwsLexBot_description (49.36s)
--- PASS: TestAccAwsLexBot_detectSentiment (51.53s)
--- PASS: TestAccAwsLexBot_disappears (39.50s)
--- PASS: TestAccAwsLexBot_enableModelImprovements (73.27s)
--- PASS: TestAccAwsLexBot_idleSessionTtlInSeconds (65.77s)
--- PASS: TestAccAwsLexBot_intents (51.47s)
--- PASS: TestAccAwsLexBot_locale (80.60s)
--- PASS: TestAccAwsLexBot_voiceId (63.26s)
--- PASS: TestAccAwsLexBot_version_serial (184.03s)
    --- PASS: TestAccAwsLexBot_version_serial/LexBot_createVersion (52.44s)
    --- PASS: TestAccAwsLexBot_version_serial/LexBotAlias_botVersion (56.87s)
    --- PASS: TestAccAwsLexBot_version_serial/DataSourceLexBot_withVersion (36.14s)
    --- PASS: TestAccAwsLexBot_version_serial/DataSourceLexBotAlias_basic (38.58s)

--- PASS: TestAccAwsLexBotAlias_basic (114.72s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsAudio (40.91s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsBoth (83.96s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsText (52.93s)
--- PASS: TestAccAwsLexBotAlias_description (82.35s)
--- PASS: TestAccAwsLexBotAlias_disappears (35.49s)

--- PASS: TestAccAwsLexIntent_basic (28.56s)
--- PASS: TestAccAwsLexIntent_conclusionStatement (80.95s)
--- PASS: TestAccAwsLexIntent_confirmationPromptAndRejectionStatement (52.63s)
--- PASS: TestAccAwsLexIntent_createVersion (51.63s)
--- PASS: TestAccAwsLexIntent_dialogCodeHook (42.01s)
--- PASS: TestAccAwsLexIntent_disappears (28.24s)
--- PASS: TestAccAwsLexIntent_followUpPrompt (47.09s)
--- PASS: TestAccAwsLexIntent_fulfillmentActivity (102.70s)
--- PASS: TestAccAwsLexIntent_sampleUtterances (132.59s)
--- PASS: TestAccAwsLexIntent_slots (49.30s)
--- PASS: TestAccAwsLexIntent_slotsCustom (131.17s)
--- PASS: TestAccAwsLexIntent_updateWithExternalChange (45.35s)

--- PASS: TestAccAwsLexSlotType_basic (67.78s)
--- PASS: TestAccAwsLexSlotType_createVersion (90.87s)
--- PASS: TestAccAwsLexSlotType_description (122.77s)
--- PASS: TestAccAwsLexSlotType_disappears (28.67s)
--- PASS: TestAccAwsLexSlotType_enumerationValues (50.86s)
--- PASS: TestAccAwsLexSlotType_name (60.90s)
--- PASS: TestAccAwsLexSlotType_valueSelectionStrategy (49.96s)
```
