### PR TITLE
tests/resource/aws_iam_user_login_profile: Ensure testDecryptPasswordAndTest honors current testing region

### DIFF
--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -253,7 +253,7 @@ func testDecryptPasswordAndTest(nProfile, nAccessKey, key string) resource.TestC
 		}
 
 		iamAsCreatedUserSession := session.New(&aws.Config{
-			Region:      aws.String("us-west-2"),
+			Region:      aws.String(testAccGetRegion()),
 			Credentials: credentials.NewStaticCredentials(accessKeyId, secretAccessKey, ""),
 		})
 		_, err = iamAsCreatedUserSession.Config.Credentials.Get()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Requires #15688
Closes #15690

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSUserLoginProfile_basic (25.86s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSUserLoginProfile_basic (36.33s)
```
