### PR TITLE
Removes `dorny/paths-filter`

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -18,32 +18,7 @@ env:
   GO111MODULE: on
 
 jobs:
-  changes:
-    name: Filter Changes
-    runs-on: ubuntu-latest
-    outputs:
-      tools: ${{ steps.filter.outputs.tools }}
-      terrafmt: ${{ steps.filter.outputs.terrafmt }}
-      validate-terraform: ${{ steps.filter.outputs.validate-terraform }}
-    steps:
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            tools:
-              - tools/go.mod
-            terrafmt: &terrafmt
-              - .github/workflows/acctest-terraform-lint.yml
-              - aws/core_acceptance_test.go
-              - aws/data_source_aws_*_test.go
-              - aws/resource_aws_[a-s]*_test.go
-            validate-terraform:
-              - *terrafmt
-              - scripts/validate-terraform.sh
-
   terrafmt:
-    needs: changes
-    if: needs.changes.outputs.terrafmt == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -81,8 +56,6 @@ jobs:
             | xargs -I {} terrafmt diff --check --quiet --fmtcompat {}
 
   validate-terraform:
-    needs: changes
-    if: needs.changes.outputs.validate-terraform == 'true' || needs.changes.outputs.tools == 'true' && startsWith(github.head_ref, 'renovate/github.com-terraform-linters-tflint-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Removes `dorny/paths-filter` since it's causing GitHub Workflows problems

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
