### PR TITLE
tests/provider: Initial migration from hardcoded regions and shared environment variable overwrite (CUR and EC2-Classic)

### DIFF
--- a/aws/cur_test.go
+++ b/aws/cur_test.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/costandusagereportservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// testAccCurRegion is the chosen Cost and Usage Reporting testing region
+//
+// Cached to prevent issues should multiple regions become available.
+var testAccCurRegion string
+
+// testAccProviderCur is the Cost and Usage Reporting provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// testAccPreCheckCur(t) must be called before using this provider instance.
+var testAccProviderCur *schema.Provider
+
+// testAccProviderCurConfigure ensures the provider is only configured once
+var testAccProviderCurConfigure sync.Once
+
+// testAccPreCheckCur verifies AWS credentials and that Cost and Usage Reporting is supported
+func testAccPreCheckCur(t *testing.T) {
+	testAccPartitionHasServicePreCheck(costandusagereportservice.ServiceName, t)
+
+	// Since we are outside the scope of the Terraform configuration we must
+	// call Configure() to properly initialize the provider configuration.
+	testAccProviderCurConfigure.Do(func() {
+		testAccProviderCur = Provider()
+
+		config := map[string]interface{}{
+			"region": testAccGetCurRegion(),
+		}
+
+		err := testAccProviderCur.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+// testAccCurRegionProviderConfig is the Terraform provider configuration for Cost and Usage Reporting region testing
+//
+// Testing Cost and Usage Reporting assumes no other provider configurations
+// are necessary and overwrites the "aws" provider configuration.
+func testAccCurRegionProviderConfig() string {
+	return testAccRegionalProviderConfig(testAccGetCurRegion())
+}
+
+// testAccGetCurRegion returns the Cost and Usage Reporting region for testing
+func testAccGetCurRegion() string {
+	if testAccCurRegion != "" {
+		return testAccCurRegion
+	}
+
+	if rs, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), testAccGetPartition(), costandusagereportservice.ServiceName); ok {
+		// return available region (random if multiple)
+		for regionID := range rs {
+			testAccCurRegion = regionID
+			return testAccCurRegion
+		}
+	}
+
+	testAccCurRegion = testAccGetRegion()
+
+	return testAccCurRegion
+}
+
+// testAccProviderFactoriesCur initializes providers for Cost and Usage Reporting testing.
+//
+// Deprecated: This will be replaced with testAccProviderFactories when it only returns the "aws" provider
+func testAccProviderFactoriesCur() map[string]func() (*schema.Provider, error) {
+	return testAccProviderFactoriesInit(nil, []string{ProviderNameAws})
+}

--- a/aws/data_source_aws_cur_report_definition_test.go
+++ b/aws/data_source_aws_cur_report_definition_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -11,12 +10,6 @@ import (
 )
 
 func TestAccDataSourceAwsCurReportDefinition_basic(t *testing.T) {
-	testAccPartitionHasServicePreCheck("cur", t) // This check must come before os.Setenv() or creds fail on GovCloud
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") // lintignore:AWSAT003
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_cur_report_definition.test"
 	datasourceName := "data.aws_cur_report_definition.test"
 
@@ -24,9 +17,9 @@ func TestAccDataSourceAwsCurReportDefinition_basic(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCur(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
+		ProviderFactories: testAccProviderFactoriesCur(),
+		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsCurReportDefinitionConfig_basic(reportName, bucketName),
@@ -47,12 +40,6 @@ func TestAccDataSourceAwsCurReportDefinition_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsCurReportDefinition_additional(t *testing.T) {
-	testAccPartitionHasServicePreCheck("cur", t) // This check must come before os.Setenv() or creds fail on GovCloud
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") //lintignore:AWSAT003
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_cur_report_definition.test"
 	datasourceName := "data.aws_cur_report_definition.test"
 
@@ -60,9 +47,9 @@ func TestAccDataSourceAwsCurReportDefinition_additional(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCur(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
+		ProviderFactories: testAccProviderFactoriesCur(),
+		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsCurReportDefinitionConfig_additional(reportName, bucketName),
@@ -98,14 +85,10 @@ func testAccDataSourceAwsCurReportDefinitionCheckExists(datasourceName, resource
 	}
 }
 
-// note: cur report definitions are currently only supported in us-east-1
 func testAccDataSourceAwsCurReportDefinitionConfig_basic(reportName string, bucketName string) string {
-	//lintignore:AWSAT003,AWSAT005
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
+	return composeConfig(
+		testAccCurRegionProviderConfig(),
+		fmt.Sprintf(`
 data "aws_billing_service_account" "test" {}
 
 resource "aws_s3_bucket" "test" {
@@ -165,16 +148,13 @@ resource "aws_cur_report_definition" "test" {
 data "aws_cur_report_definition" "test" {
   report_name = aws_cur_report_definition.test.report_name
 }
-`, reportName, bucketName)
+`, reportName, bucketName))
 }
 
 func testAccDataSourceAwsCurReportDefinitionConfig_additional(reportName string, bucketName string) string {
-	//lintignore:AWSAT003,AWSAT005
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
+	return composeConfig(
+		testAccCurRegionProviderConfig(),
+		fmt.Sprintf(`
 data "aws_billing_service_account" "test" {}
 
 resource "aws_s3_bucket" "test" {
@@ -236,5 +216,5 @@ resource "aws_cur_report_definition" "test" {
 data "aws_cur_report_definition" "test" {
   report_name = aws_cur_report_definition.test.report_name
 }
-`, reportName, bucketName)
+`, reportName, bucketName))
 }

--- a/aws/ec2_classic_test.go
+++ b/aws/ec2_classic_test.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	// EC2-Classic region testing environment variable name
+	Ec2ClassicRegionEnvVar = "AWS_EC2_CLASSIC_REGION"
+)
+
+// testAccProviderEc2Classic is the EC2-Classic provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// testAccEC2ClassicPreCheck(t) must be called before using this provider instance.
+var testAccProviderEc2Classic *schema.Provider
+
+// testAccProviderEc2ClassicConfigure ensures the provider is only configured once
+var testAccProviderEc2ClassicConfigure sync.Once
+
+// testAccEC2ClassicPreCheck verifies AWS credentials and that EC2-Classic is supported
+func testAccEC2ClassicPreCheck(t *testing.T) {
+	// Since we are outside the scope of the Terraform configuration we must
+	// call Configure() to properly initialize the provider configuration.
+	testAccProviderEc2ClassicConfigure.Do(func() {
+		testAccProviderEc2Classic = Provider()
+
+		config := map[string]interface{}{
+			"region": testAccGetEc2ClassicRegion(),
+		}
+
+		err := testAccProviderEc2Classic.Configure(context.Background(), terraform.NewResourceConfigRaw(config))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	client := testAccProviderEc2Classic.Meta().(*AWSClient)
+	platforms := client.supportedplatforms
+	region := client.region
+	if !hasEc2Classic(platforms) {
+		t.Skipf("this test can only run in EC2-Classic, platforms available in %s: %q", region, platforms)
+	}
+}
+
+// testAccEc2ClassicRegionProviderConfig is the Terraform provider configuration for EC2-Classic region testing
+//
+// Testing EC2-Classic assumes no other provider configurations are necessary
+// and overwrites the "aws" provider configuration.
+func testAccEc2ClassicRegionProviderConfig() string {
+	return testAccRegionalProviderConfig(testAccGetEc2ClassicRegion())
+}
+
+// testAccGetEc2ClassicRegion returns the EC2-Classic region for testing
+func testAccGetEc2ClassicRegion() string {
+	v := os.Getenv(Ec2ClassicRegionEnvVar)
+
+	if v != "" {
+		return v
+	}
+
+	if testAccGetPartition() == endpoints.AwsPartitionID {
+		return endpoints.UsEast1RegionID
+	}
+
+	return testAccGetRegion()
+}
+
+// testAccProviderFactoriesEc2Classic initializes providers for EC2-Classic testing.
+//
+// Deprecated: This will be replaced with testAccProviderFactories when it only returns the "aws" provider
+func testAccProviderFactoriesEc2Classic() map[string]func() (*schema.Provider, error) {
+	return testAccProviderFactoriesInit(nil, []string{ProviderNameAws})
+}

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -24,6 +24,31 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+const (
+	// Provider name for single configuration testing
+	ProviderNameAws = "aws"
+
+	// Provider name for alternate configuration testing
+	ProviderNameAwsAlternate = "awsalternate"
+
+	// Provider name for alternate account and alternate region configuration testing
+	ProviderNameAwsAlternateAccountAlternateRegion = "awsalternateaccountalternateregion"
+
+	// Provider name for alternate account and same region configuration testing
+	ProviderNameAwsAlternateAccountSameRegion = "awsalternateaccountsameregion"
+
+	// Provider name for same account and alternate region configuration testing
+	ProviderNameAwsSameAccountAlternateRegion = "awssameaccountalternateregion"
+
+	// Provider name for third configuration testing
+	ProviderNameAwsThird = "awsthird"
+
+	// Provider name for hardcoded us-east-1 configuration testing
+	//
+	// Deprecated: This will be replaced with service specific providers
+	ProviderNameAwsUsEast1 = "awsus-east-1"
+)
+
 const rfc3339RegexPattern = `^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?([Zz]|([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$`
 const uuidRegexPattern = `[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[ab89][a-f0-9]{3}-[a-f0-9]{12}`
 
@@ -34,31 +59,73 @@ var TestAccSkip = func(t *testing.T, message string) {
 	t.Skip(message)
 }
 
+// testAccProviders is a static map of provider types and their associated provider instance.
+//
+// Deprecated: Terraform Plugin SDK version 2 uses TestCase.ProviderFactories
+// but supports this value in TestCase.Providers for backwards compatibility.
+// In the future Providers: testAccProviders will be changed to
+// ProviderFactories: testAccProviderFactories
 var testAccProviders map[string]*schema.Provider
+
+// testAccProviderFactories initializes and returns Provider slice elements of a provider type and function that returns the provider instance
+//
+// Using this function will initialize all listed provider types as gRPC
+// plugins for every test, which is inefficient and can cause ulimit issues.
+//
+// Deprecated: Use specific ProviderFactories functions such as testAccProviderFactoriesEc2Classic instead.
+// In the future this will be changed to return only the aws provider and not accept a parameter.
 var testAccProviderFactories func(providers *[]*schema.Provider) map[string]func() (*schema.Provider, error)
+
+// testAccProvider is the "main" provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// testAccPreCheck(t) must be called before using this provider instance.
 var testAccProvider *schema.Provider
+
+// testAccProviderFunc is a function that returns the "main" provider instance
+//
+// Deprecated: Use testAccAwsRegionProviderFunc instead.
+// In the future this will be changed to be compatible with ProviderFactories.
 var testAccProviderFunc func() *schema.Provider
 
 func init() {
 	testAccProvider = Provider()
 	testAccProviders = map[string]*schema.Provider{
-		"aws": testAccProvider,
+		ProviderNameAws: testAccProvider,
 	}
 	testAccProviderFactories = func(providers *[]*schema.Provider) map[string]func() (*schema.Provider, error) {
-		// this is an SDKV2 compatible hack, the "factory" functions are
-		// effectively singletons for the lifecycle of a resource.Test
-		var providerNames = []string{"aws", "awseast", "awswest", "awsalternate", "awsus-east-1", "awsalternateaccountalternateregion", "awsalternateaccountsameregion", "awssameaccountalternateregion", "awsthird"}
-		var factories = make(map[string]func() (*schema.Provider, error), len(providerNames))
-		for _, name := range providerNames {
-			p := Provider()
-			factories[name] = func() (*schema.Provider, error) { //nolint:unparam
-				return p, nil
-			}
-			*providers = append(*providers, p)
-		}
-		return factories
+		return testAccProviderFactoriesInit(providers, []string{
+			ProviderNameAws,
+			ProviderNameAwsAlternate,
+			ProviderNameAwsAlternateAccountAlternateRegion,
+			ProviderNameAwsAlternateAccountSameRegion,
+			ProviderNameAwsSameAccountAlternateRegion,
+			ProviderNameAwsThird,
+			ProviderNameAwsUsEast1,
+		})
 	}
 	testAccProviderFunc = func() *schema.Provider { return testAccProvider }
+}
+
+// testAccProviderFactoriesInit creates ProviderFactories for the provider under testing.
+func testAccProviderFactoriesInit(providers *[]*schema.Provider, providerNames []string) map[string]func() (*schema.Provider, error) {
+	var factories = make(map[string]func() (*schema.Provider, error), len(providerNames))
+
+	for _, name := range providerNames {
+		p := Provider()
+
+		factories[name] = func() (*schema.Provider, error) { //nolint:unparam
+			return p, nil
+		}
+
+		if providers != nil {
+			*providers = append(*providers, p)
+		}
+	}
+
+	return factories
 }
 
 func TestProvider(t *testing.T) {
@@ -519,16 +586,6 @@ func testAccAlternateRegionPreCheck(t *testing.T) {
 	}
 }
 
-func testAccEC2ClassicPreCheck(t *testing.T) {
-	client := testAccProvider.Meta().(*AWSClient)
-	platforms := client.supportedplatforms
-	region := client.region
-	if !hasEc2Classic(platforms) {
-		t.Skipf("This test can only run in EC2 Classic, platforms available in %s: %q",
-			region, platforms)
-	}
-}
-
 func testAccEC2VPCOnlyPreCheck(t *testing.T) {
 	client := testAccProvider.Meta().(*AWSClient)
 	platforms := client.supportedplatforms
@@ -697,31 +754,16 @@ provider "awssameaccountalternateregion" {
 
 // Deprecated: Use testAccMultipleRegionProviderConfig instead
 func testAccAlternateRegionProviderConfig() string {
-	//lintignore:AT004
-	return fmt.Sprintf(`
-provider "awsalternate" {
-  region = %[1]q
-}
-`, testAccGetAlternateRegion())
+	return testAccNamedRegionalProviderConfig(ProviderNameAwsAlternate, testAccGetAlternateRegion())
 }
 
 func testAccMultipleRegionProviderConfig(regions int) string {
 	var config strings.Builder
 
-	//lintignore:AT004
-	fmt.Fprintf(&config, `
-provider "awsalternate" {
-  region = %[1]q
-}
-`, testAccGetAlternateRegion())
+	config.WriteString(testAccNamedRegionalProviderConfig(ProviderNameAwsAlternate, testAccGetAlternateRegion()))
 
 	if regions >= 3 {
-		//lintignore:AT004
-		fmt.Fprintf(&config, `
-provider "awsthird" {
-  region = %[1]q
-}
-`, testAccGetThirdRegion())
+		config.WriteString(testAccNamedRegionalProviderConfig(ProviderNameAwsThird, testAccGetThirdRegion()))
 	}
 
 	return config.String()
@@ -749,19 +791,41 @@ provider "aws" {
 `, key1)
 }
 
+// testAccNamedRegionalProviderConfig creates a new provider named configuration with a region.
+//
+// This can be used to build multiple provider configuration testing.
+func testAccNamedRegionalProviderConfig(providerName string, region string) string {
+	//lintignore:AT004
+	return fmt.Sprintf(`
+provider %[1]q {
+  region = %[2]q
+}
+`, providerName, region)
+}
+
+// testAccRegionalProviderConfig creates a new provider configuration with a region.
+//
+// This can only be used for single provider configuration testing as it
+// overwrites the "aws" provider configuration.
+func testAccRegionalProviderConfig(region string) string {
+	//lintignore:AT004
+	return fmt.Sprintf(`
+provider "aws" {
+  region = %[1]q
+}
+`, region)
+}
+
 // Provider configuration hardcoded for us-east-1.
 // This should only be necessary for testing ACM Certificates with CloudFront
 // related infrastucture such as API Gateway Domain Names for EDGE endpoints,
 // CloudFront Distribution Viewer Certificates, and Cognito User Pool Domains.
 // Other valid usage is for services only available in us-east-1 such as the
 // Cost and Usage Reporting and Pricing services.
+//
+// Deprecated: This will be replaced with service specific provider configurations.
 func testAccUsEast1RegionProviderConfig() string {
-	//lintignore:AT004
-	return `
-provider "awsus-east-1" {
-  region = "us-east-1"
-}
-`
+	return testAccNamedRegionalProviderConfig(ProviderNameAwsUsEast1, endpoints.UsEast1RegionID)
 }
 
 func testAccAwsRegionProviderFunc(region string, providers *[]*schema.Provider) func() *schema.Provider {

--- a/aws/resource_aws_cur_report_definition_test.go
+++ b/aws/resource_aws_cur_report_definition_test.go
@@ -2,11 +2,9 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/costandusagereportservice"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,21 +12,15 @@ import (
 )
 
 func TestAccAwsCurReportDefinition_basic(t *testing.T) {
-	testAccPartitionHasServicePreCheck("cur", t) // This check must come before os.Setenv() or creds fail on GovCloud
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") // lintignore:AWSAT003
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_cur_report_definition.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	reportName := acctest.RandomWithPrefix("tf_acc_test")
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCur(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
+		ProviderFactories: testAccProviderFactoriesCur(),
+		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsCurReportDefinitionConfig_basic(reportName, bucketName),
@@ -49,12 +41,6 @@ func TestAccAwsCurReportDefinition_basic(t *testing.T) {
 }
 
 func TestAccAwsCurReportDefinition_textOrCsv(t *testing.T) {
-	testAccPartitionHasServicePreCheck("cur", t) // This check must come before os.Setenv() or creds fail on GovCloud
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") // lintignore:AWSAT003
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_cur_report_definition.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	reportName := acctest.RandomWithPrefix("tf_acc_test")
@@ -67,9 +53,9 @@ func TestAccAwsCurReportDefinition_textOrCsv(t *testing.T) {
 	reportVersioning := "CREATE_NEW_REPORT"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCur(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
+		ProviderFactories: testAccProviderFactoriesCur(),
+		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsCurReportDefinitionConfig_additional(reportName, bucketName, bucketPrefix, format, compression, additionalArtifacts, refreshClosedReports, reportVersioning),
@@ -93,12 +79,6 @@ func TestAccAwsCurReportDefinition_textOrCsv(t *testing.T) {
 }
 
 func TestAccAwsCurReportDefinition_parquet(t *testing.T) {
-	testAccPartitionHasServicePreCheck("cur", t) // This check must come before os.Setenv() or creds fail on GovCloud
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") // lintignore:AWSAT003
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_cur_report_definition.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	reportName := acctest.RandomWithPrefix("tf_acc_test")
@@ -111,9 +91,9 @@ func TestAccAwsCurReportDefinition_parquet(t *testing.T) {
 	reportVersioning := "CREATE_NEW_REPORT"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCur(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
+		ProviderFactories: testAccProviderFactoriesCur(),
+		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsCurReportDefinitionConfig_additional(reportName, bucketName, bucketPrefix, format, compression, additionalArtifacts, refreshClosedReports, reportVersioning),
@@ -136,12 +116,6 @@ func TestAccAwsCurReportDefinition_parquet(t *testing.T) {
 }
 
 func TestAccAwsCurReportDefinition_athena(t *testing.T) {
-	testAccPartitionHasServicePreCheck("cur", t) // This check must come before os.Setenv() or creds fail on GovCloud
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") // lintignore:AWSAT003
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_cur_report_definition.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	reportName := acctest.RandomWithPrefix("tf_acc_test")
@@ -154,9 +128,9 @@ func TestAccAwsCurReportDefinition_athena(t *testing.T) {
 	reportVersioning := "OVERWRITE_REPORT"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCur(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
+		ProviderFactories: testAccProviderFactoriesCur(),
+		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsCurReportDefinitionConfig_additional(reportName, bucketName, bucketPrefix, format, compression, additionalArtifacts, refreshClosedReports, reportVersioning),
@@ -180,12 +154,6 @@ func TestAccAwsCurReportDefinition_athena(t *testing.T) {
 }
 
 func TestAccAwsCurReportDefinition_refresh(t *testing.T) {
-	testAccPartitionHasServicePreCheck("cur", t) // This check must come before os.Setenv() or creds fail on GovCloud
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") // lintignore:AWSAT003
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_cur_report_definition.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	reportName := acctest.RandomWithPrefix("tf_acc_test")
@@ -198,9 +166,9 @@ func TestAccAwsCurReportDefinition_refresh(t *testing.T) {
 	reportVersioning := "CREATE_NEW_REPORT"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCur(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
+		ProviderFactories: testAccProviderFactoriesCur(),
+		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsCurReportDefinitionConfig_additional(reportName, bucketName, bucketPrefix, format, compression, additionalArtifacts, refreshClosedReports, reportVersioning),
@@ -224,12 +192,6 @@ func TestAccAwsCurReportDefinition_refresh(t *testing.T) {
 }
 
 func TestAccAwsCurReportDefinition_overwrite(t *testing.T) {
-	testAccPartitionHasServicePreCheck("cur", t) // This check must come before os.Setenv() or creds fail on GovCloud
-
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1") // lintignore:AWSAT003
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	resourceName := "aws_cur_report_definition.test"
 	s3BucketResourceName := "aws_s3_bucket.test"
 	reportName := acctest.RandomWithPrefix("tf_acc_test")
@@ -242,9 +204,9 @@ func TestAccAwsCurReportDefinition_overwrite(t *testing.T) {
 	reportVersioning := "OVERWRITE_REPORT"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCur(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsCurReportDefinitionDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
+		ProviderFactories: testAccProviderFactoriesCur(),
+		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsCurReportDefinitionConfig_additional(reportName, bucketName, bucketPrefix, format, compression, additionalArtifacts, refreshClosedReports, reportVersioning),
@@ -268,7 +230,7 @@ func TestAccAwsCurReportDefinition_overwrite(t *testing.T) {
 }
 
 func testAccCheckAwsCurReportDefinitionDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).costandusagereportconn
+	conn := testAccProviderCur.Meta().(*AWSClient).costandusagereportconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_cur_report_definition" {
@@ -289,7 +251,7 @@ func testAccCheckAwsCurReportDefinitionDestroy(s *terraform.State) error {
 
 func testAccCheckAwsCurReportDefinitionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).costandusagereportconn
+		conn := testAccProviderCur.Meta().(*AWSClient).costandusagereportconn
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -307,32 +269,10 @@ func testAccCheckAwsCurReportDefinitionExists(resourceName string) resource.Test
 	}
 }
 
-func testAccPreCheckAWSCur(t *testing.T) {
-	conn := testAccProvider.Meta().(*AWSClient).costandusagereportconn
-
-	input := &costandusagereportservice.DescribeReportDefinitionsInput{
-		MaxResults: aws.Int64(5),
-	}
-
-	_, err := conn.DescribeReportDefinitions(input)
-
-	if testAccPreCheckSkipError(err) || isAWSErr(err, "AccessDeniedException", "linked account is not allowed to modify report preference") {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-}
-
-// note: cur report definitions are currently only supported in US East (Northern Va)
 func testAccAwsCurReportDefinitionConfig_basic(reportName string, bucketName string) string {
-	// lintignore:AWSAT003
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
+	return composeConfig(
+		testAccCurRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = "%[2]s"
   acl           = "private"
@@ -388,7 +328,7 @@ resource "aws_cur_report_definition" "test" {
   s3_region                  = aws_s3_bucket.test.region
   additional_artifacts       = ["REDSHIFT", "QUICKSIGHT"]
 }
-`, reportName, bucketName)
+`, reportName, bucketName))
 }
 
 func testAccAwsCurReportDefinitionConfig_additional(reportName string, bucketName string, bucketPrefix string, format string, compression string, additionalArtifacts []string, refreshClosedReports bool, reportVersioning string) string {
@@ -400,12 +340,9 @@ func testAccAwsCurReportDefinitionConfig_additional(reportName string, bucketNam
 		artifactsStr = ""
 	}
 
-	// lintignore:AWSAT003
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
+	return composeConfig(
+		testAccCurRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = "%[2]s"
   acl           = "private"
@@ -463,7 +400,7 @@ resource "aws_cur_report_definition" "test" {
   refresh_closed_reports = %[7]t
   report_versioning      = "%[8]s"
 }
-`, reportName, bucketName, bucketPrefix, format, compression, artifactsStr, refreshClosedReports, reportVersioning)
+`, reportName, bucketName, bucketPrefix, format, compression, artifactsStr, refreshClosedReports, reportVersioning))
 }
 
 func TestCheckAwsCurReportDefinitionPropertyCombination(t *testing.T) {

--- a/aws/resource_aws_redshift_security_group_test.go
+++ b/aws/resource_aws_redshift_security_group_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,19 +14,14 @@ import (
 )
 
 func TestAccAWSRedshiftSecurityGroup_basic(t *testing.T) {
-	// This is necessary to prevent "VPC-by-Default customers cannot use cluster security groups" errors
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRedshiftSecurityGroupConfig_ingressCidr(rInt),
@@ -45,18 +39,14 @@ func TestAccAWSRedshiftSecurityGroup_basic(t *testing.T) {
 }
 
 func TestAccAWSRedshiftSecurityGroup_ingressCidr(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRedshiftSecurityGroupConfig_ingressCidr(rInt),
@@ -83,18 +73,14 @@ func TestAccAWSRedshiftSecurityGroup_ingressCidr(t *testing.T) {
 }
 
 func TestAccAWSRedshiftSecurityGroup_updateIngressCidr(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRedshiftSecurityGroupConfig_ingressCidr(rInt),
@@ -130,18 +116,14 @@ func TestAccAWSRedshiftSecurityGroup_updateIngressCidr(t *testing.T) {
 }
 
 func TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRedshiftSecurityGroupConfig_ingressSgId(rInt),
@@ -165,18 +147,14 @@ func TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup(t *testing.T) {
 }
 
 func TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup(t *testing.T) {
-	oldvar := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
-
 	var v redshift.ClusterSecurityGroup
 	rInt := acctest.RandInt()
 	resourceName := "aws_redshift_security_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRedshiftSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
+		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSRedshiftSecurityGroupConfig_ingressSgId(rInt),
@@ -222,7 +200,7 @@ func testAccCheckAWSRedshiftSecurityGroupExists(n string, v *redshift.ClusterSec
 			return fmt.Errorf("No Redshift Security Group ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).redshiftconn
+		conn := testAccProviderEc2Classic.Meta().(*AWSClient).redshiftconn
 
 		opts := redshift.DescribeClusterSecurityGroupsInput{
 			ClusterSecurityGroupName: aws.String(rs.Primary.ID),
@@ -246,7 +224,7 @@ func testAccCheckAWSRedshiftSecurityGroupExists(n string, v *redshift.ClusterSec
 }
 
 func testAccCheckAWSRedshiftSecurityGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).redshiftconn
+	conn := testAccProviderEc2Classic.Meta().(*AWSClient).redshiftconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_redshift_security_group" {
@@ -280,7 +258,9 @@ func testAccCheckAWSRedshiftSecurityGroupDestroy(s *terraform.State) error {
 }
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressCidr(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_redshift_security_group" "test" {
   name = "redshift-sg-terraform-%d"
 
@@ -288,11 +268,13 @@ resource "aws_redshift_security_group" "test" {
     cidr = "10.0.0.1/24"
   }
 }
-`, rInt)
+`, rInt))
 }
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressCidrAdd(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_redshift_security_group" "test" {
   name        = "redshift-sg-terraform-%d"
   description = "this is a description"
@@ -309,11 +291,13 @@ resource "aws_redshift_security_group" "test" {
     cidr = "10.0.20.1/24"
   }
 }
-`, rInt)
+`, rInt))
 }
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressCidrReduce(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_redshift_security_group" "test" {
   name        = "redshift-sg-terraform-%d"
   description = "this is a description"
@@ -326,11 +310,13 @@ resource "aws_redshift_security_group" "test" {
     cidr = "10.0.10.1/24"
   }
 }
-`, rInt)
+`, rInt))
 }
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressSgId(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_security_group" "redshift" {
   name        = "terraform_redshift_test_%d"
   description = "Used in the redshift acceptance tests"
@@ -352,11 +338,13 @@ resource "aws_redshift_security_group" "test" {
     security_group_owner_id = aws_security_group.redshift.owner_id
   }
 }
-`, rInt, rInt)
+`, rInt, rInt))
 }
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressSgIdAdd(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_security_group" "redshift" {
   name        = "terraform_redshift_test_%d"
   description = "Used in the redshift acceptance tests"
@@ -412,11 +400,13 @@ resource "aws_redshift_security_group" "test" {
     security_group_owner_id = aws_security_group.redshift.owner_id
   }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt, rInt, rInt, rInt))
 }
 
 func testAccAWSRedshiftSecurityGroupConfig_ingressSgIdReduce(rInt int) string {
-	return fmt.Sprintf(`
+	return composeConfig(
+		testAccEc2ClassicRegionProviderConfig(),
+		fmt.Sprintf(`
 resource "aws_security_group" "redshift" {
   name        = "terraform_redshift_test_%d"
   description = "Used in the redshift acceptance tests"
@@ -455,5 +445,5 @@ resource "aws_redshift_security_group" "test" {
     security_group_owner_id = aws_security_group.redshift.owner_id
   }
 }
-`, rInt, rInt, rInt)
+`, rInt, rInt, rInt))
 }

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -403,6 +403,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `AWS_COGNITO_USER_POOL_DOMAIN_CERTIFICATE_ARN` | Amazon Resource Name of ACM Certificate in `us-east-1` for Cognito User Pool Domain Name testing. |
 | `AWS_COGNITO_USER_POOL_DOMAIN_ROOT_DOMAIN` | Root domain name to use with Cognito User Pool Domain testing. |
 | `AWS_DEFAULT_REGION` | Primary AWS region for tests. Defaults to `us-west-2`. |
+| `AWS_EC2_CLASSIC_REGION` | AWS region for EC2-Classic testing. Defaults to `us-east-1` in AWS Commercial and `AWS_DEFAULT_REGION` otherwise. |
 | `AWS_EC2_CLIENT_VPN_LIMIT` | Concurrency limit for Client VPN acceptance tests. [Default is 5](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/limits.html) if not specified. |
 | `AWS_EC2_EIP_PUBLIC_IPV4_POOL` | Identifier for EC2 Public IPv4 Pool for EC2 EIP testing. |
 | `AWS_GUARDDUTY_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for GuardDuty Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |

--- a/docs/contributing/running-and-writing-acceptance-tests.md
+++ b/docs/contributing/running-and-writing-acceptance-tests.md
@@ -777,22 +777,6 @@ resource "aws_example" "test" {
 }
 ```
 
-#### Please Note
-
-When adding a new provider to the codebase for the purposes of cross-account/cross-region testing, please ensure the provider name in the config matches an entry in the list of factories in `provider_test.go`
-
-```hcl
-# provider block, ensure name does not include periods '.'
-provider "awsnewalternate" {
-  region = "us-west-3"
-}
-```
-
-```go
-// provider_testo.go in init()
-var providerNames = []string{"aws", "awseast", "awswest", "awsalternate", /* ... */ "awsnewalternate"}
-```
-
 Searching for usage of `testAccMultipleRegionPreCheck` in the codebase will yield real world examples of this setup in action.
 
 ### Data Source Acceptance Testing


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: #8316
Reference: #15737
Reference: #15791

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This includes two related commits to show migration paths for EC2-Classic handling (Redshift Security Groups) and an example service that requires special region lookup (Cost and Usage Reporting). The additional testing provider and testing region lookup pattern should only be implemented where necessary.

As noted in the new Go documentation, there is a lot of older style handling in the testing provider initialization. It is probably worth cleaning up parts of that, in particular `testAccProviderFactories` since it is problematic as-is, before applying these types of changes across other services.

Output from acceptance testing in AWS Commercial (DynamoDB to verify existing testAccProviderFactories handling):

```
--- PASS: TestAccAWSDynamoDbTable_Replica_Single (274.15s)

--- PASS: TestAccAWSRedshiftSecurityGroup_basic (10.87s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressCidr (10.88s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup (12.45s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressCidr (24.07s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup (27.14s)

--- PASS: TestAccAwsCurReportDefinition_refresh (13.35s)
--- PASS: TestAccAwsCurReportDefinition_overwrite (13.53s)
--- PASS: TestAccAwsCurReportDefinition_athena (13.55s)
--- PASS: TestAccAwsCurReportDefinition_basic (13.56s)
--- PASS: TestAccAwsCurReportDefinition_textOrCsv (13.77s)
--- PASS: TestAccAwsCurReportDefinition_parquet (13.83s)

--- PASS: TestAccDataSourceAwsCurReportDefinition_additional (15.71s)
--- PASS: TestAccDataSourceAwsCurReportDefinition_basic (16.05s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSRedshiftSecurityGroup_updateIngressCidr (2.50s)
--- SKIP: TestAccAWSRedshiftSecurityGroup_basic (2.50s)
--- SKIP: TestAccAWSRedshiftSecurityGroup_ingressCidr (2.50s)
--- SKIP: TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup (2.50s)
--- SKIP: TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup (2.50s)

--- SKIP: TestAccAwsCurReportDefinition_refresh (1.22s)
--- SKIP: TestAccAwsCurReportDefinition_athena (1.22s)
--- SKIP: TestAccAwsCurReportDefinition_basic (1.23s)
--- SKIP: TestAccAwsCurReportDefinition_textOrCsv (1.23s)
--- SKIP: TestAccAwsCurReportDefinition_overwrite (1.24s)
--- SKIP: TestAccAwsCurReportDefinition_parquet (1.25s)

--- SKIP: TestAccDataSourceAwsCurReportDefinition_basic (1.17s)
--- SKIP: TestAccDataSourceAwsCurReportDefinition_additional (1.19s)
```