### PR TITLE
tests/resource/aws_elasticsearch_domain: Add missing ImportStateVerifyIgnore to TestAccAWSElasticSearchDomain_LogPublishingOptions_AuditLogs

### DIFF
--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -690,6 +690,8 @@ func TestAccAWSElasticSearchDomain_LogPublishingOptions_AuditLogs(t *testing.T) 
 				ImportState:       true,
 				ImportStateId:     resourceId,
 				ImportStateVerify: true,
+				// MasterUserOptions are not returned from DescribeElasticsearchDomainConfig
+				ImportStateVerifyIgnore: []string{"advanced_security_options.0.master_user_options"},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Applies the fix given to other tests with the `advanced_security_options` configuration, given the `DescribeElasticsearchDomainConfig` API does not return this information so it cannot be imported.

Previously:

```
=== CONT  TestAccAWSElasticSearchDomain_LogPublishingOptions_AuditLogs
TestAccAWSElasticSearchDomain_LogPublishingOptions_AuditLogs: resource_aws_elasticsearch_domain_test.go:673: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
(map[string]string) {
}
(map[string]string) (len=5) {
(string) (len=49) "advanced_security_options.0.master_user_options.#": (string) (len=1) "1",
(string) (len=51) "advanced_security_options.0.master_user_options.0.%": (string) (len=1) "3",
(string) (len=65) "advanced_security_options.0.master_user_options.0.master_user_arn": (string) "",
(string) (len=66) "advanced_security_options.0.master_user_options.0.master_user_name": (string) (len=14) "testmasteruser",
(string) (len=70) "advanced_security_options.0.master_user_options.0.master_user_password": (string) (len=14) "Barbarbarbar1!"
}
--- FAIL: TestAccAWSElasticSearchDomain_LogPublishingOptions_AuditLogs (1821.76s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticSearchDomain_LogPublishingOptions_AuditLogs (932.09s)
```