### PR TITLE
r/sagemaker_notebook_instance - support additional repos

### DIFF
--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -55,6 +55,11 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(sagemaker.InstanceType_Values(), false),
 			},
+			"additional_code_repositories": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 
 			"volume_size": {
 				Type:     schema.TypeInt,
@@ -165,6 +170,10 @@ func resourceAwsSagemakerNotebookInstanceCreate(d *schema.ResourceData, meta int
 		createOpts.Tags = keyvaluetags.New(v.(map[string]interface{})).IgnoreAws().SagemakerTags()
 	}
 
+	if v, ok := d.GetOk("additional_code_repositories"); ok && v.(*schema.Set).Len() > 0 {
+		createOpts.AdditionalCodeRepositories = expandStringSet(v.(*schema.Set))
+	}
+
 	log.Printf("[DEBUG] sagemaker notebook instance create config: %#v", *createOpts)
 	_, err := conn.CreateNotebookInstance(createOpts)
 	if err != nil {
@@ -251,6 +260,10 @@ func resourceAwsSagemakerNotebookInstanceRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("error setting network_interface_id for sagemaker notebook instance (%s): %w", d.Id(), err)
 	}
 
+	if err := d.Set("additional_code_repositories", flattenStringSet(notebookInstance.AdditionalCodeRepositories)); err != nil {
+		return fmt.Errorf("error setting additional_code_repositories for sagemaker notebook instance (%s): %s", d.Id(), err)
+	}
+
 	tags, err := keyvaluetags.SagemakerListTags(conn, aws.StringValue(notebookInstance.NotebookInstanceArn))
 
 	if err != nil {
@@ -316,6 +329,15 @@ func resourceAwsSagemakerNotebookInstanceUpdate(d *schema.ResourceData, meta int
 
 	if d.HasChange("root_access") {
 		updateOpts.RootAccess = aws.String(d.Get("root_access").(string))
+		hasChanged = true
+	}
+
+	if d.HasChange("additional_code_repositories") {
+		if v, ok := d.GetOk("additional_code_repositories"); ok {
+			updateOpts.AdditionalCodeRepositories = expandStringSet(v.(*schema.Set))
+		} else {
+			updateOpts.DisassociateAdditionalCodeRepositories = aws.Bool(true)
+		}
 		hasChanged = true
 	}
 

--- a/aws/resource_aws_sagemaker_notebook_instance.go
+++ b/aws/resource_aws_sagemaker_notebook_instance.go
@@ -58,6 +58,7 @@ func resourceAwsSagemakerNotebookInstance() *schema.Resource {
 			"additional_code_repositories": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				MaxItems: 3,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -41,6 +41,8 @@ The following arguments are supported:
 * `root_access` - (Optional) Whether root access is `Enabled` or `Disabled` for users of the notebook instance. The default value is `Enabled`.
 * `direct_internet_access` - (Optional) Set to `Disabled` to disable internet access to notebook. Requires `security_groups` and `subnet_id` to be set. Supported values: `Enabled` (Default) or `Disabled`. If set to `Disabled`, the notebook instance will be able to access resources only in your VPC, and will not be able to connect to Amazon SageMaker training and endpoint services unless your configure a NAT Gateway in your VPC.
 * `default_code_repository` - (Optional) The Git repository associated with the notebook instance as its default code repository
+* `additional_code_repositories` - (Optional) An array of up to three Git repositories to associate with the notebook instance.
+ These can be either the names of Git repositories stored as resources in your account, or the URL of Git repositories in [AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html) or in any other Git repository. These repositories are cloned at the same level as the default repository of your notebook instance.
 * `tags` - (Optional) A map of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_aws_sagemaker_notebook_instance - add support for `additional_code_repositories`
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccAWSSagemakerNotebookInstance_additional_code_repositories (1523.50s)
--- PASS: TestAccAWSSagemakerNotebookInstance_basic (429.08s)
```
