### PR TITLE
Enhancement/cloudwatch event target adding validation

### DIFF
--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -216,6 +216,10 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 							Type:     schema.TypeMap,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+							ValidateFunc: validation.All(
+								MapLenBetween(0, 10),
+								MapKeyNotMatch(regexp.MustCompile(`^AWS.*$`), "input_path must not start with \"AWS\""),
+							),
 						},
 						"input_template": {
 							Type:         schema.TypeString,

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -217,8 +217,8 @@ func resourceAwsCloudWatchEventTarget() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							ValidateFunc: validation.All(
-								MapLenBetween(0, 10),
-								MapKeyNotMatch(regexp.MustCompile(`^AWS.*$`), "input_path must not start with \"AWS\""),
+								MapMaxItems(10),
+								MapKeysDoNotMatch(regexp.MustCompile(`^AWS.*$`), "input_path must not start with \"AWS\""),
 							),
 						},
 						"input_template": {

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -1107,6 +1107,15 @@ resource "aws_cloudwatch_event_target" "test" {
   input_transformer {
     input_paths = {
       time = "$.time"
+      severity : "$.detail.severity",
+      Finding_ID : "$.detail.id",
+      instanceId : "$.detail.resource.instanceDetails.instanceId",
+      port : "$.detail.service.action.networkConnectionAction.localPortDetails.port",
+      eventFirstSeen : "$.detail.service.eventFirstSeen",
+      eventLastSeen : "$.detail.service.eventLastSeen",
+      count : "$.detail.service.count",
+      Finding_Type : "$.detail.type",
+      region : "$.region",
     }
 
     input_template = <<EOF
@@ -1114,7 +1123,15 @@ resource "aws_cloudwatch_event_target" "test" {
   "detail-type": "Scheduled Event",
   "source": "aws.events",
   "time": <time>,
-  "region": "eu-west-1",
+  "severity": <severity>,
+  "Finding_ID": <Finding_ID>,
+  "instanceId": <instanceId>,
+  "port": <port>,
+  "eventFirstSeen": <eventFirstSeen>,
+  "eventLastSeen": <eventLastSeen>,
+  "count": <count>,
+  "Finding_Type": <Finding_Type>,
+  "region": <region>,
   "detail": {}
 }
 EOF

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -1088,13 +1088,13 @@ func testAccAWSCloudWatchEventTargetConfigInputTransformer(rName string, inputPa
 	if len(sampleInputPaths) < inputPathCount {
 		inputPathCount = len(sampleInputPaths)
 	}
+
 	for i := 0; i < inputPathCount; i++ {
 		fmt.Fprintf(&inputPaths, `
       %s = "$.%s"`, sampleInputPaths[i], sampleInputPaths[i])
 
 		fmt.Fprintf(&inputTemplates, `
   "%s": <%s>,`, sampleInputPaths[i], sampleInputPaths[i])
-
 	}
 
 	return fmt.Sprintf(`
@@ -1139,7 +1139,8 @@ resource "aws_cloudwatch_event_target" "test" {
   rule = aws_cloudwatch_event_rule.schedule.id
 
   input_transformer {
-    input_paths = {%s
+    input_paths = {
+      %s
     }
 
     input_template = <<EOF

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2466,3 +2466,37 @@ func validateNestedExactlyOneOf(m map[string]interface{}, valid []string) error 
 	}
 	return nil
 }
+
+func MapLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		m, ok := i.(map[string]interface{})
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be map", k))
+			return warnings, errors
+		}
+
+		if len(m) < min || len(m) > max {
+			errors = append(errors, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %d", k, min, max, len(m)))
+		}
+
+		return warnings, errors
+	}
+}
+
+func MapKeyNotMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		m, ok := i.(map[string]interface{})
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be map", k))
+			return warnings, errors
+		}
+
+		for key := range m {
+			if ok := r.MatchString(key); ok {
+				errors = append(errors, fmt.Errorf("%s: %s: %s", k, message, key))
+			}
+		}
+
+		return warnings, errors
+	}
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2467,7 +2467,7 @@ func validateNestedExactlyOneOf(m map[string]interface{}, valid []string) error 
 	return nil
 }
 
-func MapLenBetween(min, max int) schema.SchemaValidateFunc {
+func MapMaxItems(max int) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		m, ok := i.(map[string]interface{})
 		if !ok {
@@ -2475,15 +2475,15 @@ func MapLenBetween(min, max int) schema.SchemaValidateFunc {
 			return warnings, errors
 		}
 
-		if len(m) < min || len(m) > max {
-			errors = append(errors, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %d", k, min, max, len(m)))
+		if len(m) > max {
+			errors = append(errors, fmt.Errorf("expected number of items in %s to be lesser than or equal to %d, got %d", k, max, len(m)))
 		}
 
 		return warnings, errors
 	}
 }
 
-func MapKeyNotMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+func MapKeysDoNotMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		m, ok := i.(map[string]interface{})
 		if !ok {

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -301,6 +301,10 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 `input_transformer` support the following:
 
 * `input_paths` - (Optional) Key value pairs specified in the form of JSONPath (for example, time = $.time)
+    * You can have as many as 10 key-value pairs.
+    * You must use JSON dot notation, not bracket notation.
+    * The keys can't start with "AWS".
+
 * `input_template` - (Required) Structure containing the template body.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10912
Closes #15653

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  TF_ACC=1 go test ./aws -v -count 1 -parallel 4 -run=TestAccAWSCloudWatchEventTarget_input_transformer -timeout 60m
=== RUN   TestAccAWSCloudWatchEventTarget_input_transformer
=== PAUSE TestAccAWSCloudWatchEventTarget_input_transformer
=== CONT  TestAccAWSCloudWatchEventTarget_input_transformer
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (39.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.304s
```
@gdavison hope you don't mind I went ahead and submitted this!

Added validation for max number of input_paths (10) and validation that they don't start with "AWS".
Updated Acc test to include 10 input_paths.