### PR TITLE
tests/provider: Fix hardcoded ARN (Glue*)

### DIFF
--- a/aws/resource_aws_glue_job_test.go
+++ b/aws/resource_aws_glue_job_test.go
@@ -730,8 +730,10 @@ func testAccCheckAWSGlueJobDestroy(s *terraform.State) error {
 
 func testAccAWSGlueJobConfig_Base(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_iam_policy" "AWSGlueServiceRole" {
-  arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
 resource "aws_iam_role" "test" {
@@ -744,7 +746,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "glue.amazonaws.com"
+        "Service": "glue.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""

--- a/aws/resource_aws_glue_ml_transform_test.go
+++ b/aws/resource_aws_glue_ml_transform_test.go
@@ -514,8 +514,10 @@ func testAccCheckAWSGlueMLTransformDestroy(s *terraform.State) error {
 
 func testAccAWSGlueMLTransformConfigBase(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_iam_policy" "AWSGlueServiceRole" {
-  arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSGlueServiceRole"
 }
 
 resource "aws_iam_role" "test" {
@@ -528,7 +530,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "glue.amazonaws.com"
+        "Service": "glue.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud) (no regressions):

```
--- PASS: TestAccAWSGlueJob_MaxCapacity (58.71s)
--- FAIL: TestAccAWSGlueJob_nonOverridableArguments (66.57s)
--- PASS: TestAccAWSGlueJob_disappears (21.47s)
--- PASS: TestAccAWSGlueJob_DefaultArguments (87.18s)
--- PASS: TestAccAWSGlueMLTransform_basic (20.64s)
--- PASS: TestAccAWSGlueJob_PythonShell (103.97s)
--- PASS: TestAccAWSGlueJob_Command (118.09s)
--- PASS: TestAccAWSGlueJob_ExecutionProperty (120.60s)
--- PASS: TestAccAWSGlueJob_MaxRetries (124.94s)
--- PASS: TestAccAWSGlueJob_GlueVersion (140.29s)
--- PASS: TestAccAWSGlueJob_WorkerType (140.70s)
--- PASS: TestAccAWSGlueJob_basic (144.75s)
--- PASS: TestAccAWSGlueJob_Description (159.32s)
--- PASS: TestAccAWSGlueMLTransform_description (77.72s)
--- PASS: TestAccAWSGlueJob_Tags (166.81s)
--- PASS: TestAccAWSGlueMLTransform_glueVersion (80.69s)
--- PASS: TestAccAWSGlueJob_SecurityConfiguration (170.81s)
--- PASS: TestAccAWSGlueMLTransform_disappears (42.52s)
--- PASS: TestAccAWSGlueMLTransform_typeFindMatchesFull (106.37s)
--- PASS: TestAccAWSGlueJob_NotificationProperty (189.17s)
--- PASS: TestAccAWSGlueJob_Timeout (189.69s)
--- PASS: TestAccAWSGlueMLTransform_maxRetries (86.59s)
--- PASS: TestAccAWSGlueMLTransform_timeout (74.75s)
--- PASS: TestAccAWSGlueMLTransform_workerType (71.75s)
--- PASS: TestAccAWSGlueMLTransform_maxCapacity (60.46s)
--- PASS: TestAccAWSGlueMLTransform_tags (84.19s)
```

***Failure is preexisting & unrelated, tracked in separate issue #15764

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSGlueJob_disappears (76.33s)
--- PASS: TestAccAWSGlueJob_basic (81.07s)
--- PASS: TestAccAWSGlueMLTransform_basic (86.66s)
--- PASS: TestAccAWSGlueJob_SecurityConfiguration (142.00s)
--- PASS: TestAccAWSGlueMLTransform_glueVersion (144.61s)
--- PASS: TestAccAWSGlueMLTransform_description (144.73s)
--- PASS: TestAccAWSGlueJob_Timeout (145.16s)
--- PASS: TestAccAWSGlueJob_Description (145.54s)
--- PASS: TestAccAWSGlueJob_MaxCapacity (146.29s)
--- PASS: TestAccAWSGlueJob_DefaultArguments (147.95s)
--- PASS: TestAccAWSGlueJob_MaxRetries (148.54s)
--- PASS: TestAccAWSGlueJob_nonOverridableArguments (149.37s)
--- PASS: TestAccAWSGlueJob_NotificationProperty (149.47s)
--- PASS: TestAccAWSGlueJob_ExecutionProperty (150.25s)
--- PASS: TestAccAWSGlueJob_Command (150.31s)
--- PASS: TestAccAWSGlueMLTransform_typeFindMatchesFull (176.94s)
--- PASS: TestAccAWSGlueJob_GlueVersion (180.31s)
--- PASS: TestAccAWSGlueJob_Tags (182.02s)
--- PASS: TestAccAWSGlueJob_WorkerType (183.34s)
--- PASS: TestAccAWSGlueJob_PythonShell (184.92s)
--- PASS: TestAccAWSGlueMLTransform_disappears (42.07s)
--- PASS: TestAccAWSGlueMLTransform_maxRetries (111.80s)
--- PASS: TestAccAWSGlueMLTransform_timeout (101.81s)
--- PASS: TestAccAWSGlueMLTransform_tags (119.57s)
--- PASS: TestAccAWSGlueMLTransform_workerType (59.53s)
--- PASS: TestAccAWSGlueMLTransform_maxCapacity (57.47s)
```
