### PR TITLE
tests/provider: Fix hardcoded ARN (Cognito)

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_test.go
+++ b/aws/resource_aws_cognito_identity_pool_test.go
@@ -191,12 +191,12 @@ func TestAccAWSCognitoIdentityPool_cognitoIdentityProviders(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "cognito_identity_providers.*", map[string]string{
 						"client_id":               "7lhlkkfbfb4q5kpp90urffao",
-						"provider_name":           "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu",
+						"provider_name":           fmt.Sprintf("cognito-idp.%[1]s.%[2]s/%[1]s_Zr231apJu", testAccGetRegion(), testAccGetPartitionDNSSuffix()),
 						"server_side_token_check": "false",
 					}),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "cognito_identity_providers.*", map[string]string{
 						"client_id":               "7lhlkkfbfb4q5kpp90urffao",
-						"provider_name":           "cognito-idp.us-east-1.amazonaws.com/us-east-1_Ab129faBb",
+						"provider_name":           fmt.Sprintf("cognito-idp.%[1]s.%[2]s/%[1]s_Ab129faBb", testAccGetRegion(), testAccGetPartitionDNSSuffix()),
 						"server_side_token_check": "false",
 					}),
 				),
@@ -213,7 +213,7 @@ func TestAccAWSCognitoIdentityPool_cognitoIdentityProviders(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "identity_pool_name", fmt.Sprintf("identity pool %s", name)),
 					tfawsresource.TestCheckTypeSetElemNestedAttrs(resourceName, "cognito_identity_providers.*", map[string]string{
 						"client_id":               "6lhlkkfbfb4q5kpp90urffae",
-						"provider_name":           "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu",
+						"provider_name":           fmt.Sprintf("cognito-idp.%[1]s.%[2]s/%[1]s_Zr231apJu", testAccGetRegion(), testAccGetPartitionDNSSuffix()),
 						"server_side_token_check": "false",
 					}),
 				),
@@ -417,22 +417,26 @@ resource "aws_cognito_identity_pool" "main" {
 
 func testAccAWSCognitoIdentityPoolConfig_openidConnectProviderArns(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool %s"
   allow_unauthenticated_identities = false
 
-  openid_connect_provider_arns = ["arn:aws:iam::123456789012:oidc-provider/server.example.com"]
+  openid_connect_provider_arns = ["arn:${data.aws_partition.current.partition}:iam::123456789012:oidc-provider/server.example.com"]
 }
 `, name)
 }
 
 func testAccAWSCognitoIdentityPoolConfig_openidConnectProviderArnsModified(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool %s"
   allow_unauthenticated_identities = false
 
-  openid_connect_provider_arns = ["arn:aws:iam::123456789012:oidc-provider/foo.example.com", "arn:aws:iam::123456789012:oidc-provider/bar.example.com"]
+  openid_connect_provider_arns = ["arn:${data.aws_partition.current.partition}:iam::123456789012:oidc-provider/foo.example.com", "arn:${data.aws_partition.current.partition}:iam::123456789012:oidc-provider/bar.example.com"]
 }
 `, name)
 }
@@ -440,55 +444,59 @@ resource "aws_cognito_identity_pool" "main" {
 func testAccAWSCognitoIdentityPoolConfig_samlProviderArns(name string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_saml_provider" "default" {
-  name                   = "myprovider-%s"
+  name                   = "myprovider-%[1]s"
   saml_metadata_document = file("./test-fixtures/saml-metadata.xml")
 }
 
 resource "aws_cognito_identity_pool" "main" {
-  identity_pool_name               = "identity pool %s"
+  identity_pool_name               = "identity pool %[1]s"
   allow_unauthenticated_identities = false
 
   saml_provider_arns = [aws_iam_saml_provider.default.arn]
 }
-`, name, name)
+`, name)
 }
 
 func testAccAWSCognitoIdentityPoolConfig_samlProviderArnsModified(name string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_saml_provider" "default" {
-  name                   = "default-%s"
+  name                   = "default-%[1]s"
   saml_metadata_document = file("./test-fixtures/saml-metadata.xml")
 }
 
 resource "aws_iam_saml_provider" "secondary" {
-  name                   = "secondary-%s"
+  name                   = "secondary-%[1]s"
   saml_metadata_document = file("./test-fixtures/saml-metadata.xml")
 }
 
 resource "aws_cognito_identity_pool" "main" {
-  identity_pool_name               = "identity pool %s"
+  identity_pool_name               = "identity pool %[1]s"
   allow_unauthenticated_identities = false
 
   saml_provider_arns = [aws_iam_saml_provider.secondary.arn]
 }
-`, name, name, name)
+`, name)
 }
 
 func testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProviders(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool %s"
   allow_unauthenticated_identities = false
 
   cognito_identity_providers {
     client_id               = "7lhlkkfbfb4q5kpp90urffao"
-    provider_name           = "cognito-idp.us-east-1.amazonaws.com/us-east-1_Ab129faBb"
+    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Ab129faBb"
     server_side_token_check = false
   }
 
   cognito_identity_providers {
     client_id               = "7lhlkkfbfb4q5kpp90urffao"
-    provider_name           = "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"
+    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Zr231apJu"
     server_side_token_check = false
   }
 }
@@ -497,13 +505,17 @@ resource "aws_cognito_identity_pool" "main" {
 
 func testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProvidersModified(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool %s"
   allow_unauthenticated_identities = false
 
   cognito_identity_providers {
     client_id               = "6lhlkkfbfb4q5kpp90urffae"
-    provider_name           = "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"
+    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Zr231apJu"
     server_side_token_check = false
   }
 }
@@ -512,23 +524,27 @@ resource "aws_cognito_identity_pool" "main" {
 
 func testAccAWSCognitoIdentityPoolConfig_cognitoIdentityProvidersAndOpenidConnectProviderArns(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
 resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool %s"
   allow_unauthenticated_identities = false
 
   cognito_identity_providers {
     client_id               = "7lhlkkfbfb4q5kpp90urffao"
-    provider_name           = "cognito-idp.us-east-1.amazonaws.com/us-east-1_Ab129faBb"
+    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Ab129faBb"
     server_side_token_check = false
   }
 
   cognito_identity_providers {
     client_id               = "7lhlkkfbfb4q5kpp90urffao"
-    provider_name           = "cognito-idp.us-east-1.amazonaws.com/us-east-1_Zr231apJu"
+    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Zr231apJu"
     server_side_token_check = false
   }
 
-  openid_connect_provider_arns = ["arn:aws:iam::123456789012:oidc-provider/server.example.com"]
+  openid_connect_provider_arns = ["arn:${data.aws_partition.current.partition}:iam::123456789012:oidc-provider/server.example.com"]
 }
 `, name)
 }
@@ -536,11 +552,11 @@ resource "aws_cognito_identity_pool" "main" {
 func testAccAWSCognitoIdentityPoolConfig_Tags1(name, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_identity_pool" "main" {
-  identity_pool_name               = %[1]q
+  identity_pool_name               = %q
   allow_unauthenticated_identities = false
 
   tags = {
-    %[2]q = %[3]q
+    %q = %q
   }
 }
 `, name, tagKey1, tagValue1)
@@ -549,12 +565,12 @@ resource "aws_cognito_identity_pool" "main" {
 func testAccAWSCognitoIdentityPoolConfig_Tags2(name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_identity_pool" "main" {
-  identity_pool_name               = %[1]q
+  identity_pool_name               = %q
   allow_unauthenticated_identities = false
 
   tags = {
-    %[2]q = %[3]q
-    %[4]q = %[5]q
+    %q = %q
+    %q = %q
   }
 }
 `, name, tagKey1, tagValue1, tagKey2, tagValue2)

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -233,7 +233,11 @@ func TestAccAWSCognitoUserPoolClient_analyticsConfig(t *testing.T) {
 	resourceName := "aws_cognito_user_pool_client.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSCognitoIdentityProvider(t)
+			testAccPreCheckAWSPinpointApp(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
@@ -469,8 +473,9 @@ resource "aws_cognito_user_pool_client" "test" {
 
 func testAccAWSCognitoUserPoolClientConfigAnalyticsConfigBase(userPoolName, clientName string) string {
 	return fmt.Sprintf(`
-data "aws_caller_identity" "current" {
-}
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
 
 resource "aws_cognito_user_pool" "test" {
   name = "%[1]s"
@@ -490,7 +495,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "cognito-idp.amazonaws.com"
+        "Service": "cognito-idp.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -514,7 +519,7 @@ resource "aws_iam_role_policy" "test" {
         "mobiletargeting:PutItems"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:mobiletargeting:*:${data.aws_caller_identity.current.account_id}:apps/${aws_pinpoint_app.test.application_id}*"
+      "Resource": "arn:${data.aws_partition.current.partition}:mobiletargeting:*:${data.aws_caller_identity.current.account_id}:apps/${aws_pinpoint_app.test.application_id}*"
     }
   ]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (30.05s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (31.76s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (33.45s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (57.66s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_disappears (61.51s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (55.76s)
--- PASS: TestAccAWSCognitoIdentityPool_basic (91.45s)
--- FAIL: TestAccAWSCognitoUserPoolClient_analyticsConfig (35.16s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (93.96s)
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (41.66s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (113.43s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (83.80s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (81.68s)
--- PASS: TestAccAWSCognitoIdentityPool_tags (116.63s)
--- PASS: TestAccAWSCognitoIdentityPool_openidConnectProviderArns (117.10s)
--- PASS: TestAccAWSCognitoIdentityPool_supportedLoginProviders (117.70s)
--- PASS: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (118.49s)
--- PASS: TestAccAWSCognitoIdentityPool_cognitoIdentityProviders (118.57s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (127.58s)
--- PASS: TestAccAWSCognitoIdentityPool_samlProviderArns (137.93s)
```

***Failure is unrelated and tracked separately in #15722.

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (37.55s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (37.71s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (37.95s)
--- PASS: TestAccAWSCognitoUserPoolClient_disappears (63.25s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_disappears (68.18s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (70.15s)
--- PASS: TestAccAWSCognitoUserPoolClient_basic (72.25s)
--- PASS: TestAccAWSCognitoUserPoolClient_Name (104.12s)
--- PASS: TestAccAWSCognitoIdentityPool_basic (104.20s)
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (105.10s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (111.51s)
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (115.48s)
--- PASS: TestAccAWSCognitoIdentityPool_openidConnectProviderArns (126.17s)
--- PASS: TestAccAWSCognitoIdentityPool_supportedLoginProviders (126.51s)
--- PASS: TestAccAWSCognitoIdentityPool_cognitoIdentityProviders (126.61s)
--- PASS: TestAccAWSCognitoIdentityPool_tags (131.46s)
--- PASS: TestAccAWSCognitoUserPoolClient_analyticsConfig (132.70s)
--- PASS: TestAccAWSCognitoIdentityPool_samlProviderArns (133.17s)
--- PASS: TestAccAWSCognitoIdentityPool_addingNewProviderKeepsOldProvider (137.81s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (146.90s)
```