### PR TITLE
.github/issues: update to using github-script action for triage labeling

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,4 +1,6 @@
-on: issues
+on:
+  issues:
+    types: [opened]
 name: Issue triage
 jobs:
   markIssuesForTriage:
@@ -6,9 +8,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1.0.0
     - name: Apply Issue Triage Label
-      uses: actions/github@v1.0.0
+      uses: actions/github-script@v3
       if: github.event.action == 'opened' && !contains(fromJSON('["anGie44", "bflad", "breathingdust", "DrFaust92", "ewbankkit", "gdavison", "maryelizbeth", "YakDriver"]'), github.actor)
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        args: label needs-triage
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['needs-triage']
+          })


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Notes:
* Current GH-Action for triage labeling errors with:
```
npm ERR! The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json 
with lockfileVersion >= 1. Run an install with npm@5 or later to generate a package-lock.json file, then try again.
```


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
N/A
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
N/A will be verified by github-actions bot triage labeling
```

Reference: 
* https://github.com/actions/github-script
