### PR TITLE
tests/provider: Fix hardcoded ARN (CloudWatch Log Res Pol)

### DIFF
--- a/aws/resource_aws_cloudwatch_log_resource_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_resource_policy_test.go
@@ -78,7 +78,7 @@ func TestAccAWSCloudWatchLogResourcePolicy_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchLogResourcePolicy(resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", name),
-					resource.TestCheckResourceAttr(resourceName, "policy_document", "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53.amazonaws.com\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/route53/*\"}]}"),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/*\"}]}", testAccGetPartitionDNSSuffix(), testAccGetPartition())),
 				),
 			},
 			{
@@ -91,7 +91,7 @@ func TestAccAWSCloudWatchLogResourcePolicy_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchLogResourcePolicy(resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", name),
-					resource.TestCheckResourceAttr(resourceName, "policy_document", "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53.amazonaws.com\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:aws:logs:*:*:log-group:/aws/route53/example.com\"}]}"),
+					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"}]}", testAccGetPartitionDNSSuffix(), testAccGetPartition())),
 				),
 			},
 		},
@@ -147,6 +147,8 @@ func testAccCheckCloudWatchLogResourcePolicyDestroy(s *terraform.State) error {
 
 func testAccCheckAWSCloudWatchLogResourcePolicyResourceConfigBasic1(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "test" {
   statement {
     actions = [
@@ -154,10 +156,10 @@ data "aws_iam_policy_document" "test" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:logs:*:*:log-group:/aws/rds/*"]
 
     principals {
-      identifiers = ["route53.amazonaws.com"]
+      identifiers = ["rds.${data.aws_partition.current.dns_suffix}"]
       type        = "Service"
     }
   }
@@ -172,6 +174,8 @@ resource "aws_cloudwatch_log_resource_policy" "test" {
 
 func testAccCheckAWSCloudWatchLogResourcePolicyResourceConfigBasic2(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "test" {
   statement {
     actions = [
@@ -179,10 +183,10 @@ data "aws_iam_policy_document" "test" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/example.com"]
+    resources = ["arn:${data.aws_partition.current.partition}:logs:*:*:log-group:/aws/rds/example.com"]
 
     principals {
-      identifiers = ["route53.amazonaws.com"]
+      identifiers = ["rds.${data.aws_partition.current.dns_suffix}"]
       type        = "Service"
     }
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

The policy was for Route53 but GovCloud did not like that and gave an error (`Writing CloudWatch log resource policy failed: InvalidParameterException: Could not convert to persistable policy.`). Now, the policy is for RDS and still tests the same thing but GovCloud is happy.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSCloudWatchLogResourcePolicy_basic (33.43s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSCloudWatchLogResourcePolicy_basic (24.72s)
```
