### PR TITLE
tests/provider: Fix hardcoded ARN (Kinesis)

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream_migrate_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_migrate_test.go
@@ -17,32 +17,32 @@ func TestAWSKinesisFirehoseMigrateState(t *testing.T) {
 			StateVersion: 0,
 			Attributes: map[string]string{
 				// EBS
-				"role_arn":            "arn:aws:iam::somenumber:role/tf_acctest_4271506651559170635",
-				"s3_bucket_arn":       "arn:aws:s3:::tf-test-bucket",
+				"role_arn":            "arn:aws:iam::somenumber:role/tf_acctest_4271506651559170635", //lintignore:AWSAT005
+				"s3_bucket_arn":       "arn:aws:s3:::tf-test-bucket",                                 //lintignore:AWSAT005
 				"s3_buffer_interval":  "400",
 				"s3_buffer_size":      "10",
 				"s3_data_compression": "GZIP",
 			},
 			Expected: map[string]string{
 				"s3_configuration.#":                    "1",
-				"s3_configuration.0.bucket_arn":         "arn:aws:s3:::tf-test-bucket",
+				"s3_configuration.0.bucket_arn":         "arn:aws:s3:::tf-test-bucket", //lintignore:AWSAT005
 				"s3_configuration.0.buffer_interval":    "400",
 				"s3_configuration.0.buffer_size":        "10",
 				"s3_configuration.0.compression_format": "GZIP",
-				"s3_configuration.0.role_arn":           "arn:aws:iam::somenumber:role/tf_acctest_4271506651559170635",
+				"s3_configuration.0.role_arn":           "arn:aws:iam::somenumber:role/tf_acctest_4271506651559170635", //lintignore:AWSAT005
 			},
 		},
 		"v0.6.16 and earlier, sparse": {
 			StateVersion: 0,
 			Attributes: map[string]string{
 				// EBS
-				"role_arn":      "arn:aws:iam::somenumber:role/tf_acctest_4271506651559170635",
-				"s3_bucket_arn": "arn:aws:s3:::tf-test-bucket",
+				"role_arn":      "arn:aws:iam::somenumber:role/tf_acctest_4271506651559170635", //lintignore:AWSAT005
+				"s3_bucket_arn": "arn:aws:s3:::tf-test-bucket",                                 //lintignore:AWSAT005
 			},
 			Expected: map[string]string{
 				"s3_configuration.#":            "1",
-				"s3_configuration.0.bucket_arn": "arn:aws:s3:::tf-test-bucket",
-				"s3_configuration.0.role_arn":   "arn:aws:iam::somenumber:role/tf_acctest_4271506651559170635",
+				"s3_configuration.0.bucket_arn": "arn:aws:s3:::tf-test-bucket",                                 //lintignore:AWSAT005
+				"s3_configuration.0.role_arn":   "arn:aws:iam::somenumber:role/tf_acctest_4271506651559170635", //lintignore:AWSAT005
 			},
 		},
 	}

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -118,7 +118,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_basic(t *testing.T) {
 			{
 				ResourceName:  resourceName,
 				ImportState:   true,
-				ImportStateId: "arn:aws:firehose:us-east-1:123456789012:missing-slash",
+				ImportStateId: "arn:aws:firehose:us-east-1:123456789012:missing-slash", //lintignore:AWSAT003,AWSAT005
 				ExpectError:   regexp.MustCompile(`Expected ID in format`),
 			},
 		},

--- a/aws/resource_aws_kinesis_stream_migrate_test.go
+++ b/aws/resource_aws_kinesis_stream_migrate_test.go
@@ -8,7 +8,7 @@ import (
 
 func testResourceAwsKinesisStreamStateDataV0() map[string]interface{} {
 	return map[string]interface{}{
-		"arn":                 "arn:aws:test:us-east-1:123456789012:test",
+		"arn":                 "arn:aws:test:us-east-1:123456789012:test", //lintignore:AWSAT003,AWSAT005
 		"encryption_type":     "NONE",
 		"kms_key_id":          "",
 		"name":                "test",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

**No code changes. Only adds `LINTIGNORE`.**

The output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_basic (81.98s)
--- PASS: TestResourceAwsKinesisStreamStateUpgradeV0 (0.00s)
--- PASS: TestAWSKinesisFirehoseMigrateState_empty (0.00s)
```
