### PR TITLE
tests/provider: Fix hardcoded (ECS task def)

### DIFF
--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -994,7 +994,7 @@ func testAccCheckAWSTaskDefinitionDockerVolumeConfigurationAutoprovisionNil(def 
 }
 
 func testAccAWSEcsTaskDefinition_constraint(tdName string) string {
-	return fmt.Sprintf(`
+	return composeConfig(testAccAvailableAZsNoOptInConfig(), fmt.Sprintf(`
 resource "aws_ecs_task_definition" "test" {
   family = "%s"
 
@@ -1045,10 +1045,10 @@ TASK_DEFINITION
 
   placement_constraints {
     type       = "memberOf"
-    expression = "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]"
+    expression = "attribute:ecs.availability-zone in [${data.aws_availability_zones.available.names[0]}, ${data.aws_availability_zones.available.names[1]}]"
   }
 }
-`, tdName)
+`, tdName))
 }
 
 func testAccAWSEcsTaskDefinition(tdName string) string {
@@ -1674,6 +1674,8 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role_policy" "test" {
   name = %[2]q
   role = aws_iam_role.test.id
@@ -1688,7 +1690,7 @@ resource "aws_iam_role_policy" "test" {
 				"s3:GetBucketLocation",
 				"s3:ListAllMyBuckets"
 			],
-			"Resource": "arn:aws:s3:::*"
+			"Resource": "arn:${data.aws_partition.current.partition}:s3:::*"
 		}
 	]
 }
@@ -1743,6 +1745,8 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role_policy" "test" {
   name = %[2]q
   role = aws_iam_role.test.id
@@ -1757,7 +1761,7 @@ resource "aws_iam_role_policy" "test" {
 			 "s3:GetBucketLocation",
 			 "s3:ListAllMyBuckets"
 		 ],
-		 "Resource": "arn:aws:s3:::*"
+		 "Resource": "arn:${data.aws_partition.current.partition}:s3:::*"
 	 }
  ]
 }
@@ -1815,6 +1819,8 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role_policy" "test" {
   name = %[2]q
   role = aws_iam_role.test.id
@@ -1829,7 +1835,7 @@ resource "aws_iam_role_policy" "test" {
 			 "s3:GetBucketLocation",
 			 "s3:ListAllMyBuckets"
 		 ],
-		 "Resource": "arn:aws:s3:::*"
+		 "Resource": "arn:${data.aws_partition.current.partition}:s3:::*"
 	 }
  ]
 }
@@ -1887,6 +1893,8 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role_policy" "test" {
   name = %[2]q
   role = aws_iam_role.test.id
@@ -1901,7 +1909,7 @@ resource "aws_iam_role_policy" "test" {
 			 "s3:GetBucketLocation",
 			 "s3:ListAllMyBuckets"
 		 ],
-		 "Resource": "arn:aws:s3:::*"
+		 "Resource": "arn:${data.aws_partition.current.partition}:s3:::*"
 	 }
  ]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
--- FAIL: TestAccAWSEcsTaskDefinition_inferenceAccelerator (9.35s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (25.75s)
--- PASS: TestAccAWSEcsTaskDefinition_basic (41.94s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (41.94s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (28.40s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (27.54s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (36.60s)
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (41.40s)
--- PASS: TestAccAWSEcsTaskDefinition_ProxyConfiguration (36.67s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (63.57s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (20.67s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (25.77s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (117.40s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSAccessPoint (42.93s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolume (37.31s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (32.77s)
--- PASS: TestAccAWSEcsTaskDefinition_withIPCMode (28.96s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (28.91s)
--- PASS: TestAccAWSEcsTaskDefinition_withPidMode (26.96s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (20.65s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (29.21s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (25.77s)
--- PASS: TestAccAWSEcsTaskDefinition_withTransitEncryptionEFSVolume (37.34s)
```

*Failure is unrelated and tracked in #15685 

The output from acceptance testing (commercial):

```
--- PASS: TestAccAWSEcsTaskDefinition_constraint (15.45s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (75.11s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (75.78s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (76.09s)
--- PASS: TestValidateAwsEcsTaskDefinitionContainerDefinitions (0.30s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (76.72s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (77.26s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (82.83s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (82.93s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (83.09s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolume (83.35s)
--- PASS: TestAccAWSEcsTaskDefinition_withPidMode (85.00s)
--- PASS: TestAccAWSEcsTaskDefinition_withIPCMode (85.29s)
--- PASS: TestAccAWSEcsTaskDefinition_withTransitEncryptionEFSVolume (85.47s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSVolumeMinimal (86.38s)
--- PASS: TestAccAWSEcsTaskDefinition_withEFSAccessPoint (87.15s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (94.73s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (97.71s)
--- PASS: TestAccAWSEcsTaskDefinition_basic (99.72s)
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (100.39s)
--- PASS: TestAccAWSEcsTaskDefinition_inferenceAccelerator (28.66s)
--- PASS: TestAccAWSEcsTaskDefinition_ProxyConfiguration (34.59s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (101.86s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (158.37s)
```