### PR TITLE
r/codeartifact_repository - support external connection

### DIFF
--- a/aws/resource_aws_codeartifact_repository.go
+++ b/aws/resource_aws_codeartifact_repository.go
@@ -61,12 +61,12 @@ func resourceAwsCodeArtifactRepository() *schema.Resource {
 			},
 			"external_connections": {
 				Type:     schema.TypeList,
-				Computed: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"external_connection_name": {
 							Type:     schema.TypeString,
-							Computed: true,
+							Optional: true,
 						},
 						"package_format": {
 							Type:     schema.TypeString,
@@ -116,6 +116,21 @@ func resourceAwsCodeArtifactRepositoryCreate(d *schema.ResourceData, meta interf
 	repo := res.Repository
 	d.SetId(aws.StringValue(repo.Arn))
 
+	if v, ok := d.GetOk("external_connections"); ok {
+		externalConnection := v.([]interface{})[0].(map[string]interface{})
+		input := &codeartifact.AssociateExternalConnectionInput{
+			Domain:             repo.DomainName,
+			Repository:         repo.Name,
+			DomainOwner:        repo.DomainOwner,
+			ExternalConnection: aws.String(externalConnection["external_connection_name"].(string)),
+		}
+
+		_, err := conn.AssociateExternalConnection(input)
+		if err != nil {
+			return fmt.Errorf("error associating associating external connection to CodeArtifact repository: %w", err)
+		}
+	}
+
 	return resourceAwsCodeArtifactRepositoryRead(d, meta)
 }
 
@@ -144,6 +159,35 @@ func resourceAwsCodeArtifactRepositoryUpdate(d *schema.ResourceData, meta interf
 	_, err := conn.UpdateRepository(params)
 	if err != nil {
 		return fmt.Errorf("error updating CodeArtifact Repository: %w", err)
+	}
+
+	if v, ok := d.GetOk("external_connections"); ok {
+		externalConnection := v.([]interface{})[0].(map[string]interface{})
+		input := &codeartifact.AssociateExternalConnectionInput{
+			Repository:         aws.String(d.Get("repository").(string)),
+			Domain:             aws.String(d.Get("domain").(string)),
+			DomainOwner:        aws.String(d.Get("domain_owner").(string)),
+			ExternalConnection: aws.String(externalConnection["external_connection_name"].(string)),
+		}
+
+		_, err := conn.AssociateExternalConnection(input)
+		if err != nil {
+			return fmt.Errorf("error associating external connection to CodeArtifact repository: %w", err)
+		}
+	} else {
+		oldConn, _ := d.GetChange("external_connections")
+		externalConnection := oldConn.([]interface{})[0].(map[string]interface{})
+		input := &codeartifact.DisassociateExternalConnectionInput{
+			Repository:         aws.String(d.Get("repository").(string)),
+			Domain:             aws.String(d.Get("domain").(string)),
+			DomainOwner:        aws.String(d.Get("domain_owner").(string)),
+			ExternalConnection: aws.String(externalConnection["external_connection_name"].(string)),
+		}
+
+		_, err := conn.DisassociateExternalConnection(input)
+		if err != nil {
+			return fmt.Errorf("error disassociating external connection to CodeArtifact repository: %w", err)
+		}
 	}
 
 	return resourceAwsCodeArtifactRepositoryRead(d, meta)

--- a/aws/resource_aws_codeartifact_repository.go
+++ b/aws/resource_aws_codeartifact_repository.go
@@ -37,10 +37,11 @@ func resourceAwsCodeArtifactRepository() *schema.Resource {
 				ForceNew: true,
 			},
 			"domain_owner": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validateAwsAccountId,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -66,7 +67,7 @@ func resourceAwsCodeArtifactRepository() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"external_connection_name": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 						},
 						"package_format": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_codeartifact_repository.go
+++ b/aws/resource_aws_codeartifact_repository.go
@@ -127,7 +127,7 @@ func resourceAwsCodeArtifactRepositoryCreate(d *schema.ResourceData, meta interf
 
 		_, err := conn.AssociateExternalConnection(input)
 		if err != nil {
-			return fmt.Errorf("error associating associating external connection to CodeArtifact repository: %w", err)
+			return fmt.Errorf("error associating external connection to CodeArtifact repository: %w", err)
 		}
 	}
 
@@ -161,32 +161,34 @@ func resourceAwsCodeArtifactRepositoryUpdate(d *schema.ResourceData, meta interf
 		return fmt.Errorf("error updating CodeArtifact Repository: %w", err)
 	}
 
-	if v, ok := d.GetOk("external_connections"); ok {
-		externalConnection := v.([]interface{})[0].(map[string]interface{})
-		input := &codeartifact.AssociateExternalConnectionInput{
-			Repository:         aws.String(d.Get("repository").(string)),
-			Domain:             aws.String(d.Get("domain").(string)),
-			DomainOwner:        aws.String(d.Get("domain_owner").(string)),
-			ExternalConnection: aws.String(externalConnection["external_connection_name"].(string)),
-		}
+	if d.HasChange("external_connections") {
+		if v, ok := d.GetOk("external_connections"); ok {
+			externalConnection := v.([]interface{})[0].(map[string]interface{})
+			input := &codeartifact.AssociateExternalConnectionInput{
+				Repository:         aws.String(d.Get("repository").(string)),
+				Domain:             aws.String(d.Get("domain").(string)),
+				DomainOwner:        aws.String(d.Get("domain_owner").(string)),
+				ExternalConnection: aws.String(externalConnection["external_connection_name"].(string)),
+			}
 
-		_, err := conn.AssociateExternalConnection(input)
-		if err != nil {
-			return fmt.Errorf("error associating external connection to CodeArtifact repository: %w", err)
-		}
-	} else {
-		oldConn, _ := d.GetChange("external_connections")
-		externalConnection := oldConn.([]interface{})[0].(map[string]interface{})
-		input := &codeartifact.DisassociateExternalConnectionInput{
-			Repository:         aws.String(d.Get("repository").(string)),
-			Domain:             aws.String(d.Get("domain").(string)),
-			DomainOwner:        aws.String(d.Get("domain_owner").(string)),
-			ExternalConnection: aws.String(externalConnection["external_connection_name"].(string)),
-		}
+			_, err := conn.AssociateExternalConnection(input)
+			if err != nil {
+				return fmt.Errorf("error associating external connection to CodeArtifact repository: %w", err)
+			}
+		} else {
+			oldConn, _ := d.GetChange("external_connections")
+			externalConnection := oldConn.([]interface{})[0].(map[string]interface{})
+			input := &codeartifact.DisassociateExternalConnectionInput{
+				Repository:         aws.String(d.Get("repository").(string)),
+				Domain:             aws.String(d.Get("domain").(string)),
+				DomainOwner:        aws.String(d.Get("domain_owner").(string)),
+				ExternalConnection: aws.String(externalConnection["external_connection_name"].(string)),
+			}
 
-		_, err := conn.DisassociateExternalConnection(input)
-		if err != nil {
-			return fmt.Errorf("error disassociating external connection to CodeArtifact repository: %w", err)
+			_, err := conn.DisassociateExternalConnection(input)
+			if err != nil {
+				return fmt.Errorf("error disassociating external connection to CodeArtifact repository: %w", err)
+			}
 		}
 	}
 

--- a/aws/resource_aws_codeartifact_repository.go
+++ b/aws/resource_aws_codeartifact_repository.go
@@ -63,7 +63,6 @@ func resourceAwsCodeArtifactRepository() *schema.Resource {
 			"external_connections": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_codeartifact_repository.go
+++ b/aws/resource_aws_codeartifact_repository.go
@@ -63,6 +63,8 @@ func resourceAwsCodeArtifactRepository() *schema.Resource {
 			"external_connections": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"external_connection_name": {

--- a/website/docs/r/codeartifact_repository.html.markdown
+++ b/website/docs/r/codeartifact_repository.html.markdown
@@ -46,6 +46,24 @@ resource "aws_codeartifact_repository" "test" {
 }
 ```
 
+## Example Usage with external connection
+
+```hcl
+resource "aws_codeartifact_repository" "upstream" {
+  repository = "upstream"
+  domain     = aws_codeartifact_domain.test.domain
+}
+
+resource "aws_codeartifact_repository" "test" {
+  repository = "example"
+  domain     = aws_codeartifact_domain.example.domain
+
+  external_connections {
+    external_connection_name = "public:npmjs"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -55,10 +73,15 @@ The following arguments are supported:
 * `domain_owner` - (Optional) The account number of the AWS account that owns the domain.
 * `description` - (Optional) The description of the repository.
 * `upstream` - (Optional) A list of upstream repositories to associate with the repository. The order of the upstream repositories in the list determines their priority order when AWS CodeArtifact looks for a requested package version. see [Upstream](#upstream)
+* `external_connections` - An array of external connections associated with the repository. see [External Connections](#external-connections)
 
 ### Upstream
 
 * `repository_name` - (Required) The name of an upstream repository.
+
+### External Connections
+
+* `external_connection_name` - (Required) The name of the external connection associated with a repository.
 
 ## Attributes Reference
 
@@ -67,13 +90,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The Name of the repository.
 * `arn` - The ARN of the repository.
 * `administrator_account` - The account number of the AWS account that manages the repository.
-* `external_connections` - An array of external connections associated with the repository. see [External Connections](#external-connections)
-
-### External Connections
-
-* `external_connection_name` - The name of the external connection associated with a repository.
-* `package_format` - The package format associated with a repository's external connection.
-* `status` - The status of the external connection of a repository.
 
 ## Import
 

--- a/website/docs/r/codeartifact_repository.html.markdown
+++ b/website/docs/r/codeartifact_repository.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 * `domain_owner` - (Optional) The account number of the AWS account that owns the domain.
 * `description` - (Optional) The description of the repository.
 * `upstream` - (Optional) A list of upstream repositories to associate with the repository. The order of the upstream repositories in the list determines their priority order when AWS CodeArtifact looks for a requested package version. see [Upstream](#upstream)
-* `external_connections` - An array of external connections associated with the repository. see [External Connections](#external-connections)
+* `external_connections` - An array of external connections associated with the repository. Only one extrenal connection can be set per repository. see [External Connections](#external-connections). Note that setting an external connection may replace any extrenal connections created outside of terraform.
 
 ### Upstream
 

--- a/website/docs/r/codeartifact_repository.html.markdown
+++ b/website/docs/r/codeartifact_repository.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 * `domain_owner` - (Optional) The account number of the AWS account that owns the domain.
 * `description` - (Optional) The description of the repository.
 * `upstream` - (Optional) A list of upstream repositories to associate with the repository. The order of the upstream repositories in the list determines their priority order when AWS CodeArtifact looks for a requested package version. see [Upstream](#upstream)
-* `external_connections` - An array of external connections associated with the repository. Only one extrenal connection can be set per repository. see [External Connections](#external-connections). Note that setting an external connection may replace any extrenal connections created outside of terraform.
+* `external_connections` - An array of external connections associated with the repository. Only one external connection can be set per repository. see [External Connections](#external-connections).
 
 ### Upstream
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13714

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_ codeartifact_repository - support external connections - Note that setting an external connection may replace any external connections created outside of terraform.
resource_aws_ codeartifact_repository - add plan time validation to `domain_owner`.
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSCodeArtifactRepository_'
--- PASS: TestAccAWSCodeArtifactRepository_disappears (52.49s)
--- PASS: TestAccAWSCodeArtifactRepository_basic (57.92s)
--- PASS: TestAccAWSCodeArtifactRepository_owner (57.98s)
--- PASS: TestAccAWSCodeArtifactRepository_description (94.39s)
--- PASS: TestAccAWSCodeArtifactRepository_externalConnection (136.09s)
--- PASS: TestAccAWSCodeArtifactRepository_upstreams (145.97s)
```
