### PR TITLE
tests/provider: Fix hardcoded ARN (CodeDeploy Dep Group)

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -289,7 +289,7 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 						"InstanceFailure",
 					}),
 					testAccCheckCodeDeployDeploymentGroupTriggerTargetArn(&group, "test-trigger-2",
-						regexp.MustCompile("^arn:aws:sns:[^:]+:[0-9]{12}:tf-acc-test-2-"+rName+"$")),
+						regexp.MustCompile(fmt.Sprintf("^arn:%s:sns:[^:]+:[0-9]{12}:tf-acc-test-2-%s$", testAccGetPartition(), rName))),
 				),
 			},
 			{
@@ -310,7 +310,7 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 						"InstanceFailure",
 					}),
 					testAccCheckCodeDeployDeploymentGroupTriggerTargetArn(&group, "test-trigger-2",
-						regexp.MustCompile("^arn:aws:sns:[^:]+:[0-9]{12}:tf-acc-test-3-"+rName+"$")),
+						regexp.MustCompile(fmt.Sprintf("^arn:%s:sns:[^:]+:[0-9]{12}:tf-acc-test-3-%s$", testAccGetPartition(), rName))),
 				),
 			},
 			{
@@ -1626,7 +1626,7 @@ func TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs(t *testing.T) {
 				"DeploymentFailure",
 			}),
 			"trigger_name":       "test-trigger",
-			"trigger_target_arn": "arn:aws:sns:us-west-2:123456789012:test-topic",
+			"trigger_target_arn": "arn:aws:sns:us-west-2:123456789012:test-topic", // lintignore:AWSAT003,AWSAT005 // unit test
 		},
 	}
 
@@ -1636,7 +1636,7 @@ func TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs(t *testing.T) {
 				aws.String("DeploymentFailure"),
 			},
 			TriggerName:      aws.String("test-trigger"),
-			TriggerTargetArn: aws.String("arn:aws:sns:us-west-2:123456789012:test-topic"),
+			TriggerTargetArn: aws.String("arn:aws:sns:us-west-2:123456789012:test-topic"), // lintignore:AWSAT003,AWSAT005 // unit test
 		},
 	}
 
@@ -1656,7 +1656,7 @@ func TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap(t *testing.T) {
 				aws.String("InstanceFailure"),
 			},
 			TriggerName:      aws.String("test-trigger-2"),
-			TriggerTargetArn: aws.String("arn:aws:sns:us-west-2:123456789012:test-topic-2"),
+			TriggerTargetArn: aws.String("arn:aws:sns:us-west-2:123456789012:test-topic-2"), // lintignore:AWSAT003,AWSAT005 // unit test
 		},
 	}
 
@@ -1666,7 +1666,7 @@ func TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap(t *testing.T) {
 			"InstanceFailure",
 		}),
 		"trigger_name":       "test-trigger-2",
-		"trigger_target_arn": "arn:aws:sns:us-west-2:123456789012:test-topic-2",
+		"trigger_target_arn": "arn:aws:sns:us-west-2:123456789012:test-topic-2", // lintignore:AWSAT003,AWSAT005 // unit test
 	}
 
 	actual := triggerConfigsToMap(input)[0]
@@ -2299,6 +2299,8 @@ resource "aws_iam_role_policy" "test" {
 EOF
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = "tf-acc-test-%[1]s"
 
@@ -2311,7 +2313,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "codedeploy.amazonaws.com"
+          "codedeploy.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": "sts:AssumeRole"
@@ -2388,6 +2390,8 @@ resource "aws_iam_role_policy" "test" {
 EOF
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test_updated" {
   name = "tf-acc-test-updated-%[1]s"
 
@@ -2400,7 +2404,7 @@ resource "aws_iam_role" "test_updated" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "codedeploy.amazonaws.com"
+          "codedeploy.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": "sts:AssumeRole"
@@ -2447,6 +2451,8 @@ resource "aws_iam_role_policy" "test" {
 EOF
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = "tf-acc-test-%[1]s"
 
@@ -2459,7 +2465,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "codedeploy.amazonaws.com"
+          "codedeploy.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": "sts:AssumeRole"
@@ -2520,6 +2526,8 @@ resource "aws_iam_role_policy" "test" {
 EOF
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = "tf-acc-test-%[1]s"
 
@@ -2531,7 +2539,7 @@ resource "aws_iam_role" "test" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "codedeploy.amazonaws.com"
+        "Service": "codedeploy.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -3405,6 +3413,8 @@ resource "aws_codedeploy_app" "test" {
   name             = %[1]q
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -3418,7 +3428,7 @@ resource "aws_iam_role" "test" {
       "Action": "sts:AssumeRole",
       "Principal": {
         "Service": [
-          "codedeploy.amazonaws.com"
+          "codedeploy.${data.aws_partition.current.dns_suffix}"
         ]
       }
     }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (44.48s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (63.47s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (67.24s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (81.81s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (82.33s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (82.96s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (96.41s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (102.03s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (108.11s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (66.26s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (111.16s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (112.36s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (121.58s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (129.85s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (133.92s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (136.61s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (66.33s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (60.82s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs (0.19s)
--- PASS: TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap (0.26s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildAutoRollbackConfig (0.22s)
--- PASS: TestAWSCodeDeployDeploymentGroup_autoRollbackConfigToMap (0.27s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandDeploymentStyle (0.38s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenDeploymentStyle (0.24s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandLoadBalancerInfo (0.39s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenLoadBalancerInfo (0.29s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandBlueGreenDeploymentConfig (0.27s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenBlueGreenDeploymentConfig (0.20s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildAlarmConfig (0.28s)
--- PASS: TestAWSCodeDeployDeploymentGroup_alarmConfigToMap (0.24s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (97.89s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (101.97s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (60.27s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (95.23s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (94.79s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (85.18s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (83.47s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (86.64s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (67.16s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (66.08s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (63.93s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (145.11s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (167.36s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (295.52s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (59.75s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (65.49s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (70.06s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (79.19s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (79.80s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (98.28s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (100.86s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (136.16s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (149.08s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (152.95s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (153.11s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (153.34s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (155.65s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs (0.38s)
--- PASS: TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap (0.44s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildAutoRollbackConfig (0.30s)
--- PASS: TestAWSCodeDeployDeploymentGroup_autoRollbackConfigToMap (0.24s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandDeploymentStyle (0.33s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenDeploymentStyle (0.46s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandLoadBalancerInfo (0.26s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenLoadBalancerInfo (0.48s)
--- PASS: TestAWSCodeDeployDeploymentGroup_expandBlueGreenDeploymentConfig (0.40s)
--- PASS: TestAWSCodeDeployDeploymentGroup_flattenBlueGreenDeploymentConfig (0.21s)
--- PASS: TestAWSCodeDeployDeploymentGroup_buildAlarmConfig (0.35s)
--- PASS: TestAWSCodeDeployDeploymentGroup_alarmConfigToMap (0.29s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (161.14s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (96.38s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (162.27s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (163.52s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (163.98s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (166.76s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_create (88.09s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (170.44s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (175.09s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (119.15s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (112.79s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (104.28s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_inPlaceDeploymentWithTrafficControl_update (92.16s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (54.70s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (55.31s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (61.01s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (170.66s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (200.71s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (310.30s)
```