### PR TITLE
tests/provider: Fix hardcoded (EKS Cluster)

### DIFF
--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -528,8 +528,10 @@ data "aws_availability_zones" "available" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
-  name = "%s"
+  name = %[1]q
 
   assume_role_policy = <<POLICY
 {
@@ -538,7 +540,7 @@ resource "aws_iam_role" "test" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "eks.amazonaws.com"
+        "Service": "eks.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -548,7 +550,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "test-AmazonEKSClusterPolicy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSClusterPolicy"
   role       = aws_iam_role.test.name
 }
 
@@ -556,8 +558,8 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name                       = "terraform-testacc-eks-cluster-base"
-    "kubernetes.io/cluster/%s" = "shared"
+    Name                          = "terraform-testacc-eks-cluster-base"
+    "kubernetes.io/cluster/%[1]s" = "shared"
   }
 }
 
@@ -569,19 +571,17 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name                       = "terraform-testacc-eks-cluster-base"
-    "kubernetes.io/cluster/%s" = "shared"
+    Name                          = "terraform-testacc-eks-cluster-base"
+    "kubernetes.io/cluster/%[1]s" = "shared"
   }
 }
-`, rName, rName, rName)
+`, rName)
 }
 
 func testAccAWSEksClusterConfig_Required(rName string) string {
-	return fmt.Sprintf(`
-%s
-
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = "%s"
+  name     = %q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
@@ -590,17 +590,15 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, testAccAWSEksClusterConfig_Base(rName), rName)
+`, rName))
 }
 
 func testAccAWSEksClusterConfig_Version(rName, version string) string {
-	return fmt.Sprintf(`
-%s
-
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = "%s"
+  name     = %q
   role_arn = aws_iam_role.test.arn
-  version  = "%s"
+  version  = %q
 
   vpc_config {
     subnet_ids = aws_subnet.test[*].id
@@ -608,15 +606,13 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, testAccAWSEksClusterConfig_Base(rName), rName, version)
+`, rName, version))
 }
 
 func testAccAWSEksClusterConfig_Logging(rName string, logTypes []string) string {
-	return fmt.Sprintf(`
-%s
-
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name                      = "%s"
+  name                      = %q
   role_arn                  = aws_iam_role.test.arn
   enabled_cluster_log_types = ["%v"]
 
@@ -626,11 +622,11 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, testAccAWSEksClusterConfig_Base(rName), rName, strings.Join(logTypes, "\", \""))
+`, rName, strings.Join(logTypes, "\", \"")))
 }
 
 func testAccAWSEksClusterConfigTags1(rName, tagKey1, tagValue1 string) string {
-	return testAccAWSEksClusterConfig_Base(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
   name     = %[1]q
   role_arn = aws_iam_role.test.arn
@@ -645,11 +641,11 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccAWSEksClusterConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAWSEksClusterConfig_Base(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
   name     = %[1]q
   role_arn = aws_iam_role.test.arn
@@ -665,11 +661,11 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccAWSEksClusterConfig_EncryptionConfig(rName string) string {
-	return testAccAWSEksClusterConfig_Base(rName) + fmt.Sprintf(`
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
@@ -693,13 +689,11 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSEksClusterConfig_VpcConfig_SecurityGroupIds(rName string) string {
-	return fmt.Sprintf(`
-%s
-
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 
@@ -709,7 +703,7 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_eks_cluster" "test" {
-  name     = "%s"
+  name     = %q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
@@ -719,53 +713,47 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, testAccAWSEksClusterConfig_Base(rName), rName)
+`, rName))
 }
 
 func testAccAWSEksClusterConfig_VpcConfig_EndpointPrivateAccess(rName string, endpointPrivateAccess bool) string {
-	return fmt.Sprintf(`
-%[1]s
-
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %[2]q
+  name     = %q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
-    endpoint_private_access = %[3]t
+    endpoint_private_access = %t
     endpoint_public_access  = true
     subnet_ids              = aws_subnet.test[*].id
   }
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, testAccAWSEksClusterConfig_Base(rName), rName, endpointPrivateAccess)
+`, rName, endpointPrivateAccess))
 }
 
 func testAccAWSEksClusterConfig_VpcConfig_EndpointPublicAccess(rName string, endpointPublicAccess bool) string {
-	return fmt.Sprintf(`
-%[1]s
-
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %[2]q
+  name     = %q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
     endpoint_private_access = true
-    endpoint_public_access  = %[3]t
+    endpoint_public_access  = %t
     subnet_ids              = aws_subnet.test[*].id
   }
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, testAccAWSEksClusterConfig_Base(rName), rName, endpointPublicAccess)
+`, rName, endpointPublicAccess))
 }
 
 func testAccAWSEksClusterConfig_VpcConfig_PublicAccessCidrs(rName string, publicAccessCidr string) string {
-	return fmt.Sprintf(`
-%[1]s
-
+	return composeConfig(testAccAWSEksClusterConfig_Base(rName), fmt.Sprintf(`
 resource "aws_eks_cluster" "test" {
-  name     = %[2]q
+  name     = %q
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
@@ -777,5 +765,5 @@ resource "aws_eks_cluster" "test" {
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]
 }
-`, testAccAWSEksClusterConfig_Base(rName), rName, publicAccessCidr)
+`, rName, publicAccessCidr))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15648
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (19.48s)
--- PASS: TestAccAWSEksCluster_basic (613.49s)
--- PASS: TestAccAWSEksCluster_Tags (681.85s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig (684.90s)
--- PASS: TestAccAWSEksCluster_Logging (714.74s)
--- PASS: TestAccAWSEksClusterDataSource_basic (735.12s)
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (803.35s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (920.09s)
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (969.78s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (1327.11s)
--- PASS: TestAccAWSEksCluster_Version (2293.79s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSEksClusterAuthDataSource_basic (22.49s)
--- PASS: TestAccAWSEksCluster_Tags (645.95s)
--- PASS: TestAccAWSEksCluster_basic (661.86s)
--- PASS: TestAccAWSEksCluster_Logging (754.77s)
--- PASS: TestAccAWSEksClusterDataSource_basic (782.01s)
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (812.81s)
--- PASS: TestAccAWSEksCluster_EncryptionConfig (814.13s)
--- PASS: TestAccAWSEksCluster_VpcConfig_PublicAccessCidrs (949.28s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (1268.16s)
--- PASS: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (1880.98s)
--- PASS: TestAccAWSEksCluster_Version (2396.12s)
```
