### PR TITLE
r/sagemaker_code_repository - new resource

### DIFF
--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -1,0 +1,25 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+)
+
+// FincCodeRepositoryByName returns the code repository corresponding to the specified name.
+// Returns nil if no code repository is found.
+func FincCodeRepositoryByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeCodeRepositoryOutput, error) {
+	input := &sagemaker.DescribeCodeRepositoryInput{
+		CodeRepositoryName: aws.String(name),
+	}
+
+	output, err := conn.DescribeCodeRepository(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, nil
+	}
+
+	return output, nil
+}

--- a/aws/internal/service/sagemaker/finder/finder.go
+++ b/aws/internal/service/sagemaker/finder/finder.go
@@ -5,9 +5,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 )
 
-// FincCodeRepositoryByName returns the code repository corresponding to the specified name.
+// CodeRepositoryByName returns the code repository corresponding to the specified name.
 // Returns nil if no code repository is found.
-func FincCodeRepositoryByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeCodeRepositoryOutput, error) {
+func CodeRepositoryByName(conn *sagemaker.SageMaker, name string) (*sagemaker.DescribeCodeRepositoryOutput, error) {
 	input := &sagemaker.DescribeCodeRepositoryInput{
 		CodeRepositoryName: aws.String(name),
 	}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -829,6 +829,7 @@ func Provider() *schema.Provider {
 			"aws_route_table":                                         resourceAwsRouteTable(),
 			"aws_default_route_table":                                 resourceAwsDefaultRouteTable(),
 			"aws_route_table_association":                             resourceAwsRouteTableAssociation(),
+			"aws_sagemaker_code_repository":                           resourceAwsSagemakerCodeRepository(),
 			"aws_sagemaker_model":                                     resourceAwsSagemakerModel(),
 			"aws_sagemaker_endpoint_configuration":                    resourceAwsSagemakerEndpointConfiguration(),
 			"aws_sagemaker_endpoint":                                  resourceAwsSagemakerEndpoint(),

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -74,7 +74,7 @@ func resourceAwsSagemakerCodeRepositoryCreate(d *schema.ResourceData, meta inter
 	log.Printf("[DEBUG] sagemaker code repository create config: %#v", *createOpts)
 	_, err := conn.CreateCodeRepository(createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating Sagemaker code repository: %w", err)
+		return fmt.Errorf("error creating SageMaker code repository: %w", err)
 	}
 
 	d.SetId(name)
@@ -85,17 +85,18 @@ func resourceAwsSagemakerCodeRepositoryCreate(d *schema.ResourceData, meta inter
 func resourceAwsSagemakerCodeRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sagemakerconn
 
-	describeNotebookInput := &sagemaker.DescribeCodeRepositoryInput{
+	input := &sagemaker.DescribeCodeRepositoryInput{
 		CodeRepositoryName: aws.String(d.Id()),
 	}
-	CodeRepository, err := conn.DescribeCodeRepository(describeNotebookInput)
+
+	codeRepository, err := conn.DescribeCodeRepository(describeNotebookInput)
 	if err != nil {
 		if isAWSErr(err, "ValidationException", "Cannot find CodeRepository") {
 			d.SetId("")
 			log.Printf("[WARN] Unable to find SageMaker code repository (%s); removing from state", d.Id())
 			return nil
 		}
-		return fmt.Errorf("error finding sagemaker code repository (%s): %w", d.Id(), err)
+		return fmt.Errorf("error reading SageMaker code repository (%s): %w", d.Id(), err)
 
 	}
 
@@ -125,7 +126,7 @@ func resourceAwsSagemakerCodeRepositoryUpdate(d *schema.ResourceData, meta inter
 	log.Printf("[DEBUG] sagemaker code repository update config: %#v", *input)
 	_, err := conn.UpdateCodeRepository(input)
 	if err != nil {
-		return fmt.Errorf("Error updating Sagemaker code repository: %w", err)
+		return fmt.Errorf("error updating SageMaker code repository: %w", err)
 	}
 
 	return resourceAwsSagemakerCodeRepositoryRead(d, meta)
@@ -142,7 +143,7 @@ func resourceAwsSagemakerCodeRepositoryDelete(d *schema.ResourceData, meta inter
 		if isAWSErr(err, "ValidationException", "Cannot find CodeRepository") {
 			return nil
 		}
-		return fmt.Errorf("error trying to delete sagemaker code repository (%s): %w", d.Id(), err)
+		return fmt.Errorf("error deleting SageMaker code repository (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -89,7 +89,7 @@ func resourceAwsSagemakerCodeRepositoryRead(d *schema.ResourceData, meta interfa
 		CodeRepositoryName: aws.String(d.Id()),
 	}
 
-	codeRepository, err := conn.DescribeCodeRepository(describeNotebookInput)
+	codeRepository, err := conn.DescribeCodeRepository(input)
 	if err != nil {
 		if isAWSErr(err, "ValidationException", "Cannot find CodeRepository") {
 			d.SetId("")
@@ -100,10 +100,10 @@ func resourceAwsSagemakerCodeRepositoryRead(d *schema.ResourceData, meta interfa
 
 	}
 
-	d.Set("code_repository_name", CodeRepository.CodeRepositoryName)
-	d.Set("arn", CodeRepository.CodeRepositoryArn)
+	d.Set("code_repository_name", codeRepository.CodeRepositoryName)
+	d.Set("arn", codeRepository.CodeRepositoryArn)
 
-	if err := d.Set("git_config", flattenSagemakerCodeRepositoryGitConfig(CodeRepository.GitConfig)); err != nil {
+	if err := d.Set("git_config", flattenSagemakerCodeRepositoryGitConfig(codeRepository.GitConfig)); err != nil {
 		return fmt.Errorf("error setting git_config for sagemaker code repository (%s): %w", d.Id(), err)
 	}
 

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sageamker/finder"
 )
 
 func resourceAwsSagemakerCodeRepository() *schema.Resource {
@@ -89,11 +90,7 @@ func resourceAwsSagemakerCodeRepositoryCreate(d *schema.ResourceData, meta inter
 func resourceAwsSagemakerCodeRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sagemakerconn
 
-	input := &sagemaker.DescribeCodeRepositoryInput{
-		CodeRepositoryName: aws.String(d.Id()),
-	}
-
-	codeRepository, err := conn.DescribeCodeRepository(input)
+	codeRepository, err := finder.FincCodeRepositoryByName(conn, d.Id())
 	if err != nil {
 		if isAWSErr(err, "ValidationException", "Cannot find CodeRepository") {
 			d.SetId("")

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -1,0 +1,205 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsSagemakerCodeRepository() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSagemakerCodeRepositoryCreate,
+		Read:   resourceAwsSagemakerCodeRepositoryRead,
+		Update: resourceAwsSagemakerCodeRepositoryUpdate,
+		Delete: resourceAwsSagemakerCodeRepositoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"code_repository_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 63),
+			},
+			"git_config": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"repository_url": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Required: true,
+						},
+						"branch": {
+							Type:         schema.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 1024),
+						},
+						"secret_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateArn,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsSagemakerCodeRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	name := d.Get("code_repository_name").(string)
+
+	createOpts := &sagemaker.CreateCodeRepositoryInput{
+		CodeRepositoryName: aws.String(name),
+		GitConfig:          expandSagemakerCodeRepositoryGitConfig(d.Get("git_config").([]interface{})),
+	}
+
+	log.Printf("[DEBUG] sagemaker code repository create config: %#v", *createOpts)
+	_, err := conn.CreateCodeRepository(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating Sagemaker code repository: %w", err)
+	}
+
+	d.SetId(name)
+
+	return resourceAwsSagemakerCodeRepositoryRead(d, meta)
+}
+
+func resourceAwsSagemakerCodeRepositoryRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	describeNotebookInput := &sagemaker.DescribeCodeRepositoryInput{
+		CodeRepositoryName: aws.String(d.Id()),
+	}
+	CodeRepository, err := conn.DescribeCodeRepository(describeNotebookInput)
+	if err != nil {
+		if isAWSErr(err, "ValidationException", "Cannot find CodeRepository") {
+			d.SetId("")
+			log.Printf("[WARN] Unable to find SageMaker code repository (%s); removing from state", d.Id())
+			return nil
+		}
+		return fmt.Errorf("error finding sagemaker code repository (%s): %w", d.Id(), err)
+
+	}
+
+	if err := d.Set("code_repository_name", CodeRepository.CodeRepositoryName); err != nil {
+		return fmt.Errorf("error setting code_repository_name for sagemaker code repository (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("arn", CodeRepository.CodeRepositoryArn); err != nil {
+		return fmt.Errorf("error setting arn for sagemaker code repository (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("git_config", flattenSagemakerCodeRepositoryGitConfig(CodeRepository.GitConfig)); err != nil {
+		return fmt.Errorf("error setting git_config for sagemaker code repository (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsSagemakerCodeRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.UpdateCodeRepositoryInput{
+		CodeRepositoryName: aws.String(d.Id()),
+		GitConfig:          expandSagemakerCodeRepositoryUpdateGitConfig(d.Get("git_config").([]interface{})),
+	}
+
+	log.Printf("[DEBUG] sagemaker code repository update config: %#v", *input)
+	_, err := conn.UpdateCodeRepository(input)
+	if err != nil {
+		return fmt.Errorf("Error updating Sagemaker code repository: %w", err)
+	}
+
+	return resourceAwsSagemakerCodeRepositoryRead(d, meta)
+}
+
+func resourceAwsSagemakerCodeRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sagemakerconn
+
+	input := &sagemaker.DeleteCodeRepositoryInput{
+		CodeRepositoryName: aws.String(d.Id()),
+	}
+
+	if _, err := conn.DeleteCodeRepository(input); err != nil {
+		if isAWSErr(err, "ValidationException", "Cannot find CodeRepository") {
+			return nil
+		}
+		return fmt.Errorf("error trying to delete sagemaker code repository (%s): %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandSagemakerCodeRepositoryGitConfig(l []interface{}) *sagemaker.GitConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.GitConfig{
+		RepositoryUrl: aws.String(m["repository_url"].(string)),
+	}
+
+	if v, ok := m["branch"].(string); ok && v != "" {
+		config.Branch = aws.String(v)
+	}
+
+	if v, ok := m["secret_arn"].(string); ok && v != "" {
+		config.SecretArn = aws.String(v)
+	}
+
+	return config
+}
+
+func flattenSagemakerCodeRepositoryGitConfig(config *sagemaker.GitConfig) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"repository_url": aws.StringValue(config.RepositoryUrl),
+	}
+
+	if config.Branch != nil {
+		m["branch"] = aws.StringValue(config.Branch)
+	}
+
+	if config.SecretArn != nil {
+		m["secret_arn"] = aws.StringValue(config.SecretArn)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandSagemakerCodeRepositoryUpdateGitConfig(l []interface{}) *sagemaker.GitConfigForUpdate {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.GitConfigForUpdate{
+		SecretArn: aws.String(m["secret_arn"].(string)),
+	}
+
+	return config
+}

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
@@ -27,10 +28,13 @@ func resourceAwsSagemakerCodeRepository() *schema.Resource {
 			},
 
 			"code_repository_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 63),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])*$`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
+				),
 			},
 			"git_config": {
 				Type:     schema.TypeList,

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -71,13 +71,13 @@ func resourceAwsSagemakerCodeRepositoryCreate(d *schema.ResourceData, meta inter
 
 	name := d.Get("code_repository_name").(string)
 
-	createOpts := &sagemaker.CreateCodeRepositoryInput{
+	input := &sagemaker.CreateCodeRepositoryInput{
 		CodeRepositoryName: aws.String(name),
 		GitConfig:          expandSagemakerCodeRepositoryGitConfig(d.Get("git_config").([]interface{})),
 	}
 
-	log.Printf("[DEBUG] sagemaker code repository create config: %#v", *createOpts)
-	_, err := conn.CreateCodeRepository(createOpts)
+	log.Printf("[DEBUG] sagemaker code repository create config: %#v", *input)
+	_, err := conn.CreateCodeRepository(input)
 	if err != nil {
 		return fmt.Errorf("error creating SageMaker code repository: %w", err)
 	}

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sageamker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
 func resourceAwsSagemakerCodeRepository() *schema.Resource {

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -90,7 +90,7 @@ func resourceAwsSagemakerCodeRepositoryCreate(d *schema.ResourceData, meta inter
 func resourceAwsSagemakerCodeRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).sagemakerconn
 
-	codeRepository, err := finder.FincCodeRepositoryByName(conn, d.Id())
+	codeRepository, err := finder.CodeRepositoryByName(conn, d.Id())
 	if err != nil {
 		if isAWSErr(err, "ValidationException", "Cannot find CodeRepository") {
 			d.SetId("")

--- a/aws/resource_aws_sagemaker_code_repository.go
+++ b/aws/resource_aws_sagemaker_code_repository.go
@@ -100,13 +100,8 @@ func resourceAwsSagemakerCodeRepositoryRead(d *schema.ResourceData, meta interfa
 
 	}
 
-	if err := d.Set("code_repository_name", CodeRepository.CodeRepositoryName); err != nil {
-		return fmt.Errorf("error setting code_repository_name for sagemaker code repository (%s): %w", d.Id(), err)
-	}
-
-	if err := d.Set("arn", CodeRepository.CodeRepositoryArn); err != nil {
-		return fmt.Errorf("error setting arn for sagemaker code repository (%s): %w", d.Id(), err)
-	}
+	d.Set("code_repository_name", CodeRepository.CodeRepositoryName)
+	d.Set("arn", CodeRepository.CodeRepositoryArn)
 
 	if err := d.Set("git_config", flattenSagemakerCodeRepositoryGitConfig(CodeRepository.GitConfig)); err != nil {
 		return fmt.Errorf("error setting git_config for sagemaker code repository (%s): %w", d.Id(), err)

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -258,7 +258,7 @@ resource "aws_secretsmanager_secret_version" "test" {
   secret_id     = aws_secretsmanager_secret.test.id
   secret_string = jsonencode({ username = "example", passowrd = "example" })
 }
-	
+
 resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
 
@@ -282,7 +282,7 @@ resource "aws_secretsmanager_secret_version" "test2" {
   secret_id     = aws_secretsmanager_secret.test2.id
   secret_string = jsonencode({ username = "example", passowrd = "example" })
 }
-	
+
 resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
 

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -256,7 +256,7 @@ resource "aws_secretsmanager_secret" "test" {
 
 resource "aws_secretsmanager_secret_version" "test" {
   secret_id     = aws_secretsmanager_secret.test.id
-  secret_string = jsonencode({username = "test", passowrd = "test"})
+  secret_string = jsonencode({ username = "example", passowrd = "example" })
 }
 	
 resource "aws_sagemaker_code_repository" "test" {
@@ -280,7 +280,7 @@ resource "aws_secretsmanager_secret" "test2" {
 
 resource "aws_secretsmanager_secret_version" "test2" {
   secret_id     = aws_secretsmanager_secret.test2.id
-  secret_string = jsonencode({username = "test", passowrd = "test"})
+  secret_string = jsonencode({ username = "example", passowrd = "example" })
 }
 	
 resource "aws_sagemaker_code_repository" "test" {

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sageamker/finder"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sagemaker/finder"
 )
 
 func init() {

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -1,0 +1,170 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_sagemaker_code_repository", &resource.Sweeper{
+		Name: "aws_sagemaker_code_repository",
+		F:    testSweepSagemakerCodeRepositories,
+	})
+}
+
+func testSweepSagemakerCodeRepositories(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).sagemakerconn
+
+	err = conn.ListCodeRepositoriesPages(&sagemaker.ListCodeRepositoriesInput{}, func(page *sagemaker.ListCodeRepositoriesOutput, lastPage bool) bool {
+		for _, instance := range page.CodeRepositorySummaryList {
+			name := aws.StringValue(instance.CodeRepositoryName)
+
+			input := &sagemaker.DeleteCodeRepositoryInput{
+				CodeRepositoryName: instance.CodeRepositoryName,
+			}
+
+			log.Printf("[INFO] Deleting SageMaker Code Repository: %s", name)
+			if _, err := conn.DeleteCodeRepository(input); err != nil {
+				log.Printf("[ERROR] Error deleting SageMaker Code Repository (%s): %s", name, err)
+				continue
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping SageMaker Code Repository sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving SageMaker Code Repositorys: %w", err)
+	}
+
+	return nil
+}
+
+func TestAccAWSSagemakerCodeRepository_basic(t *testing.T) {
+	var notebook sagemaker.DescribeCodeRepositoryOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_code_repository.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerCodeRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerCodeRepositoryBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerCodeRepositoryExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "code_repository_name", rName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("code-repository/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "git_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "git_config.0.repository_url", "https://github.com/terraform-providers/terraform-provider-aws.git"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSagemakerCodeRepository_disappears(t *testing.T) {
+	var notebook sagemaker.DescribeCodeRepositoryOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_sagemaker_code_repository.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerCodeRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerCodeRepositoryBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerCodeRepositoryExists(resourceName, &notebook),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsSagemakerCodeRepository(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSagemakerCodeRepositoryDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_code_repository" {
+			continue
+		}
+
+		describeNotebookInput := &sagemaker.DescribeCodeRepositoryInput{
+			CodeRepositoryName: aws.String(rs.Primary.ID),
+		}
+		CodeRepository, err := conn.DescribeCodeRepository(describeNotebookInput)
+		if err != nil {
+			return nil
+		}
+
+		if aws.StringValue(CodeRepository.CodeRepositoryName) == rs.Primary.ID {
+			return fmt.Errorf("sagemaker Code Repository %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSSagemakerCodeRepositoryExists(n string, notebook *sagemaker.DescribeCodeRepositoryOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No sagmaker Code Repository ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
+		opts := &sagemaker.DescribeCodeRepositoryInput{
+			CodeRepositoryName: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.DescribeCodeRepository(opts)
+		if err != nil {
+			return err
+		}
+
+		*notebook = *resp
+
+		return nil
+	}
+}
+
+func testAccAWSSagemakerCodeRepositoryBasicConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sagemaker_code_repository" "test" {
+  code_repository_name = %[1]q
+
+  git_config {
+    repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+  }
+}
+`, rName)
+}

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -246,8 +246,8 @@ resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
 
   git_config {
-	repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
-	branch         = "master"
+    repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+    branch         = "master"
   }
 }
 `, rName)
@@ -268,8 +268,8 @@ resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
 
   git_config {
-	repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
-	secret_arn     = aws_secretsmanager_secret.test.arn
+    repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+    secret_arn     = aws_secretsmanager_secret.test.arn
   }
 
   depends_on = [aws_secretsmanager_secret_version.test]
@@ -292,8 +292,8 @@ resource "aws_sagemaker_code_repository" "test" {
   code_repository_name = %[1]q
 
   git_config {
-	repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
-	secret_arn     = aws_secretsmanager_secret.test2.arn
+    repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+    secret_arn     = aws_secretsmanager_secret.test2.arn
   }
 
   depends_on = [aws_secretsmanager_secret_version.test2]

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -187,7 +187,7 @@ func testAccCheckAWSSagemakerCodeRepositoryDestroy(s *terraform.State) error {
 			continue
 		}
 
-		codeRepository, err := finder.FincCodeRepositoryByName(conn, rs.Primary.ID)
+		codeRepository, err := finder.CodeRepositoryByName(conn, rs.Primary.ID)
 		if err != nil {
 			return nil
 		}
@@ -212,7 +212,7 @@ func testAccCheckAWSSagemakerCodeRepositoryExists(n string, codeRepo *sagemaker.
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
-		resp, err := finder.FincCodeRepositoryByName(conn, rs.Primary.ID)
+		resp, err := finder.CodeRepositoryByName(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -200,7 +200,7 @@ func testAccCheckAWSSagemakerCodeRepositoryDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSSagemakerCodeRepositoryExists(n string, notebook *sagemaker.DescribeCodeRepositoryOutput) resource.TestCheckFunc {
+func testAccCheckAWSSagemakerCodeRepositoryExists(n string, codeRepo *sagemaker.DescribeCodeRepositoryOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -212,12 +212,12 @@ func testAccCheckAWSSagemakerCodeRepositoryExists(n string, notebook *sagemaker.
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
-		codeRepository, err := finder.FincCodeRepositoryByName(conn, rs.Primary.ID)
+		resp, err := finder.FincCodeRepositoryByName(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		*codeRepository = *resp
+		*codeRepo = *resp
 
 		return nil
 	}

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -141,6 +141,17 @@ func TestAccAWSSagemakerCodeRepository_gitConfig_secret(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAWSSagemakerCodeRepositoryGitConfigSecretUpdatedConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerCodeRepositoryExists(resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "code_repository_name", rName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "sagemaker", fmt.Sprintf("code-repository/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "git_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "git_config.0.repository_url", "https://github.com/terraform-providers/terraform-provider-aws.git"),
+					resource.TestCheckResourceAttrPair(resourceName, "git_config.0.secret_arn", "aws_secretsmanager_secret.test2", "arn"),
+				),
+			},
 		},
 	})
 }
@@ -245,7 +256,7 @@ resource "aws_sagemaker_code_repository" "test" {
 func testAccAWSSagemakerCodeRepositoryGitConfigSecretConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
-  name = "%[1]s"
+  name = %[1]q
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
@@ -262,6 +273,30 @@ resource "aws_sagemaker_code_repository" "test" {
   }
 
   depends_on = [aws_secretsmanager_secret_version.test]
+}
+`, rName)
+}
+
+func testAccAWSSagemakerCodeRepositoryGitConfigSecretUpdatedConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test2" {
+  name = "%[1]s-2"
+}
+
+resource "aws_secretsmanager_secret_version" "test2" {
+  secret_id     = aws_secretsmanager_secret.test2.id
+  secret_string = jsonencode({username = "test", passowrd = "test"})
+}
+	
+resource "aws_sagemaker_code_repository" "test" {
+  code_repository_name = %[1]q
+
+  git_config {
+	repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+	secret_arn     = aws_secretsmanager_secret.test2.arn
+  }
+
+  depends_on = [aws_secretsmanager_secret_version.test2]
 }
 `, rName)
 }

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -187,7 +187,7 @@ func testAccCheckAWSSagemakerCodeRepositoryDestroy(s *terraform.State) error {
 			continue
 		}
 
-		codeRepository, err := finder.FincCodeRepositoryByName(conn, d.Id())
+		codeRepository, err := finder.FincCodeRepositoryByName(conn, rs.Primary.ID)
 		if err != nil {
 			return nil
 		}
@@ -212,7 +212,7 @@ func testAccCheckAWSSagemakerCodeRepositoryExists(n string, notebook *sagemaker.
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
-		codeRepository, err := finder.FincCodeRepositoryByName(conn, d.Id())
+		codeRepository, err := finder.FincCodeRepositoryByName(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_sagemaker_code_repository_test.go
+++ b/aws/resource_aws_sagemaker_code_repository_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/service/sageamker/finder"
 )
 
 func init() {
@@ -186,15 +187,12 @@ func testAccCheckAWSSagemakerCodeRepositoryDestroy(s *terraform.State) error {
 			continue
 		}
 
-		describeNotebookInput := &sagemaker.DescribeCodeRepositoryInput{
-			CodeRepositoryName: aws.String(rs.Primary.ID),
-		}
-		CodeRepository, err := conn.DescribeCodeRepository(describeNotebookInput)
+		codeRepository, err := finder.FincCodeRepositoryByName(conn, d.Id())
 		if err != nil {
 			return nil
 		}
 
-		if aws.StringValue(CodeRepository.CodeRepositoryName) == rs.Primary.ID {
+		if aws.StringValue(codeRepository.CodeRepositoryName) == rs.Primary.ID {
 			return fmt.Errorf("sagemaker Code Repository %q still exists", rs.Primary.ID)
 		}
 	}
@@ -214,15 +212,12 @@ func testAccCheckAWSSagemakerCodeRepositoryExists(n string, notebook *sagemaker.
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
-		opts := &sagemaker.DescribeCodeRepositoryInput{
-			CodeRepositoryName: aws.String(rs.Primary.ID),
-		}
-		resp, err := conn.DescribeCodeRepository(opts)
+		codeRepository, err := finder.FincCodeRepositoryByName(conn, d.Id())
 		if err != nil {
 			return err
 		}
 
-		*notebook = *resp
+		*codeRepository = *resp
 
 		return nil
 	}

--- a/website/docs/r/sagemaker_code_repository.htm.markdown
+++ b/website/docs/r/sagemaker_code_repository.htm.markdown
@@ -19,7 +19,7 @@ resource "aws_sagemaker_code_repository" "example" {
   code_repository_name = "example"
 
   git_config {
-	repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+    repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
   }
 }
 ```
@@ -40,8 +40,8 @@ resource "aws_sagemaker_code_repository" "example" {
   code_repository_name = "example"
 
   git_config {
-	repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
-	secret_arn     = aws_secretsmanager_secret.example.arn
+    repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+    secret_arn     = aws_secretsmanager_secret.example.arn
   }
 
   depends_on = [aws_secretsmanager_secret_version.example]

--- a/website/docs/r/sagemaker_code_repository.htm.markdown
+++ b/website/docs/r/sagemaker_code_repository.htm.markdown
@@ -33,7 +33,7 @@ resource "aws_secretsmanager_secret" "example" {
 
 resource "aws_secretsmanager_secret_version" "example" {
   secret_id     = aws_secretsmanager_secret.example.id
-  secret_string = jsonencode({username = "example", passowrd = "example"})
+  secret_string = jsonencode({ username = "example", passowrd = "example" })
 }
 
 resource "aws_sagemaker_code_repository" "example" {

--- a/website/docs/r/sagemaker_code_repository.htm.markdown
+++ b/website/docs/r/sagemaker_code_repository.htm.markdown
@@ -12,11 +12,39 @@ Provides a Sagemaker Code Repository resource.
 
 ## Example Usage
 
-Basic usage:
+### Basic usage:
 
 ```hcl
-resource "aws_sagemaker_code_repository" "ni" {
+resource "aws_sagemaker_code_repository" "example" {
+  code_repository_name = "example"
 
+  git_config {
+	repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+  }
+}
+```
+
+### Example with Secret:
+
+```hcl
+resource "aws_secretsmanager_secret" "example" {
+  name = "example"
+}
+
+resource "aws_secretsmanager_secret_version" "example" {
+  secret_id     = aws_secretsmanager_secret.example.id
+  secret_string = jsonencode({username = "example", passowrd = "example"})
+}
+	
+resource "aws_sagemaker_code_repository" "example" {
+  code_repository_name = "example"
+
+  git_config {
+	repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+	secret_arn     = aws_secretsmanager_secret.example.arn
+  }
+
+  depends_on = [aws_secretsmanager_secret_version.example]
 }
 ```
 

--- a/website/docs/r/sagemaker_code_repository.htm.markdown
+++ b/website/docs/r/sagemaker_code_repository.htm.markdown
@@ -12,7 +12,7 @@ Provides a Sagemaker Code Repository resource.
 
 ## Example Usage
 
-### Basic usage:
+### Basic usage
 
 ```hcl
 resource "aws_sagemaker_code_repository" "example" {
@@ -24,7 +24,7 @@ resource "aws_sagemaker_code_repository" "example" {
 }
 ```
 
-### Example with Secret:
+### Example with Secret
 
 ```hcl
 resource "aws_secretsmanager_secret" "example" {
@@ -35,7 +35,7 @@ resource "aws_secretsmanager_secret_version" "example" {
   secret_id     = aws_secretsmanager_secret.example.id
   secret_string = jsonencode({username = "example", passowrd = "example"})
 }
-	
+
 resource "aws_sagemaker_code_repository" "example" {
   code_repository_name = "example"
 
@@ -56,10 +56,10 @@ The following arguments are supported:
 * `git_config` - (Required) Specifies details about the repository. see [Git Config](#git-config) details below.
 
 ### Git Config
- 
- * `repository_url` - (Required) The URL where the Git repository is located.
- * `branch` - (Optional) The default branch for the Git repository.
- * `secret_arn` - (Optional) The Amazon Resource Name (ARN) of the AWS Secrets Manager secret that contains the credentials used to access the git repository. The secret must have a staging label of AWSCURRENT and must be in the following format: `{"username": UserName, "password": Password}`
+
+* `repository_url` - (Required) The URL where the Git repository is located.
+* `branch` - (Optional) The default branch for the Git repository.
+* `secret_arn` - (Optional) The Amazon Resource Name (ARN) of the AWS Secrets Manager secret that contains the credentials used to access the git repository. The secret must have a staging label of AWSCURRENT and must be in the following format: `{"username": UserName, "password": Password}`
 
 ## Attributes Reference
 

--- a/website/docs/r/sagemaker_code_repository.htm.markdown
+++ b/website/docs/r/sagemaker_code_repository.htm.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "Sagemaker"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_code_repository"
+description: |-
+  Provides a Sagemaker Code Repository resource.
+---
+
+# Resource: aws_sagemaker_code_repository
+
+Provides a Sagemaker Code Repository resource.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "aws_sagemaker_code_repository" "ni" {
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `code_repository_name` - (Required) The name of the Code Repository (must be unique).
+* `git_config` - (Required) Specifies details about the repository. see [Git Config](#git-config) details below.
+
+### Git Config
+ 
+ * `repository_url` - (Required) The URL where the Git repository is located.
+ * `branch` - (Optional) The default branch for the Git repository.
+ * `secret_arn` - (Optional) The Amazon Resource Name (ARN) of the AWS Secrets Manager secret that contains the credentials used to access the git repository. The secret must have a staging label of AWSCURRENT and must be in the following format: `{"username": UserName, "password": Password}`
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The name of the Code Repository.
+* `arn` - The Amazon Resource Name (ARN) assigned by AWS to this Code Repository.
+
+## Import
+
+Sagemaker Code Repositories can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_sagemaker_code_repository.test_code_repository my-code-repo
+```

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -12,13 +12,36 @@ Provides a Sagemaker Notebook Instance resource.
 
 ## Example Usage
 
-Basic usage:
+### Basic usage
 
 ```hcl
 resource "aws_sagemaker_notebook_instance" "ni" {
   name          = "my-notebook-instance"
   role_arn      = aws_iam_role.role.arn
   instance_type = "ml.t2.medium"
+
+  tags = {
+    Name = "foo"
+  }
+}
+```
+
+### Code repository usage
+
+```hcl
+resource "aws_sagemaker_code_repository" "example" {
+  code_repository_name = "my-notebook-instance-code-repo"
+
+  git_config {
+    repository_url = "https://github.com/terraform-providers/terraform-provider-aws.git"
+  }
+}
+
+resource "aws_sagemaker_notebook_instance" "ni" {
+  name                    = "my-notebook-instance"
+  role_arn                = aws_iam_role.role.arn
+  instance_type           = "ml.t2.medium"
+  default_code_repository = aws_sagemaker_code_repository.example.code_repository_name
 
   tags = {
     Name = "foo"
@@ -40,9 +63,9 @@ The following arguments are supported:
 * `lifecycle_config_name` - (Optional) The name of a lifecycle configuration to associate with the notebook instance.
 * `root_access` - (Optional) Whether root access is `Enabled` or `Disabled` for users of the notebook instance. The default value is `Enabled`.
 * `direct_internet_access` - (Optional) Set to `Disabled` to disable internet access to notebook. Requires `security_groups` and `subnet_id` to be set. Supported values: `Enabled` (Default) or `Disabled`. If set to `Disabled`, the notebook instance will be able to access resources only in your VPC, and will not be able to connect to Amazon SageMaker training and endpoint services unless your configure a NAT Gateway in your VPC.
-* `default_code_repository` - (Optional) The Git repository associated with the notebook instance as its default code repository
 * `additional_code_repositories` - (Optional) An array of up to three Git repositories to associate with the notebook instance.
  These can be either the names of Git repositories stored as resources in your account, or the URL of Git repositories in [AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html) or in any other Git repository. These repositories are cloned at the same level as the default repository of your notebook instance.
+* `default_code_repository` - (Optional) The Git repository associated with the notebook instance as its default code repository. This can be either the name of a Git repository stored as a resource in your account, or the URL of a Git repository in [AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html) or in any other Git repository.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #13817

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_code_repository - new resource
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccAWSSagemakerCodeRepository_'
--- PASS: TestAccAWSSagemakerCodeRepository_disappears (26.45s)
--- PASS: TestAccAWSSagemakerCodeRepository_gitConfig_branch (35.76s)
--- PASS: TestAccAWSSagemakerCodeRepository_basic (36.04s)
--- PASS: TestAccAWSSagemakerCodeRepository_gitConfig_secret (84.66s)
```


`--- PASS: TestAccAWSSagemakerNotebookInstance_default_code_repository_sagemakerRepo (1165.81s)`

