### PR TITLE
tests/resource/aws_opsworks_application: Fix ImportStateVerifyIgnore for TestAccAWSOpsworksApplication_basic

### DIFF
--- a/aws/resource_aws_opsworks_application_test.go
+++ b/aws/resource_aws_opsworks_application_test.go
@@ -47,9 +47,8 @@ func TestAccAWSOpsworksApplication_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				// TODO: TypeSet check ImportStateVerifyIgnore with hash keys
-				ImportStateVerifyIgnore: []string{"environment.3077298702.key", "environment.#",
-					"environment.3077298702.secure", "environment.3077298702.value"},
+				// Environment variable import is not supported currently.
+				ImportStateVerifyIgnore: []string{"environment"},
 			},
 			{
 				Config: testAccAwsOpsworksApplicationUpdate(rName),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The Terraform Plugin SDK v2.0.4 upgrade lost the ability to track TypeSet attributes with the proper indexing, similar to how other checks needed similar fixes. Rather than `ImportStateVerifyIgnore` individual `environment` attribute bits, this changes the testing to the standard of just including the attribute itself.

Previously:

```
=== CONT  TestAccAWSOpsworksApplication_basic
TestAccAWSOpsworksApplication_basic: resource_aws_opsworks_application_test.go:22: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
(map[string]string) {
}
(map[string]string) (len=4) {
(string) (len=15) "environment.0.%": (string) (len=1) "3",
(string) (len=17) "environment.0.key": (string) (len=4) "key1",
(string) (len=20) "environment.0.secure": (string) (len=5) "false",
(string) (len=19) "environment.0.value": (string) (len=6) "value1"
}
--- FAIL: TestAccAWSOpsworksApplication_basic (72.51s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSOpsworksApplication_basic (74.52s)
```
