### PR TITLE
tests/provider: Fix hardcoded ARN (EMR*)

### DIFF
--- a/aws/resource_aws_emr_security_configuration_test.go
+++ b/aws/resource_aws_emr_security_configuration_test.go
@@ -96,6 +96,12 @@ func testAccCheckEmrSecurityConfigurationExists(n string) resource.TestCheckFunc
 }
 
 const testAccEmrSecurityConfigurationConfig = `
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
 resource "aws_emr_security_configuration" "test" {
   configuration = <<EOF
 {
@@ -106,7 +112,7 @@ resource "aws_emr_security_configuration" "test" {
       },
       "LocalDiskEncryptionConfiguration": {
         "EncryptionKeyProviderType": "AwsKms",
-        "AwsKmsKey": "arn:aws:kms:us-west-2:187416307283:alias/tf_emr_test_key"
+        "AwsKmsKey": "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/tf_emr_test_key"
       }
     },
     "EnableInTransitEncryption": false,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSEmrSecurityConfiguration_basic (21.17s) ***
--- FAIL: TestAccAWSEMRInstanceFleet_zero_count (34.48s) *
```

*Preexisting failure, tracked in #15607 

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSEmrSecurityConfiguration_basic (14.48s) ***
--- PASS: TestAccAWSEMRInstanceFleet_zero_count (1298.54s) ***
--- PASS: TestAccAWSEMRInstanceFleet_ebsBasic (434.67s)
--- PASS: TestAccAWSEMRInstanceFleet_basic (486.44s)
--- PASS: TestAccAWSEMRInstanceFleet_full (488.28s)
--- PASS: TestAccAWSEMRInstanceFleet_disappears (493.61s)
```

***Fixed after TC run