### PR TITLE
tests/provider: Fix hardcoded ARN (Organizations)

### DIFF
--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -220,7 +220,7 @@ func testAccAwsOrganizationsPolicy_type_Backup(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_organizations_policy.test"
 	// Reference: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_backup_syntax.html
-	backupPolicyContent := `{
+	backupPolicyContent := fmt.Sprintf(`{
    "plans":{
       "PII_Backup_Plan":{
          "regions":{
@@ -253,9 +253,9 @@ func testAccAwsOrganizationsPolicy_type_Backup(t *testing.T) {
                   "@@assign":"FortKnox"
                },
                "copy_actions":{
-                  "arn:aws:backup:us-east-1:$account:backup-vault:secondary_vault":{
+                  "arn:%[1]s:backup:us-east-1:$account:backup-vault:secondary_vault":{
                      "target_backup_vault_arn":{
-                        "@@assign":"arn:aws:backup:us-east-1:$account:backup-vault:secondary_vault"
+                        "@@assign":"arn:%[1]s:backup:us-east-1:$account:backup-vault:secondary_vault"
                      },
                      "lifecycle":{
                         "delete_after_days":{
@@ -273,7 +273,7 @@ func testAccAwsOrganizationsPolicy_type_Backup(t *testing.T) {
             "tags":{
                "datatype":{
                   "iam_role_arn":{
-                     "@@assign":"arn:aws:iam::$account:role/MyIamRole"
+                     "@@assign":"arn:%[1]s:iam::$account:role/MyIamRole"
                   },
                   "tag_key":{
                      "@@assign":"dataType"
@@ -289,7 +289,7 @@ func testAccAwsOrganizationsPolicy_type_Backup(t *testing.T) {
          }
       }
    }
-}`
+}`, testAccGetPartition())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSOrganizations_serial (39.16s)
    --- PASS: TestAccAWSOrganizations_serial/Organization (9.82s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/basic (2.32s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/AwsServiceAccessPrincipals (1.84s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/EnabledPolicyTypes (1.84s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/FeatureSet (1.88s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/DataSource (1.95s)
    --- PASS: TestAccAWSOrganizations_serial/Account (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/basic (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/ParentId (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/Tags (0.00s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit (3.70s)
        --- SKIP: TestAccAWSOrganizations_serial/OrganizationalUnit/basic (1.84s)
        --- SKIP: TestAccAWSOrganizations_serial/OrganizationalUnit/Name (1.86s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnits (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/OrganizationalUnits/DataSource (1.98s)
    --- PASS: TestAccAWSOrganizations_serial/Policy (18.15s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/ImportAwsManagedPolicy (1.83s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/disappears (1.79s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Type_AI_OPT_OUT (1.80s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Type_Backup (1.87s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Type_SCP (1.79s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Type_Tag (1.89s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/basic (1.78s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/concurrent (1.80s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Description (1.78s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Tags (1.81s)
    --- PASS: TestAccAWSOrganizations_serial/PolicyAttachment (5.51s)
        --- SKIP: TestAccAWSOrganizations_serial/PolicyAttachment/Account (1.83s)
        --- SKIP: TestAccAWSOrganizations_serial/PolicyAttachment/OrganizationalUnit (1.89s)
        --- SKIP: TestAccAWSOrganizations_serial/PolicyAttachment/Root (1.79s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSOrganizations_serial (20.60s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnits (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/OrganizationalUnits/DataSource (0.95s)
    --- PASS: TestAccAWSOrganizations_serial/Policy (10.21s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/concurrent (0.78s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Description (1.55s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Type_AI_OPT_OUT (0.81s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/ImportAwsManagedPolicy (0.74s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/basic (0.74s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/disappears (0.77s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Type_Backup (0.75s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Type_SCP (2.58s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Type_Tag (0.76s)
        --- SKIP: TestAccAWSOrganizations_serial/Policy/Tags (0.74s)
    --- PASS: TestAccAWSOrganizations_serial/PolicyAttachment (3.09s)
        --- SKIP: TestAccAWSOrganizations_serial/PolicyAttachment/Account (0.73s)
        --- SKIP: TestAccAWSOrganizations_serial/PolicyAttachment/OrganizationalUnit (1.56s)
        --- SKIP: TestAccAWSOrganizations_serial/PolicyAttachment/Root (0.80s)
    --- PASS: TestAccAWSOrganizations_serial/Organization (4.80s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/basic (0.74s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/AwsServiceAccessPrincipals (0.77s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/EnabledPolicyTypes (0.74s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/FeatureSet (0.75s)
        --- SKIP: TestAccAWSOrganizations_serial/Organization/DataSource (1.80s)
    --- PASS: TestAccAWSOrganizations_serial/Account (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/basic (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/ParentId (0.00s)
        --- SKIP: TestAccAWSOrganizations_serial/Account/Tags (0.00s)
    --- PASS: TestAccAWSOrganizations_serial/OrganizationalUnit (1.55s)
        --- SKIP: TestAccAWSOrganizations_serial/OrganizationalUnit/Name (0.75s)
        --- SKIP: TestAccAWSOrganizations_serial/OrganizationalUnit/basic (0.80s)
```
