### PR TITLE
resource/aws_emr_instance_fleet: Prevent error on deletion when EMR Cluster is no longer running

### DIFF
--- a/aws/resource_aws_emr_instance_fleet.go
+++ b/aws/resource_aws_emr_instance_fleet.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/emr"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -356,6 +357,11 @@ func resourceAwsEMRInstanceFleetDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	_, err := conn.ModifyInstanceFleet(modifyInstanceFleetInput)
+
+	if tfawserr.ErrMessageContains(err, emr.ErrCodeInvalidRequestException, "instance fleet may only be modified when the cluster is running or waiting") {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("error deleting/modifying EMR Instance Fleet (%s): %w", d.Id(), err)
 	}

--- a/aws/resource_aws_emr_instance_fleet_test.go
+++ b/aws/resource_aws_emr_instance_fleet_test.go
@@ -133,6 +133,8 @@ func TestAccAWSEMRInstanceFleet_disappears(t *testing.T) {
 	var fleet emr.InstanceFleet
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_emr_instance_fleet.task"
+	emrClusterResourceName := "aws_emr_cluster.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -140,8 +142,11 @@ func TestAccAWSEMRInstanceFleet_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEmrInstanceFleetConfig(rName),
-				Check: resource.ComposeTestCheckFunc(testAccCheckAWSEmrInstanceFleetExists(resourceName, &fleet),
-					resource.TestCheckResourceAttr(resourceName, "instance_type_configs.#", "1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEmrInstanceFleetExists(resourceName, &fleet),
+					// EMR Instance Fleet can only be scaled down and are not removed until the
+					// Cluster is removed. Verify EMR Cluster disappearance handling.
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsEMRCluster(), emrClusterResourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_emr_instance_fleet: Prevent error on deletion when EMR Cluster is no longer running
```

The Terraform Plugin SDK v2.0.4 upgrade fixed some `ExpectNonEmptyPlan` testing behaviors and began showing `TestAccAWSEMRInstanceFleet_disappears` test failures that should have been occurring all along. EMR Instance Fleets cannot be deleted themselves, so switched this to verify EMR Cluster deletion handling which highlighted this bug on deletion.

Previously:

```
=== CONT  TestAccAWSEMRInstanceFleet_disappears
TestAccAWSEMRInstanceFleet_disappears: resource_aws_emr_instance_fleet_test.go:136: Step 1/1 error: Expected a non-empty plan, but got an empty plan!
--- FAIL: TestAccAWSEMRInstanceFleet_disappears (478.30s)
```

After adjusting the test to delete the EMR Cluster:

```
=== CONT  TestAccAWSEMRInstanceFleet_disappears
    testing_new.go:62: Error running post-test destroy, there may be dangling resources: 2020/10/07 14:25:31 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: error deleting/modifying EMR Instance Fleet (if-9F0XM3B3BVPS): InvalidRequestException: An instance fleet may only be modified when the cluster is running or waiting.
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "d0ac3071-8f85-45a2-a938-1cba69d4ca1d"
          },
          ErrorCode: "MODIFY_INSTANCE_FLEET_OF_RUNNING_JOBFLOW_ONLY",
          Message_: "An instance fleet may only be modified when the cluster is running or waiting."
        }

--- FAIL: TestAccAWSEMRInstanceFleet_disappears (411.82s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEMRInstanceFleet_disappears (493.55s)
```

