### PR TITLE
tests/provider: Fix hardcoded ARN (CloudWatch Event Target)

### DIFF
--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -469,6 +469,8 @@ resource "aws_cloudwatch_event_rule" "test" {
   role_arn            = aws_iam_role.role.arn
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "role" {
   name = "%s"
 
@@ -479,7 +481,7 @@ resource "aws_iam_role" "role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "events.amazonaws.com"
+        "Service": "events.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -582,6 +584,8 @@ resource "aws_cloudwatch_event_target" "test" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test_role" {
   name = "%s"
 
@@ -592,7 +596,7 @@ resource "aws_iam_role" "test_role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "events.amazonaws.com"
+        "Service": "events.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -658,6 +662,8 @@ resource "aws_cloudwatch_event_target" "test" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test_role" {
   name = "%s"
 
@@ -668,7 +674,7 @@ resource "aws_iam_role" "test_role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "events.amazonaws.com"
+        "Service": "events.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -759,6 +765,8 @@ resource "aws_cloudwatch_event_target" "test" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test_role" {
   name = "%[1]s"
 
@@ -769,7 +777,7 @@ resource "aws_iam_role" "test_role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "events.amazonaws.com"
+        "Service": "events.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -852,6 +860,8 @@ resource "aws_cloudwatch_event_target" "test" {
   ]
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "event_iam_role" {
   name = "event_%[1]s"
 
@@ -863,7 +873,7 @@ resource "aws_iam_role" "event_iam_role" {
       "Action": "sts:AssumeRole",
       "Effect": "Allow",
       "Principal": {
-        "Service": "events.amazonaws.com"
+        "Service": "events.${data.aws_partition.current.dns_suffix}"
       }
     }
   ]
@@ -882,7 +892,7 @@ resource "aws_iam_role" "ecs_iam_role" {
       "Action": "sts:AssumeRole",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
       }
     }
   ]
@@ -892,7 +902,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "ecs_policy_attachment" {
   role       = aws_iam_role.ecs_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_instance_profile" "iam_instance_profile" {
@@ -911,7 +921,7 @@ resource "aws_iam_role" "batch_iam_role" {
         "Action": "sts:AssumeRole",
         "Effect": "Allow",
         "Principal": {
-          "Service": "batch.amazonaws.com"
+          "Service": "batch.${data.aws_partition.current.dns_suffix}"
         }
     }
     ]
@@ -921,7 +931,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "batch_policy_attachment" {
   role       = aws_iam_role.batch_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
 
 resource "aws_security_group" "security_group" {
@@ -1012,6 +1022,8 @@ resource "aws_cloudwatch_event_target" "test" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "iam_role" {
   name = "event_%[1]s"
 
@@ -1023,7 +1035,7 @@ resource "aws_iam_role" "iam_role" {
       "Action": "sts:AssumeRole",
       "Effect": "Allow",
       "Principal": {
-        "Service": "events.amazonaws.com"
+        "Service": "events.${data.aws_partition.current.dns_suffix}"
       }
     }
   ]
@@ -1064,6 +1076,8 @@ resource "aws_sqs_queue" "sqs_queue" {
 
 func testAccAWSCloudWatchEventTargetConfigInputTransformer(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "iam_for_lambda" {
   name = "tf_acc_input_transformer"
 
@@ -1074,7 +1088,7 @@ resource "aws_iam_role" "iam_for_lambda" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "lambda.amazonaws.com"
+        "Service": "lambda.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSCloudWatchEventTarget_sqs (24.11s)
--- PASS: TestAccAWSCloudWatchEventTarget_missingTargetId (24.72s)
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (25.84s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (35.70s)
--- PASS: TestAccAWSCloudWatchEventTarget_basic (36.54s)
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (37.08s)
--- PASS: TestAccAWSCloudWatchEventTarget_full (62.17s)
--- PASS: TestAccAWSCloudWatchEventTarget_kinesis (62.40s)
--- PASS: TestAccAWSCloudWatchEventTarget_batch (121.52s)
--- FAIL: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (143.40s)
```

*Failure is unrelated and tracked in #15668

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSCloudWatchEventTarget_missingTargetId (24.53s)
--- PASS: TestAccAWSCloudWatchEventTarget_sqs (24.88s)
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (29.08s)
--- PASS: TestAccAWSCloudWatchEventTarget_basic (37.08s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecs (37.27s)
--- PASS: TestAccAWSCloudWatchEventTarget_ecsWithBlankTaskCount (37.56s)
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (45.71s)
--- PASS: TestAccAWSCloudWatchEventTarget_full (61.58s)
--- PASS: TestAccAWSCloudWatchEventTarget_kinesis (63.81s)
--- PASS: TestAccAWSCloudWatchEventTarget_batch (92.66s)
```