### PR TITLE
tests/resource/aws_db_proxy_default_target_group: Check disappearance with DB Proxy removal since default Target Group cannot be removed

### DIFF
--- a/aws/resource_aws_db_proxy_default_target_group_test.go
+++ b/aws/resource_aws_db_proxy_default_target_group_test.go
@@ -216,6 +216,7 @@ func TestAccAWSDBProxyDefaultTargetGroup_SessionPinningFilters(t *testing.T) {
 
 func TestAccAWSDBProxyDefaultTargetGroup_disappears(t *testing.T) {
 	var v rds.DBProxy
+	dbProxyResourceName := "aws_db_proxy.test"
 	resourceName := "aws_db_proxy_default_target_group.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
@@ -227,7 +228,9 @@ func TestAccAWSDBProxyDefaultTargetGroup_disappears(t *testing.T) {
 				Config: testAccAWSDBProxyDefaultTargetGroupConfig_Basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBProxyExists(resourceName, &v),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsDbProxyDefaultTargetGroup(), resourceName),
+					// DB Proxy default Target Group implicitly exists so it cannot be removed.
+					// Verify disappearance handling for DB Proxy removal instead.
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsDbProxy(), dbProxyResourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```
=== CONT  TestAccAWSDBProxyDefaultTargetGroup_disappears
TestAccAWSDBProxyDefaultTargetGroup_disappears: resource_aws_db_proxy_default_target_group_test.go:221: Step 1/1 error: Expected a non-empty plan, but got an empty plan!
--- FAIL: TestAccAWSDBProxyDefaultTargetGroup_disappears (597.58s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDBProxyDefaultTargetGroup_disappears (682.08s)
```
