### PR TITLE
tests/provider: Add prechecks (OpsWorks)

### DIFF
--- a/aws/resource_aws_opsworks_application_test.go
+++ b/aws/resource_aws_opsworks_application_test.go
@@ -20,7 +20,7 @@ func TestAccAWSOpsworksApplication_basic(t *testing.T) {
 	resourceName := "aws_opsworks_application.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksApplicationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/aws/resource_aws_opsworks_custom_layer_test.go
@@ -22,7 +22,7 @@ func TestAccAWSOpsworksCustomLayer_basic(t *testing.T) {
 	resourceName := "aws_opsworks_custom_layer.tf-acc"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksCustomLayerDestroy,
 		Steps: []resource.TestStep{
@@ -64,7 +64,7 @@ func TestAccAWSOpsworksCustomLayer_tags(t *testing.T) {
 	resourceName := "aws_opsworks_custom_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksCustomLayerDestroy,
 		Steps: []resource.TestStep{
@@ -108,7 +108,7 @@ func TestAccAWSOpsworksCustomLayer_noVPC(t *testing.T) {
 	resourceName := "aws_opsworks_custom_layer.tf-acc"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksCustomLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_ganglia_layer_test.go
+++ b/aws/resource_aws_opsworks_ganglia_layer_test.go
@@ -15,7 +15,7 @@ func TestAccAWSOpsworksGangliaLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_ganglia_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksGangliaLayerDestroy,
 		Steps: []resource.TestStep{
@@ -35,7 +35,7 @@ func TestAccAWSOpsworksGangliaLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_ganglia_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksGangliaLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_haproxy_layer_test.go
+++ b/aws/resource_aws_opsworks_haproxy_layer_test.go
@@ -15,7 +15,7 @@ func TestAccAWSOpsworksHAProxyLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_haproxy_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksHAProxyLayerDestroy,
 		Steps: []resource.TestStep{
@@ -35,7 +35,7 @@ func TestAccAWSOpsworksHAProxyLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_haproxy_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksHAProxyLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_instance_test.go
+++ b/aws/resource_aws_opsworks_instance_test.go
@@ -18,7 +18,7 @@ func TestAccAWSOpsworksInstance_basic(t *testing.T) {
 	resourceName := "aws_opsworks_instance.tf-acc"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -67,7 +67,7 @@ func TestAccAWSOpsworksInstance_UpdateHostNameForceNew(t *testing.T) {
 	var before, after opsworks.Instance
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksInstanceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_java_app_layer_test.go
+++ b/aws/resource_aws_opsworks_java_app_layer_test.go
@@ -18,7 +18,7 @@ func TestAccAWSOpsworksJavaAppLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_java_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksJavaAppLayerDestroy,
 		Steps: []resource.TestStep{
@@ -37,7 +37,7 @@ func TestAccAWSOpsworksJavaAppLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_java_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksJavaAppLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_memcached_layer_test.go
+++ b/aws/resource_aws_opsworks_memcached_layer_test.go
@@ -18,7 +18,7 @@ func TestAccAWSOpsworksMemcachedLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_memcached_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksMemcachedLayerDestroy,
 		Steps: []resource.TestStep{
@@ -37,7 +37,7 @@ func TestAccAWSOpsworksMemcachedLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_memcached_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksMemcachedLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_mysql_layer_test.go
+++ b/aws/resource_aws_opsworks_mysql_layer_test.go
@@ -18,7 +18,7 @@ func TestAccAWSOpsworksMysqlLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_mysql_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksMysqlLayerDestroy,
 		Steps: []resource.TestStep{
@@ -37,7 +37,7 @@ func TestAccAWSOpsworksMysqlLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_mysql_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksMysqlLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_nodejs_app_layer_test.go
+++ b/aws/resource_aws_opsworks_nodejs_app_layer_test.go
@@ -18,7 +18,7 @@ func TestAccAWSOpsworksNodejsAppLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_nodejs_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksNodejsAppLayerDestroy,
 		Steps: []resource.TestStep{
@@ -37,7 +37,7 @@ func TestAccAWSOpsworksNodejsAppLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_nodejs_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksNodejsAppLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_permission_test.go
+++ b/aws/resource_aws_opsworks_permission_test.go
@@ -16,7 +16,7 @@ func TestAccAWSOpsworksPermission_basic(t *testing.T) {
 	sName := fmt.Sprintf("tf-ops-perm-%d", acctest.RandInt())
 	var opsperm opsworks.Permission
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksPermissionDestroy,
 		Steps: []resource.TestStep{
@@ -99,7 +99,7 @@ func TestAccAWSOpsworksPermission_Self(t *testing.T) {
 	resourceName := "aws_opsworks_permission.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil, // Cannot delete own OpsWorks Permission
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_php_app_layer_test.go
+++ b/aws/resource_aws_opsworks_php_app_layer_test.go
@@ -18,7 +18,7 @@ func TestAccAWSOpsworksPhpAppLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_php_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksPhpAppLayerDestroy,
 		Steps: []resource.TestStep{
@@ -42,7 +42,7 @@ func TestAccAWSOpsworksPhpAppLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_php_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksPhpAppLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_rails_app_layer_test.go
+++ b/aws/resource_aws_opsworks_rails_app_layer_test.go
@@ -18,7 +18,7 @@ func TestAccAWSOpsworksRailsAppLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_rails_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksRailsAppLayerDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccAWSOpsworksRailsAppLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_rails_app_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksRailsAppLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -16,7 +16,7 @@ func TestAccAWSOpsworksRdsDbInstance_basic(t *testing.T) {
 	sName := fmt.Sprintf("test-db-instance-%d", acctest.RandInt())
 	var opsdb opsworks.RdsDbInstance
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksRdsDbDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -23,7 +23,11 @@ func TestAccAWSOpsworksStack_noVpcBasic(t *testing.T) {
 	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOpsWorksStacks(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck("opsworks", t)
+			testAccPreCheckAWSOpsWorksStacks(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{
@@ -49,7 +53,11 @@ func TestAccAWSOpsworksStack_noVpcChangeServiceRoleForceNew(t *testing.T) {
 	var before, after opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOpsWorksStacks(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck("opsworks", t)
+			testAccPreCheckAWSOpsWorksStacks(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{
@@ -81,7 +89,11 @@ func TestAccAWSOpsworksStack_vpc(t *testing.T) {
 	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOpsWorksStacks(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck("opsworks", t)
+			testAccPreCheckAWSOpsWorksStacks(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{
@@ -125,7 +137,11 @@ func TestAccAWSOpsworksStack_noVpcCreateTags(t *testing.T) {
 	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOpsWorksStacks(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck("opsworks", t)
+			testAccPreCheckAWSOpsWorksStacks(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{
@@ -164,7 +180,11 @@ func TestAccAWSOpsworksStack_CustomCookbooks_SetPrivateProperties(t *testing.T) 
 	var opsstack opsworks.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSOpsWorksStacks(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPartitionHasServicePreCheck("opsworks", t)
+			testAccPreCheckAWSOpsWorksStacks(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_static_web_layer_test.go
+++ b/aws/resource_aws_opsworks_static_web_layer_test.go
@@ -18,7 +18,7 @@ func TestAccAWSOpsworksStaticWebLayer_basic(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_static_web_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStaticWebLayerDestroy,
 		Steps: []resource.TestStep{
@@ -42,7 +42,7 @@ func TestAccAWSOpsworksStaticWebLayer_tags(t *testing.T) {
 	stackName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_opsworks_static_web_layer.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStaticWebLayerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_opsworks_user_profile_test.go
+++ b/aws/resource_aws_opsworks_user_profile_test.go
@@ -16,7 +16,7 @@ func TestAccAWSOpsworksUserProfile_basic(t *testing.T) {
 	rName := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	updateRName := fmt.Sprintf("test-user-%d", acctest.RandInt())
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("opsworks", t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksUserProfileDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15812

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- SKIP: TestAccAWSOpsworksCustomLayer_noVPC (0.00s)
--- SKIP: TestAccAWSOpsworksCustomLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksApplication_basic (0.00s)
--- SKIP: TestAccAWSOpsworksCustomLayer_basic (0.00s)
--- SKIP: TestAccAWSOpsworksInstance_basic (0.00s)
--- SKIP: TestAccAWSOpsworksHAProxyLayer_basic (0.00s)
--- SKIP: TestAccAWSOpsworksHAProxyLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksGangliaLayer_basic (0.01s)
--- SKIP: TestAccAWSOpsworksInstance_UpdateHostNameForceNew (0.01s)
--- SKIP: TestAccAWSOpsworksGangliaLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksMysqlLayer_basic (0.00s)
--- SKIP: TestAccAWSOpsworksMemcachedLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksJavaAppLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksMemcachedLayer_basic (0.02s)
--- SKIP: TestAccAWSOpsworksJavaAppLayer_basic (0.00s)
--- SKIP: TestAccAWSOpsworksNodejsAppLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksStack_noVpcBasic (0.00s)
--- SKIP: TestAccAWSOpsworksPhpAppLayer_basic (0.00s)
--- SKIP: TestAccAWSOpsworksPhpAppLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksNodejsAppLayer_basic (0.00s)
--- SKIP: TestAccAWSOpsworksStack_CustomCookbooks_SetPrivateProperties (0.00s)
--- SKIP: TestAccAWSOpsworksMysqlLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksRailsAppLayer_basic (0.00s)
--- SKIP: TestAccAWSOpsworksStack_vpc (0.00s)
--- SKIP: TestAccAWSOpsworksPermission_basic (0.00s)
--- SKIP: TestAccAWSOpsworksStaticWebLayer_basic (0.00s)
--- SKIP: TestAccAWSOpsworksRailsAppLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksRdsDbInstance_basic (0.00s)
--- SKIP: TestAccAWSOpsworksPermission_Self (0.00s)
--- SKIP: TestAccAWSOpsworksStack_noVpcChangeServiceRoleForceNew (0.00s)
--- SKIP: TestAccAWSOpsworksStack_noVpcCreateTags (0.00s)
--- SKIP: TestAccAWSOpsWorksStack_classicEndpoints (0.00s)
--- SKIP: TestAccAWSOpsworksStaticWebLayer_tags (0.00s)
--- SKIP: TestAccAWSOpsworksUserProfile_basic (0.00s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSOpsworksGangliaLayer_basic (61.65s)
--- PASS: TestAccAWSOpsworksCustomLayer_basic (84.96s)
--- PASS: TestAccAWSOpsworksJavaAppLayer_basic (87.77s)
--- PASS: TestAccAWSOpsworksMemcachedLayer_basic (91.95s)
--- PASS: TestAccAWSOpsworksNodejsAppLayer_basic (92.22s)
--- PASS: TestAccAWSOpsworksHAProxyLayer_basic (97.04s)
--- PASS: TestAccAWSOpsworksMysqlLayer_basic (107.93s)
--- PASS: TestAccAWSOpsworksPermission_Self (138.65s)
--- PASS: TestAccAWSOpsworksCustomLayer_noVPC (145.04s)
--- PASS: TestAccAWSOpsworksPhpAppLayer_basic (98.62s)
--- PASS: TestAccAWSOpsworksApplication_basic (164.32s)
--- PASS: TestAccAWSOpsworksInstance_UpdateHostNameForceNew (173.93s)
--- PASS: TestAccAWSOpsworksJavaAppLayer_tags (181.38s)
--- PASS: TestAccAWSOpsworksInstance_basic (186.63s)
--- PASS: TestAccAWSOpsworksStack_noVpcBasic (94.38s)
--- PASS: TestAccAWSOpsworksGangliaLayer_tags (207.52s)
--- PASS: TestAccAWSOpsworksCustomLayer_tags (208.71s)
--- PASS: TestAccAWSOpsworksMemcachedLayer_tags (215.00s)
--- PASS: TestAccAWSOpsworksNodejsAppLayer_tags (216.65s)
--- PASS: TestAccAWSOpsworksHAProxyLayer_tags (221.56s)
--- PASS: TestAccAWSOpsworksMysqlLayer_tags (222.59s)
--- PASS: TestAccAWSOpsworksRailsAppLayer_basic (135.79s)
--- PASS: TestAccAWSOpsworksPermission_basic (230.62s)
--- PASS: TestAccAWSOpsworksStack_CustomCookbooks_SetPrivateProperties (73.39s)
--- PASS: TestAccAWSOpsworksStaticWebLayer_basic (68.76s)
--- PASS: TestAccAWSOpsworksStack_noVpcChangeServiceRoleForceNew (144.30s)
--- PASS: TestAccAWSOpsworksPhpAppLayer_tags (169.77s)
--- PASS: TestAccAWSOpsworksStack_noVpcCreateTags (110.34s)
--- PASS: TestAccAWSOpsworksUserProfile_basic (69.03s)
--- PASS: TestAccAWSOpsworksStack_vpc (117.27s)
--- PASS: TestAccAWSOpsworksRailsAppLayer_tags (164.34s)
--- PASS: TestAccAWSOpsWorksStack_classicEndpoints (93.87s)
--- PASS: TestAccAWSOpsworksStaticWebLayer_tags (99.11s)
--- PASS: TestAccAWSOpsworksRdsDbInstance_basic (745.09s)
```