### PR TITLE
tests/provider: Fix hardcoded (Lambda Perm)

### DIFF
--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -29,7 +29,7 @@ func TestLambdaPermissionUnmarshalling(t *testing.T) {
 		t.Fatalf("Expected Sid to match (%q != %q)", v.Statement[0].Sid, expectedSid)
 	}
 
-	expectedFunctionName := "arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction"
+	expectedFunctionName := "arn:aws:lambda:eu-west-1:319201112229:function:myCustomFunction" // lintignore:AWSAT003,AWSAT005 // unit test
 	if v.Statement[0].Resource != expectedFunctionName {
 		t.Fatalf("Expected function name to match (%q != %q)", v.Statement[0].Resource, expectedFunctionName)
 	}
@@ -60,7 +60,7 @@ func TestLambdaPermissionUnmarshalling(t *testing.T) {
 }
 
 func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_alias(t *testing.T) {
-	arnWithAlias := "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name:testalias"
+	arnWithAlias := "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name:testalias" // lintignore:AWSAT003,AWSAT005 // unit test
 	expectedQualifier := "testalias"
 	qualifier, err := getQualifierFromLambdaAliasOrVersionArn(arnWithAlias)
 	if err != nil {
@@ -71,7 +71,7 @@ func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_alias(t *testin
 	}
 }
 func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_govcloud(t *testing.T) {
-	arnWithAlias := "arn:aws-us-gov:lambda:us-gov-west-1:187636751137:function:lambda_function_name:testalias"
+	arnWithAlias := "arn:aws-us-gov:lambda:us-gov-west-1:187636751137:function:lambda_function_name:testalias" // lintignore:AWSAT003,AWSAT005 // unit test
 	expectedQualifier := "testalias"
 	qualifier, err := getQualifierFromLambdaAliasOrVersionArn(arnWithAlias)
 	if err != nil {
@@ -83,7 +83,7 @@ func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_govcloud(t *tes
 }
 
 func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_version(t *testing.T) {
-	arnWithVersion := "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name:223"
+	arnWithVersion := "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name:223" // lintignore:AWSAT003,AWSAT005 // unit test
 	expectedQualifier := "223"
 	qualifier, err := getQualifierFromLambdaAliasOrVersionArn(arnWithVersion)
 	if err != nil {
@@ -95,7 +95,7 @@ func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_version(t *test
 }
 
 func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_invalid(t *testing.T) {
-	invalidArn := "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name"
+	invalidArn := "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name" // lintignore:AWSAT003,AWSAT005 // unit test
 	qualifier, err := getQualifierFromLambdaAliasOrVersionArn(invalidArn)
 	if err == nil {
 		t.Fatalf("Expected error when getting qualifier")
@@ -105,7 +105,7 @@ func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_invalid(t *test
 	}
 
 	// with trailing colon
-	invalidArn = "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name:"
+	invalidArn = "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name:" // lintignore:AWSAT003,AWSAT005 // unit test
 	qualifier, err = getQualifierFromLambdaAliasOrVersionArn(invalidArn)
 	if err == nil {
 		t.Fatalf("Expected error when getting qualifier")
@@ -116,7 +116,7 @@ func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_invalid(t *test
 }
 
 func TestLambdaPermissionGetFunctionNameFromLambdaArn_invalid(t *testing.T) {
-	invalidArn := "arn:aws:lambda:us-west-2:187636751137:function:"
+	invalidArn := "arn:aws:lambda:us-west-2:187636751137:function:" // lintignore:AWSAT003,AWSAT005 // unit test
 	fn, err := getFunctionNameFromLambdaArn(invalidArn)
 	if err == nil {
 		t.Fatalf("Expected error when parsing invalid ARN (%q)", invalidArn)
@@ -127,7 +127,7 @@ func TestLambdaPermissionGetFunctionNameFromLambdaArn_invalid(t *testing.T) {
 }
 
 func TestLambdaPermissionGetFunctionNameFromLambdaArn_valid(t *testing.T) {
-	validArn := "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name"
+	validArn := "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name" // lintignore:AWSAT003,AWSAT005 // unit test
 	fn, err := getFunctionNameFromLambdaArn(validArn)
 	if err != nil {
 		t.Fatalf("Expected no error (%q): %q", validArn, err)
@@ -139,7 +139,7 @@ func TestLambdaPermissionGetFunctionNameFromLambdaArn_valid(t *testing.T) {
 	}
 
 	// With qualifier
-	validArn = "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name:12"
+	validArn = "arn:aws:lambda:us-west-2:187636751137:function:lambda_function_name:12" // lintignore:AWSAT003,AWSAT005 // unit test
 	fn, err = getFunctionNameFromLambdaArn(validArn)
 	if err != nil {
 		t.Fatalf("Expected no error (%q): %q", validArn, err)
@@ -152,7 +152,7 @@ func TestLambdaPermissionGetFunctionNameFromLambdaArn_valid(t *testing.T) {
 }
 
 func TestLambdaPermissionGetFunctionNameFromGovCloudLambdaArn(t *testing.T) {
-	validArn := "arn:aws-us-gov:lambda:us-gov-west-1:187636751137:function:lambda_function_name"
+	validArn := "arn:aws-us-gov:lambda:us-gov-west-1:187636751137:function:lambda_function_name" // lintignore:AWSAT003,AWSAT005 // unit test
 	fn, err := getFunctionNameFromLambdaArn(validArn)
 	if err != nil {
 		t.Fatalf("Expected no error (%q): %q", validArn, err)
@@ -884,6 +884,7 @@ EOF
 }
 
 func testAccAWSLambdaPermissionConfig_withQualifier(aliasName, funcName, roleName string) string {
+	// lintignore:AWSAT003,AWSAT005 // ARN, region not actually used
 	return fmt.Sprintf(`
 resource "aws_lambda_permission" "with_qualifier" {
   statement_id   = "AllowExecutionWithQualifier"
@@ -1128,6 +1129,7 @@ EOF
 `, funcName, roleName)
 }
 
+// lintignore:AWSAT003,AWSAT005 // unit test
 var testLambdaPolicy = []byte(`{
   "Version": "2012-10-17",
   "Statement": [


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

### No code changes. Added `lintignore` for unit tests, not-used ARNs.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_invalid (0.11s)
--- PASS: TestLambdaPermissionUnmarshalling (0.27s)
--- PASS: TestLambdaPermissionGetFunctionNameFromLambdaArn_valid (0.39s)
--- PASS: TestLambdaPermissionGetFunctionNameFromLambdaArn_invalid (0.40s)
--- PASS: TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_version (0.42s)
--- PASS: TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_alias (0.44s)
--- PASS: TestLambdaPermissionGetFunctionNameFromGovCloudLambdaArn (0.46s)
--- PASS: TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_govcloud (0.56s)
--- PASS: TestAccAWSLambdaPermission_withStatementIdPrefix (44.11s)
--- PASS: TestAccAWSLambdaPermission_basic (46.14s)
--- PASS: TestAccAWSLambdaPermission_withRawFunctionName (46.58s)
--- PASS: TestAccAWSLambdaPermission_withQualifier (46.83s)
--- PASS: TestAccAWSLambdaPermission_withIAMRole (46.70s)
--- PASS: TestAccAWSLambdaPermission_withS3 (47.14s)
--- PASS: TestAccAWSLambdaPermission_withSNS (47.43s)
--- PASS: TestAccAWSLambdaPermission_multiplePerms (53.89s)
--- PASS: TestAccAWSLambdaPermission_StatementId_Duplicate (85.23s)
--- PASS: TestAccAWSLambdaPermission_disappears (104.32s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestLambdaPermissionGetFunctionNameFromLambdaArn_invalid (0.24s)
--- PASS: TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_invalid (0.26s)
--- PASS: TestLambdaPermissionGetFunctionNameFromLambdaArn_valid (0.33s)
--- PASS: TestLambdaPermissionGetFunctionNameFromGovCloudLambdaArn (0.36s)
--- PASS: TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_alias (0.37s)
--- PASS: TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_version (0.42s)
--- PASS: TestLambdaPermissionUnmarshalling (0.43s)
--- PASS: TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_govcloud (0.51s)
--- PASS: TestAccAWSLambdaPermission_withIAMRole (39.94s)
--- PASS: TestAccAWSLambdaPermission_basic (52.54s)
--- PASS: TestAccAWSLambdaPermission_withQualifier (53.90s)
--- PASS: TestAccAWSLambdaPermission_withStatementIdPrefix (54.94s)
--- PASS: TestAccAWSLambdaPermission_withRawFunctionName (55.14s)
--- PASS: TestAccAWSLambdaPermission_withS3 (55.72s)
--- PASS: TestAccAWSLambdaPermission_withSNS (56.02s)
--- PASS: TestAccAWSLambdaPermission_multiplePerms (69.13s)
--- PASS: TestAccAWSLambdaPermission_StatementId_Duplicate (96.83s)
--- PASS: TestAccAWSLambdaPermission_disappears (104.50s)
```