### PR TITLE
tests/provider: Fix hardcoded ARN (Route53)

### DIFF
--- a/aws/resource_aws_route53_query_log_test.go
+++ b/aws/resource_aws_route53_query_log_test.go
@@ -161,6 +161,8 @@ resource "aws_cloudwatch_log_group" "test" {
   retention_in_days = 1
 }
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "test" {
   statement {
     actions = [
@@ -168,10 +170,10 @@ data "aws_iam_policy_document" "test" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:logs:*:*:log-group:/aws/route53/*"]
 
     principals {
-      identifiers = ["route53.amazonaws.com"]
+      identifiers = ["route53.${data.aws_partition.current.dns_suffix}"]
       type        = "Service"
     }
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- FAIL: TestAccAWSRoute53QueryLog_basic (0.42s)
```

***Failure is preexisting & unrelated, tracked in separate issue #15737.

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSRoute53QueryLog_basic (55.03s)
```
