### PR TITLE
r/sagemaker_notebook_instance - add `url` and `network_interface_id` attributes

### DIFF
--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -108,7 +108,14 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_interface_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -234,6 +241,14 @@ func resourceAwsSagemakerNotebookInstanceRead(d *schema.ResourceData, meta inter
 
 	if err := d.Set("default_code_repository", notebookInstance.DefaultCodeRepository); err != nil {
 		return fmt.Errorf("error setting default_code_repository for sagemaker notebook instance (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("url", notebookInstance.Url); err != nil {
+		return fmt.Errorf("error setting url for sagemaker notebook instance (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("network_interface_id", notebookInstance.NetworkInterfaceId); err != nil {
+		return fmt.Errorf("error setting network_interface_id for sagemaker notebook instance (%s): %w", d.Id(), err)
 	}
 
 	tags, err := keyvaluetags.SagemakerListTags(conn, aws.StringValue(notebookInstance.NotebookInstanceArn))

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -95,6 +95,7 @@ func TestAccAWSSagemakerNotebookInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_code_repository", ""),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "url"),
 				),
 			},
 			{
@@ -434,6 +435,7 @@ func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Disabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 				),
 			},
 			{
@@ -448,6 +450,7 @@ func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 				),
 			},
 		},

--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -435,7 +436,7 @@ func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Disabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
+					resource.TestMatchResourceAttr(resourceName, "network_interface_id", regexp.MustCompile("eni-.*")),
 				),
 			},
 			{
@@ -450,7 +451,7 @@ func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", "aws_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
+					resource.TestMatchResourceAttr(resourceName, "network_interface_id", regexp.MustCompile("eni-.*")),
 				),
 			},
 		},

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
 * `direct_internet_access` - (Optional) Set to `Disabled` to disable internet access to notebook. Requires `security_groups` and `subnet_id` to be set. Supported values: `Enabled` (Default) or `Disabled`. If set to `Disabled`, the notebook instance will be able to access resources only in your VPC, and will not be able to connect to Amazon SageMaker training and endpoint services unless your configure a NAT Gateway in your VPC.
 * `default_code_repository` - (Optional) The Git repository associated with the notebook instance as its default code repository
 * `tags` - (Optional) A map of tags to assign to the resource.
+* `url` - The URL that you use to connect to the Jupyter notebook that is running in your notebook instance.
+* `network_interface_id` - The network interface ID that Amazon SageMaker created at the time of creating the instance. Only available when setting `subnet_id`.
 
 ## Attributes Reference
 

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -42,8 +42,6 @@ The following arguments are supported:
 * `direct_internet_access` - (Optional) Set to `Disabled` to disable internet access to notebook. Requires `security_groups` and `subnet_id` to be set. Supported values: `Enabled` (Default) or `Disabled`. If set to `Disabled`, the notebook instance will be able to access resources only in your VPC, and will not be able to connect to Amazon SageMaker training and endpoint services unless your configure a NAT Gateway in your VPC.
 * `default_code_repository` - (Optional) The Git repository associated with the notebook instance as its default code repository
 * `tags` - (Optional) A map of tags to assign to the resource.
-* `url` - The URL that you use to connect to the Jupyter notebook that is running in your notebook instance.
-* `network_interface_id` - The network interface ID that Amazon SageMaker created at the time of creating the instance. Only available when setting `subnet_id`.
 
 ## Attributes Reference
 
@@ -51,6 +49,8 @@ The following attributes are exported:
 
 * `id` - The name of the notebook instance.
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this notebook instance.
+* `url` - The URL that you use to connect to the Jupyter notebook that is running in your notebook instance.
+* `network_interface_id` - The network interface ID that Amazon SageMaker created at the time of creating the instance. Only available when setting `subnet_id`.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_notebook_instance - add `url` and `network_interface_id` attributes
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSSagemakerNotebookInstance_basic (334.35s)
--- PASS: TestAccAWSSagemakerNotebookInstance_direct_internet_access (770.32s)
```
