### PR TITLE
tests/provider: Fix hardcoded (S resources)

### DIFF
--- a/aws/resource_aws_sns_platform_application_test.go
+++ b/aws/resource_aws_sns_platform_application_test.go
@@ -502,6 +502,8 @@ resource "aws_sns_platform_application" "test" {
 
 func testAccAwsSnsPlatformApplicationConfig_iamRoleAttribute(name string, platform *testAccAwsSnsPlatformApplicationPlatform, attributeKey, iamRoleName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
 {
@@ -509,7 +511,7 @@ resource "aws_iam_role" "test" {
   "Statement": {
     "Effect": "Allow",
     "Principal": {
-      "Service": "sns.amazonaws.com"
+      "Service": "sns.${data.aws_partition.current.dns_suffix}"
     },
     "Action": "sts:AssumeRole"
   }
@@ -520,12 +522,11 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/CloudWatchLogsFullAccess"
   role       = aws_iam_role.test.id
 }
 
 %s
-
 `, iamRoleName, testAccAwsSnsPlatformApplicationConfig_basicAttribute(name, platform, attributeKey, "${aws_iam_role.test.arn}"))
 }
 
@@ -536,6 +537,5 @@ resource "aws_sns_topic" "test" {
 }
 
 %s
-
 `, snsTopicName, testAccAwsSnsPlatformApplicationConfig_basicAttribute(name, platform, attributeKey, "${aws_sns_topic.test.arn}"))
 }

--- a/aws/resource_aws_sns_topic_test.go
+++ b/aws/resource_aws_sns_topic_test.go
@@ -169,7 +169,7 @@ func TestAccAWSSNSTopic_policy(t *testing.T) {
 	attributes := make(map[string]string)
 	resourceName := "aws_sns_topic.test"
 	rName := acctest.RandString(10)
-	expectedPolicy := `{"Statement":[{"Sid":"Stmt1445931846145","Effect":"Allow","Principal":{"AWS":"*"},"Action":"sns:Publish","Resource":"arn:aws:sns:us-west-2::example"}],"Version":"2012-10-17","Id":"Policy1445931846145"}`
+	expectedPolicy := fmt.Sprintf(`{"Statement":[{"Sid":"Stmt1445931846145","Effect":"Allow","Principal":{"AWS":"*"},"Action":"sns:Publish","Resource":"arn:%s:sns:%s::example"}],"Version":"2012-10-17","Id":"Policy1445931846145"}`, testAccGetPartition(), testAccGetRegion())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -539,6 +539,10 @@ resource "aws_sns_topic" "test" {
 
 func testAccAWSSNSTopicWithPolicy(r string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_sns_topic" "test" {
   name = "example-%s"
 
@@ -552,7 +556,7 @@ resource "aws_sns_topic" "test" {
         "AWS": "*"
       },
       "Action": "sns:Publish",
-      "Resource": "arn:aws:sns:us-west-2::example"
+      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}::example"
     }
   ],
   "Version": "2012-10-17",
@@ -566,8 +570,10 @@ EOF
 // Test for https://github.com/hashicorp/terraform/issues/3660
 func testAccAWSSNSTopicConfig_withIAMRole(r string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "example" {
-  name = "tf_acc_test_%s"
+  name = "tf_acc_test_%[1]s"
   path = "/test/"
 
   assume_role_policy = <<EOF
@@ -577,7 +583,7 @@ resource "aws_iam_role" "example" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "ec2.amazonaws.com"
+        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -587,8 +593,10 @@ resource "aws_iam_role" "example" {
 EOF
 }
 
+data "aws_region" "current" {}
+
 resource "aws_sns_topic" "test" {
-  name = "tf-acc-test-with-iam-role-%s"
+  name = "tf-acc-test-with-iam-role-%[1]s"
 
   policy = <<EOF
 {
@@ -600,7 +608,7 @@ resource "aws_sns_topic" "test" {
         "AWS": "${aws_iam_role.example.arn}"
       },
       "Action": "sns:Publish",
-      "Resource": "arn:aws:sns:us-west-2::example"
+      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}::example"
     }
   ],
   "Version": "2012-10-17",
@@ -608,7 +616,7 @@ resource "aws_sns_topic" "test" {
 }
 EOF
 }
-`, r, r)
+`, r)
 }
 
 // Test for https://github.com/hashicorp/terraform/issues/14024
@@ -640,6 +648,10 @@ EOF
 // Test for https://github.com/hashicorp/terraform/issues/3660
 func testAccAWSSNSTopicConfig_withFakeIAMRole(r string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_sns_topic" "test" {
   name = "tf_acc_test_fake_iam_role_%s"
 
@@ -650,10 +662,10 @@ resource "aws_sns_topic" "test" {
       "Sid": "Stmt1445931846145",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::012345678901:role/wooo"
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::012345678901:role/wooo"
       },
       "Action": "sns:Publish",
-      "Resource": "arn:aws:sns:us-west-2::example"
+      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}::example"
     }
   ],
   "Version": "2012-10-17",
@@ -668,7 +680,7 @@ func testAccAWSSNSTopicConfig_deliveryStatus(r string) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   depends_on                               = [aws_iam_role_policy.example]
-  name                                     = "sns-delivery-status-topic-%s"
+  name                                     = "sns-delivery-status-topic-%[1]s"
   application_success_feedback_role_arn    = aws_iam_role.example.arn
   application_success_feedback_sample_rate = 100
   application_failure_feedback_role_arn    = aws_iam_role.example.arn
@@ -683,8 +695,10 @@ resource "aws_sns_topic" "test" {
   sqs_failure_feedback_role_arn            = aws_iam_role.example.arn
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "example" {
-  name = "sns-delivery-status-role-%s"
+  name = "sns-delivery-status-role-%[1]s"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -694,7 +708,7 @@ resource "aws_iam_role" "example" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "sns.amazonaws.com"
+        "Service": "sns.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -704,7 +718,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "example" {
-  name = "sns-delivery-status-role-policy-%s"
+  name = "sns-delivery-status-role-policy-%[1]s"
   role = aws_iam_role.example.id
 
   policy = <<EOF
@@ -728,7 +742,7 @@ resource "aws_iam_role_policy" "example" {
 }
 EOF
 }
-`, r, r, r)
+`, r)
 }
 
 func testAccAWSSNSTopicConfig_withEncryption(r string) string {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1293,7 +1293,7 @@ func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(sfr *ec2.SpotFleetReq
 			return fmt.Errorf("Expected IamInstanceProfile to be set, got nil")
 		}
 		//Validate the string whether it is ARN
-		re := regexp.MustCompile(`arn:aws:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`)
+		re := regexp.MustCompile(fmt.Sprintf(`arn:%s:iam::\d{12}:instance-profile/?[a-zA-Z0-9+=,.@-_].*`, testAccGetPartition()))
 		if !re.MatchString(*profile.Arn) {
 			return fmt.Errorf("Expected IamInstanceProfile input as ARN, got %s", *profile.Arn)
 		}
@@ -1317,6 +1317,8 @@ resource "aws_key_pair" "test" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -1329,8 +1331,8 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "spotfleet.amazonaws.com",
-          "ec2.amazonaws.com"
+          "spotfleet.${data.aws_partition.current.dns_suffix}",
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": "sts:AssumeRole"
@@ -1682,8 +1684,8 @@ resource "aws_iam_role" "test-role1" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "spotfleet.amazonaws.com",
-          "ec2.amazonaws.com"
+          "spotfleet.${data.aws_partition.current.dns_suffix}",
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": "sts:AssumeRole"
@@ -1716,7 +1718,7 @@ resource "aws_iam_instance_profile" "test-iam-instance-profile1" {
 
 resource "aws_spot_fleet_request" "test" {
   iam_fleet_role                      = aws_iam_role.test.arn
-  spot_price                          = "0.05"
+  spot_price                          = "0.25"
   target_capacity                     = 2
   valid_until                         = %[2]q
   terminate_instances_with_expiration = true

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -229,10 +229,6 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
 
-	expectedPolicyText := fmt.Sprintf(
-		`{"Version": "2012-10-17","Id": "sqspolicy","Statement":[{"Sid": "Stmt1451501026839","Effect": "Allow","Principal":"*","Action":"sqs:SendMessage","Resource":"arn:aws:sqs:us-west-2:470663696735:%s","Condition":{"ArnEquals":{"aws:SourceArn":"arn:aws:sns:us-west-2:470663696735:%s"}}}]}`,
-		topicName, queueName)
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -242,7 +238,7 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 				Config: testAccAWSSQSConfig_PolicyFormat(topicName, queueName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSQueueExists("aws_sqs_queue.test-email-events", &queueAttributes),
-					testAccCheckAWSSQSQueuePolicyAttribute(&queueAttributes, expectedPolicyText),
+					testAccCheckAWSSQSQueuePolicyAttribute(&queueAttributes, topicName, queueName),
 				),
 			},
 			{
@@ -485,8 +481,13 @@ func testAccCheckAWSSQSQueueDestroy(s *terraform.State) error {
 
 	return nil
 }
-func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]*string, expectedPolicyText string) resource.TestCheckFunc {
+func testAccCheckAWSSQSQueuePolicyAttribute(queueAttributes *map[string]*string, topicName, queueName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		accountID := testAccProvider.Meta().(*AWSClient).accountid
+
+		expectedPolicyFormat := `{"Version": "2012-10-17","Id": "sqspolicy","Statement":[{"Sid": "Stmt1451501026839","Effect": "Allow","Principal":"*","Action":"sqs:SendMessage","Resource":"arn:%[1]s:sqs:%[2]s:%[3]s:%[4]s","Condition":{"ArnEquals":{"aws:SourceArn":"arn:%[1]s:sns:%[2]s:%[3]s:%[5]s"}}}]}`
+		expectedPolicyText := fmt.Sprintf(expectedPolicyFormat, testAccGetPartition(), testAccGetRegion(), accountID, topicName, queueName)
+
 		var actualPolicyText string
 		for key, valuePointer := range *queueAttributes {
 			if key == "Policy" {
@@ -638,7 +639,7 @@ resource "aws_sqs_queue" "queue" {
 func testAccAWSSQSConfigWithRedrive(name string) string {
 	return fmt.Sprintf(`
 resource "aws_sqs_queue" "my_queue" {
-  name                       = "tftestqueuq-%s"
+  name                       = "tftestqueuq-%[1]s"
   delay_seconds              = 0
   visibility_timeout_seconds = 300
 
@@ -651,9 +652,9 @@ EOF
 }
 
 resource "aws_sqs_queue" "my_dead_letter_queue" {
-  name = "tfotherqueuq-%s"
+  name = "tfotherqueuq-%[1]s"
 }
-`, name, name)
+`, name)
 }
 
 func testAccAWSSQSConfig_PolicyFormat(queue, topic string) string {
@@ -669,6 +670,12 @@ variable "sqs_name" {
 resource "aws_sns_topic" "test_topic" {
   name = var.sns_name
 }
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
 
 resource "aws_sqs_queue" "test-email-events" {
   name                       = var.sqs_name
@@ -689,10 +696,10 @@ resource "aws_sqs_queue" "test-email-events" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "sqs:SendMessage",
-      "Resource": "arn:aws:sqs:us-west-2:470663696735:${var.sqs_name}",
+      "Resource": "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.sqs_name}",
       "Condition": {
         "ArnEquals": {
-          "aws:SourceArn": "arn:aws:sns:us-west-2:470663696735:${var.sns_name}"
+          "aws:SourceArn": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.sns_name}"
         }
       }
     }

--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -243,6 +243,8 @@ func testAccCheckAWSSSMActivationDestroy(s *terraform.State) error {
 
 func testAccAWSSSMActivationBasicConfigBase(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test_role" {
   name = %[1]q
 
@@ -253,7 +255,7 @@ resource "aws_iam_role" "test_role" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "ssm.amazonaws.com"
+        "Service": "ssm.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -265,7 +267,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "test_attach" {
   role       = aws_iam_role.test_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 `, rName)
 }

--- a/aws/resource_aws_ssm_resource_data_sync_test.go
+++ b/aws/resource_aws_ssm_resource_data_sync_test.go
@@ -95,9 +95,11 @@ func testAccCheckAWSSsmResourceDataSyncExists(name string) resource.TestCheckFun
 func testAccSsmResourceDataSyncConfig(rInt int, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "hoge" {
-  bucket        = "tf-test-bucket-%d"
+  bucket        = "tf-test-bucket-%[1]d"
   force_destroy = true
 }
+
+data "aws_partition" "current" {}
 
 resource "aws_s3_bucket_policy" "hoge" {
   bucket = aws_s3_bucket.hoge.bucket
@@ -110,20 +112,20 @@ resource "aws_s3_bucket_policy" "hoge" {
       "Sid": "SSMBucketPermissionsCheck",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ssm.amazonaws.com"
+        "Service": "ssm.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "s3:GetBucketAcl",
-      "Resource": "arn:aws:s3:::tf-test-bucket-%d"
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-bucket-%[1]d"
     },
     {
       "Sid": " SSMBucketDelivery",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ssm.amazonaws.com"
+        "Service": "ssm.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "s3:PutObject",
       "Resource": [
-        "arn:aws:s3:::tf-test-bucket-%d/*"
+        "arn:${data.aws_partition.current.partition}:s3:::tf-test-bucket-%[1]d/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -138,22 +140,24 @@ resource "aws_s3_bucket_policy" "hoge" {
 }
 
 resource "aws_ssm_resource_data_sync" "test" {
-  name = "tf-test-ssm-%s"
+  name = "tf-test-ssm-%[2]s"
 
   s3_destination {
     bucket_name = aws_s3_bucket.hoge.bucket
     region      = aws_s3_bucket.hoge.region
   }
 }
-`, rInt, rInt, rInt, rName)
+`, rInt, rName)
 }
 
 func testAccSsmResourceDataSyncConfigUpdate(rInt int, rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "hoge" {
-  bucket        = "tf-test-bucket-%d"
+  bucket        = "tf-test-bucket-%[1]d"
   force_destroy = true
 }
+
+data "aws_partition" "current" {}
 
 resource "aws_s3_bucket_policy" "hoge" {
   bucket = aws_s3_bucket.hoge.bucket
@@ -166,20 +170,20 @@ resource "aws_s3_bucket_policy" "hoge" {
       "Sid": "SSMBucketPermissionsCheck",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ssm.amazonaws.com"
+        "Service": "ssm.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "s3:GetBucketAcl",
-      "Resource": "arn:aws:s3:::tf-test-bucket-%d"
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::tf-test-bucket-%[1]d"
     },
     {
       "Sid": " SSMBucketDelivery",
       "Effect": "Allow",
       "Principal": {
-        "Service": "ssm.amazonaws.com"
+        "Service": "ssm.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "s3:PutObject",
       "Resource": [
-        "arn:aws:s3:::tf-test-bucket-%d/*"
+        "arn:${data.aws_partition.current.partition}:s3:::tf-test-bucket-%[1]d/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -194,7 +198,7 @@ resource "aws_s3_bucket_policy" "hoge" {
 }
 
 resource "aws_ssm_resource_data_sync" "test" {
-  name = "tf-test-ssm-%s"
+  name = "tf-test-ssm-%[2]s"
 
   s3_destination {
     bucket_name = aws_s3_bucket.hoge.bucket
@@ -202,5 +206,5 @@ resource "aws_ssm_resource_data_sync" "test" {
     prefix      = "test-"
   }
 }
-`, rInt, rInt, rInt, rName)
+`, rInt, rName)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud) (4 failures, no regressions):

```
--- PASS: TestDecodeResourceAwsSnsPlatformApplicationID (0.09s)
--- SKIP: TestAccAWSSnsPlatformApplication_basicAttributes (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_iamRoleAttributes (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_basic (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_snsTopicAttributes (0.00s)
--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (35.15s)
--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (42.52s)
--- PASS: TestAccAWSSNSTopicPolicy_basic (48.95s)
--- PASS: TestAccAWSSNSTopicSubscription_basic (49.07s)
--- PASS: TestAccAWSSNSTopic_basic (55.48s)
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (55.97s)
--- PASS: TestAccAWSSNSTopic_name (56.90s)
--- PASS: TestAccAWSSNSTopic_policy (57.33s)
--- PASS: TestAccAWSSNSTopic_namePrefix (57.50s)
--- PASS: TestAccAWSSNSTopic_withIAMRole (61.42s)
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (93.26s)
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (93.28s)
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (93.92s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (117.82s) ***
--- PASS: TestAccAWSSNSTopic_encryption (61.27s)
--- PASS: TestAccAWSSNSTopic_tags (64.82s)
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (140.79s)
--- FAIL: TestAccAWSSNSTopic_deliveryStatus (140.43s)
--- PASS: TestAccAWSSpotFleetRequest_basic (128.39s)
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (131.26s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (130.47s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (132.51s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (133.43s)
--- PASS: TestAccAWSSpotFleetRequest_tags (164.27s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (122.67s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (122.66s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (109.06s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (108.93s)
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (227.26s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (232.50s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (117.22s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (122.23s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (122.65s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (223.79s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (213.56s)
--- SKIP: TestAccAWSSpotFleetRequest_WithInstanceStoreAmi (0.00s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (150.56s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (112.68s)
--- PASS: TestAccAWSSQSQueuePolicy_disappears_queue (8.71s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (156.26s)
--- PASS: TestAccAWSSQSQueuePolicy_basic (29.02s)
--- PASS: TestAccAWSSQSQueuePolicy_disappears (23.81s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (138.12s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (140.57s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (89.36s)
--- PASS: TestAccAWSSQSQueue_namePrefix (71.89s)
--- PASS: TestAccAWSSQSQueue_policy (28.25s)***
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (223.25s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (228.67s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (159.49s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (354.16s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (162.27s)
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (65.05s)
--- PASS: TestAccAWSSpotFleetRequest_disappears (133.16s)
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (12.31s)
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (13.64s)
--- FAIL: TestAccAWSSQSQueue_basic (121.28s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (44.43s)
--- PASS: TestAccAWSSQSQueue_Policybasic (47.38s)
--- PASS: TestAccAWSSQSQueue_FIFO (43.28s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (89.72s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (175.14s)
--- PASS: TestAccAWSSQSQueue_tags (133.00s)
--- PASS: TestAccAWSSQSQueue_Encryption (39.15s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (41.25s)
--- PASS: TestAccAWSSSMActivation_basic (46.16s)
--- PASS: TestAccAWSSSMActivation_expirationDate (45.84s)
--- PASS: TestAccAWSSsmResourceDataSync_basic (36.10s)
--- PASS: TestAccAWSSSMActivation_disappears (37.34s)
--- PASS: TestAccAWSSSMActivation_update (55.30s)
--- PASS: TestAccAWSSsmResourceDataSync_update (35.69s)
--- PASS: TestAccAWSSpotFleetRequest_zero_capacity (223.87s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (251.47s)
```

Output from acceptance testing (commercial) (0 failures, no regressions):

```
--- PASS: TestDecodeResourceAwsSnsPlatformApplicationID (0.12s)
--- SKIP: TestAccAWSSnsPlatformApplication_basicAttributes (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_snsTopicAttributes (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_basic (0.00s)
--- SKIP: TestAccAWSSnsPlatformApplication_iamRoleAttributes (0.00s)
--- PASS: TestAccAWSSNSTopic_withIAMRole (25.76s) ***
--- PASS: TestAccAWSSNSTopicPolicy_basic (61.56s)
--- PASS: TestAccAWSSNSTopicSubscription_basic (65.32s)
--- PASS: TestAccAWSSNSTopic_namePrefix (71.02s)
--- PASS: TestAccAWSSNSTopic_policy (71.18s)
--- PASS: TestAccAWSSNSTopic_basic (73.30s)
--- PASS: TestAccAWSSNSTopic_name (74.51s)
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (75.39s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (124.54s) ***
--- PASS: TestAccAWSSNSTopic_deliveryStatus (81.60s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (93.81s)
--- PASS: TestAccAWSSNSTopic_encryption (106.84s)
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (116.26s)
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (117.71s)
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (118.28s)
--- PASS: TestAccAWSSNSTopic_tags (118.51s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (126.42s)
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (143.57s)
--- PASS: TestAccAWSSpotFleetRequest_basic (148.97s)
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (150.57s)
--- PASS: TestAccAWSSpotFleetRequest_tags (182.04s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate (156.13s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateWithOverrides (146.13s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplate_multiple (150.96s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (142.37s)
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (147.85s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (129.90s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (126.47s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (134.21s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (132.07s)
--- SKIP: TestAccAWSSpotFleetRequest_WithInstanceStoreAmi (0.00s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (125.05s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (131.82s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (130.94s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (169.51s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (170.54s)
--- PASS: TestAccAWSSQSQueuePolicy_disappears_queue (12.63s)
--- PASS: TestAccAWSSpotFleetRequest_placementTenancyAndGroup (79.38s)
--- PASS: TestAccAWSSQSQueuePolicy_disappears (19.39s)
--- PASS: TestAccAWSSQSQueuePolicy_basic (33.93s)
--- PASS: TestAccAWSSQSQueue_namePrefix (27.91s)
--- PASS: TestAccAWSSQSQueue_policy (20.57s) ***
--- PASS: TestAccAWSSpotFleetRequest_launchSpecToLaunchTemplate (270.85s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (268.19s)
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (46.30s)
--- PASS: TestAccAWSSpotFleetRequest_launchTemplateToLaunchSpec (276.35s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (269.17s)
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (18.63s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_RootBlockDevice_KmsKeyId (153.63s)
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (20.48s)
--- PASS: TestAccAWSSpotFleetRequest_LaunchSpecification_EbsBlockDevice_KmsKeyId (158.89s)
--- PASS: TestAccAWSSpotFleetRequest_withTags (159.30s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (166.84s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (63.26s)
--- PASS: TestAccAWSSQSQueue_Policybasic (68.37s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (86.58s)
--- PASS: TestAccAWSSQSQueue_FIFO (55.05s)
--- PASS: TestAccAWSSQSQueue_basic (110.42s)
--- PASS: TestAccAWSSQSQueue_tags (110.79s)
--- PASS: TestAccAWSSpotFleetRequest_disappears (140.54s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (53.01s)
--- PASS: TestAccAWSSQSQueue_Encryption (41.38s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (222.56s)
--- PASS: TestAccAWSSSMActivation_disappears (43.69s)
--- PASS: TestAccAWSSsmResourceDataSync_basic (40.00s)
--- PASS: TestAccAWSSSMActivation_expirationDate (55.65s)
--- PASS: TestAccAWSSSMActivation_basic (56.69s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (192.59s)
--- PASS: TestAccAWSSSMActivation_update (65.55s)
--- PASS: TestAccAWSSsmResourceDataSync_update (57.06s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (392.19s)
--- PASS: TestAccAWSSpotFleetRequest_zero_capacity (236.25s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (320.35s)
```
***Fixed after TeamCity run, tested locally