### PR TITLE
tests/provider: Fix hardcoded ARN (Cloud*)

### DIFF
--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -578,6 +578,8 @@ BODY
 }
 
 var testAccAWSCloudFormationStackConfig_allAttributesWithBodies_tpl = `
+data "aws_partition" "current" {}
+
 resource "aws_cloudformation_stack" "test" {
   name          = "%[1]s"
   template_body = <<STACK
@@ -614,7 +616,7 @@ resource "aws_cloudformation_stack" "test" {
           "Version": "2012-10-17",
           "Statement": [ {
             "Effect": "Allow",
-            "Principal": { "Service": "ec2.amazonaws.com" },
+            "Principal": { "Service": "ec2.${data.aws_partition.current.dns_suffix}" },
             "Action": "sts:AssumeRole"
           } ]
         },
@@ -739,6 +741,10 @@ func testAccAWSCloudFormationStackConfig_withParams_modified(stackName string) s
 
 func testAccAWSCloudFormationStackConfig_templateUrl_withParams(rName, bucketKey, vpcCidr string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_s3_bucket" "b" {
   bucket = "%[1]s"
   acl    = "public-read"
@@ -754,7 +760,7 @@ resource "aws_s3_bucket" "b" {
         "AWS": "*"
       },
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::%[1]s/*"
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*"
     }
   ]
 }
@@ -780,7 +786,7 @@ resource "aws_cloudformation_stack" "test" {
     VpcCIDR = "%[3]s"
   }
 
-  template_url       = "https://${aws_s3_bucket.b.id}.s3-us-west-2.amazonaws.com/${aws_s3_bucket_object.object.key}"
+  template_url       = "https://${aws_s3_bucket.b.id}.s3-${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${aws_s3_bucket_object.object.key}"
   on_failure         = "DELETE"
   timeout_in_minutes = 1
 }
@@ -789,6 +795,10 @@ resource "aws_cloudformation_stack" "test" {
 
 func testAccAWSCloudFormationStackConfig_templateUrl_withParams_withYaml(rName, bucketKey, vpcCidr string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_s3_bucket" "b" {
   bucket = "%[1]s"
   acl    = "public-read"
@@ -804,7 +814,7 @@ resource "aws_s3_bucket" "b" {
         "AWS": "*"
       },
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::%[1]s/*"
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*"
     }
   ]
 }
@@ -830,7 +840,7 @@ resource "aws_cloudformation_stack" "test" {
     VpcCIDR = "%[3]s"
   }
 
-  template_url       = "https://${aws_s3_bucket.b.id}.s3-us-west-2.amazonaws.com/${aws_s3_bucket_object.object.key}"
+  template_url       = "https://${aws_s3_bucket.b.id}.s3-${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${aws_s3_bucket_object.object.key}"
   on_failure         = "DELETE"
   timeout_in_minutes = 1
 }
@@ -885,7 +895,6 @@ resource "aws_cloudformation_stack" "with-transform" {
   }
 }
 STACK
-
 
   capabilities       = ["CAPABILITY_AUTO_EXPAND"]
   on_failure         = "DELETE"

--- a/aws/resource_aws_cloudfront_origin_access_identity_test.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity_test.go
@@ -29,7 +29,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "s3_canonical_user_id", regexp.MustCompile("^[a-z0-9]+")),
 					resource.TestMatchResourceAttr(resourceName, "cloudfront_access_identity_path", regexp.MustCompile("^origin-access-identity/cloudfront/[A-Z0-9]+")),
 					//lintignore:AWSAT001
-					resource.TestMatchResourceAttr(resourceName, "iam_arn", regexp.MustCompile("^arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity [A-Z0-9]+")),
+					resource.TestMatchResourceAttr(resourceName, "iam_arn", regexp.MustCompile(fmt.Sprintf("^arn:%s:iam::cloudfront:user/CloudFront Origin Access Identity [A-Z0-9]+", testAccGetPartition()))),
 				),
 			},
 			{
@@ -58,7 +58,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_noComment(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "s3_canonical_user_id", regexp.MustCompile("^[a-z0-9]+")),
 					resource.TestMatchResourceAttr(resourceName, "cloudfront_access_identity_path", regexp.MustCompile("^origin-access-identity/cloudfront/[A-Z0-9]+")),
 					//lintignore:AWSAT001
-					resource.TestMatchResourceAttr(resourceName, "iam_arn", regexp.MustCompile("^arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity [A-Z0-9]+")),
+					resource.TestMatchResourceAttr(resourceName, "iam_arn", regexp.MustCompile(fmt.Sprintf("^arn:%s:iam::cloudfront:user/CloudFront Origin Access Identity [A-Z0-9]+", testAccGetPartition()))),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_Default (0.00s)
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_NoEcho (0.00s)
--- PASS: TestAccAWSCloudFormationStackSet_disappears (48.22s)
--- PASS: TestAccAWSCloudFormationStackSet_basic (52.27s)
--- PASS: TestAccAWSCloudFormationStackSet_Name (59.40s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (71.83s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (72.14s)
--- PASS: TestAccAWSCloudFormationStackSet_Description (75.33s)
--- PASS: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (83.86s)
--- PASS: TestAccAWSCloudFormationStackSet_ExecutionRoleName (85.34s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateBody (48.95s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateUrl (53.03s)
--- PASS: TestAccAWSCloudFormationStackSet_Parameters (115.15s)
--- PASS: TestAccAWSCloudFormationStackSet_Tags (126.23s)
--- PASS: TestAccAWSCloudFormationStack_basic (71.69s)
--- SKIP: TestAccAWSCloudFrontOriginAccessIdentity_basic (0.00s)
--- SKIP: TestAccAWSCloudFrontOriginAccessIdentity_noComment (0.00s)
--- SKIP: TestAccAWSCloudFrontOriginAccessIdentity_disappears (0.00s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (137.12s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears (140.60s)
--- PASS: TestAccAWSCloudFormationStack_yaml (71.93s)
--- PASS: TestAccAWSCloudFormationStack_disappears (74.03s)
--- PASS: TestAccAWSCloudFormationStack_defaultParams (74.01s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (151.91s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (72.22s)
--- PASS: TestAccAWSCloudFormationStack_allAttributes (94.16s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (187.52s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (74.01s)
--- PASS: TestAccAWSCloudFormationStack_withTransform (66.63s)
--- PASS: TestAccAWSCloudFormationStack_withParams (133.13s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (131.47s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (237.98s)
```

Output from acceptance testing (commercial):

```
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_Default (0.00s)
--- SKIP: TestAccAWSCloudFormationStackSet_Parameters_NoEcho (0.00s)
--- PASS: TestAccAWSCloudFormationStackSet_disappears (53.53s)
--- PASS: TestAccAWSCloudFormationStackSet_basic (59.65s)
--- PASS: TestAccAWSCloudFormationStackSet_Description (81.03s)
--- PASS: TestAccAWSCloudFormationStack_disappears (85.60s)
--- PASS: TestAccAWSCloudFormationStackSet_Name (90.07s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateUrl (93.26s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (95.34s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (95.48s)
--- PASS: TestAccAWSCloudFormationStack_basic (95.51s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateBody (96.18s)
--- PASS: TestAccAWSCloudFormationStackSet_ExecutionRoleName (96.49s)
--- PASS: TestAccAWSCloudFormationStack_yaml (96.02s)
--- PASS: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (98.44s)
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_disappears (30.75s)
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_basic (40.92s)
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_noComment (41.68s)
--- PASS: TestAccAWSCloudFormationStack_defaultParams (91.03s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (145.42s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears (148.04s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (152.01s)
--- PASS: TestAccAWSCloudFormationStackSet_Parameters (157.84s)
--- PASS: TestAccAWSCloudFormationStackSet_Tags (166.10s)
--- PASS: TestAccAWSCloudFormationStack_withTransform (78.30s)
--- PASS: TestAccAWSCloudFormationStack_allAttributes (118.39s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (90.94s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (113.79s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (214.01s)
--- PASS: TestAccAWSCloudFormationStack_withParams (149.59s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (152.77s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (276.11s)
```
