### PR TITLE
tests/provider: Add precheck (Lex)

### DIFF
--- a/aws/data_source_aws_lex_bot_alias_test.go
+++ b/aws/data_source_aws_lex_bot_alias_test.go
@@ -14,7 +14,7 @@ func testAccDataSourceAwsLexBotAlias_basic(t *testing.T) {
 
 	// If this test runs in parallel with other Lex Bot tests, it loses its description
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_lex_bot_test.go
+++ b/aws/data_source_aws_lex_bot_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceAwsLexBot_basic(t *testing.T) {
 	resourceName := "aws_lex_bot.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -51,7 +51,7 @@ func testAccDataSourceAwsLexBot_withVersion(t *testing.T) {
 
 	// If this test runs in parallel with other Lex Bot tests, it loses its description
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_lex_intent_test.go
+++ b/aws/data_source_aws_lex_intent_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceAwsLexIntent_basic(t *testing.T) {
 	resourceName := "aws_lex_intent.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -41,7 +41,7 @@ func TestAccDataSourceAwsLexIntent_withVersion(t *testing.T) {
 	resourceName := "aws_lex_intent.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_lex_slot_type_test.go
+++ b/aws/data_source_aws_lex_slot_type_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceAwsLexSlotType_basic(t *testing.T) {
 	resourceName := "aws_lex_slot_type.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -42,7 +42,7 @@ func TestAccDataSourceAwsLexSlotType_withVersion(t *testing.T) {
 	resourceName := "aws_lex_slot_type.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_lex_bot_alias_test.go
+++ b/aws/resource_aws_lex_bot_alias_test.go
@@ -20,7 +20,7 @@ func TestAccAwsLexBotAlias_basic(t *testing.T) {
 	testBotAliasID := "test_bot_alias" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotAliasDestroy(testBotAliasID, testBotAliasID),
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func testAccAwsLexBotAlias_botVersion(t *testing.T) {
 
 	// If this test runs in parallel with other Lex Bot tests, it loses its description
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotAliasDestroy(testBotAliasID, testBotAliasID),
 		Steps: []resource.TestStep{
@@ -110,7 +110,7 @@ func TestAccAwsLexBotAlias_conversationLogsText(t *testing.T) {
 	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotAliasDestroy(testBotID, testBotAliasID),
 		Steps: []resource.TestStep{
@@ -156,7 +156,7 @@ func TestAccAwsLexBotAlias_conversationLogsAudio(t *testing.T) {
 	kmsKeyResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotAliasDestroy(testBotID, testBotAliasID),
 		Steps: []resource.TestStep{
@@ -203,7 +203,7 @@ func TestAccAwsLexBotAlias_conversationLogsBoth(t *testing.T) {
 	kmsKeyResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotAliasDestroy(testBotID, testBotAliasID),
 		Steps: []resource.TestStep{
@@ -249,7 +249,7 @@ func TestAccAwsLexBotAlias_description(t *testing.T) {
 	testBotAliasID := "test_bot_alias" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotAliasDestroy(testBotAliasID, testBotAliasID),
 		Steps: []resource.TestStep{
@@ -294,7 +294,7 @@ func TestAccAwsLexBotAlias_disappears(t *testing.T) {
 	testBotAliasID := "test_bot_alias" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_lex_bot_test.go
+++ b/aws/resource_aws_lex_bot_test.go
@@ -18,7 +18,7 @@ func TestAccAwsLexBot_basic(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -86,7 +86,7 @@ func testAccAwsLexBot_createVersion(t *testing.T) {
 
 	// If this test runs in parallel with other Lex Bot tests, it loses its description
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -129,7 +129,7 @@ func TestAccAwsLexBot_abortStatement(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -185,7 +185,7 @@ func TestAccAwsLexBot_clarificationPrompt(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -237,7 +237,7 @@ func TestAccAwsLexBot_childDirected(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -280,7 +280,7 @@ func TestAccAwsLexBot_description(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -323,7 +323,7 @@ func TestAccAwsLexBot_detectSentiment(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -366,7 +366,7 @@ func TestAccAwsLexBot_enableModelImprovements(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -410,7 +410,7 @@ func TestAccAwsLexBot_idleSessionTtlInSeconds(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -453,7 +453,7 @@ func TestAccAwsLexBot_intents(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -496,7 +496,7 @@ func TestAccAwsLexBot_locale(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -539,7 +539,7 @@ func TestAccAwsLexBot_voiceId(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{
@@ -582,7 +582,7 @@ func TestAccAwsLexBot_disappears(t *testing.T) {
 	testBotID := "test_bot_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexBotDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_lex_intent_test.go
+++ b/aws/resource_aws_lex_intent_test.go
@@ -20,7 +20,7 @@ func TestAccAwsLexIntent_basic(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -65,7 +65,7 @@ func TestAccAwsLexIntent_createVersion(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -106,7 +106,7 @@ func TestAccAwsLexIntent_conclusionStatement(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -158,7 +158,7 @@ func TestAccAwsLexIntent_confirmationPromptAndRejectionStatement(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -220,7 +220,7 @@ func TestAccAwsLexIntent_dialogCodeHook(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -252,7 +252,7 @@ func TestAccAwsLexIntent_followUpPrompt(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -320,7 +320,7 @@ func TestAccAwsLexIntent_fulfillmentActivity(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -354,7 +354,7 @@ func TestAccAwsLexIntent_sampleUtterances(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -395,7 +395,7 @@ func TestAccAwsLexIntent_slots(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -447,7 +447,7 @@ func TestAccAwsLexIntent_slotsCustom(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -490,7 +490,7 @@ func TestAccAwsLexIntent_disappears(t *testing.T) {
 	testIntentID := "test_intent_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{
@@ -549,7 +549,7 @@ func TestAccAwsLexIntent_updateWithExternalChange(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexIntentDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_lex_slot_type_test.go
+++ b/aws/resource_aws_lex_slot_type_test.go
@@ -19,7 +19,7 @@ func TestAccAwsLexSlotType_basic(t *testing.T) {
 	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexSlotTypeDestroy,
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func TestAccAwsLexSlotType_createVersion(t *testing.T) {
 	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexSlotTypeDestroy,
 		Steps: []resource.TestStep{
@@ -102,7 +102,7 @@ func TestAccAwsLexSlotType_description(t *testing.T) {
 	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexSlotTypeDestroy,
 		Steps: []resource.TestStep{
@@ -142,7 +142,7 @@ func TestAccAwsLexSlotType_enumerationValues(t *testing.T) {
 	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexSlotTypeDestroy,
 		Steps: []resource.TestStep{
@@ -188,7 +188,7 @@ func TestAccAwsLexSlotType_name(t *testing.T) {
 	testSlotTypeID2 := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexSlotTypeDestroy,
 		Steps: []resource.TestStep{
@@ -228,7 +228,7 @@ func TestAccAwsLexSlotType_valueSelectionStrategy(t *testing.T) {
 	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexSlotTypeDestroy,
 		Steps: []resource.TestStep{
@@ -268,7 +268,7 @@ func TestAccAwsLexSlotType_disappears(t *testing.T) {
 	testSlotTypeID := "test_slot_type_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("models.lex", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsLexSlotTypeDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Close #14893, Relates #14188 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):


```
    provider_test.go:544: skipping tests; partition aws-us-gov does not support models.lex service
--- SKIP: TestAccDataSourceAwsLexBot_basic (0.00s)
--- SKIP: TestAccAwsLexBot_basic (0.00s)
--- SKIP: TestAccDataSourceAwsLexIntent_basic (0.00s)
--- SKIP: TestAccAwsLexBotAlias_conversationLogsText (0.00s)
--- SKIP: TestAccAwsLexBotAlias_conversationLogsAudio (0.00s)
--- SKIP: TestAccAwsLexBot_clarificationPrompt (0.00s)
--- SKIP: TestAccAwsLexBot_abortStatement (0.00s)
--- SKIP: TestAccAwsLexBotAlias_conversationLogsBoth (0.00s)
--- SKIP: TestAccAwsLexBotAlias_disappears (0.00s)
--- SKIP: TestAccAwsLexBotAlias_description (0.00s)
--- PASS: TestAccAwsLexBot_version_serial (1.32s)
--- SKIP: TestAccDataSourceAwsLexSlotType_basic (0.00s)
--- SKIP: TestAccDataSourceAwsLexSlotType_withVersion (0.00s)
--- SKIP: TestAccAwsLexBotAlias_basic (0.00s)
--- SKIP: TestAccAwsLexBot_childDirected (0.00s)
--- SKIP: TestAccAwsLexBot_detectSentiment (0.00s)
--- SKIP: TestAccDataSourceAwsLexIntent_withVersion (0.00s)
--- SKIP: TestAccAwsLexBot_description (0.00s)
--- SKIP: TestAccAwsLexBot_voiceId (0.00s)
--- SKIP: TestAccAwsLexBot_enableModelImprovements (0.00s)
--- SKIP: TestAccAwsLexBot_locale (0.00s)
--- SKIP: TestAccAwsLexBot_intents (0.00s)
--- SKIP: TestAccAwsLexIntent_confirmationPromptAndRejectionStatement (0.00s)
--- SKIP: TestAccAwsLexIntent_dialogCodeHook (0.00s)
--- SKIP: TestAccAwsLexIntent_basic (0.00s)
--- SKIP: TestAccAwsLexIntent_slots (0.00s)
--- SKIP: TestAccAwsLexIntent_followUpPrompt (0.00s)
--- SKIP: TestAccAwsLexIntent_sampleUtterances (0.00s)
--- SKIP: TestAccAwsLexIntent_fulfillmentActivity (0.00s)
--- SKIP: TestAccAwsLexBot_idleSessionTtlInSeconds (0.00s)
--- SKIP: TestAccAwsLexBot_disappears (0.00s)
--- SKIP: TestAccAwsLexIntent_createVersion (0.00s)
--- SKIP: TestAccAwsLexIntent_conclusionStatement (0.00s)
--- SKIP: TestAccAwsLexIntent_slotsCustom (0.00s)
--- SKIP: TestAccAwsLexIntent_updateWithExternalChange (0.00s)
--- SKIP: TestAccAwsLexSlotType_enumerationValues (0.00s)
--- SKIP: TestAccAwsLexSlotType_description (0.00s)
--- SKIP: TestAccAwsLexSlotType_name (0.00s)
--- SKIP: TestAccAwsLexSlotType_disappears (0.00s)
--- SKIP: TestAccAwsLexSlotType_basic (0.00s)
--- SKIP: TestAccAwsLexIntent_disappears (0.00s)
--- SKIP: TestAccAwsLexSlotType_createVersion (0.00s)
--- SKIP: TestAccAwsLexSlotType_valueSelectionStrategy (0.00s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccDataSourceAwsLexSlotType_basic (53.90s)
--- PASS: TestAccDataSourceAwsLexIntent_basic (55.19s)
--- PASS: TestAccDataSourceAwsLexIntent_withVersion (55.78s)
--- PASS: TestAccDataSourceAwsLexSlotType_withVersion (56.91s)
--- PASS: TestAccAwsLexBotAlias_basic (69.99s)
--- PASS: TestAccAwsLexBotAlias_disappears (108.59s)
--- PASS: TestAccAwsLexBot_description (118.23s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsAudio (123.63s)
--- PASS: TestAccAwsLexBot_idleSessionTtlInSeconds (124.79s)
--- PASS: TestAccAwsLexIntent_basic (55.85s)
--- PASS: TestAccDataSourceAwsLexBot_basic (157.69s)
--- PASS: TestAccAwsLexBot_voiceId (109.97s)
--- PASS: TestAccAwsLexBot_disappears (111.59s)
--- PASS: TestAccAwsLexIntent_createVersion (60.94s)
--- PASS: TestAccAwsLexIntent_conclusionStatement (56.78s)
--- PASS: TestAccAwsLexIntent_confirmationPromptAndRejectionStatement (53.59s)
--- PASS: TestAccAwsLexIntent_followUpPrompt (53.10s)
--- PASS: TestAccAwsLexIntent_dialogCodeHook (56.01s)
--- PASS: TestAccAwsLexBot_clarificationPrompt (194.08s)
--- PASS: TestAccAwsLexIntent_disappears (19.07s)
--- PASS: TestAccAwsLexIntent_slots (55.59s)
--- PASS: TestAccAwsLexSlotType_basic (49.31s)
--- PASS: TestAccAwsLexIntent_updateWithExternalChange (51.68s)
--- PASS: TestAccAwsLexSlotType_createVersion (51.47s)
--- PASS: TestAccAwsLexBot_basic (234.68s)
--- PASS: TestAccAwsLexBot_detectSentiment (238.80s)
--- PASS: TestAccAwsLexSlotType_disappears (14.13s)
--- PASS: TestAccAwsLexSlotType_description (50.19s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsBoth (248.09s)
--- PASS: TestAccAwsLexBot_enableModelImprovements (250.79s)
--- PASS: TestAccAwsLexBot_childDirected (252.81s)
--- PASS: TestAccAwsLexSlotType_enumerationValues (62.45s)
--- PASS: TestAccAwsLexIntent_fulfillmentActivity (100.58s)
--- PASS: TestAccAwsLexSlotType_valueSelectionStrategy (30.27s)
--- PASS: TestAccAwsLexSlotType_name (36.99s)
--- PASS: TestAccAwsLexBot_abortStatement (292.00s)
--- PASS: TestAccAwsLexIntent_sampleUtterances (129.65s)
--- PASS: TestAccAwsLexBot_intents (251.58s)
--- PASS: TestAccAwsLexBotAlias_conversationLogsText (308.89s)
--- FAIL: TestAccAwsLexBot_version_serial (311.31s)
--- PASS: TestAccAwsLexBot_locale (259.23s)
--- PASS: TestAccAwsLexIntent_slotsCustom (148.16s)
--- FAIL: TestAccAwsLexBotAlias_description (320.56s)
```

* 2 failures are flaky and unrelated (tracked in #15555, #15605)