### PR TITLE
service/rds: Increase default proxy deletion timeout, ensure proxy target import includes all attributes

### DIFF
--- a/aws/resource_aws_db_proxy.go
+++ b/aws/resource_aws_db_proxy.go
@@ -26,7 +26,7 @@ func resourceAwsDbProxy() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_db_proxy_target.go
+++ b/aws/resource_aws_db_proxy_target.go
@@ -154,10 +154,12 @@ func resourceAwsDbProxyTargetRead(d *schema.ResourceData, meta interface{}) erro
 		return nil
 	}
 
+	d.Set("db_proxy_name", dbProxyName)
 	d.Set("endpoint", dbProxyTarget.Endpoint)
 	d.Set("port", dbProxyTarget.Port)
 	d.Set("rds_resource_id", dbProxyTarget.RdsResourceId)
 	d.Set("target_arn", dbProxyTarget.TargetArn)
+	d.Set("target_group_name", targetGroupName)
 	d.Set("tracked_cluster_id", dbProxyTarget.TrackedClusterId)
 	d.Set("type", dbProxyTarget.Type)
 

--- a/website/docs/r/db_proxy.html.markdown
+++ b/website/docs/r/db_proxy.html.markdown
@@ -50,7 +50,6 @@ The following arguments are supported:
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role that the proxy uses to access secrets in AWS Secrets Manager.
 * `vpc_security_group_ids` - (Optional) One or more VPC security group IDs to associate with the new proxy.
 * `vpc_subnet_ids` - (Required) One or more VPC subnet IDs to associate with the new proxy.
-describe-db-parameters.html) after initial creation of the group.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 `auth` blocks support the following:
@@ -75,7 +74,7 @@ In addition to all arguments above, the following attributes are exported:
 
 - `create` - (Default `30 minutes`) Used for creating DB proxies.
 - `update` - (Default `30 minutes`) Used for modifying DB proxies.
-- `delete` - (Default `30 minutes`) Used for destroying DB proxies.
+- `delete` - (Default `60 minutes`) Used for destroying DB proxies.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_proxy: Increase default deletion timeout to 60 minutes
* resource/aws_db_proxy_target: Ensure `db_proxy_name` and `target_group_name` attributes are properly imported
```

The Terraform Plugin SDK version 2.0.4 upgrade fixed something with `ImportStateVerify` testing, which now catches these arguments were not properly being set during `Read`.

The timeout issue was occurring inconsistently across tests, but is a good signal that our initial default deletion timeout value might have been too low.

Previously:

```
=== CONT  TestAccAWSDBProxyTarget_Cluster
TestAccAWSDBProxyTarget_Cluster: resource_aws_db_proxy_target_test.go:51: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
(map[string]string) {
}
(map[string]string) (len=2) {
(string) (len=13) "db_proxy_name": (string) (len=31) "tf-acc-test-7766132173812142965",
(string) (len=17) "target_group_name": (string) (len=7) "default"
}
--- FAIL: TestAccAWSDBProxyTarget_Cluster (600.94s)

=== CONT  TestAccAWSDBProxyTarget_Instance
TestAccAWSDBProxyTarget_Instance: resource_aws_db_proxy_target_test.go:20: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
(map[string]string) {
}
(map[string]string) (len=2) {
(string) (len=13) "db_proxy_name": (string) (len=31) "tf-acc-test-4517387436607757033",
(string) (len=17) "target_group_name": (string) (len=7) "default"
}
TestAccAWSDBProxyTarget_Instance: testing_new.go:62: Error running post-test destroy, there may be dangling resources: 2020/10/07 06:29:56 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0
Error: Error waiting for DB Proxy deletion: timeout while waiting for state to become '' (last state: 'deleting', timeout: 30m0s)
--- FAIL: TestAccAWSDBProxyTarget_Instance (2044.98s)

=== CONT  TestAccAWSDBProxyTarget_disappears
TestAccAWSDBProxyTarget_disappears: testing_new.go:62: Error running post-test destroy, there may be dangling resources: 2020/10/07 06:31:38 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0
Error: Error waiting for DB Proxy deletion: timeout while waiting for state to become '' (last state: 'deleting', timeout: 30m0s)
--- FAIL: TestAccAWSDBProxyTarget_disappears (2010.78s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDBProxy_AuthDescription (636.54s)
--- PASS: TestAccAWSDBProxy_AuthIamAuth (628.26s)
--- PASS: TestAccAWSDBProxy_AuthSecretArn (784.97s)
--- PASS: TestAccAWSDBProxy_basic (665.92s)
--- PASS: TestAccAWSDBProxy_DebugLogging (790.23s)
--- PASS: TestAccAWSDBProxy_disappears (631.87s)
--- PASS: TestAccAWSDBProxy_IdleClientTimeout (860.70s)
--- PASS: TestAccAWSDBProxy_Name (718.38s)
--- PASS: TestAccAWSDBProxy_RequireTls (721.11s)
--- PASS: TestAccAWSDBProxy_RoleArn (690.45s)
--- PASS: TestAccAWSDBProxy_Tags (695.16s)
--- PASS: TestAccAWSDBProxy_VpcSecurityGroupIds (652.93s)

--- PASS: TestAccAWSDBProxyTarget_Cluster (621.13s)
--- PASS: TestAccAWSDBProxyTarget_disappears (618.64s)
--- PASS: TestAccAWSDBProxyTarget_Instance (640.24s)
```
