### PR TITLE
tests/provider: Fix hardcoded ARN (Flow Log)

### DIFF
--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -245,7 +245,7 @@ func TestAccAWSFlowLog_LogDestinationType_S3_Invalid(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccFlowLogConfig_LogDestinationType_S3_Invalid(rName),
-				ExpectError: regexp.MustCompile(`Access Denied for LogDestination`),
+				ExpectError: regexp.MustCompile(`(Access Denied for LogDestination|does not exist)`),
 			},
 		},
 	})
@@ -414,6 +414,8 @@ resource "aws_vpc" "test" {
 
 func testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -425,7 +427,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "ec2.amazonaws.com"
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": [
@@ -469,8 +471,10 @@ resource "aws_flow_log" "test" {
 
 func testAccFlowLogConfig_LogDestinationType_S3_Invalid(rName string) string {
 	return testAccFlowLogConfigBase(rName) + `
+data "aws_partition" "current" {}
+
 resource "aws_flow_log" "test" {
-  log_destination      = "arn:aws:s3:::does-not-exist"
+  log_destination      = "arn:${data.aws_partition.current.partition}:s3:::does-not-exist"
   log_destination_type = "s3"
   traffic_type         = "ALL"
   vpc_id               = aws_vpc.test.id
@@ -489,6 +493,8 @@ resource "aws_subnet" "test" {
   }
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -500,7 +506,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "ec2.amazonaws.com"
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": [
@@ -527,6 +533,8 @@ resource "aws_flow_log" "test" {
 
 func testAccFlowLogConfig_VPCID(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -538,7 +546,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "ec2.amazonaws.com"
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": [
@@ -565,6 +573,8 @@ resource "aws_flow_log" "test" {
 
 func testAccFlowLogConfig_LogFormat(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -576,7 +586,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "ec2.amazonaws.com"
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": [
@@ -609,6 +619,8 @@ resource "aws_flow_log" "test" {
 
 func testAccFlowLogConfigTags1(rName, tagKey1, tagValue1 string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -620,7 +632,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "ec2.amazonaws.com"
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": [
@@ -651,6 +663,8 @@ resource "aws_flow_log" "test" {
 
 func testAccFlowLogConfigTags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -662,7 +676,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "ec2.amazonaws.com"
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": [
@@ -694,6 +708,8 @@ resource "aws_flow_log" "test" {
 
 func testAccFlowLogConfig_MaxAggregationInterval(rName string) string {
 	return testAccFlowLogConfigBase(rName) + fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -705,7 +721,7 @@ resource "aws_iam_role" "test" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
-          "ec2.amazonaws.com"
+          "ec2.${data.aws_partition.current.dns_suffix}"
         ]
       },
       "Action": [


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662
Fixes #15765

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3_Invalid (15.94s) ***
--- PASS: TestAccAWSFlowLog_disappears (28.87s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3 (31.20s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_MaxAggregationInterval (32.81s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs (34.01s)
--- PASS: TestAccAWSFlowLog_SubnetID (34.77s)
--- PASS: TestAccAWSFlowLog_VPCID (42.90s)
--- PASS: TestAccAWSFlowLog_LogFormat (47.13s)
--- PASS: TestAccAWSFlowLog_tags (51.06s)
```

***Fixed after initial TC run (preexisting failure fixed).

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3_Invalid (14.06s) ***
--- PASS: TestAccAWSFlowLog_disappears (29.33s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3 (32.41s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs (35.45s)
--- PASS: TestAccAWSFlowLog_SubnetID (36.78s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_MaxAggregationInterval (37.56s)
--- PASS: TestAccAWSFlowLog_VPCID (47.68s)
--- PASS: TestAccAWSFlowLog_LogFormat (50.73s)
--- PASS: TestAccAWSFlowLog_tags (58.50s)
```

***Fixed after initial TC run (no regression on commercial).