### PR TITLE
tests/provider: Fix hardcoded ARN (S3)

### DIFF
--- a/aws/resource_aws_s3_bucket_inventory_test.go
+++ b/aws/resource_aws_s3_bucket_inventory_test.go
@@ -106,7 +106,7 @@ func TestAccAWSS3BucketInventory_encryptWithSSEKMS(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketInventoryConfigExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.bucket.0.encryption.0.sse_kms.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "destination.0.bucket.0.encryption.0.sse_kms.0.key_id", regexp.MustCompile("^arn:aws:kms:")),
+					resource.TestMatchResourceAttr(resourceName, "destination.0.bucket.0.encryption.0.sse_kms.0.key_id", regexp.MustCompile(fmt.Sprintf("^arn:%s:kms:", testAccGetPartition()))),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (13.99s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (14.02s)
--- PASS: TestAccAWSS3BucketInventory_basic (14.03s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (17.46s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (19.33s)
--- PASS: TestAccAWSS3BucketInventory_basic (19.44s)
```
