### PR TITLE
tests/provider: Fix hardcoded ARNs (data sources)

### DIFF
--- a/aws/data_source_aws_acmpca_certificate_authority_test.go
+++ b/aws/data_source_aws_acmpca_certificate_authority_test.go
@@ -73,6 +73,7 @@ data "aws_acmpca_certificate_authority" "test" {
 }
 `
 
+//lintignore:AWSAT003,AWSAT005
 const testAccDataSourceAwsAcmpcaCertificateAuthorityConfig_NonExistent = `
 data "aws_acmpca_certificate_authority" "test" {
   arn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/tf-acc-test-does-not-exist"

--- a/aws/data_source_aws_arn_test.go
+++ b/aws/data_source_aws_arn_test.go
@@ -41,6 +41,7 @@ func testAccDataSourceAwsArn(name string) resource.TestCheckFunc {
 	}
 }
 
+//lintignore:AWSAT003,AWSAT005
 const testAccDataSourceAwsArnConfig = `
 data "aws_arn" "test" {
   arn = "arn:aws:rds:eu-west-1:123456789012:db:mysql-db"

--- a/aws/data_source_aws_cur_report_definition_test.go
+++ b/aws/data_source_aws_cur_report_definition_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestAccDataSourceAwsCurReportDefinition_basic(t *testing.T) {
+	if testAccGetPartition() != "aws" {
+		t.Skipf("skipping test; hardcoded us-east-1 test, not supported in partition %s", testAccGetPartition()) //lintignore:AWSAT003
+	}
+
 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
@@ -45,8 +49,12 @@ func TestAccDataSourceAwsCurReportDefinition_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsCurReportDefinition_additional(t *testing.T) {
+	if testAccGetPartition() != "aws" {
+		t.Skipf("skipping test; hardcoded us-east-1 test, not supported in partition %s", testAccGetPartition()) //lintignore:AWSAT003
+	}
+
 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") //lintignore:AWSAT003
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
 
 	resourceName := "aws_cur_report_definition.test"
@@ -96,6 +104,7 @@ func testAccDataSourceAwsCurReportDefinitionCheckExists(datasourceName, resource
 
 // note: cur report definitions are currently only supported in us-east-1
 func testAccDataSourceAwsCurReportDefinitionConfig_basic(reportName string, bucketName string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 provider "aws" {
   region = "us-east-1"
@@ -164,6 +173,7 @@ data "aws_cur_report_definition" "test" {
 }
 
 func testAccDataSourceAwsCurReportDefinitionConfig_additional(reportName string, bucketName string) string {
+	//lintignore:AWSAT003,AWSAT005
 	return fmt.Sprintf(`
 provider "aws" {
   region = "us-east-1"

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -80,6 +80,8 @@ locals {
   random_name = "test-es-%d"
 }
 
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
@@ -96,7 +98,7 @@ resource "aws_elasticsearch_domain" "test" {
       "Action": "es:*",
       "Principal": "*",
       "Effect": "Allow",
-      "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*",
+      "Resource": "arn:${data.aws_partition.current.partition}:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*",
       "Condition": {
         "IpAddress": {
           "aws:SourceIp": [

--- a/aws/data_source_aws_lambda_invocation_test.go
+++ b/aws/data_source_aws_lambda_invocation_test.go
@@ -107,8 +107,10 @@ resource "aws_iam_role" "lambda_role" {
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role_policy_attachment" "lambda_role_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   role       = aws_iam_role.lambda_role.name
 }
 `, roleName)

--- a/aws/data_source_aws_secretsmanager_secret_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_test.go
@@ -147,6 +147,7 @@ const testAccDataSourceAwsSecretsManagerSecretConfig_MissingRequired = `
 data "aws_secretsmanager_secret" "test" {}
 `
 
+//lintignore:AWSAT003,AWSAT005
 const testAccDataSourceAwsSecretsManagerSecretConfig_MultipleSpecified = `
 data "aws_secretsmanager_secret" "test" {
   arn  = "arn:aws:secretsmanager:us-east-1:123456789012:secret:tf-acc-test-does-not-exist"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Resolves AWSAT005 issues with remaining data sources.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
kommer snart
```

The output from acceptance testing (GovCloud):

```
kommer snart
```
