### PR TITLE
d/codeartifact_repository_endpoint - new data source

### DIFF
--- a/aws/data_source_aws_codeartifact_repository_endpoint.go
+++ b/aws/data_source_aws_codeartifact_repository_endpoint.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codeartifact"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceAwsCodeArtifactRepositoryEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCodeArtifactRepositoryEndpointRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"format": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(codeartifact.PackageFormat_Values(), false),
+			},
+			"domain_owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateAwsAccountId,
+			},
+			"repository_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCodeArtifactRepositoryEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codeartifactconn
+	domainOwner := meta.(*AWSClient).accountid
+	domain := d.Get("domain").(string)
+	repo := d.Get("repository").(string)
+	format := d.Get("format").(string)
+	params := &codeartifact.GetRepositoryEndpointInput{
+		Domain:     aws.String(domain),
+		Repository: aws.String(repo),
+		Format:     aws.String(format),
+	}
+
+	if v, ok := d.GetOk("domain_owner"); ok {
+		params.DomainOwner = aws.String(v.(string))
+		domainOwner = v.(string)
+	}
+
+	log.Printf("[DEBUG] Getting CodeArtifact Repository Endpoint")
+	out, err := conn.GetRepositoryEndpoint(params)
+	if err != nil {
+		return fmt.Errorf("error getting CodeArtifact Repository Endpoint: %w", err)
+	}
+	log.Printf("[DEBUG] CodeArtifact Repository Endpoint: %#v", out)
+
+	d.SetId(fmt.Sprintf("%s:%s:%s:%s", domainOwner, domain, repo, format))
+	d.Set("repository_endpoint", out.RepositoryEndpoint)
+	d.Set("domain_owner", domainOwner)
+
+	return nil
+}

--- a/aws/data_source_aws_codeartifact_repository_endpoint_test.go
+++ b/aws/data_source_aws_codeartifact_repository_endpoint_test.go
@@ -59,8 +59,8 @@ resource "aws_codeartifact_domain" "test" {
 }
 
 resource "aws_codeartifact_repository" "test" {
-  repository  = %[1]q
-  domain      = aws_codeartifact_domain.test.domain
+  repository = %[1]q
+  domain     = aws_codeartifact_domain.test.domain
 }
 `, rName)
 }

--- a/aws/data_source_aws_codeartifact_repository_endpoint_test.go
+++ b/aws/data_source_aws_codeartifact_repository_endpoint_test.go
@@ -1,0 +1,89 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAWSCodeArtifactRepositoryEndpointDataSource_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_codeartifact_repository_endpoint.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "repository_endpoint"),
+					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeArtifactRepositoryEndpointDataSource_owner(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_codeartifact_repository_endpoint.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAWSCodeArtifactRepositoryEndpointOwnerConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "repository_endpoint"),
+					testAccCheckResourceAttrAccountID(dataSourceName, "domain_owner"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCodeArtifactRepositoryEndpointBaseConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_codeartifact_domain" "test" {
+  domain         = %[1]q
+  encryption_key = aws_kms_key.test.arn
+}
+
+resource "aws_codeartifact_repository" "test" {
+  repository  = %[1]q
+  domain      = aws_codeartifact_domain.test.domain
+}
+`, rName)
+}
+
+func testAccCheckAWSCodeArtifactRepositoryEndpointBasicConfig(rName string) string {
+	return testAccCheckAWSCodeArtifactRepositoryEndpointBaseConfig(rName) +
+		fmt.Sprintf(`
+data "aws_codeartifact_repository_endpoint" "test" {
+  domain     = aws_codeartifact_domain.test.domain
+  repository = aws_codeartifact_repository.test.repository
+  format     = "npm"
+}
+`)
+}
+
+func testAccCheckAWSCodeArtifactRepositoryEndpointOwnerConfig(rName string) string {
+	return testAccCheckAWSCodeArtifactRepositoryEndpointBaseConfig(rName) +
+		fmt.Sprintf(`
+data "aws_codeartifact_repository_endpoint" "test" {
+  domain       = aws_codeartifact_domain.test.domain
+  repository   = aws_codeartifact_repository.test.repository
+  domain_owner = aws_codeartifact_domain.test.owner
+  format       = "npm"
+}
+`)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -194,6 +194,7 @@ func Provider() *schema.Provider {
 			"aws_cloudtrail_service_account":                 dataSourceAwsCloudTrailServiceAccount(),
 			"aws_cloudwatch_log_group":                       dataSourceAwsCloudwatchLogGroup(),
 			"aws_codeartifact_authorization_token":           dataSourceAwsCodeArtifactAuthorizationToken(),
+			"aws_codeartifact_repository_endpoint":           dataSourceAwsCodeArtifactRepositoryEndpoint(),
 			"aws_cognito_user_pools":                         dataSourceAwsCognitoUserPools(),
 			"aws_codecommit_repository":                      dataSourceAwsCodeCommitRepository(),
 			"aws_cur_report_definition":                      dataSourceAwsCurReportDefinition(),

--- a/website/docs/d/codeartifact_repository_endpoint.html.markdown
+++ b/website/docs/d/codeartifact_repository_endpoint.html.markdown
@@ -1,0 +1,36 @@
+---
+subcategory: "CodeArtifact"
+layout: "aws"
+page_title: "AWS: aws_codeartifact_repository_endpoint"
+description: |-
+    Provides details about a CodeArtifact Repository Endpoint
+---
+
+# Data Source: aws_codeartifact_repository_endpoint
+
+The CodeArtifact Repository Endpoint data source returns the endpoint of a repository for a specific package format.
+
+## Example Usage
+
+```hcl
+data "aws_codeartifact_repository_endpoint" "test" {
+  domain     = aws_codeartifact_domain.test.domain
+  repository = aws_codeartifact_repository.test.repository
+  format     = "npm"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The name of the domain that contains the repository.
+* `repository` - (Required) The name of the repository.
+* `format` - (Required) Which endpoint of a repository to return. A repository has one endpoint for each package format: `npm`, `pypi`, and `maven`.
+* `domain_owner` - (Optional) The account number of the AWS account that owns the domain.
+
+## Attributes Reference
+
+In addition to the argument above, the following attributes are exported:
+
+* `repository_endpoint` - The URL of the returned endpoint.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #13714

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
data_source_aws_codeartifact_repository_endpoint - new data source
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeArtifactRepositoryEndpointDataSource_'
--- PASS: TestAccAWSCodeArtifactRepositoryEndpointDataSource_basic (57.09s)
--- PASS: TestAccAWSCodeArtifactRepositoryEndpointDataSource_owner (56.63s)
...
```
