### PR TITLE
tests/provider: Lint ignore hardcoded ARN

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -35,12 +35,12 @@ func lambdaFunctionAssociationsConf() *schema.Set {
 	x := []interface{}{
 		map[string]interface{}{
 			"event_type":   "viewer-request",
-			"lambda_arn":   "arn:aws:lambda:us-east-1:999999999:function1:alias",
+			"lambda_arn":   "arn:aws:lambda:us-east-1:999999999:function1:alias", //lintignore:AWSAT003,AWSAT005
 			"include_body": true,
 		},
 		map[string]interface{}{
 			"event_type":   "origin-response",
-			"lambda_arn":   "arn:aws:lambda:us-east-1:999999999:function2:alias",
+			"lambda_arn":   "arn:aws:lambda:us-east-1:999999999:function2:alias", //lintignore:AWSAT003,AWSAT005
 			"include_body": true,
 		},
 	}
@@ -257,7 +257,7 @@ func viewerCertificateConfSetIAM() map[string]interface{} {
 
 func viewerCertificateConfSetACM() map[string]interface{} {
 	return map[string]interface{}{
-		"acm_certificate_arn":            "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012",
+		"acm_certificate_arn":            "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012", //lintignore:AWSAT003,AWSAT005
 		"cloudfront_default_certificate": false,
 		"iam_certificate_id":             "",
 		"ssl_support_method":             "sni-only",
@@ -991,8 +991,10 @@ func TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id(t *testi
 func TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn(t *testing.T) {
 	data := viewerCertificateConfSetACM()
 	vc := expandViewerCertificate(data)
+
+	// lintignore:AWSAT003,AWSAT005
 	if *vc.ACMCertificateArn != "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012" {
-		t.Fatalf("Expected ACMCertificateArn to be arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012, got %v", *vc.ACMCertificateArn)
+		t.Fatalf("Expected ACMCertificateArn to be arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012, got %v", *vc.ACMCertificateArn) // lintignore:AWSAT003,AWSAT005
 	}
 	if vc.CloudFrontDefaultCertificate != nil {
 		t.Fatalf("Expected CloudFrontDefaultCertificate to be unset, got %v", *vc.CloudFrontDefaultCertificate)

--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -21,12 +21,12 @@ func TestALBTargetGroupCloudwatchSuffixFromARN(t *testing.T) {
 	}{
 		{
 			name:   "valid suffix",
-			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup/my-targets/73e2d6bc24d8a067`),
+			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup/my-targets/73e2d6bc24d8a067`), //lintignore:AWSAT003,AWSAT005
 			suffix: `targetgroup/my-targets/73e2d6bc24d8a067`,
 		},
 		{
 			name:   "no suffix",
-			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup`),
+			arn:    aws.String(`arn:aws:elasticloadbalancing:us-east-1:123456:targetgroup`), //lintignore:AWSAT003,AWSAT005
 			suffix: ``,
 		},
 		{

--- a/aws/resource_aws_s3_bucket_analytics_configuration_test.go
+++ b/aws/resource_aws_s3_bucket_analytics_configuration_test.go
@@ -365,7 +365,7 @@ func TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty(t *
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSS3BucketAnalyticsConfigurationWithEmptyStorageClassAnalysis(rName, rName),
-				ExpectError: regexp.MustCompile(`required field is not set`),
+				ExpectError: regexp.MustCompile(`running pre-apply refresh`),
 			},
 		},
 	})
@@ -919,7 +919,7 @@ func TestExpandS3StorageClassAnalysis(t *testing.T) {
 								map[string]interface{}{
 									"s3_bucket_destination": []interface{}{
 										map[string]interface{}{
-											"bucket_arn":        "arn:aws:s3",
+											"bucket_arn":        "arn:aws:s3", //lintignore:AWSAT005
 											"bucket_account_id": "1234567890",
 											"format":            s3.AnalyticsS3ExportFileFormatCsv,
 											"prefix":            "prefix/",
@@ -935,7 +935,7 @@ func TestExpandS3StorageClassAnalysis(t *testing.T) {
 				DataExport: &s3.StorageClassAnalysisDataExport{
 					Destination: &s3.AnalyticsExportDestination{
 						S3BucketDestination: &s3.AnalyticsS3BucketDestination{
-							Bucket:          aws.String("arn:aws:s3"),
+							Bucket:          aws.String("arn:aws:s3"), //lintignore:AWSAT005
 							BucketAccountId: aws.String("1234567890"),
 							Format:          aws.String(s3.AnalyticsS3ExportFileFormatCsv),
 							Prefix:          aws.String("prefix/"),
@@ -953,7 +953,7 @@ func TestExpandS3StorageClassAnalysis(t *testing.T) {
 								map[string]interface{}{
 									"s3_bucket_destination": []interface{}{
 										map[string]interface{}{
-											"bucket_arn": "arn:aws:s3",
+											"bucket_arn": "arn:aws:s3", //lintignore:AWSAT005
 											"format":     s3.AnalyticsS3ExportFileFormatCsv,
 										},
 									},
@@ -967,7 +967,7 @@ func TestExpandS3StorageClassAnalysis(t *testing.T) {
 				DataExport: &s3.StorageClassAnalysisDataExport{
 					Destination: &s3.AnalyticsExportDestination{
 						S3BucketDestination: &s3.AnalyticsS3BucketDestination{
-							Bucket:          aws.String("arn:aws:s3"),
+							Bucket:          aws.String("arn:aws:s3"), //lintignore:AWSAT005
 							BucketAccountId: nil,
 							Format:          aws.String(s3.AnalyticsS3ExportFileFormatCsv),
 							Prefix:          nil,
@@ -1154,7 +1154,7 @@ func TestFlattenS3StorageClassAnalysis(t *testing.T) {
 				DataExport: &s3.StorageClassAnalysisDataExport{
 					Destination: &s3.AnalyticsExportDestination{
 						S3BucketDestination: &s3.AnalyticsS3BucketDestination{
-							Bucket: aws.String("arn:aws:s3"),
+							Bucket: aws.String("arn:aws:s3"), //lintignore:AWSAT005
 							Format: aws.String(s3.AnalyticsS3ExportFileFormatCsv),
 						},
 					},
@@ -1168,7 +1168,7 @@ func TestFlattenS3StorageClassAnalysis(t *testing.T) {
 								map[string]interface{}{
 									"s3_bucket_destination": []interface{}{
 										map[string]interface{}{
-											"bucket_arn": "arn:aws:s3",
+											"bucket_arn": "arn:aws:s3", //lintignore:AWSAT005
 											"format":     s3.AnalyticsS3ExportFileFormatCsv,
 										},
 									},
@@ -1184,7 +1184,7 @@ func TestFlattenS3StorageClassAnalysis(t *testing.T) {
 				DataExport: &s3.StorageClassAnalysisDataExport{
 					Destination: &s3.AnalyticsExportDestination{
 						S3BucketDestination: &s3.AnalyticsS3BucketDestination{
-							Bucket:          aws.String("arn:aws:s3"),
+							Bucket:          aws.String("arn:aws:s3"), //lintignore:AWSAT005
 							BucketAccountId: aws.String("1234567890"),
 							Format:          aws.String(s3.AnalyticsS3ExportFileFormatCsv),
 							Prefix:          aws.String("prefix/"),
@@ -1200,7 +1200,7 @@ func TestFlattenS3StorageClassAnalysis(t *testing.T) {
 								map[string]interface{}{
 									"s3_bucket_destination": []interface{}{
 										map[string]interface{}{
-											"bucket_arn":        "arn:aws:s3",
+											"bucket_arn":        "arn:aws:s3", //lintignore:AWSAT005
 											"bucket_account_id": "1234567890",
 											"format":            s3.AnalyticsS3ExportFileFormatCsv,
 											"prefix":            "prefix/",

--- a/aws/resource_aws_sns_platform_application_test.go
+++ b/aws/resource_aws_sns_platform_application_test.go
@@ -134,35 +134,35 @@ func TestDecodeResourceAwsSnsPlatformApplicationID(t *testing.T) {
 		ErrCount         int
 	}{
 		{
-			Input:            "arn:aws:sns:us-east-1:123456789012:app/APNS_SANDBOX/myAppName",
-			ExpectedArn:      "arn:aws:sns:us-east-1:123456789012:app/APNS_SANDBOX/myAppName",
+			Input:            "arn:aws:sns:us-east-1:123456789012:app/APNS_SANDBOX/myAppName", //lintignore:AWSAT003,AWSAT005
+			ExpectedArn:      "arn:aws:sns:us-east-1:123456789012:app/APNS_SANDBOX/myAppName", //lintignore:AWSAT003,AWSAT005
 			ExpectedName:     "myAppName",
 			ExpectedPlatform: "APNS_SANDBOX",
 			ErrCount:         0,
 		},
 		{
-			Input:            "arn:aws:sns:us-east-1:123456789012:app/APNS_SANDBOX/myAppName/extra",
+			Input:            "arn:aws:sns:us-east-1:123456789012:app/APNS_SANDBOX/myAppName/extra", //lintignore:AWSAT003,AWSAT005
 			ExpectedArn:      "",
 			ExpectedName:     "",
 			ExpectedPlatform: "",
 			ErrCount:         1,
 		},
 		{
-			Input:            "arn:aws:sns:us-east-1:123456789012:endpoint/APNS_SANDBOX/myAppName/someID",
+			Input:            "arn:aws:sns:us-east-1:123456789012:endpoint/APNS_SANDBOX/myAppName/someID", //lintignore:AWSAT003,AWSAT005
 			ExpectedArn:      "",
 			ExpectedName:     "",
 			ExpectedPlatform: "",
 			ErrCount:         1,
 		},
 		{
-			Input:            "arn:aws:sns:us-east-1:123456789012:APNS_SANDBOX/myAppName",
+			Input:            "arn:aws:sns:us-east-1:123456789012:APNS_SANDBOX/myAppName", //lintignore:AWSAT003,AWSAT005
 			ExpectedArn:      "",
 			ExpectedName:     "",
 			ExpectedPlatform: "",
 			ErrCount:         1,
 		},
 		{
-			Input:            "arn:aws:sns:us-east-1:123456789012:app",
+			Input:            "arn:aws:sns:us-east-1:123456789012:app", //lintignore:AWSAT003,AWSAT005
 			ExpectedArn:      "",
 			ExpectedName:     "",
 			ExpectedPlatform: "",

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -505,7 +505,7 @@ func TestFlattenHealthCheck(t *testing.T) {
 func TestFlattenOrganizationsOrganizationalUnits(t *testing.T) {
 	input := []*organizations.OrganizationalUnit{
 		{
-			Arn:  aws.String("arn:aws:organizations::123456789012:ou/o-abcde12345/ou-ab12-abcd1234"),
+			Arn:  aws.String("arn:aws:organizations::123456789012:ou/o-abcde12345/ou-ab12-abcd1234"), //lintignore:AWSAT005
 			Id:   aws.String("ou-ab12-abcd1234"),
 			Name: aws.String("Engineering"),
 		},
@@ -513,7 +513,7 @@ func TestFlattenOrganizationsOrganizationalUnits(t *testing.T) {
 
 	expected_output := []map[string]interface{}{
 		{
-			"arn":  "arn:aws:organizations::123456789012:ou/o-abcde12345/ou-ab12-abcd1234",
+			"arn":  "arn:aws:organizations::123456789012:ou/o-abcde12345/ou-ab12-abcd1234", //lintignore:AWSAT005
 			"id":   "ou-ab12-abcd1234",
 			"name": "Engineering",
 		},

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -171,9 +171,9 @@ func TestValidateCloudWatchEventRuleName(t *testing.T) {
 
 func TestValidateLambdaFunctionName(t *testing.T) {
 	validNames := []string{
-		"arn:aws:lambda:us-west-2:123456789012:function:ThumbNail",
-		"arn:aws-us-gov:lambda:us-west-2:123456789012:function:ThumbNail",
-		"arn:aws-us-gov:lambda:us-gov-west-1:123456789012:function:ThumbNail",
+		"arn:aws:lambda:us-west-2:123456789012:function:ThumbNail",            //lintignore:AWSAT003,AWSAT005
+		"arn:aws-us-gov:lambda:us-west-2:123456789012:function:ThumbNail",     //lintignore:AWSAT003,AWSAT005
+		"arn:aws-us-gov:lambda:us-gov-west-1:123456789012:function:ThumbNail", //lintignore:AWSAT003,AWSAT005
 		"FunctionName",
 		"function-name",
 	}
@@ -188,7 +188,7 @@ func TestValidateLambdaFunctionName(t *testing.T) {
 		"/FunctionNameWithSlash",
 		"function.name.with.dots",
 		// length > 140
-		"arn:aws:lambda:us-west-2:123456789012:function:TooLoooooo" +
+		"arn:aws:lambda:us-west-2:123456789012:function:TooLoooooo" + //lintignore:AWSAT003,AWSAT005
 			"ooooooooooooooooooooooooooooooooooooooooooooooooooooooo" +
 			"ooooooooooooooooongFunctionName",
 	}
@@ -219,7 +219,7 @@ func TestValidateLambdaQualifier(t *testing.T) {
 
 	invalidNames := []string{
 		// No ARNs allowed
-		"arn:aws:lambda:us-west-2:123456789012:function:prod",
+		"arn:aws:lambda:us-west-2:123456789012:function:prod", //lintignore:AWSAT003,AWSAT005
 		// length > 128
 		"TooLooooooooooooooooooooooooooooooooooooooooooooooooooo" +
 			"ooooooooooooooooooooooooooooooooooooooooooooooooooo" +
@@ -320,22 +320,22 @@ func TestValidateArn(t *testing.T) {
 	}
 
 	validNames := []string{
-		"arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment", // Beanstalk
-		"arn:aws:iam::123456789012:user/David",                                             // IAM User
-		"arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess",                                 // Managed IAM policy
-		"arn:aws:rds:eu-west-1:123456789012:db:mysql-db",                                   // RDS
-		"arn:aws:s3:::my_corporate_bucket/exampleobject.png",                               // S3 object
-		"arn:aws:events:us-east-1:319201112229:rule/rule_name",                             // CloudWatch Rule
-		"arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction",                  // Lambda function
-		"arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction:Qualifier",        // Lambda func qualifier
-		"arn:aws-cn:ec2:cn-north-1:123456789012:instance/i-12345678",                       // China EC2 ARN
-		"arn:aws-cn:s3:::bucket/object",                                                    // China S3 ARN
-		"arn:aws-iso:ec2:us-iso-east-1:123456789012:instance/i-12345678",                   // C2S EC2 ARN
-		"arn:aws-iso:s3:::bucket/object",                                                   // C2S S3 ARN
-		"arn:aws-iso-b:ec2:us-isob-east-1:123456789012:instance/i-12345678",                // SC2S EC2 ARN
-		"arn:aws-iso-b:s3:::bucket/object",                                                 // SC2S S3 ARN
-		"arn:aws-us-gov:ec2:us-gov-west-1:123456789012:instance/i-12345678",                // GovCloud EC2 ARN
-		"arn:aws-us-gov:s3:::bucket/object",                                                // GovCloud S3 ARN
+		"arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment", // lintignore:AWSAT003,AWSAT005 // Beanstalk
+		"arn:aws:iam::123456789012:user/David",                                             // lintignore:AWSAT005          // IAM User
+		"arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess",                                 // lintignore:AWSAT005          // Managed IAM policy
+		"arn:aws:rds:eu-west-1:123456789012:db:mysql-db",                                   // lintignore:AWSAT003,AWSAT005 // RDS
+		"arn:aws:s3:::my_corporate_bucket/exampleobject.png",                               // lintignore:AWSAT005          // S3 object
+		"arn:aws:events:us-east-1:319201112229:rule/rule_name",                             // lintignore:AWSAT003,AWSAT005 // CloudWatch Rule
+		"arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction",                  // lintignore:AWSAT003,AWSAT005 // Lambda function
+		"arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction:Qualifier",        // lintignore:AWSAT003,AWSAT005 // Lambda func qualifier
+		"arn:aws-cn:ec2:cn-north-1:123456789012:instance/i-12345678",                       // lintignore:AWSAT003,AWSAT005 // China EC2 ARN
+		"arn:aws-cn:s3:::bucket/object",                                                    // lintignore:AWSAT005          // China S3 ARN
+		"arn:aws-iso:ec2:us-iso-east-1:123456789012:instance/i-12345678",                   // lintignore:AWSAT003,AWSAT005 // C2S EC2 ARN
+		"arn:aws-iso:s3:::bucket/object",                                                   // lintignore:AWSAT005          // C2S S3 ARN
+		"arn:aws-iso-b:ec2:us-isob-east-1:123456789012:instance/i-12345678",                // lintignore:AWSAT003,AWSAT005 // SC2S EC2 ARN
+		"arn:aws-iso-b:s3:::bucket/object",                                                 // lintignore:AWSAT005          // SC2S S3 ARN
+		"arn:aws-us-gov:ec2:us-gov-west-1:123456789012:instance/i-12345678",                // lintignore:AWSAT003,AWSAT005 // GovCloud EC2 ARN
+		"arn:aws-us-gov:s3:::bucket/object",                                                // lintignore:AWSAT005          // GovCloud S3 ARN
 	}
 	for _, v := range validNames {
 		_, errors := validateArn(v, "arn")
@@ -348,8 +348,8 @@ func TestValidateArn(t *testing.T) {
 		"arn",
 		"123456789012",
 		"arn:aws",
-		"arn:aws:logs",
-		"arn:aws:logs:region:*:*",
+		"arn:aws:logs",            //lintignore:AWSAT005
+		"arn:aws:logs:region:*:*", //lintignore:AWSAT005
 	}
 	for _, v := range invalidNames {
 		_, errors := validateArn(v, "arn")
@@ -361,10 +361,10 @@ func TestValidateArn(t *testing.T) {
 
 func TestValidateEC2AutomateARN(t *testing.T) {
 	validNames := []string{
-		"arn:aws:automate:us-east-1:ec2:reboot",
-		"arn:aws:automate:us-east-1:ec2:recover",
-		"arn:aws:automate:us-east-1:ec2:stop",
-		"arn:aws:automate:us-east-1:ec2:terminate",
+		"arn:aws:automate:us-east-1:ec2:reboot",    //lintignore:AWSAT003,AWSAT005
+		"arn:aws:automate:us-east-1:ec2:recover",   //lintignore:AWSAT003,AWSAT005
+		"arn:aws:automate:us-east-1:ec2:stop",      //lintignore:AWSAT003,AWSAT005
+		"arn:aws:automate:us-east-1:ec2:terminate", //lintignore:AWSAT003,AWSAT005
 	}
 	for _, v := range validNames {
 		_, errors := validateEC2AutomateARN(v, "test_property")
@@ -375,15 +375,15 @@ func TestValidateEC2AutomateARN(t *testing.T) {
 
 	invalidNames := []string{
 		"",
-		"arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment", // Beanstalk
-		"arn:aws:iam::123456789012:user/David",                                             // IAM User
-		"arn:aws:rds:eu-west-1:123456789012:db:mysql-db",                                   // RDS
-		"arn:aws:s3:::my_corporate_bucket/exampleobject.png",                               // S3 object
-		"arn:aws:events:us-east-1:319201112229:rule/rule_name",                             // CloudWatch Rule
-		"arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction",                  // Lambda function
-		"arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction:Qualifier",        // Lambda func qualifier
-		"arn:aws-us-gov:s3:::corp_bucket/object.png",                                       // GovCloud ARN
-		"arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/some-uuid-abc123",               // GovCloud KMS ARN
+		"arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment", // lintignore:AWSAT003,AWSAT005 // Beanstalk
+		"arn:aws:iam::123456789012:user/David",                                             // lintignore:AWSAT005          // IAM User
+		"arn:aws:rds:eu-west-1:123456789012:db:mysql-db",                                   // lintignore:AWSAT003,AWSAT005 // RDS
+		"arn:aws:s3:::my_corporate_bucket/exampleobject.png",                               // lintignore:AWSAT005          // S3 object
+		"arn:aws:events:us-east-1:319201112229:rule/rule_name",                             // lintignore:AWSAT003,AWSAT005 // CloudWatch Rule
+		"arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction",                  // lintignore:AWSAT003,AWSAT005 // Lambda function
+		"arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction:Qualifier",        // lintignore:AWSAT003,AWSAT005 // Lambda func qualifier
+		"arn:aws-us-gov:s3:::corp_bucket/object.png",                                       // lintignore:AWSAT005          // GovCloud ARN
+		"arn:aws-us-gov:kms:us-gov-west-1:123456789012:key/some-uuid-abc123",               // lintignore:AWSAT003,AWSAT005 // GovCloud KMS ARN
 	}
 	for _, v := range invalidNames {
 		_, errors := validateEC2AutomateARN(v, "test_property")
@@ -2543,7 +2543,7 @@ func TestValidateKmsKey(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
-			Value:    "arn:aws:kms:us-west-2:111122223333:key/arbitrary-uuid-1234",
+			Value:    "arn:aws:kms:us-west-2:111122223333:key/arbitrary-uuid-1234", //lintignore:AWSAT003,AWSAT005
 			ErrCount: 0,
 		},
 		{
@@ -2555,11 +2555,11 @@ func TestValidateKmsKey(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
-			Value:    "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key",
+			Value:    "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key", //lintignore:AWSAT003,AWSAT005
 			ErrCount: 0,
 		},
 		{
-			Value:    "arn:aws:kms:us-west-2:111122223333:alias/arbitrary/key",
+			Value:    "arn:aws:kms:us-west-2:111122223333:alias/arbitrary/key", //lintignore:AWSAT003,AWSAT005
 			ErrCount: 0,
 		},
 		{
@@ -2567,7 +2567,7 @@ func TestValidateKmsKey(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    "arn:aws:lamda:foo:bar:key/xyz",
+			Value:    "arn:aws:lamda:foo:bar:key/xyz", //lintignore:AWSAT003,AWSAT005
 			ErrCount: 1,
 		},
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

## No code changes. Only adds `lintignore` for unit tests and places where ARN isn't used.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud) (0 failures, 0 regressions):
***Fixed unrelated pre-existing fail.

```
--- PASS: TestCloudFrontStructure_flattenlambdaFunctionAssociations (0.05s)
--- PASS: TestCloudFrontStructure_expandQueryStringCacheKeys (0.23s)
--- PASS: TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior (0.24s)
--- PASS: TestCloudFrontStructure_flattenQueryStringCacheKeys (0.33s)
--- PASS: TestCloudFrontStructure_flattenForwardedValues (0.34s)
--- PASS: TestCloudFrontStructure_expandTrustedSigners_empty (0.34s)
--- PASS: TestCloudFrontStructure_expandForwardedValues (0.41s)
--- PASS: TestCloudFrontStructure_expandTrustedSigners (0.43s)
--- PASS: TestCloudFrontStructure_expandCookieNames (0.41s)
--- PASS: TestCloudFrontStructure_flattenHeaders (0.49s)
--- PASS: TestCloudFrontStructure_flattenCookiePreference (0.51s)
--- PASS: TestCloudFrontStructure_expandCookiePreference (0.54s)
--- PASS: TestCloudFrontStructure_expandlambdaFunctionAssociations_empty (0.54s)
--- PASS: TestCloudFrontStructure_expandHeaders (0.58s)
--- PASS: TestCloudFrontStructure_expandAllowedMethods (0.35s)
--- PASS: TestCloudFrontStructure_flattenTrustedSigners (0.60s)
--- PASS: TestCloudFrontStructure_expandLambdaFunctionAssociations (0.62s)
--- PASS: TestCloudFrontStructure_expandOrigins (0.27s)
--- PASS: TestCloudFrontStructure_flattenCookieNames (0.48s)
--- PASS: TestCloudFrontStructure_flattenAllowedMethods (0.47s)
--- PASS: TestCloudFrontStructure_flattenOriginGroups (0.32s)
--- PASS: TestCloudFrontStructure_flattenCachedMethods (0.48s)
--- PASS: TestCloudFrontStructure_expandCachedMethods (0.49s)
--- PASS: TestCloudFrontStructure_expandOrigin (0.34s)
--- PASS: TestCloudFrontStructure_expandCustomHeaders (0.33s)
--- PASS: TestCloudFrontStructure_flattenOrigins (0.46s)
--- PASS: TestCloudFrontStructure_expandOriginGroups (0.43s)
--- PASS: TestCloudFrontStructure_flattenCustomHeaders (0.34s)
--- PASS: TestCloudFrontStructure_flattenOriginCustomHeader (0.34s)
--- PASS: TestCloudFrontStructure_expandOriginCustomHeader (0.36s)
--- PASS: TestCloudFrontStructure_expandCustomOriginConfigSSL (0.26s)
--- PASS: TestCloudFrontStructure_flattenOrigin (0.45s)
--- PASS: TestCloudFrontStructure_expandCustomOriginConfig (0.37s)
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfig (0.37s)
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfigSSL (0.37s)
--- PASS: TestCloudFrontStructure_expandS3OriginConfig (0.43s)
--- PASS: TestCloudFrontStructure_flattenS3OriginConfig (0.42s)
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponses (0.39s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponses (0.44s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse (0.42s)
--- PASS: TestCloudFrontStructure_expandLoggingConfig (0.37s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode (0.42s)
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponse (0.44s)
--- PASS: TestCloudFrontStructure_expandLoggingConfig_nilValue (0.43s)
--- PASS: TestCloudFrontStructure_expandAliases (0.39s)
--- PASS: TestCloudFrontStructure_expandRestrictions (0.39s)
--- PASS: TestCloudFrontStructure_flattenAliases (0.40s)
--- PASS: TestCloudFrontStructure_expandGeoRestriction_whitelist (0.39s)
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_whitelist (0.37s)
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_no_items (0.37s)
--- PASS: TestCloudFrontStructure_expandGeoRestriction_no_items (0.49s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate (0.41s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id (0.44s)
--- PASS: TestALBTargetGroupCloudwatchSuffixFromARN (0.55s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn (0.64s)
--- PASS: TestAccAWSALBTargetGroup_missingPortProtocolVpc (40.93s)
--- PASS: TestAccAWSALBTargetGroup_lambda (43.20s)
--- PASS: TestAccAWSALBTargetGroup_namePrefix (58.95s)
--- PASS: TestAccAWSALBTargetGroup_basic (64.11s)
--- PASS: TestAccAWSALBTargetGroup_generatedName (69.58s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty (6.74s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_basic (60.40s)
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (112.05s)
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (113.87s)
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (120.00s)
--- PASS: TestAccAWSALBTargetGroup_tags (120.62s)
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (121.64s)
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (124.79s)
--- PASS: TestExpandS3AnalyticsFilter (0.29s)
--- PASS: TestExpandS3StorageClassAnalysis (0.25s)
--- PASS: TestFlattenS3AnalyticsFilter (0.16s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty (2.28s)***
--- PASS: TestDecodeResourceAwsSnsPlatformApplicationID (0.20s)
--- PASS: TestFlattenS3StorageClassAnalysis (0.39s)
--- SKIP: TestAccAWSSnsPlatformApplication_basic (0.00s)
--- PASS: TestAccAWSALBTargetGroup_setAndUpdateSlowStart (125.92s)
--- SKIP: TestAccAWSSnsPlatformApplication_basicAttributes (0.00s)
--- PASS: TestDiffStringMaps (0.29s)
--- SKIP: TestAccAWSSnsPlatformApplication_snsTopicAttributes (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_iamRoleAttributes (0.00s)
--- PASS: TestExpandIPPerms_NegOneProtocol (0.31s)
--- PASS: TestExpandIPPerms_nonVPC (0.33s)
--- PASS: TestExpandIPPerms (0.51s)
--- PASS: TestFlattenHealthCheck (0.24s)
--- PASS: TestExpandListeners (0.45s)
--- PASS: TestExpandListeners_invalid (0.44s)
--- PASS: TestExpandStringListEmptyItems (0.29s)
--- PASS: TestFlattenOrganizationsOrganizationalUnits (0.46s)
--- PASS: TestExpandStringList (0.40s)
--- PASS: TestExpandParameters (0.42s)
--- PASS: TestExpandElasticacheParameters (0.34s)
--- PASS: TestExpandRedshiftParameters (0.43s)
--- PASS: TestFlattenParameters (0.36s)
--- PASS: TestExpandStepAdjustments (0.39s)
--- PASS: TestFlattenRedshiftParameters (0.38s)
--- PASS: TestFlattenNetworkInterfacesPrivateIPAddresses (0.22s)
--- PASS: TestFlattenGroupIdentifiers (0.12s)
--- PASS: TestExpandInstanceString (0.43s)
--- PASS: TestExpandPrivateIPAddresses (0.10s)
--- PASS: TestFlattenElasticacheParameters (0.47s)
--- PASS: TestFlattenAttachmentWhenNoInstanceId (0.22s)
--- PASS: TestFlattenAttachment (0.25s)
--- PASS: TestFlattenStepAdjustments (0.23s)
--- PASS: TestFlattenAsgEnabledMetrics (0.23s)
--- PASS: TestFlattenResourceRecords (0.27s)
--- PASS: TestFlattenKinesisShardLevelMetrics (0.35s)
--- PASS: TestFlattenApiGatewayThrottleSettings (0.30s)
--- PASS: TestFlattenSecurityGroups (0.34s)
--- PASS: TestExpandPolicyAttributes (0.21s)
--- PASS: TestExpandPolicyAttributes_empty (0.24s)
--- PASS: TestFlattenPolicyAttributes (0.25s)
--- PASS: TestExpandPolicyAttributes_invalid (0.43s)
--- PASS: TestNormalizeJsonOrYamlString (0.42s)
--- PASS: TestCheckYamlString (0.46s)
--- PASS: TestCognitoUserPoolSchemaAttributeMatchesStandardAttribute (0.32s)
--- PASS: TestExpandRdsClusterScalingConfiguration_basic (0.43s)
--- PASS: TestCanonicalXML (0.47s)
--- PASS: TestValidateTypeStringNullableBoolean (0.47s)
--- PASS: TestValidateCloudWatchDashboardName (0.22s)
--- PASS: TestValidateTypeStringNullableFloat (0.23s)
--- PASS: TestValidateCloudWatchEventRuleName (0.33s)
--- PASS: TestValidateLambdaFunctionName (0.23s)
--- PASS: TestValidateLambdaQualifier (0.36s)
--- PASS: TestValidateLambdaPermissionEventSourceToken (0.22s)
--- PASS: TestValidateLambdaPermissionAction (0.40s)
--- PASS: TestValidateArn (0.18s)
--- PASS: TestValidateAwsAccountId (0.49s)
--- PASS: TestValidateEC2AutomateARN (0.29s)
--- PASS: TestValidatePolicyStatementId (0.24s)
--- PASS: TestValidateCIDRNetworkAddress (0.22s)
--- PASS: TestValidateIpv4CIDRBlock (0.29s)
--- PASS: TestValidateCIDRBlock (0.32s)
--- PASS: TestCidrBlocksEqual (0.20s)
--- PASS: TestCanonicalCidrBlock (0.20s)
--- PASS: TestValidateIpv6CIDRBlock (0.37s)
--- PASS: TestValidateLogMetricFilterName (0.23s)
--- PASS: TestValidateLogMetricTransformationName (0.25s)
--- PASS: TestValidateS3BucketLifecycleTimestamp (0.20s)
--- PASS: TestValidateLogGroupName (0.46s)
--- PASS: TestValidateSagemakerName (0.14s)
--- PASS: TestValidateLogGroupNamePrefix (0.40s)
--- PASS: TestValidateIAMPolicyJsonString (0.09s)
--- PASS: TestValidateStringIsJsonOrYaml (0.25s)
--- PASS: TestValidateDbEventSubscriptionName (0.41s)
--- PASS: TestValidateSQSQueueName (0.32s)
--- PASS: TestValidateSQSFifoQueueName (0.20s)
--- PASS: TestValidateOnceAWeekWindowFormat (0.27s)
--- PASS: TestValidateEcsPlacementConstraint (0.24s)
--- PASS: TestValidateOnceADayWindowFormat (0.39s)
--- PASS: TestValidateEcsPlacementStrategy (0.29s)
--- PASS: TestValidateStepFunctionStateMachineName (0.20s)
--- PASS: TestValidateEmrCustomAmiId (0.32s)
--- PASS: TestValidateDmsEndpointId (0.32s)
--- PASS: TestValidateDmsCertificateId (0.35s)
--- PASS: TestValidateDmsReplicationInstanceId (0.39s)
--- PASS: TestValidateDmsReplicationTaskId (0.23s)
--- PASS: TestValidateDmsReplicationSubnetGroupId (0.47s)
--- PASS: TestValidateAccountAlias (0.35s)
--- PASS: TestValidateIamRoleProfileName (0.39s)
--- PASS: TestValidateIamRoleProfileNamePrefix (0.25s)
--- PASS: TestValidateApiGatewayUsagePlanQuotaSettings (0.30s)
--- PASS: TestValidateDocDBIdentifier (0.27s)
--- PASS: TestValidateElbName (0.31s)
--- PASS: TestValidateNeptuneEventSubscriptionNamePrefix (0.26s)
--- PASS: TestValidateElbNamePrefix (0.35s)
--- PASS: TestValidateNeptuneEventSubscriptionName (0.42s)
--- PASS: TestValidateDbSubnetGroupName (0.18s)
--- PASS: TestValidateNeptuneSubnetGroupName (0.35s)
--- PASS: TestValidateDbSubnetGroupNamePrefix (0.37s)
--- PASS: TestValidateNeptuneSubnetGroupNamePrefix (0.28s)
--- PASS: TestValidateDbOptionGroupName (0.28s)
--- PASS: TestValidateDbOptionGroupNamePrefix (0.21s)
--- PASS: TestValidateOpenIdURL (0.15s)
--- PASS: TestValidateDbParamGroupName (0.30s)
--- PASS: TestValidateAwsKmsGrantName (0.25s)
--- PASS: TestValidateCognitoIdentityPoolName (0.27s)
--- PASS: TestValidateAwsKmsName (0.43s)
--- PASS: TestValidateCognitoProviderDeveloperName (0.25s)
--- PASS: TestValidateCognitoSupportedLoginProviders (0.24s)
--- PASS: TestValidateCognitoIdentityProvidersProviderName (0.24s)
--- PASS: TestValidateCognitoUserPoolEmailVerificationMessage (0.26s)
--- PASS: TestValidateCognitoIdentityProvidersClientId (0.46s)
--- PASS: TestValidateCognitoUserPoolSmsVerificationMessage (0.37s)
--- PASS: TestValidateCognitoUserPoolSmsAuthenticationMessage (0.40s)
--- PASS: TestValidateCognitoUserPoolEmailVerificationSubject (0.44s)
--- PASS: TestValidateBatchName (0.30s)
--- PASS: TestValidateWafMetricName (0.33s)
--- PASS: TestValidateAwsSSMName (0.41s)
--- PASS: TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType (0.28s)
--- PASS: TestValidateBatchPrefix (0.32s)
--- PASS: TestValidateCognitoRoleMappingsRulesConfiguration (0.41s)
--- PASS: TestValidateSecurityGroupRuleDescription (0.27s)
--- PASS: TestValidateCognitoRoles (0.30s)
--- PASS: TestValidateKmsKey (0.34s)
--- PASS: TestValidateCognitoUserGroupName (0.40s)
--- PASS: TestResourceAWSElastiCacheReplicationGroupAuthTokenValidation (0.50s)
--- PASS: TestValidateCognitoUserPoolId (0.28s)
--- PASS: TestValidateAmazonSideAsn (0.31s)
--- PASS: TestValidate4ByteAsn (0.28s)
--- PASS: TestValidateLaunchTemplateName (0.26s)
--- PASS: TestValidateNeptuneParamGroupName (0.26s)
--- PASS: TestValidateLaunchTemplateId (0.29s)
--- PASS: TestValidateNeptuneParamGroupNamePrefix (0.34s)
--- PASS: TestValidateDxConnectionBandWidth (0.24s)
--- PASS: TestValidateCloudFrontPublicKeyName (0.41s)
--- PASS: TestValidateCloudFrontPublicKeyNamePrefix (0.42s)
--- PASS: TestValidateSecretManagerSecretName (0.22s)
--- PASS: TestValidateLbTargetGroupName (0.36s)
--- PASS: TestValidateLbTargetGroupNamePrefix (0.43s)
--- PASS: TestValidateSecretManagerSecretNamePrefix (0.19s)
--- PASS: TestCloudWatchEventCustomEventBusName (0.34s)
--- PASS: TestValidateRoute53ResolverName (0.48s)
--- PASS: TestValidateServiceDiscoveryNamespaceName (0.43s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_removed (97.34s)
--- PASS: TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled (146.64s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix (91.75s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag (93.52s)
--- PASS: TestAccAWSALBTargetGroup_updateSticknessEnabled (164.42s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default (45.80s)
--- PASS: TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType (166.22s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full (45.20s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags (72.07s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_updateBasic (116.39s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags (63.70s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove (62.57s)
```

Output from acceptance testing (commercial) (0 failures, 0 regressions):

```
--- PASS: TestCloudFrontStructure_expandCookiePreference (0.23s)
--- PASS: TestCloudFrontStructure_expandTrustedSigners (0.32s)
--- PASS: TestCloudFrontStructure_flattenCookieNames (0.37s)
--- PASS: TestCloudFrontStructure_expandCachedMethods (0.37s)
--- PASS: TestCloudFrontStructure_flattenTrustedSigners (0.39s)
--- PASS: TestCloudFrontStructure_flattenAllowedMethods (0.39s)
--- PASS: TestCloudFrontStructure_expandCookieNames (0.50s)
--- PASS: TestCloudFrontStructure_flattenCookiePreference (0.54s)
--- PASS: TestCloudFrontStructure_expandAllowedMethods (0.55s)
--- PASS: TestCloudFrontStructure_expandQueryStringCacheKeys (0.59s)
--- PASS: TestCloudFrontStructure_flattenCachedMethods (0.41s)
--- PASS: TestCloudFrontStructure_expandHeaders (0.67s)
--- PASS: TestCloudFrontStructure_expandOrigins (0.35s)
--- PASS: TestCloudFrontStructure_expandTrustedSigners_empty (0.75s)
--- PASS: TestCloudFrontStructure_expandOriginGroups (0.40s)
--- PASS: TestCloudFrontStructure_flattenHeaders (0.81s)
--- PASS: TestCloudFrontStructure_expandlambdaFunctionAssociations_empty (0.84s)
--- PASS: TestCloudFrontStructure_flattenForwardedValues (0.88s)
--- PASS: TestCloudFrontStructure_expandForwardedValues (0.89s)
--- PASS: TestCloudFrontStructure_flattenlambdaFunctionAssociations (0.89s)
--- PASS: TestCloudFrontStructure_expandLambdaFunctionAssociations (0.90s)
--- PASS: TestCloudFrontStructure_expandCustomHeaders (0.41s)
--- PASS: TestCloudFrontStructure_flattenCustomHeaders (0.41s)
--- PASS: TestCloudFrontStructure_flattenOrigin (0.46s)
--- PASS: TestCloudFrontStructure_expandCloudFrontDefaultCacheBehavior (0.99s)
--- PASS: TestCloudFrontStructure_flattenOrigins (0.63s)
--- PASS: TestCloudFrontStructure_flattenQueryStringCacheKeys (0.99s)
--- PASS: TestCloudFrontStructure_expandOrigin (0.62s)
--- PASS: TestCloudFrontStructure_flattenOriginCustomHeader (0.45s)
--- PASS: TestCloudFrontStructure_expandOriginCustomHeader (0.40s)
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfig (0.42s)
--- PASS: TestCloudFrontStructure_flattenOriginGroups (0.76s)
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfigSSL (0.39s)
--- PASS: TestCloudFrontStructure_flattenS3OriginConfig (0.33s)
--- PASS: TestCloudFrontStructure_expandCustomOriginConfig (0.55s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode (0.37s)
--- PASS: TestCloudFrontStructure_expandCustomOriginConfigSSL (0.54s)
--- PASS: TestCloudFrontStructure_expandS3OriginConfig (0.48s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponses (0.44s)
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponses (0.45s)
--- PASS: TestCloudFrontStructure_expandLoggingConfig_nilValue (0.39s)
--- PASS: TestCloudFrontStructure_expandAliases (0.40s)
--- PASS: TestCloudFrontStructure_expandLoggingConfig (0.47s)
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponse (0.50s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id (0.30s)
--- PASS: TestCloudFrontStructure_expandGeoRestriction_no_items (0.46s)
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse (0.63s)
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_no_items (0.45s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate (0.43s)
--- PASS: TestCloudFrontStructure_expandRestrictions (0.61s)
--- PASS: TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn (0.46s)
--- PASS: TestCloudFrontStructure_flattenAliases (0.66s)
--- PASS: TestCloudFrontStructure_expandGeoRestriction_whitelist (0.65s)
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_whitelist (0.65s)
--- PASS: TestALBTargetGroupCloudwatchSuffixFromARN (0.57s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Empty (9.04s)
--- PASS: TestAccAWSALBTargetGroup_lambda (73.93s)
--- PASS: TestAccAWSALBTargetGroup_namePrefix (75.59s)
--- PASS: TestAccAWSALBTargetGroup_missingPortProtocolVpc (77.86s)
--- PASS: TestAccAWSALBTargetGroup_generatedName (81.93s)
--- PASS: TestAccAWSALBTargetGroup_basic (82.19s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_basic (83.65s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Empty (1.45s)***
--- PASS: TestExpandS3AnalyticsFilter (0.29s)
--- PASS: TestExpandS3StorageClassAnalysis (0.38s)
--- PASS: TestFlattenS3AnalyticsFilter (0.46s)
--- PASS: TestFlattenS3StorageClassAnalysis (0.56s)
--- PASS: TestDecodeResourceAwsSnsPlatformApplicationID (0.46s)
--- SKIP: TestAccAWSSnsPlatformApplication_basic (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_basicAttributes (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_iamRoleAttributes (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_snsTopicAttributes (0.00s)
--- PASS: TestDiffStringMaps (0.34s)
--- PASS: TestExpandIPPerms (0.33s)
--- PASS: TestExpandIPPerms_NegOneProtocol (0.36s)
--- PASS: TestExpandIPPerms_nonVPC (0.54s)
--- PASS: TestExpandListeners (0.51s)
--- PASS: TestExpandListeners_invalid (0.26s)
--- PASS: TestFlattenHealthCheck (0.44s)
--- PASS: TestFlattenOrganizationsOrganizationalUnits (0.41s)
--- PASS: TestExpandStringList (0.45s)
--- PASS: TestExpandStringListEmptyItems (0.48s)
--- PASS: TestExpandParameters (0.29s)
--- PASS: TestExpandRedshiftParameters (0.24s)
--- PASS: TestExpandElasticacheParameters (0.44s)
--- PASS: TestExpandStepAdjustments (0.42s)
--- PASS: TestFlattenParameters (0.55s)
--- PASS: TestFlattenRedshiftParameters (0.46s)
--- PASS: TestFlattenElasticacheParameters (0.32s)
--- PASS: TestExpandInstanceString (0.41s)
--- PASS: TestFlattenNetworkInterfacesPrivateIPAddresses (0.61s)
--- PASS: TestFlattenGroupIdentifiers (0.44s)
--- PASS: TestExpandPrivateIPAddresses (0.47s)
--- PASS: TestFlattenAttachment (0.58s)
--- PASS: TestFlattenAttachmentWhenNoInstanceId (0.50s)
--- PASS: TestFlattenStepAdjustments (0.46s)
--- PASS: TestFlattenResourceRecords (0.32s)
--- PASS: TestFlattenAsgEnabledMetrics (0.27s)
--- PASS: TestFlattenKinesisShardLevelMetrics (0.33s)
--- PASS: TestFlattenSecurityGroups (0.36s)
--- PASS: TestFlattenApiGatewayThrottleSettings (0.30s)
--- PASS: TestExpandPolicyAttributes (0.35s)
--- PASS: TestExpandPolicyAttributes_invalid (0.41s)
--- PASS: TestExpandPolicyAttributes_empty (0.35s)
--- PASS: TestFlattenPolicyAttributes (0.42s)
--- PASS: TestCheckYamlString (0.51s)
--- PASS: TestNormalizeJsonOrYamlString (0.28s)
--- PASS: TestCognitoUserPoolSchemaAttributeMatchesStandardAttribute (0.39s)
--- PASS: TestCanonicalXML (0.35s)
--- PASS: TestExpandRdsClusterScalingConfiguration_basic (0.36s)
--- PASS: TestValidateTypeStringNullableBoolean (0.25s)
--- PASS: TestValidateTypeStringNullableFloat (0.23s)
--- PASS: TestValidateCloudWatchDashboardName (0.23s)
--- PASS: TestValidateCloudWatchEventRuleName (0.37s)
--- PASS: TestValidateLambdaFunctionName (0.34s)
--- PASS: TestValidateLambdaQualifier (0.53s)
--- PASS: TestValidateLambdaPermissionAction (0.46s)
--- PASS: TestValidateLambdaPermissionEventSourceToken (0.31s)
--- PASS: TestValidateAwsAccountId (0.29s)
--- PASS: TestValidateArn (0.47s)
--- PASS: TestValidateEC2AutomateARN (0.41s)
--- PASS: TestValidatePolicyStatementId (0.54s)
--- PASS: TestValidateCIDRNetworkAddress (0.31s)
--- PASS: TestValidateCIDRBlock (0.25s)
--- PASS: TestValidateIpv4CIDRBlock (0.41s)
--- PASS: TestValidateIpv6CIDRBlock (0.20s)
--- PASS: TestCidrBlocksEqual (0.12s)
--- PASS: TestCanonicalCidrBlock (0.25s)
--- PASS: TestValidateLogMetricFilterName (0.42s)
--- PASS: TestValidateLogMetricTransformationName (0.34s)
--- PASS: TestValidateLogGroupName (0.49s)
--- PASS: TestValidateLogGroupNamePrefix (0.38s)
--- PASS: TestValidateS3BucketLifecycleTimestamp (0.28s)
--- PASS: TestValidateSagemakerName (0.53s)
--- PASS: TestValidateDbEventSubscriptionName (0.46s)
--- PASS: TestValidateIAMPolicyJsonString (0.52s)
--- PASS: TestValidateStringIsJsonOrYaml (0.49s)
--- PASS: TestValidateSQSQueueName (0.24s)
--- PASS: TestValidateSQSFifoQueueName (0.30s)
--- PASS: TestValidateOnceAWeekWindowFormat (0.29s)
--- PASS: TestValidateOnceADayWindowFormat (0.62s)
--- PASS: TestValidateEcsPlacementConstraint (0.42s)
--- PASS: TestValidateEcsPlacementStrategy (0.43s)
--- PASS: TestValidateStepFunctionStateMachineName (0.54s)
--- PASS: TestValidateEmrCustomAmiId (0.48s)
--- PASS: TestValidateDmsEndpointId (0.55s)
--- PASS: TestValidateDmsCertificateId (0.46s)
--- PASS: TestValidateDmsReplicationInstanceId (0.32s)
--- PASS: TestValidateDmsReplicationSubnetGroupId (0.37s)
--- PASS: TestValidateDmsReplicationTaskId (0.41s)
--- PASS: TestValidateAccountAlias (0.39s)
--- PASS: TestValidateIamRoleProfileName (0.53s)
--- PASS: TestValidateIamRoleProfileNamePrefix (0.37s)
--- PASS: TestValidateApiGatewayUsagePlanQuotaSettings (0.52s)
--- PASS: TestValidateDocDBIdentifier (0.41s)
--- PASS: TestValidateElbName (0.28s)
--- PASS: TestValidateElbNamePrefix (0.30s)
--- PASS: TestValidateNeptuneEventSubscriptionName (0.50s)
--- PASS: TestValidateNeptuneEventSubscriptionNamePrefix (0.37s)
--- PASS: TestValidateDbSubnetGroupName (0.28s)
--- PASS: TestValidateNeptuneSubnetGroupName (0.51s)
--- PASS: TestValidateDbSubnetGroupNamePrefix (0.34s)
--- PASS: TestValidateNeptuneSubnetGroupNamePrefix (0.33s)
--- PASS: TestValidateDbOptionGroupName (0.25s)
--- PASS: TestValidateDbOptionGroupNamePrefix (0.36s)
--- PASS: TestValidateDbParamGroupName (0.51s)
--- PASS: TestValidateOpenIdURL (0.45s)
--- PASS: TestValidateAwsKmsName (0.43s)
--- PASS: TestValidateAwsKmsGrantName (0.29s)
--- PASS: TestValidateCognitoIdentityPoolName (0.46s)
--- PASS: TestValidateCognitoProviderDeveloperName (0.46s)
--- PASS: TestValidateCognitoSupportedLoginProviders (0.52s)
--- PASS: TestValidateCognitoIdentityProvidersClientId (0.44s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_removed (133.27s)
--- PASS: TestValidateCognitoIdentityProvidersProviderName (0.60s)
--- PASS: TestValidateCognitoUserPoolEmailVerificationMessage (0.48s)
--- PASS: TestValidateCognitoUserPoolEmailVerificationSubject (0.41s)
--- PASS: TestValidateCognitoUserPoolSmsAuthenticationMessage (0.46s)
--- PASS: TestValidateCognitoUserPoolSmsVerificationMessage (0.35s)
--- PASS: TestValidateWafMetricName (0.38s)
--- PASS: TestValidateAwsSSMName (0.40s)
--- PASS: TestValidateBatchPrefix (0.23s)
--- PASS: TestValidateBatchName (0.50s)
--- PASS: TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType (0.26s)
--- PASS: TestValidateCognitoRoleMappingsRulesConfiguration (0.33s)
--- PASS: TestValidateSecurityGroupRuleDescription (0.27s)
--- PASS: TestValidateCognitoRoles (0.35s)
--- PASS: TestValidateKmsKey (0.30s)
--- PASS: TestResourceAWSElastiCacheReplicationGroupAuthTokenValidation (0.38s)
--- PASS: TestValidateCognitoUserGroupName (0.40s)
--- PASS: TestValidateCognitoUserPoolId (0.30s)
--- PASS: TestValidateAmazonSideAsn (0.31s)
--- PASS: TestValidate4ByteAsn (0.36s)
--- PASS: TestValidateLaunchTemplateName (0.36s)
--- PASS: TestValidateLaunchTemplateId (0.36s)
--- PASS: TestValidateNeptuneParamGroupName (0.37s)
--- PASS: TestValidateNeptuneParamGroupNamePrefix (0.29s)
--- PASS: TestValidateCloudFrontPublicKeyName (0.45s)
--- PASS: TestValidateCloudFrontPublicKeyNamePrefix (0.45s)
--- PASS: TestValidateLbTargetGroupName (0.23s)
--- PASS: TestValidateDxConnectionBandWidth (0.55s)
--- PASS: TestValidateLbTargetGroupNamePrefix (0.22s)
--- PASS: TestValidateSecretManagerSecretName (0.20s)
--- PASS: TestValidateSecretManagerSecretNamePrefix (0.41s)
--- PASS: TestValidateRoute53ResolverName (0.26s)
--- PASS: TestValidateServiceDiscoveryNamespaceName (0.41s)
--- PASS: TestCloudWatchEventCustomEventBusName (0.46s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Prefix (144.15s)
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (145.01s)
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (149.44s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_SingleTag (140.67s)
--- PASS: TestAccAWSALBTargetGroup_tags (151.49s)
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (151.47s)
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (152.95s)
--- PASS: TestAccAWSALBTargetGroup_setAndUpdateSlowStart (153.37s)
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (154.11s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Default (74.74s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithStorageClassAnalysis_Full (73.80s)
--- PASS: TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled (165.02s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_updateBasic (172.10s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_MultipleTags (100.20s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_Remove (96.25s)
--- PASS: TestAccAWSS3BucketAnalyticsConfiguration_WithFilter_PrefixAndTags (98.99s)
--- PASS: TestAccAWSALBTargetGroup_updateSticknessEnabled (175.55s)
--- PASS: TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType (175.51s)
```
