### PR TITLE
Clarifies requirement for ignore_changes when using Auto Scaling Attachment

### DIFF
--- a/website/docs/r/autoscaling_attachment.html.markdown
+++ b/website/docs/r/autoscaling_attachment.html.markdown
@@ -8,15 +8,16 @@ description: |-
 
 # Resource: aws_autoscaling_attachment
 
-Provides an AutoScaling Attachment resource.
+Provides an Auto Scaling Attachment resource.
 
-~> **NOTE on AutoScaling Groups and ASG Attachments:** Terraform currently provides
-both a standalone ASG Attachment resource (describing an ASG attached to
-an ELB or ALB), and an [AutoScaling Group resource](autoscaling_group.html) with
-`load_balancers` and `target_group_arns` defined in-line. At this time you can use an ASG with in-line
-`load balancers` or `target_group_arns` in conjunction with an ASG Attachment resource, however, to prevent
-unintended resource updates, the `aws_autoscaling_group` resource must be configured
-to ignore changes to the `load_balancers` and `target_group_arns` arguments within a [`lifecycle` configuration block](/docs/configuration/resources.html#lifecycle-lifecycle-customizations).
+~> **NOTE on Auto Scaling Groups and ASG Attachments:** Terraform currently provides
+both a standalone [`aws_autoscaling_attachment`](autoscaling_attachment.html) resource
+(describing an ASG attached to an ELB or ALB), and an [`aws_autoscaling_group`](autoscaling_group.html)
+with `load_balancers` and `target_group_arns` defined in-line. These two methods are not
+mutually-exclusive. If `aws_autoscaling_attachment` resources are used, either alone or with inline
+`load_balancers` or `target_group_arns`, the `aws_autoscaling_group` resource must be configured
+to ignore changes to the `load_balancers` and `target_group_arns` arguments within a
+[`lifecycle` configuration block](/docs/configuration/resources.html#lifecycle-lifecycle-customizations).
 
 ## Example Usage
 

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -8,9 +8,18 @@ description: |-
 
 # Resource: aws_autoscaling_group
 
-Provides an AutoScaling Group resource.
+Provides an Auto Scaling Group resource.
 
 -> **Note:** You must specify either `launch_configuration`, `launch_template`, or `mixed_instances_policy`.
+
+~> **NOTE on Auto Scaling Groups and ASG Attachments:** Terraform currently provides
+both a standalone [`aws_autoscaling_attachment`](autoscaling_attachment.html) resource
+(describing an ASG attached to an ELB or ALB), and an [`aws_autoscaling_group`](autoscaling_group.html)
+with `load_balancers` and `target_group_arns` defined in-line. These two methods are not
+mutually-exclusive. If `aws_autoscaling_attachment` resources are used, either alone or with inline
+`load_balancers` or `target_group_arns`, the `aws_autoscaling_group` resource must be configured
+to ignore changes to the `load_balancers` and `target_group_arns` arguments within a
+[`lifecycle` configuration block](/docs/configuration/resources.html#lifecycle-lifecycle-customizations).
 
 ## Example Usage
 


### PR DESCRIPTION
Updates documentation for `aws_autoscaling_group` and `aws_autoscaling_attachment` to clarify that `ignore_changes` is always required when `aws_autoscaling_attachment` resources are used.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates  #15032

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
