### PR TITLE
tests/resource/aws_iam_group: Prevent sweeper error with user membership in group

### DIFF
--- a/aws/resource_aws_iam_group_test.go
+++ b/aws/resource_aws_iam_group_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -42,9 +43,6 @@ func testSweepIamGroups(region string) error {
 		}
 
 		for _, group := range page.Groups {
-			input := &iam.DeleteGroupInput{
-				GroupName: group.GroupName,
-			}
 			name := aws.StringValue(group.GroupName)
 
 			if name == "Admin" || name == "TerraformAccTests" {
@@ -52,6 +50,53 @@ func testSweepIamGroups(region string) error {
 			}
 
 			log.Printf("[INFO] Deleting IAM Group: %s", name)
+
+			getGroupInput := &iam.GetGroupInput{
+				GroupName: group.GroupName,
+			}
+
+			getGroupOutput, err := conn.GetGroup(getGroupInput)
+
+			if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+				continue
+			}
+
+			if err != nil {
+				sweeperErr := fmt.Errorf("error reading IAM Group (%s): %w", name, err)
+				log.Printf("[ERROR] %s", sweeperErr)
+				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+				continue
+			}
+
+			if getGroupOutput != nil {
+				for _, user := range getGroupOutput.Users {
+					username := aws.StringValue(user.UserName)
+
+					log.Printf("[INFO] Removing IAM User (%s) from Group: %s", username, name)
+
+					input := &iam.RemoveUserFromGroupInput{
+						UserName:  user.UserName,
+						GroupName: group.GroupName,
+					}
+
+					_, err := conn.RemoveUserFromGroup(input)
+
+					if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
+						continue
+					}
+
+					if err != nil {
+						sweeperErr := fmt.Errorf("error removing IAM User (%s) from IAM Group (%s): %w", username, name, err)
+						log.Printf("[ERROR] %s", sweeperErr)
+						sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+						continue
+					}
+				}
+			}
+
+			input := &iam.DeleteGroupInput{
+				GroupName: group.GroupName,
+			}
 
 			if err := deleteAwsIamGroupPolicyAttachments(conn, name); err != nil {
 				sweeperErr := fmt.Errorf("error deleting IAM Group (%s) policy attachments: %w", name, err)
@@ -67,9 +112,9 @@ func testSweepIamGroups(region string) error {
 				continue
 			}
 
-			_, err := conn.DeleteGroup(input)
+			_, err = conn.DeleteGroup(input)
 
-			if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
 				continue
 			}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

If desired, some of this logic (removing users, deleting inline policies, etc.) could be bundled into a `force_destroy` flag in the `aws_iam_group` resource in the future.

Previously:

```
2020/10/19 13:26:01 [DEBUG] Running Sweeper (aws_iam_group) in region (us-west-2)
2020/10/19 13:26:01 [INFO] Deleting IAM Group: test-datasource-group-63237345062939813
2020/10/19 13:26:12 [ERROR] error deleting IAM Group (test-datasource-group-63237345062939813): DeleteConflict: Cannot delete entity, must remove users from group first.
	status code: 409, request id: 8e402f36-201c-41d0-84c2-074896a32f51
```

Output from sweeper:

```console
$ go test ./aws -v -timeout=10h -sweep-allow-failures -sweep=us-west-2 -sweep-run=aws_iam_group
2020/10/19 13:28:30 [DEBUG] Running Sweepers for region (us-west-2):
2020/10/19 13:28:30 [DEBUG] Sweeper (aws_iam_group) has dependency (aws_iam_user), running..
2020/10/19 13:28:30 [DEBUG] Running Sweeper (aws_iam_user) in region (us-west-2)
2020/10/19 13:28:30 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2020/10/19 13:28:30 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/10/19 13:28:30 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2020/10/19 13:28:31 [DEBUG] No IAM Users to sweep
2020/10/19 13:28:31 [DEBUG] Running Sweeper (aws_iam_group) in region (us-west-2)
2020/10/19 13:28:31 [INFO] Deleting IAM Group: test-datasource-group-63237345062939813
2020/10/19 13:28:31 [INFO] Removing IAM User (test-datasource-user-5093273308090868383-0) from Group: test-datasource-group-63237345062939813
2020/10/19 13:28:32 [DEBUG] Sweeper (aws_iam_user) already ran in region (us-west-2)
2020/10/19 13:28:32 Sweeper Tests ran successfully:
	- aws_iam_user
	- aws_iam_group
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.754s
```
