### PR TITLE
f/aws_sagemaker_notebook_instance: Volume size

### DIFF
--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -46,6 +46,12 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 				Required: true,
 			},
 
+			"volume_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  5,
+			},
+
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -121,6 +127,10 @@ func resourceAwsSagemakerNotebookInstanceCreate(d *schema.ResourceData, meta int
 
 	if s, ok := d.GetOk("subnet_id"); ok {
 		createOpts.SubnetId = aws.String(s.(string))
+	}
+
+	if v, ok := d.GetOk("volume_size"); ok {
+		createOpts.VolumeSizeInGB = aws.Int64(int64(v.(int)))
 	}
 
 	if k, ok := d.GetOk("kms_key_id"); ok {
@@ -200,6 +210,10 @@ func resourceAwsSagemakerNotebookInstanceRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("error setting kms_key_id for sagemaker notebook instance (%s): %s", d.Id(), err)
 	}
 
+	if err := d.Set("volume_size", notebookInstance.VolumeSizeInGB); err != nil {
+		return fmt.Errorf("error setting volume_size for sagemaker notebook instance (%s): %s", d.Id(), err)
+	}
+
 	if err := d.Set("lifecycle_config_name", notebookInstance.NotebookInstanceLifecycleConfigName); err != nil {
 		return fmt.Errorf("error setting lifecycle_config_name for sagemaker notebook instance (%s): %s", d.Id(), err)
 	}
@@ -253,6 +267,11 @@ func resourceAwsSagemakerNotebookInstanceUpdate(d *schema.ResourceData, meta int
 
 	if d.HasChange("instance_type") {
 		updateOpts.InstanceType = aws.String(d.Get("instance_type").(string))
+		hasChanged = true
+	}
+
+	if d.HasChange("volume_size") {
+		updateOpts.VolumeSizeInGB = aws.Int64(int64(d.Get("volume_size").(int)))
 		hasChanged = true
 	}
 

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -123,6 +123,8 @@ func TestAccAWSSagemakerNotebookInstance_update(t *testing.T) {
 
 					resource.TestCheckResourceAttr(
 						"aws_sagemaker_notebook_instance.foo", "instance_type", "ml.t2.medium"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_notebook_instance.foo", "volume_size", "5"),
 				),
 			},
 
@@ -133,6 +135,8 @@ func TestAccAWSSagemakerNotebookInstance_update(t *testing.T) {
 
 					resource.TestCheckResourceAttr(
 						"aws_sagemaker_notebook_instance.foo", "instance_type", "ml.m4.xlarge"),
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_notebook_instance.foo", "volume_size", "8"),
 				),
 			},
 			{
@@ -472,6 +476,7 @@ resource "aws_sagemaker_notebook_instance" "foo" {
   name          = "%s"
   role_arn      = aws_iam_role.foo.arn
   instance_type = "ml.m4.xlarge"
+  volume_size   = "8"
 }
 
 resource "aws_iam_role" "foo" {

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -33,6 +33,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the notebook instance (must be unique).
 * `role_arn` - (Required) The ARN of the IAM role to be used by the notebook instance which allows SageMaker to call other services on your behalf.
 * `instance_type` - (Required) The name of ML compute instance type.
+* `volume_size` - (Optional) The size, in GB, of the ML storage volume to attach to the notebook instance. The default value is 5 GB.
 * `subnet_id` - (Optional) The VPC subnet ID.
 * `security_groups` - (Optional) The associated security groups.
 * `kms_key_id` - (Optional) The AWS Key Management Service (AWS KMS) key that Amazon SageMaker uses to encrypt the model artifacts at rest using Amazon S3 server-side encryption.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #15521

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance_volumesize'
--- PASS: TestAccAWSSagemakerNotebookInstance_volumesize (908.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	910.463s
$ make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance_basic'
--- PASS: TestAccAWSSagemakerNotebookInstance_basic (470.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	472.978s
...
```
