### PR TITLE
tests/provider: Fix hardcoded ARN (provider)

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -1420,9 +1420,11 @@ provider "aws" {
   }
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `, endpoints)
 }
@@ -1439,9 +1441,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `
 }
@@ -1456,9 +1460,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `
 }
@@ -1477,9 +1483,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `, tagPrefix1)
 }
@@ -1498,9 +1506,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `, tagPrefix1, tagPrefix2)
 }
@@ -1515,9 +1525,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `
 }
@@ -1536,9 +1548,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `, tag1)
 }
@@ -1557,9 +1571,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `, tag1, tag2)
 }
@@ -1575,9 +1591,11 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_partition" "provider_test" {}
+
 # Required to initialize the provider
 data "aws_arn" "test" {
-  arn = "arn:aws:s3:::test"
+  arn = "arn:${data.aws_partition.provider_test.partition}:s3:::test"
 }
 `, region)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSProvider_Endpoints (7.55s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (7.28s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (7.35s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (7.32s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (7.45s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (7.25s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (7.63s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (7.50s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (5.21s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSProvider_Endpoints (6.10s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (5.96s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (5.91s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (5.91s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (5.80s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (5.75s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (6.09s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (4.58s)
```