### PR TITLE
tests/provider: Fix hardcoded (EMR Cluster)

### DIFF
--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -1643,8 +1643,15 @@ func testAccAWSEmrComposeConfig(mapPublicIPOnLaunch bool, config ...string) stri
 	return composeConfig(append(config, testAccAWSEmrClusterConfigBaseVpc(mapPublicIPOnLaunch))...)
 }
 
+func testAccAWSEmrClusterConfigCurrentPartition() string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+`)
+}
+
 func testAccAWSEmrClusterConfig_bootstrap(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigBootstrapActionBucket(r),
@@ -1707,6 +1714,7 @@ resource "aws_emr_cluster" "test" {
 
 func testAccAWSEmrClusterConfig_bootstrapAdd(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigBootstrapActionBucket(r),
@@ -1775,6 +1783,7 @@ resource "aws_emr_cluster" "test" {
 
 func testAccAWSEmrClusterConfig_bootstrapReorder(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigBootstrapActionBucket(r),
@@ -1843,6 +1852,7 @@ resource "aws_emr_cluster" "test" {
 
 func testAccAWSEmrClusterConfig(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -1899,6 +1909,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 func testAccAWSEmrClusterConfigAdditionalInfo(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -1964,6 +1975,7 @@ EOF
 
 func testAccAWSEmrClusterConfigConfigurationsJson(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		fmt.Sprintf(`
@@ -2087,6 +2099,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 func testAccAWSEmrClusterConfig_SecurityConfiguration(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -2265,7 +2278,9 @@ resource "aws_s3_bucket" "test" {
 }
 
 func testAccAWSEmrClusterConfigCoreInstanceGroupAutoscalingPolicy(rName, autoscalingPolicy string) string {
-	return testAccAWSEmrComposeConfig(false, fmt.Sprintf(`
+	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
+		fmt.Sprintf(`
 data "aws_iam_policy_document" "test" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -2273,15 +2288,13 @@ data "aws_iam_policy_document" "test" {
 
     principals {
       identifiers = [
-        "application-autoscaling.amazonaws.com",
-        "elasticmapreduce.amazonaws.com",
+        "application-autoscaling.${data.aws_partition.current.dns_suffix}",
+        "elasticmapreduce.${data.aws_partition.current.dns_suffix}",
       ]
       type = "Service"
     }
   }
 }
-
-data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test" {
   name               = %[1]q
@@ -2329,7 +2342,9 @@ POLICY
 }
 
 func testAccAWSEmrClusterConfigCoreInstanceGroupAutoscalingPolicyRemoved(rName string) string {
-	return testAccAWSEmrComposeConfig(false, fmt.Sprintf(`
+	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
+		fmt.Sprintf(`
 data "aws_iam_policy_document" "test" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -2337,15 +2352,13 @@ data "aws_iam_policy_document" "test" {
 
     principals {
       identifiers = [
-        "application-autoscaling.amazonaws.com",
-        "elasticmapreduce.amazonaws.com",
+        "application-autoscaling.${data.aws_partition.current.dns_suffix}",
+        "elasticmapreduce.${data.aws_partition.current.dns_suffix}",
       ]
       type = "Service"
     }
   }
 }
-
-data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test" {
   name               = %[1]q
@@ -2653,6 +2666,7 @@ resource "aws_emr_cluster" "test" {
 
 func testAccAWSEmrClusterConfigTerminationPolicy(r string, term string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -2706,6 +2720,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 func testAccAWSEmrClusterConfig_keepJob(r string, keepJob string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -2769,6 +2784,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 func testAccAWSEmrClusterConfigVisibleToAllUsersUpdated(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -2822,6 +2838,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 func testAccAWSEmrClusterConfigUpdatedTags(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -2874,6 +2891,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 func testAccAWSEmrClusterConfigUpdatedRootVolumeSize(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -2927,7 +2945,9 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 }
 
 func testAccAWSEmrClusterConfigS3Logging(r string) string {
-	return testAccAWSEmrComposeConfig(false, fmt.Sprintf(`
+	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
+		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = "%[1]s"
   force_destroy = true
@@ -2953,13 +2973,13 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   log_uri = "s3://${aws_s3_bucket.test.bucket}/"
 
   ec2_attributes {
-    instance_profile                  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/EMR_EC2_DefaultRole"
+    instance_profile                  = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:instance-profile/EMR_EC2_DefaultRole"
     emr_managed_master_security_group = aws_security_group.test.id
     emr_managed_slave_security_group  = aws_security_group.test.id
     subnet_id                         = aws_subnet.test.id
   }
 
-  service_role = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/EMR_DefaultRole"
+  service_role = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/EMR_DefaultRole"
 }
 
 data "aws_caller_identity" "current" {}
@@ -2969,6 +2989,7 @@ data "aws_caller_identity" "current" {}
 
 func testAccAWSEmrClusterConfigCustomAmiID(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleCustomAmiID(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigIAMAutoscalingRole(r),
@@ -3021,7 +3042,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 data "aws_ami" "emr-custom-ami" {
   most_recent = true
-  owners      = ["137112412989"]
+  owners      = ["amazon"]
 
   filter {
     name   = "name"
@@ -3171,7 +3192,7 @@ resource "aws_iam_role" "emr_service" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "elasticmapreduce.amazonaws.com"
+        "Service": "elasticmapreduce.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -3182,7 +3203,7 @@ EOT
 
 resource "aws_iam_role_policy_attachment" "emr_service" {
   role       = aws_iam_role.emr_service.id
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonElasticMapReduceRole"
 }
 
 `, r)
@@ -3201,7 +3222,7 @@ resource "aws_iam_role" "emr_service" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "elasticmapreduce.amazonaws.com"
+        "Service": "elasticmapreduce.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -3305,7 +3326,7 @@ resource "aws_iam_role" "emr_instance_profile" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -3373,14 +3394,14 @@ data "aws_iam_policy_document" "emr_autoscaling_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["elasticmapreduce.amazonaws.com", "application-autoscaling.amazonaws.com"]
+      identifiers = ["elasticmapreduce.${data.aws_partition.current.dns_suffix}", "application-autoscaling.${data.aws_partition.current.dns_suffix}"]
     }
   }
 }
 
 resource "aws_iam_role_policy_attachment" "emr_autoscaling_role" {
   role       = aws_iam_role.emr_autoscaling_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
 }
 `, r)
 }
@@ -3453,6 +3474,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 func testAccAWSEmrClusterConfigInstanceFleets(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigBootstrapActionBucket(r),
@@ -3539,6 +3561,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
 func testAccAWSEmrClusterConfigInstanceFleetsMasterOnly(r string) string {
 	return testAccAWSEmrComposeConfig(false,
+		testAccAWSEmrClusterConfigCurrentPartition(),
 		testAccAWSEmrClusterConfigIAMServiceRoleBase(r),
 		testAccAWSEmrClusterConfigIAMInstanceProfileBase(r),
 		testAccAWSEmrClusterConfigBootstrapActionBucket(r),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15584
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):


```
--- PASS: TestAccAWSEMRCluster_additionalInfo (408.11s)
--- PASS: TestAccAWSEMRCluster_basic (413.79s)
--- PASS: TestAccAWSEMRCluster_disappears (429.36s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy (453.63s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount (520.64s)
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (562.69s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (603.51s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType (741.37s)
--- PASS: TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups (794.80s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice (808.58s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (369.06s)
--- PASS: TestAccAWSEMRCluster_security_config (435.07s)
--- PASS: TestAccAWSEMRCluster_Step_Basic (434.11s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Name (850.33s)
--- FAIL: TestAccAWSEMRCluster_bootstrap_ordering (332.96s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType (875.24s)
--- FAIL: TestAccAWSEMRCluster_instance_fleet (26.28s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice (883.38s)
--- FAIL: TestAccAWSEMRCluster_instance_fleet_master_only (25.54s)
--- PASS: TestAccAWSEMRCluster_keepJob (317.48s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (381.75s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Name (946.47s)
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (777.51s)
--- PASS: TestAccAWSEMRCluster_step_concurrency_level (407.40s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount (1263.04s)
--- PASS: TestAccAWSEMRCluster_ebs_config (439.52s)
--- PASS: TestAccAWSEMRCluster_s3Logging (496.25s)
--- PASS: TestAccAWSEMRCluster_custom_ami_id (457.87s)
--- PASS: TestAccAWSEMRCluster_tags (662.37s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (733.62s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (691.90s)
```

*Failures are unrelated and tracked in separate issues: #15608, #15607 

The output from acceptance testing (commercial):


```
--- PASS: TestAccAWSEMRCluster_disappears (406.56s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (427.83s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (455.99s)
--- PASS: TestAccAWSEMRCluster_Step_Basic (488.49s)
--- PASS: TestAccAWSEMRCluster_security_config (495.99s)
--- PASS: TestAccAWSEMRCluster_basic (517.58s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy (556.26s)
--- PASS: TestAccAWSEMRCluster_additionalInfo (675.79s)
--- PASS: TestAccAWSEMRCluster_Ec2Attributes_DefaultManagedSecurityGroups (762.57s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice (925.43s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice (925.55s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Name (971.56s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount (974.08s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Name (978.40s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (590.60s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType (1001.95s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType (1003.73s)
--- PASS: TestAccAWSEMRCluster_s3Logging (538.72s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceCount (1029.92s)
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (1043.24s)
--- PASS: TestAccAWSEMRCluster_step_concurrency_level (492.57s)
--- FAIL: TestAccAWSEMRCluster_keepJob (667.89s)
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (1106.16s)
--- PASS: TestAccAWSEMRCluster_ebs_config (456.74s)
--- PASS: TestAccAWSEMRCluster_custom_ami_id (461.75s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (809.42s)
--- PASS: TestAccAWSEMRCluster_instance_fleet_master_only (432.43s)
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (1413.88s)
--- PASS: TestAccAWSEMRCluster_tags (957.77s)
--- PASS: TestAccAWSEMRCluster_instance_fleet (529.69s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (1033.31s)
```
*failure is flaky