### PR TITLE
Enables Organizations policy import AWS-managed acceptance test

### DIFF
--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -378,7 +378,6 @@ func testAccAwsOrganizationsPolicy_ImportAwsManagedPolicy(t *testing.T) {
 
 	resourceID := "p-FullAWSAccess"
 
-	t.Skip("This test requires SDK 2.0.4 or higher for `ExpectError` with `ImportState`")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
@@ -392,7 +391,7 @@ func testAccAwsOrganizationsPolicy_ImportAwsManagedPolicy(t *testing.T) {
 				ResourceName:  resourceName,
 				ImportStateId: resourceID,
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(fmt.Sprintf("AWS-managed Organizations policy (%s) cannot be imported.", resourceID)),
+				ExpectError:   regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf("AWS-managed Organizations policy (%s) cannot be imported.", resourceID))),
 			},
 		},
 	})


### PR DESCRIPTION
Enables Organizations policy import AWS-managed acceptance test which required Plugin SDK 2.0.4

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15446

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSOrganizations_serial/Policy/ImportAwsManagedPolicy'

--- PASS: TestAccAWSOrganizations_serial (61.59s)
    --- PASS: TestAccAWSOrganizations_serial/Policy (61.59s)
        --- PASS: TestAccAWSOrganizations_serial/Policy/ImportAwsManagedPolicy (61.59s)
```
