### PR TITLE
tests/provider: Fix hardcoded ARN (IOT Topic)

### DIFF
--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -620,6 +620,8 @@ func testAccCheckAWSIoTTopicRuleExists(name string) resource.TestCheckFunc {
 }
 
 const testAccAWSIoTTopicRuleRole = `
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "iot_role" {
   name = "test_role_%[1]s"
 
@@ -630,7 +632,7 @@ resource "aws_iam_role" "iot_role" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "iot.amazonaws.com"
+        "Service": "iot.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -794,7 +796,7 @@ resource "aws_iot_topic_rule" "rule" {
   sql_version = "2015-10-08"
 
   elasticsearch {
-    endpoint = "https://domain.${data.aws_region.current.name}.es.amazonaws.com"
+    endpoint = "https://domain.${data.aws_region.current.name}.es.${data.aws_partition.current.dns_suffix}"
     id       = "myIdentifier"
     index    = "myindex"
     type     = "mydocument"
@@ -858,6 +860,8 @@ resource "aws_iot_topic_rule" "rule" {
 
 func testAccAWSIoTTopicRule_lambda(rName string) string {
 	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
+data "aws_region" "current" {}
+
 resource "aws_iot_topic_rule" "rule" {
   name        = "test_rule_%[1]s"
   description = "Example rule"
@@ -866,7 +870,7 @@ resource "aws_iot_topic_rule" "rule" {
   sql_version = "2015-10-08"
 
   lambda {
-    function_arn = "arn:aws:lambda:us-east-1:123456789012:function:ProcessKinesisRecords"
+    function_arn = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.name}:123456789012:function:ProcessKinesisRecords"
   }
 }
 `, rName)
@@ -927,6 +931,8 @@ resource "aws_iot_topic_rule" "rule" {
 
 func testAccAWSIoTTopicRule_sns(rName string) string {
 	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
+data "aws_region" "current" {}
+
 resource "aws_iot_topic_rule" "rule" {
   name        = "test_rule_%[1]s"
   description = "Example rule"
@@ -936,7 +942,7 @@ resource "aws_iot_topic_rule" "rule" {
 
   sns {
     role_arn   = aws_iam_role.iot_role.arn
-    target_arn = "arn:aws:sns:us-east-1:123456789012:my_corporate_topic"
+    target_arn = "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}:123456789012:my_corporate_topic"
   }
 }
 `, rName)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSIoTTopicRule_dynamoDbv2 (56.38s)
--- PASS: TestAccAWSIoTTopicRule_lambda (61.87s)
--- PASS: TestAccAWSIoTTopicRule_firehose (62.12s)
--- PASS: TestAccAWSIoTTopicRule_elasticsearch (62.18s)
--- PASS: TestAccAWSIoTTopicRule_basic (63.04s)
--- PASS: TestAccAWSIoTTopicRule_republish_with_qos (63.87s)
--- PASS: TestAccAWSIoTTopicRule_sns (64.43s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchalarm (64.56s)
--- PASS: TestAccAWSIoTTopicRule_sqs (64.58s)
--- PASS: TestAccAWSIoTTopicRule_s3 (65.10s)
--- PASS: TestAccAWSIoTTopicRule_kinesis (65.35s)
--- PASS: TestAccAWSIoTTopicRule_republish (65.57s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchmetric (65.74s)
--- FAIL: TestAccAWSIoTTopicRule_iot_analytics (14.44s)
--- FAIL: TestAccAWSIoTTopicRule_iot_events (14.96s)
--- PASS: TestAccAWSIoTTopicRule_dynamodb (83.00s)
--- PASS: TestAccAWSIoTTopicRule_firehose_separator (84.49s)
--- PASS: TestAccAWSIoTTopicRule_step_functions (29.48s)
--- PASS: TestAccAWSIoTTopicRule_errorAction (23.64s)
--- PASS: TestAccAWSIoTTopicRule_Tags (36.02s)
```

***Failures are preexisting & unrelated, tracked in separate issue #15763

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSIoTTopicRule_s3 (74.89s)
--- PASS: TestAccAWSIoTTopicRule_iot_analytics (75.58s)
--- PASS: TestAccAWSIoTTopicRule_iot_events (77.89s)
--- PASS: TestAccAWSIoTTopicRule_dynamoDbv2 (79.11s)
--- PASS: TestAccAWSIoTTopicRule_elasticsearch (82.10s)
--- PASS: TestAccAWSIoTTopicRule_lambda (82.37s)
--- PASS: TestAccAWSIoTTopicRule_step_functions (82.54s)
--- PASS: TestAccAWSIoTTopicRule_errorAction (82.88s)
--- PASS: TestAccAWSIoTTopicRule_republish_with_qos (84.93s)
--- PASS: TestAccAWSIoTTopicRule_sqs (84.94s)
--- PASS: TestAccAWSIoTTopicRule_firehose (84.94s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchmetric (84.97s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchalarm (86.88s)
--- PASS: TestAccAWSIoTTopicRule_basic (87.05s)
--- PASS: TestAccAWSIoTTopicRule_sns (87.08s)
--- PASS: TestAccAWSIoTTopicRule_republish (87.17s)
--- PASS: TestAccAWSIoTTopicRule_kinesis (87.36s)
--- PASS: TestAccAWSIoTTopicRule_dynamodb (98.20s)
--- PASS: TestAccAWSIoTTopicRule_firehose_separator (98.40s)
--- PASS: TestAccAWSIoTTopicRule_Tags (113.04s)
```
