### PR TITLE
docs/resources/wafv2_web_acl: provide a link to the AWS WAF managed rules group names

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -458,7 +458,7 @@ The `xss_match_statement` block supports the following arguments:
 
 The `excluded_rule` block supports the following arguments:
 
-* `name` - (Required) The name of the rule to exclude.
+* `name` - (Required) The name of the rule to exclude. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) for a list of names in the "AWSManagedRulesCommonRuleSet" managed rule group.
 
 ### Field to Match
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -458,7 +458,7 @@ The `xss_match_statement` block supports the following arguments:
 
 The `excluded_rule` block supports the following arguments:
 
-* `name` - (Required) The name of the rule to exclude. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) for a list of names in the "AWSManagedRulesCommonRuleSet" managed rule group.
+* `name` - (Required) The name of the rule to exclude. If the rule group is managed by AWS, see the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) for a list of names in the appropriate rule group in use.
 
 ### Field to Match
 


### PR DESCRIPTION
Make it easier for people to find an initial list of AWS WAF managed rules groups names - this is what I suspect most people will want to use to get started so let's make it easy to find what to use.