### PR TITLE
resource/aws_glue_workflow: Ensure max_concurrent_runs attribute is saved during import

### DIFF
--- a/aws/resource_aws_glue_workflow.go
+++ b/aws/resource_aws_glue_workflow.go
@@ -121,6 +121,7 @@ func resourceAwsGlueWorkflowRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error setting default_run_properties: %w", err)
 	}
 	d.Set("description", workflow.Description)
+	d.Set("max_concurrent_runs", workflow.MaxConcurrentRuns)
 	d.Set("name", workflow.Name)
 
 	tags, err := keyvaluetags.GlueListTags(conn, workFlowArn)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_glue_workflow: Ensure `max_concurrent_runs` attribute is properly saved during import
```

The Terraform Plugin SDK version 2.0.4 upgrade fixed something with `ImportStateVerify` testing, which now catches these arguments were not properly being set during `Read`.

Previously:

```
=== CONT  TestAccAWSGlueWorkflow_maxConcurrentRuns
TestAccAWSGlueWorkflow_maxConcurrentRuns: resource_aws_glue_workflow_test.go:82: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
(map[string]string) {
}
(map[string]string) (len=1) {
(string) (len=19) "max_concurrent_runs": (string) (len=1) "1"
}
--- FAIL: TestAccAWSGlueWorkflow_maxConcurrentRuns (53.75s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSGlueWorkflow_basic (18.54s)
--- PASS: TestAccAWSGlueWorkflow_DefaultRunProperties (18.56s)
--- PASS: TestAccAWSGlueWorkflow_Description (33.03s)
--- PASS: TestAccAWSGlueWorkflow_disappears (14.56s)
--- PASS: TestAccAWSGlueWorkflow_maxConcurrentRuns (50.47s)
--- PASS: TestAccAWSGlueWorkflow_Tags (48.23s)
```
