### PR TITLE
Consider Workspace State Fully Terminated Only After Directory Metadata Cleanup

### DIFF
--- a/aws/internal/service/workspaces/waiter/status.go
+++ b/aws/internal/service/workspaces/waiter/status.go
@@ -34,10 +34,17 @@ func WorkspaceState(conn *workspaces.WorkSpaces, workspaceID string) resource.St
 		}
 
 		if len(output.Workspaces) == 0 {
-			return nil, workspaces.WorkspaceStateTerminated, nil
+			return nil, "", nil
 		}
 
 		workspace := output.Workspaces[0]
+
+		// https://docs.aws.amazon.com/workspaces/latest/api/API_TerminateWorkspaces.html
+		// State TERMINATED is overridden with TERMINATING to catch up directory metadata clean up.
+		if aws.StringValue(workspace.State) == workspaces.WorkspaceStateTerminated {
+			return workspace, workspaces.WorkspaceStateTerminating, nil
+		}
+
 		return workspace, aws.StringValue(workspace.State), nil
 	}
 }

--- a/aws/internal/service/workspaces/waiter/waiter.go
+++ b/aws/internal/service/workspaces/waiter/waiter.go
@@ -109,9 +109,7 @@ func WorkspaceTerminated(conn *workspaces.WorkSpaces, workspaceID string) (*work
 			workspaces.WorkspaceStateTerminating,
 			workspaces.WorkspaceStateError,
 		},
-		Target: []string{
-			workspaces.WorkspaceStateTerminated,
-		},
+		Target:  []string{},
 		Refresh: WorkspaceState(conn, workspaceID),
 		Timeout: WorkspaceTerminatedTimeout,
 	}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #15190
Closes #14517
Relates #14135
Relates #14950

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
aws_workspaces_workspace: Fix the terminated state resolution
```

### Acceptance Tests

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsWorkspacesWorkspace_recreate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 1 -run=TestAccAwsWorkspacesWorkspace_recreate -timeout 120m
=== RUN   TestAccAwsWorkspacesWorkspace_recreate
=== PAUSE TestAccAwsWorkspacesWorkspace_recreate
=== CONT  TestAccAwsWorkspacesWorkspace_recreate
--- PASS: TestAccAwsWorkspacesWorkspace_recreate (952.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	955.269s
```

### References

- [TerminateWorkspaces API](https://docs.aws.amazon.com/workspaces/latest/api/API_TerminateWorkspaces.html)