### PR TITLE
tests/provider: Fix hardcoded ARN (Transfer User)

### DIFF
--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -276,13 +276,14 @@ resource "aws_transfer_server" "foo" {
     NAME = "tf-acc-test-transfer-server"
   }
 }
+
+data "aws_partition" "current" {}
 `
 
 func testAccAWSTransferUserConfig_basic(rName string) string {
-	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
-
+	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
 resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-user-iam-role-%s"
+  name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -291,7 +292,7 @@ resource "aws_iam_role" "foo" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "transfer.amazonaws.com"
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -301,7 +302,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-user-iam-policy-%s"
+  name = "tf-test-transfer-user-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
 
   policy = <<POLICY
@@ -326,12 +327,11 @@ resource "aws_transfer_user" "foo" {
   user_name = "tftestuser"
   role      = aws_iam_role.foo.arn
 }
-`, rName, rName)
+`, rName))
 }
 
 func testAccAWSTransferUserName_validation(rName string) string {
-	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
-
+	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
 resource "aws_transfer_user" "foo" {
   server_id = aws_transfer_server.foo.id
   user_name = "%s"
@@ -348,7 +348,7 @@ resource "aws_iam_role" "foo" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "transfer.amazonaws.com"
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -356,14 +356,13 @@ resource "aws_iam_role" "foo" {
 }
 EOF
 }
-`, rName)
+`, rName))
 }
 
 func testAccAWSTransferUserConfig_options(rName string) string {
-	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
-
+	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
 resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-user-iam-role-%s"
+  name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -372,7 +371,7 @@ resource "aws_iam_role" "foo" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "transfer.amazonaws.com"
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -382,7 +381,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-user-iam-policy-%s"
+  name = "tf-test-transfer-user-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
 
   policy = <<POLICY
@@ -411,7 +410,7 @@ data "aws_iam_policy_document" "foo" {
     ]
 
     resources = [
-      "arn:aws:s3:::&{transfer:HomeBucket}",
+      "arn:${data.aws_partition.current.partition}:s3:::&{transfer:HomeBucket}",
     ]
   }
 
@@ -440,7 +439,7 @@ data "aws_iam_policy_document" "foo" {
     ]
 
     resources = [
-      "arn:aws:s3:::&{transfer:HomeDirectory}*",
+      "arn:${data.aws_partition.current.partition}:s3:::&{transfer:HomeDirectory}*",
     ]
   }
 }
@@ -458,14 +457,13 @@ resource "aws_transfer_user" "foo" {
     ADMIN = "test"
   }
 }
-`, rName, rName)
+`, rName))
 }
 
 func testAccAWSTransferUserConfig_modify(rName string) string {
-	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
-
+	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
 resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-user-iam-role-%s"
+  name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -474,7 +472,7 @@ resource "aws_iam_role" "foo" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "transfer.amazonaws.com"
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -484,7 +482,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-user-iam-policy-%s"
+  name = "tf-test-transfer-user-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
 
   policy = <<POLICY
@@ -513,7 +511,7 @@ data "aws_iam_policy_document" "foo" {
     ]
 
     resources = [
-      "arn:aws:s3:::&{transfer:HomeBucket}",
+      "arn:${data.aws_partition.current.partition}:s3:::&{transfer:HomeBucket}",
     ]
   }
 
@@ -540,7 +538,7 @@ data "aws_iam_policy_document" "foo" {
     ]
 
     resources = [
-      "arn:aws:s3:::&{transfer:HomeDirectory}*",
+      "arn:${data.aws_partition.current.partition}:s3:::&{transfer:HomeDirectory}*",
     ]
   }
 }
@@ -557,14 +555,13 @@ resource "aws_transfer_user" "foo" {
     TEST = "test2"
   }
 }
-`, rName, rName)
+`, rName))
 }
 
 func testAccAWSTransferUserConfig_forceNew(rName string) string {
-	return testAccAWSTransferUserConfig_base + fmt.Sprintf(`
-
+	return composeConfig(testAccAWSTransferUserConfig_base, fmt.Sprintf(`
 resource "aws_iam_role" "foo" {
-  name = "tf-test-transfer-user-iam-role-%s"
+  name = "tf-test-transfer-user-iam-role-%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -573,7 +570,7 @@ resource "aws_iam_role" "foo" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "transfer.amazonaws.com"
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -583,7 +580,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
-  name = "tf-test-transfer-user-iam-policy-%s"
+  name = "tf-test-transfer-user-iam-policy-%[1]s"
   role = aws_iam_role.foo.id
 
   policy = <<POLICY
@@ -612,7 +609,7 @@ data "aws_iam_policy_document" "foo" {
     ]
 
     resources = [
-      "arn:aws:s3:::&{transfer:HomeBucket}",
+      "arn:${data.aws_partition.current.partition}:s3:::&{transfer:HomeBucket}",
     ]
   }
 
@@ -641,7 +638,7 @@ data "aws_iam_policy_document" "foo" {
     ]
 
     resources = [
-      "arn:aws:s3:::&{transfer:HomeDirectory}*",
+      "arn:${data.aws_partition.current.partition}:s3:::&{transfer:HomeDirectory}*",
     ]
   }
 }
@@ -658,7 +655,7 @@ resource "aws_transfer_user" "foo" {
     TEST = "test2"
   }
 }
-`, rName, rName)
+`, rName))
 }
 
 func testAccAWSTransferUserConfig_homeDirectoryMappings(rName string) string {
@@ -675,7 +672,7 @@ resource "aws_iam_role" "foo" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "transfer.amazonaws.com"
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }
@@ -733,7 +730,7 @@ resource "aws_iam_role" "foo" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "transfer.amazonaws.com"
+        "Service": "transfer.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "sts:AssumeRole"
     }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud) (no regressions):

```
--- FAIL: TestAccAWSTransferUser_homeDirectoryMappings (9.40s)
--- FAIL: TestAccAWSTransferUser_modifyWithOptions (10.00s)
--- FAIL: TestAccAWSTransferUser_basic (10.17s)
--- FAIL: TestAccAWSTransferUser_disappears (10.21s)
--- PASS: TestAccAWSTransferUser_UserName_Validation (13.24s)
```

***Failures preexisting & unrelated and tracked in #15761.

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSTransferUser_UserName_Validation (14.61s)
--- PASS: TestAccAWSTransferUser_basic (196.52s)
--- PASS: TestAccAWSTransferUser_disappears (203.21s)
--- PASS: TestAccAWSTransferUser_homeDirectoryMappings (220.40s)
--- PASS: TestAccAWSTransferUser_modifyWithOptions (225.30s)
```