### PR TITLE
tests/provider: Fix hardcoded ARN (ds/iam_policy_doc)

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -650,6 +650,13 @@ func testAccRegionPreCheck(t *testing.T, region string) {
 	}
 }
 
+// testAccPartitionPreCheck checks that the test partition is the specified partition.
+func testAccPartitionPreCheck(partition string, t *testing.T) {
+	if testAccGetPartition() != partition {
+		t.Skipf("skipping tests; current partition (%s) does not equal %s", testAccGetPartition(), partition)
+	}
+}
+
 func testAccOrganizationsAccountPreCheck(t *testing.T) {
 	conn := testAccProvider.Meta().(*AWSClient).organizationsconn
 	input := &organizations.DescribeOrganizationInput{}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestProvider_impl (0.76s)
--- SKIP: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsAWS (0.00s)
--- PASS: TestProvider (1.70s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice (46.11s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (50.67s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (52.09s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (52.78s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (51.18s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (53.05s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov (53.15s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (52.42s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (53.27s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (53.94s)
--- PASS: TestAccAWSProvider_Endpoints (55.92s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (55.53s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (58.65s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (73.30s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (23.19s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (24.31s)
--- PASS: TestAccAWSProvider_Region_AwsChina (24.88s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (78.04s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (32.66s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (27.42s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (28.84s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (26.90s)
```

The output from acceptance testing (commercial):

```
--- PASS: TestProvider_impl (0.81s)
--- PASS: TestProvider (2.45s)
--- SKIP: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsGov (0.00s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (50.95s)
--- PASS: TestAccAWSProvider_Region_AwsChina (52.87s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (65.75s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (68.71s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_MultiplePrincipalsAWS (68.82s)
--- PASS: TestAccAWSProvider_Endpoints (68.83s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (69.01s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (69.15s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (69.17s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (69.21s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (68.39s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementOverride (69.83s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (70.71s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Statement_Principal_Identifiers_StringAndSlice (70.83s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (70.85s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_noStatementMerge (71.08s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (71.15s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_duplicateSid (73.01s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (22.16s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (79.80s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (27.00s)
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (82.66s)
```