### PR TITLE
tests/resource/aws_elastic_transcoder_preset: Adjust ImportStateVerifyIgnore handling in TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty

### DIFF
--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -79,7 +79,7 @@ func TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"audio_codec_options.#"}, // Due to incorrect schema (should be nested under audio)
+				ImportStateVerifyIgnore: []string{"audio_codec_options"}, // Due to incorrect schema (should be nested under audio)
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The Terraform Plugin SDK v2.0.4 update includes some additional attribute information in the flatmap state. Tests needing `ImportStateVerifyIgnore` should use the attribute itself, not anything flatmap-specific in the ignore in this case. We may consider adding linting for this in the future after we investigate if there are anti-patterns where using special flatmap syntax is actually more correct.

Previously:

```
=== CONT  TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty
TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty: resource_aws_elastic_transcoder_preset_test.go:67: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
(map[string]string) {
}
(map[string]string) (len=1) {
(string) (len=23) "audio_codec_options.0.%": (string) (len=1) "4"
}
--- FAIL: TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty (23.52s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticTranscoderPreset_AudioCodecOptions_empty (15.15s)
```