### PR TITLE
tests/provider: Fix hardcoded ARN (GuardDuty)

### DIFF
--- a/aws/resource_aws_guardduty_publishing_destination_test.go
+++ b/aws/resource_aws_guardduty_publishing_destination_test.go
@@ -45,11 +45,11 @@ func testSweepGuarddutyPublishingDestinations(region string) error {
 						DetectorId:    detectorID,
 					}
 
-					log.Printf("[INFO] Deleting GuardDuty Publish Destination: %s", *destination_element.DestinationId)
+					log.Printf("[INFO] Deleting GuardDuty Publishing Destination: %s", *destination_element.DestinationId)
 					_, err := conn.DeletePublishingDestination(input)
 
 					if err != nil {
-						sweeperErr := fmt.Errorf("error deleting GuardDuty Pusblish Destination (%s): %w", *destination_element.DestinationId, err)
+						sweeperErr := fmt.Errorf("error deleting GuardDuty Publishing Destination (%s): %w", *destination_element.DestinationId, err)
 						log.Printf("[ERROR] %s", sweeperErr)
 						sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 					}
@@ -61,18 +61,18 @@ func testSweepGuarddutyPublishingDestinations(region string) error {
 	})
 
 	if err != nil {
-		sweeperErr := fmt.Errorf("Error receiving Guardduty detectors for publish sweep : %w", err)
+		sweeperErr := fmt.Errorf("Error receiving Guardduty detectors for publishing sweep : %w", err)
 		log.Printf("[ERROR] %s", sweeperErr)
 		sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
 	}
 
 	if testSweepSkipSweepError(err) {
-		log.Printf("[WARN] Skipping GuardDuty Publish Destination sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping GuardDuty Publishing Destination sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error retrieving GuardDuty Publish Destinations: %s", err)
+		return fmt.Errorf("error retrieving GuardDuty Publishing Destinations: %s", err)
 	}
 
 	return sweeperErrs.ErrorOrNil()
@@ -136,6 +136,8 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "bucket_pol" {
   statement {
     sid = "Allow PutObject"
@@ -149,7 +151,7 @@ data "aws_iam_policy_document" "bucket_pol" {
 
     principals {
       type        = "Service"
-      identifiers = ["guardduty.amazonaws.com"]
+      identifiers = ["guardduty.${data.aws_partition.current.dns_suffix}"]
     }
   }
 
@@ -165,7 +167,7 @@ data "aws_iam_policy_document" "bucket_pol" {
 
     principals {
       type        = "Service"
-      identifiers = ["guardduty.amazonaws.com"]
+      identifiers = ["guardduty.${data.aws_partition.current.dns_suffix}"]
     }
   }
 }
@@ -179,12 +181,12 @@ data "aws_iam_policy_document" "kms_pol" {
     ]
 
     resources = [
-      "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+      "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
     ]
 
     principals {
       type        = "Service"
-      identifiers = ["guardduty.amazonaws.com"]
+      identifiers = ["guardduty.${data.aws_partition.current.dns_suffix}"]
     }
   }
 
@@ -195,12 +197,12 @@ data "aws_iam_policy_document" "kms_pol" {
     ]
 
     resources = [
-      "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+      "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
     ]
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- FAIL: TestAccAWSGuardDuty_serial (91.27s)
    --- FAIL: TestAccAWSGuardDuty_serial/Detector (17.15s)
        --- FAIL: TestAccAWSGuardDuty_serial/Detector/basic (3.94s)
        --- FAIL: TestAccAWSGuardDuty_serial/Detector/tags (4.00s)
        --- FAIL: TestAccAWSGuardDuty_serial/Detector/datasource_basic (4.01s)
        --- FAIL: TestAccAWSGuardDuty_serial/Detector/datasource_id (5.20s)
    --- FAIL: TestAccAWSGuardDuty_serial/IPSet (15.01s)
        --- FAIL: TestAccAWSGuardDuty_serial/IPSet/tags (7.47s)
        --- FAIL: TestAccAWSGuardDuty_serial/IPSet/basic (7.54s)
    --- PASS: TestAccAWSGuardDuty_serial/OrganizationAdminAccount (1.04s)
        --- SKIP: TestAccAWSGuardDuty_serial/OrganizationAdminAccount/basic (1.04s)
    --- PASS: TestAccAWSGuardDuty_serial/OrganizationConfiguration (0.98s)
        --- SKIP: TestAccAWSGuardDuty_serial/OrganizationConfiguration/basic (0.98s)
    --- FAIL: TestAccAWSGuardDuty_serial/Filter (18.76s)
        --- FAIL: TestAccAWSGuardDuty_serial/Filter/update (4.15s)
        --- FAIL: TestAccAWSGuardDuty_serial/Filter/tags (6.35s)
        --- FAIL: TestAccAWSGuardDuty_serial/Filter/disappears (4.08s)
        --- FAIL: TestAccAWSGuardDuty_serial/Filter/basic (4.18s)
    --- PASS: TestAccAWSGuardDuty_serial/InviteAccepter (0.00s)
        --- SKIP: TestAccAWSGuardDuty_serial/InviteAccepter/basic (0.00s)
    --- FAIL: TestAccAWSGuardDuty_serial/ThreatIntelSet (15.82s)
        --- FAIL: TestAccAWSGuardDuty_serial/ThreatIntelSet/basic (7.66s)
        --- FAIL: TestAccAWSGuardDuty_serial/ThreatIntelSet/tags (8.16s)
    --- FAIL: TestAccAWSGuardDuty_serial/Member (4.13s)
        --- FAIL: TestAccAWSGuardDuty_serial/Member/basic (4.13s)
        --- SKIP: TestAccAWSGuardDuty_serial/Member/inviteOnUpdate (0.00s)
        --- SKIP: TestAccAWSGuardDuty_serial/Member/inviteDisassociate (0.00s)
        --- SKIP: TestAccAWSGuardDuty_serial/Member/invitationMessage (0.00s)
    --- FAIL: TestAccAWSGuardDuty_serial/PublishingDestination (18.37s)
        --- FAIL: TestAccAWSGuardDuty_serial/PublishingDestination/disappears (9.04s)
        --- FAIL: TestAccAWSGuardDuty_serial/PublishingDestination/basic (9.33s)
```

Output from acceptance testing (commercial): (no regressions)

```
--- FAIL: TestAccAWSGuardDuty_serial (91.27s)
    --- FAIL: TestAccAWSGuardDuty_serial/Detector (17.15s)
        --- FAIL: TestAccAWSGuardDuty_serial/Detector/basic (3.94s)
        --- FAIL: TestAccAWSGuardDuty_serial/Detector/tags (4.00s)
        --- FAIL: TestAccAWSGuardDuty_serial/Detector/datasource_basic (4.01s)
        --- FAIL: TestAccAWSGuardDuty_serial/Detector/datasource_id (5.20s)
    --- FAIL: TestAccAWSGuardDuty_serial/IPSet (15.01s)
        --- FAIL: TestAccAWSGuardDuty_serial/IPSet/tags (7.47s)
        --- FAIL: TestAccAWSGuardDuty_serial/IPSet/basic (7.54s)
    --- PASS: TestAccAWSGuardDuty_serial/OrganizationAdminAccount (1.04s)
        --- SKIP: TestAccAWSGuardDuty_serial/OrganizationAdminAccount/basic (1.04s)
    --- PASS: TestAccAWSGuardDuty_serial/OrganizationConfiguration (0.98s)
        --- SKIP: TestAccAWSGuardDuty_serial/OrganizationConfiguration/basic (0.98s)
    --- FAIL: TestAccAWSGuardDuty_serial/Filter (18.76s)
        --- FAIL: TestAccAWSGuardDuty_serial/Filter/update (4.15s)
        --- FAIL: TestAccAWSGuardDuty_serial/Filter/tags (6.35s)
        --- FAIL: TestAccAWSGuardDuty_serial/Filter/disappears (4.08s)
        --- FAIL: TestAccAWSGuardDuty_serial/Filter/basic (4.18s)
    --- PASS: TestAccAWSGuardDuty_serial/InviteAccepter (0.00s)
        --- SKIP: TestAccAWSGuardDuty_serial/InviteAccepter/basic (0.00s)
    --- FAIL: TestAccAWSGuardDuty_serial/ThreatIntelSet (15.82s)
        --- FAIL: TestAccAWSGuardDuty_serial/ThreatIntelSet/basic (7.66s)
        --- FAIL: TestAccAWSGuardDuty_serial/ThreatIntelSet/tags (8.16s)
    --- FAIL: TestAccAWSGuardDuty_serial/Member (4.13s)
        --- FAIL: TestAccAWSGuardDuty_serial/Member/basic (4.13s)
        --- SKIP: TestAccAWSGuardDuty_serial/Member/inviteOnUpdate (0.00s)
        --- SKIP: TestAccAWSGuardDuty_serial/Member/inviteDisassociate (0.00s)
        --- SKIP: TestAccAWSGuardDuty_serial/Member/invitationMessage (0.00s)
    --- FAIL: TestAccAWSGuardDuty_serial/PublishingDestination (18.37s)
        --- FAIL: TestAccAWSGuardDuty_serial/PublishingDestination/disappears (9.04s)
        --- FAIL: TestAccAWSGuardDuty_serial/PublishingDestination/basic (9.33s)
```