### PR TITLE
tests/provider: Fix hardcoded ARN (DB*)

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -38,7 +38,7 @@ func resourceAwsDbInstance() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(40 * time.Minute),
 			Update: schema.DefaultTimeout(80 * time.Minute),
-			Delete: schema.DefaultTimeout(40 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -1110,9 +1110,9 @@ func TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier(t *testing.T
 	var dbInstance, sourceDbInstance rds.DBInstance
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	caName := "rds-ca-2019"
 	sourceResourceName := "aws_db_instance.source"
 	resourceName := "aws_db_instance.test"
+	dataSourceName := "data.aws_rds_certificate.latest"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1120,13 +1120,13 @@ func TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier(t *testing.T
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfig_ReplicateSourceDb_CACertificateIdentifier(rName, caName),
+				Config: testAccAWSDBInstanceConfig_ReplicateSourceDb_CACertificateIdentifier(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					testAccCheckAWSDBInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
-					resource.TestCheckResourceAttr(sourceResourceName, "ca_cert_identifier", caName),
-					resource.TestCheckResourceAttr(resourceName, "ca_cert_identifier", caName),
+					resource.TestCheckResourceAttrPair(sourceResourceName, "ca_cert_identifier", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "ca_cert_identifier", dataSourceName, "id"),
 				),
 			},
 		},
@@ -2975,7 +2975,7 @@ func TestAccAWSDBInstance_CACertificateIdentifier(t *testing.T) {
 	var dbInstance rds.DBInstance
 
 	resourceName := "aws_db_instance.bar"
-	cacID := "rds-ca-2019"
+	dataSourceName := "data.aws_rds_certificate.latest"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -2983,10 +2983,10 @@ func TestAccAWSDBInstance_CACertificateIdentifier(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfig_WithCACertificateIdentifier(cacID),
+				Config: testAccAWSDBInstanceConfig_WithCACertificateIdentifier(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
-					resource.TestCheckResourceAttr(resourceName, "ca_cert_identifier", cacID),
+					resource.TestCheckResourceAttrPair(resourceName, "ca_cert_identifier", dataSourceName, "id"),
 				),
 			},
 		},
@@ -3129,12 +3129,16 @@ resource "aws_db_instance" "bar" {
 `, rInt)
 }
 
-func testAccAWSDBInstanceConfig_WithCACertificateIdentifier(cacID string) string {
+func testAccAWSDBInstanceConfig_WithCACertificateIdentifier() string {
 	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
+data "aws_rds_certificate" "latest" {
+  latest_valid_till = true
+}
+
 resource "aws_db_instance" "bar" {
   allocated_storage   = 10
   apply_immediately   = true
-  ca_cert_identifier  = %q
+  ca_cert_identifier  = data.aws_rds_certificate.latest.id
   engine              = data.aws_rds_orderable_db_instance.test.engine
   instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   name                = "baz"
@@ -3142,7 +3146,7 @@ resource "aws_db_instance" "bar" {
   skip_final_snapshot = true
   username            = "foo"
 }
-`, cacID))
+`))
 }
 
 func testAccAWSDBInstanceConfig_WithOptionGroup(rName string) string {
@@ -3239,6 +3243,8 @@ resource "aws_s3_bucket_object" "xtrabackup_db" {
   etag   = filemd5("./testdata/mysql-5-6-xtrabackup.tar.gz")
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "rds_s3_access_role" {
   name = "%[3]s-role"
 
@@ -3250,7 +3256,7 @@ resource "aws_iam_role" "rds_s3_access_role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "rds.amazonaws.com"
+        "Service": "rds.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -3399,8 +3405,7 @@ resource "aws_db_instance" "snapshot" {
 
 func testAccAWSDbInstanceConfig_MonitoringInterval(rName string, monitoringInterval int) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {
-}
+data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -3413,7 +3418,7 @@ resource "aws_iam_role" "test" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "monitoring.rds.amazonaws.com"
+        "Service": "monitoring.rds.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -3491,8 +3496,7 @@ resource "aws_db_instance" "test" {
 
 func testAccAWSDbInstanceConfig_MonitoringRoleArn(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {
-}
+data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -3505,7 +3509,7 @@ resource "aws_iam_role" "test" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "monitoring.rds.amazonaws.com"
+        "Service": "monitoring.rds.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -4047,6 +4051,8 @@ resource "aws_directory_service_directory" "bar" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "role" {
   name = "tf-acc-db-instance-mssql-domain-role-%[1]d"
 
@@ -4057,7 +4063,7 @@ resource "aws_iam_role" "role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "rds.amazonaws.com"
+        "Service": "rds.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -4069,7 +4075,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "attatch-policy" {
   role       = aws_iam_role.role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
 }
 `, rInt))
 }
@@ -4176,6 +4182,8 @@ resource "aws_directory_service_directory" "bar" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "role" {
   name = "tf-acc-db-instance-mssql-domain-role-%[1]d"
 
@@ -4186,7 +4194,7 @@ resource "aws_iam_role" "role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "rds.amazonaws.com"
+        "Service": "rds.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -4198,7 +4206,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "attatch-policy" {
   role       = aws_iam_role.role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
 }
 `, rInt))
 }
@@ -4309,6 +4317,8 @@ resource "aws_directory_service_directory" "foo" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "role" {
   name = "tf-acc-db-instance-mssql-domain-role-%[1]d"
 
@@ -4319,7 +4329,7 @@ resource "aws_iam_role" "role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "rds.amazonaws.com"
+        "Service": "rds.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -4331,7 +4341,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "attatch-policy" {
   role       = aws_iam_role.role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess"
 }
 `, rInt))
 }
@@ -5673,8 +5683,7 @@ resource "aws_db_instance" "test" {
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_Monitoring(rName string, monitoringInterval int) string {
 	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
-data "aws_partition" "current" {
-}
+data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -5687,7 +5696,7 @@ resource "aws_iam_role" "test" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "monitoring.rds.amazonaws.com"
+        "Service": "monitoring.rds.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -5835,8 +5844,12 @@ resource "aws_db_instance" "test" {
 `, rName))
 }
 
-func testAccAWSDBInstanceConfig_ReplicateSourceDb_CACertificateIdentifier(rName string, caName string) string {
+func testAccAWSDBInstanceConfig_ReplicateSourceDb_CACertificateIdentifier(rName string) string {
 	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMysql(), fmt.Sprintf(`
+data "aws_rds_certificate" "latest" {
+  latest_valid_till = true
+}
+
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
   backup_retention_period = 1
@@ -5845,7 +5858,7 @@ resource "aws_db_instance" "source" {
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
-  ca_cert_identifier      = %[2]q
+  ca_cert_identifier      = data.aws_rds_certificate.latest.id
   skip_final_snapshot     = true
 }
 
@@ -5853,10 +5866,10 @@ resource "aws_db_instance" "test" {
   identifier          = %[1]q
   instance_class      = aws_db_instance.source.instance_class
   replicate_source_db = aws_db_instance.source.id
-  ca_cert_identifier  = %[2]q
+  ca_cert_identifier  = data.aws_rds_certificate.latest.id
   skip_final_snapshot = true
 }
-`, rName, caName))
+`, rName))
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier(rName string) string {
@@ -6472,8 +6485,7 @@ resource "aws_db_instance" "test" {
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_Monitoring(rName string, monitoringInterval int) string {
 	return composeConfig(testAccAWSDBInstanceConfig_orderableClassMariadb(), fmt.Sprintf(`
-data "aws_partition" "current" {
-}
+data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -6486,7 +6498,7 @@ resource "aws_iam_role" "test" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "monitoring.rds.amazonaws.com"
+        "Service": "monitoring.rds.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }

--- a/aws/resource_aws_db_option_group_test.go
+++ b/aws/resource_aws_db_option_group_test.go
@@ -360,14 +360,14 @@ func TestAccAWSDBOptionGroup_OracleOptionsUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName, "12.1.0.4.v1"),
+				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName, "13.2.0.0.v2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
 					resource.TestCheckResourceAttr(
 						"aws_db_option_group.bar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"aws_db_option_group.bar", "option.#", "1"),
-					testAccCheckAWSDBOptionGroupOptionVersionAttribute(&v, "12.1.0.4.v1"),
+					testAccCheckAWSDBOptionGroupOptionVersionAttribute(&v, "13.2.0.0.v2"),
 				),
 			},
 			{
@@ -378,14 +378,14 @@ func TestAccAWSDBOptionGroup_OracleOptionsUpdate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"name_prefix", "option"},
 			},
 			{
-				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName, "12.1.0.5.v1"),
+				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName, "13.3.0.0.v2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
 					resource.TestCheckResourceAttr(
 						"aws_db_option_group.bar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"aws_db_option_group.bar", "option.#", "1"),
-					testAccCheckAWSDBOptionGroupOptionVersionAttribute(&v, "12.1.0.5.v1"),
+					testAccCheckAWSDBOptionGroupOptionVersionAttribute(&v, "13.3.0.0.v2"),
 				),
 			},
 		},
@@ -568,7 +568,7 @@ func testAccCheckAWSDBOptionGroupOptionSettingsIAMRole(optionGroup *rds.OptionGr
 		}
 
 		settingValue := aws.StringValue(optionGroup.Options[0].OptionSettings[0].Value)
-		iamArnRegExp := regexp.MustCompile(`^arn:aws:iam::\d{12}:role/.+`)
+		iamArnRegExp := regexp.MustCompile(fmt.Sprintf(`^arn:%s:iam::\d{12}:role/.+`, testAccGetPartition()))
 		if !iamArnRegExp.MatchString(settingValue) {
 			return fmt.Errorf("Expected option setting to be a valid IAM role but received %s", settingValue)
 		}
@@ -733,24 +733,26 @@ resource "aws_db_option_group" "bar" {
 
 func testAccAWSDBOptionGroupOptionSettingsIAMRole(r string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "rds_assume_role" {
   statement {
     actions = ["sts:AssumeRole"]
 
     principals {
       type        = "Service"
-      identifiers = ["rds.amazonaws.com"]
+      identifiers = ["rds.${data.aws_partition.current.dns_suffix}"]
     }
   }
 }
 
 resource "aws_iam_role" "sql_server_backup" {
-  name               = "rds-backup-%s"
+  name               = "rds-backup-%[1]s"
   assume_role_policy = data.aws_iam_policy_document.rds_assume_role.json
 }
 
 resource "aws_db_option_group" "bar" {
-  name                     = "%s"
+  name                     = "%[1]s"
   option_group_description = "Test option group for terraform"
   engine_name              = "sqlserver-ex"
   major_engine_version     = "14.00"
@@ -764,7 +766,7 @@ resource "aws_db_option_group" "bar" {
     }
   }
 }
-`, r, r)
+`, r)
 }
 
 func testAccAWSDBOptionGroupOptionSettings_update(r string) string {

--- a/aws/resource_aws_db_security_group_test.go
+++ b/aws/resource_aws_db_security_group_test.go
@@ -21,6 +21,7 @@ func TestAccAWSDBSecurityGroup_basic(t *testing.T) {
 	oldvar := os.Getenv("AWS_DEFAULT_REGION")
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	resourceName := "aws_db_security_group.test"
 	rName := fmt.Sprintf("tf-acc-%s", acctest.RandString(5))
 

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -858,6 +858,7 @@ func TestAccAWSRDSClusterInstance_CACertificateIdentifier(t *testing.T) {
 	var dbInstance rds.DBInstance
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_rds_cluster_instance.test"
+	dataSourceName := "data.aws_rds_certificate.latest"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -865,10 +866,10 @@ func TestAccAWSRDSClusterInstance_CACertificateIdentifier(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRDSClusterInstanceConfig_CACertificateIdentifier(rName, "rds-ca-2019"),
+				Config: testAccAWSRDSClusterInstanceConfig_CACertificateIdentifier(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists(resourceName, &dbInstance),
-					resource.TestCheckResourceAttr(resourceName, "ca_cert_identifier", "rds-ca-2019"),
+					resource.TestCheckResourceAttrPair(resourceName, "ca_cert_identifier", dataSourceName, "id"),
 				),
 			},
 			{
@@ -1640,7 +1641,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 `, n, f))
 }
 
-func testAccAWSRDSClusterInstanceConfig_CACertificateIdentifier(rName string, caCertificateIdentifier string) string {
+func testAccAWSRDSClusterInstanceConfig_CACertificateIdentifier(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
   cluster_identifier  = %[1]q
@@ -1655,12 +1656,16 @@ data "aws_rds_orderable_db_instance" "test" {
   preferred_instance_classes = ["db.t3.small", "db.t2.small", "db.t3.medium"]
 }
 
+data "aws_rds_certificate" "latest" {
+  latest_valid_till = true
+}
+
 resource "aws_rds_cluster_instance" "test" {
   apply_immediately  = true
   cluster_identifier = aws_rds_cluster.test.id
   identifier         = %[1]q
   instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
-  ca_cert_identifier = %[2]q
+  ca_cert_identifier = data.aws_rds_certificate.latest.id
 }
-`, rName, caCertificateIdentifier)
+`, rName)
 }

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -239,7 +239,7 @@ This will not recreate the resource if the S3 object changes in some way.  It's 
 - `create` - (Default `40 minutes`) Used for Creating Instances, Replicas, and
 restoring from Snapshots.
 - `update` - (Default `80 minutes`) Used for Database modifications.
-- `delete` - (Default `40 minutes`) Used for destroying databases. This includes
+- `delete` - (Default `60 minutes`) Used for destroying databases. This includes
 the time required to take snapshots.
 
 [1]:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662, #15737, #15775
Fixes #15770
Fixes #15772

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud) (no regressions, 13 preexisting fails):

```
--- FAIL: TestAccAWSDbInstanceDataSource_ec2Classic (0.00s)                             (************** See 8.)
--- PASS: TestProvider_impl (0.48s)
--- PASS: TestProvider (1.26s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (34.77s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (36.27s)
--- PASS: TestAccAWSProvider_Region_AwsChina (38.03s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (44.48s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (45.18s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (45.61s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (46.12s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (46.18s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (46.05s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (46.55s)
--- PASS: TestAccAWSProvider_Endpoints (47.59s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (47.71s)
--- FAIL: TestAccAWSDBInstance_DbSubnetGroupName_RamShared (2.06s)                      (************** See 4.)
--- PASS: TestAccAWSDBInstance_optionGroup (404.18s)
--- PASS: TestAccAWSDBInstance_basic (451.06s)
--- PASS: TestAccAWSDBInstance_namePrefix (469.27s)
--- PASS: TestAccAWSDBInstance_generatedName (455.57s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName (466.11s)
--- PASS: TestAccAWSDbInstanceDataSource_basic (524.74s)
--- PASS: TestAccAWSDBInstance_iamAuth (484.25s)
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (501.75s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (506.06s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds (546.38s)
--- PASS: TestAccAWSDBInstance_kmsKey (556.99s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared (0.39s)    (************** See 4.)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName (11.71s)             (*********** See 6, 7.)
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds (11.76s) (*** See 6, 7.)
--- PASS: TestAccAWSDBInstance_DeletionProtection (561.04s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (583.75s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (845.96s)
--- PASS: TestAccAWSDBInstance_Password (487.25s)
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (583.25s)
--- PASS: TestAccAWSDBInstance_subnetGroup (1024.31s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1332.78s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1312.25s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1362.72s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1352.11s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1322.71s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1473.76s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1443.12s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1463.76s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1625.18s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1585.15s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1767.03s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1402.62s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1332.38s)
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared (0.55s)   (************** See 4.)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1453.40s)
--- FAIL: TestAccAWSDBInstance_S3Import (660.38s)                                       (************** See 5.)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier (711.06s)      (************** See 2.)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1078.66s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (998.15s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1119.72s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2362.14s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1422.48s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1109.44s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName (1109.73s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1613.88s)
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (0.00s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1382.55s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1090.92s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds (1201.07s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1169.32s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1211.20s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1624.23s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (1957.95s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1160.40s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1260.76s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (772.61s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (813.71s)
--- PASS: TestAccAWSDBInstance_portUpdate (530.06s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1119.84s)
--- FAIL: TestAccAWSDBInstance_ec2Classic (0.00s)                                       (************** See 8.)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (762.64s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1060.32s)
--- PASS: TestAccAWSDBInstance_separateIopsUpdate (794.05s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1322.79s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1110.02s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1099.81s)
--- SKIP: TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled (0.00s)
--- SKIP: TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled (0.00s)
--- SKIP: TestAccAWSDBInstance_PerformanceInsightsKmsKeyId (0.00s)
--- SKIP: TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod (0.00s)
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (0.00s)
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (0.00s)
--- PASS: TestAccAWSDBInstance_MonitoringInterval (1181.10s)
--- PASS: TestAccAWSDBOptionGroup_basic (7.81s)
--- PASS: TestAccAWSDBOptionGroup_timeoutBlock (7.75s)
--- PASS: TestAccAWSDBOptionGroup_namePrefix (8.03s)
--- PASS: TestAccAWSDBOptionGroup_generatedName (7.81s)
--- PASS: TestAccAWSDBOptionGroupConfig_OptionGroupDescription (7.54s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (355.58s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings (14.99s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings_IAMRole (16.93s)
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (13.67s)
--- PASS: TestAccAWSDBOptionGroup_OracleOptionsUpdate (40.64s)                          (************** See 3.)
--- PASS: TestAccAWSDBInstance_MinorVersion (422.23s)
--- PASS: TestAccAWSDBOptionGroup_multipleOptions (9.65s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings_MultipleNonDefault (16.99s)
--- PASS: TestAccAWSDBOptionGroup_Tags (23.14s)
--- PASS: TestAccAWSDBOptionGroup_Tags_WithOptions (23.05s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1787.18s)
--- PASS: TestAccAWSDBInstance_CACertificateIdentifier (554.03s)                        (************** See 2.)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (495.88s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL (656.02s)
--- PASS: TestAccAWSDBInstance_NoDeleteAutomatedBackups (594.71s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MySQL (770.88s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (706.67s)
--- PASS: TestAccAWSDBOptionGroup_basicDestroyWithInstance (533.70s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1615.04s)
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1766.50s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (3738.62s)
--- FAIL: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (4770.82s)                   (************** See 1.)
--- FAIL: TestAccAWSDBInstance_MSSQL_Domain (4980.84s)                                  (************** See 1.)
```

Output from acceptance testing (commercial) (no regressions, 1 flaky fail, 4 preexisting conditions):

```
--- PASS: TestProvider_impl (0.89s)
--- PASS: TestProvider (1.73s)
--- SKIP: TestAccAWSDbInstanceDataSource_ec2Classic (0.00s)
--- PASS: TestAccAWSProvider_Region_AwsChina (40.77s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (41.77s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (41.85s)
--- FAIL: TestAccAWSDBInstance_DbSubnetGroupName_RamShared (2.34s)                      (************** See 4.)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (49.12s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (51.61s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (52.16s)
--- PASS: TestAccAWSProvider_Endpoints (52.32s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (52.52s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (52.75s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (53.16s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (54.12s)
--- PASS: TestAccAWSProvider_AssumeRole_Empty (57.21s)
--- PASS: TestAccAWSDBInstance_optionGroup (399.17s)
--- PASS: TestAccAWSDBInstance_kmsKey (402.14s)
--- PASS: TestAccAWSDBInstance_iamAuth (450.05s)
--- PASS: TestAccAWSDBInstance_generatedName (460.28s)
--- PASS: TestAccAWSDBInstance_DeletionProtection (431.92s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName (454.49s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared (1.15s)    (************** See 4.)
--- PASS: TestAccAWSDBInstance_namePrefix (498.91s)
--- SKIP: TestAccAWSDBInstance_ReplicateSourceDb_DeletionProtection (0.00s)
--- PASS: TestAccAWSDBInstance_basic (501.81s)
--- PASS: TestAccAWSDBInstance_Password (463.42s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (478.09s)
--- PASS: TestAccAWSDBInstance_DbSubnetGroupName_VpcSecurityGroupIds (502.43s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (557.76s)
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (622.69s)
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (643.86s)
--- PASS: TestAccAWSDBInstance_subnetGroup (830.50s)
--- PASS: TestAccAWSDbInstanceDataSource_basic (853.77s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (802.83s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1408.33s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade (1464.04s)
--- FAIL: TestAccAWSDBInstance_S3Import (724.00s)                                       (************** See 5.)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1227.38s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1445.40s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1449.45s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1387.07s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1409.56s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1418.95s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1293.02s)
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared (1.20s)   (************** See 4.)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1910.96s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1116.56s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1529.86s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1338.58s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1550.73s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier (1369.73s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1762.40s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (1954.61s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds (2140.26s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName (2218.38s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1176.02s)
--- SKIP: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (0.00s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1479.96s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1034.34s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1135.84s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_VpcSecurityGroupIds (1105.74s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName (1115.88s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1559.96s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1186.15s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1287.17s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1144.67s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1146.83s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1226.45s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1267.59s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1528.81s)
--- SKIP: TestAccAWSDBInstance_ec2Classic (0.00s)
--- PASS: TestAccAWSDBInstance_portUpdate (549.77s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_RemovedToEnabled (613.25s)
--- PASS: TestAccAWSDBInstance_MinorVersion (488.76s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1255.18s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1144.84s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade (2224.43s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToRemoved (757.82s)
--- PASS: TestAccAWSDBInstance_MonitoringRoleArn_EnabledToDisabled (777.77s)
--- PASS: TestAccAWSDBInstance_separateIopsUpdate (782.19s)
--- PASS: TestAccAWSDBInstance_MonitoringInterval (933.13s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1266.21s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (575.42s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1247.73s)
--- PASS: TestAccAWSDBOptionGroup_basic (12.72s)
--- PASS: TestAccAWSDBOptionGroup_timeoutBlock (12.42s)
--- PASS: TestAccAWSDBOptionGroup_namePrefix (12.62s)
--- PASS: TestAccAWSDBOptionGroup_generatedName (13.86s)
--- PASS: TestAccAWSDBOptionGroupConfig_OptionGroupDescription (12.45s)
--- FAIL: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MySQL (543.23s)             (************** See 7.)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings (24.40s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (2023.39s)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings_IAMRole (33.44s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1306.24s)
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (23.31s)
--- PASS: TestAccAWSDBOptionGroup_multipleOptions (15.62s)
--- PASS: TestAccAWSDBOptionGroup_OracleOptionsUpdate (32.48s)                          (************** See 3.)
--- PASS: TestAccAWSDBOptionGroup_Option_OptionSettings_MultipleNonDefault (28.42s)
--- PASS: TestAccAWSDBOptionGroup_Tags (41.22s)
--- PASS: TestAccAWSDBOptionGroup_Tags_WithOptions (41.48s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (572.35s)
--- PASS: TestAccAWSDBInstance_CACertificateIdentifier (497.61s)                        (************** See 2.)
--- PASS: TestAccAWSDBInstance_NoDeleteAutomatedBackups (620.06s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_MSSQL (813.21s)
--- PASS: TestAccAWSDBInstance_PerformanceInsightsEnabled_DisabledToEnabled (721.34s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (826.52s)
--- PASS: TestAccAWSDBOptionGroup_basicDestroyWithInstance (558.31s)
--- PASS: TestAccAWSDBInstance_PerformanceInsightsEnabled_EnabledToDisabled (900.09s)
--- PASS: TestAccAWSDBInstance_PerformanceInsightsRetentionPeriod (897.75s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1664.03s)
--- PASS: TestAccAWSDBInstance_PerformanceInsightsKmsKeyId (1091.60s)
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1902.27s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1488.92s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (1893.37s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (3831.45s)
--- PASS: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (3136.66s)
--- PASS: TestAccAWSDBInstance_MSSQL_Domain (3693.04s)
```

1. (GovCloud only) Preexisting & unrelated, tracked in #15775
2. (GovCloud only) This PR partially fixes (fixed after TC run) (issue #15772) (`TestAccAWSDBInstance_ReplicateSourceDb_CACertificateIdentifier` has new, unrelated issue on GovCloud; no regression in commercial)
3. (GovCloud only) This PR fixes (fixed after TC run) (issue #15770) (no regression in commercial)
4. Preexisting & unrelated, tracked in #15767
5. Preexisting & unrelated, tracked in #13391
6. (GovCloud only) Preexisting & unrelated, tracked in #15777
7. Appears flaky
8. Preexisting & unrelated, tracked in #15737 (see also #8316)