### PR TITLE
fix typo example of backup vault notifications

### DIFF
--- a/website/docs/r/backup_vault_notifications.html.markdown
+++ b/website/docs/r/backup_vault_notifications.html.markdown
@@ -47,7 +47,7 @@ resource "aws_sns_topic_policy" "test" {
 
 resource "aws_backup_vault_notifications" "test" {
   backup_vault_name   = "example_backup_vault"
-  sns_topic_arn       = sns_topic_arn.test.arn
+  sns_topic_arn       = aws_sns_topic.test.arn
   backup_vault_events = ["BACKUP_JOB_STARTED", "RESTORE_JOB_COMPLETED"]
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

While try `aws_backup_vault_notifications` as the [doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_notifications), we meet below error message:
```
A managed resource "sns_topic_arn" "test" has not been declared in the root module.
```

After go through the code, we found it should changed to "aws_sns_topic".
If we need an issue to track it before this PR, please let me know.