### PR TITLE
tests/provider: Fix hardcoded ARN (IAM)

### DIFF
--- a/aws/resource_aws_iam_service_linked_role_test.go
+++ b/aws/resource_aws_iam_service_linked_role_test.go
@@ -90,25 +90,25 @@ func TestDecodeIamServiceLinkedRoleID(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Input:    "arn:aws:iam::123456789012:role/not-service-linked-role",
+			Input:    "arn:aws:iam::123456789012:role/not-service-linked-role", //lintignore:AWSAT005
 			ErrCount: 1,
 		},
 		{
-			Input:        "arn:aws:iam::123456789012:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+			Input:        "arn:aws:iam::123456789012:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling", //lintignore:AWSAT005
 			ServiceName:  "autoscaling.amazonaws.com",
 			RoleName:     "AWSServiceRoleForAutoScaling",
 			CustomSuffix: "",
 			ErrCount:     0,
 		},
 		{
-			Input:        "arn:aws:iam::123456789012:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling_custom-suffix",
+			Input:        "arn:aws:iam::123456789012:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling_custom-suffix", //lintignore:AWSAT005
 			ServiceName:  "autoscaling.amazonaws.com",
 			RoleName:     "AWSServiceRoleForAutoScaling_custom-suffix",
 			CustomSuffix: "custom-suffix",
 			ErrCount:     0,
 		},
 		{
-			Input:        "arn:aws:iam::123456789012:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
+			Input:        "arn:aws:iam::123456789012:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable", //lintignore:AWSAT005
 			ServiceName:  "dynamodb.application-autoscaling.amazonaws.com",
 			RoleName:     "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
 			CustomSuffix: "DynamoDBTable",

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -323,6 +323,8 @@ resource "aws_iam_user" "user" {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "user" {
   statement {
     effect    = "Allow"
@@ -333,7 +335,7 @@ data "aws_iam_policy_document" "user" {
   statement {
     effect    = "Allow"
     actions   = ["iam:ChangePassword"]
-    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
+    resources = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
   }
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The output from acceptance testing (GovCloud):

```
--- PASS: TestDecodeIamServiceLinkedRoleID (0.00s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (15.44s)
--- PASS: TestAccAWSUserLoginProfile_notAKey (15.44s)
--- PASS: TestAccAWSUserLoginProfile_keybase (25.80s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (25.80s)
--- FAIL: TestAccAWSUserLoginProfile_basic (137.39s)
```
 *Failure is unrelated and tracked in #15690 

The output from acceptance testing (commercial):

```
--- PASS: TestDecodeIamServiceLinkedRoleID (0.00s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (8.26s)
--- PASS: TestAccAWSUserLoginProfile_notAKey (8.34s)
--- PASS: TestAccAWSUserLoginProfile_keybase (16.29s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (16.35s)
--- PASS: TestAccAWSUserLoginProfile_basic (30.01s)
```