### PR TITLE
docs/providers: Fix resource types in titles and import sections

### DIFF
--- a/website/docs/r/appmesh_route.html.markdown
+++ b/website/docs/r/appmesh_route.html.markdown
@@ -301,7 +301,7 @@ App Mesh virtual routes can be imported using `mesh_name` and `virtual_router_na
 e.g.
 
 ```
-$ terraform import aws_appmesh_virtual_route.serviceb simpleapp/serviceB/serviceB-route
+$ terraform import aws_appmesh_route.serviceb simpleapp/serviceB/serviceB-route
 ```
 
 [1]: /docs/providers/aws/index.html

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -114,5 +114,5 @@ In addition to all arguments above, the following attributes are exported:
 CloudFormation StackSets can be imported using the `name`, e.g.
 
 ```
-$ terraform import aws_cloudformation_stack.example example
+$ terraform import aws_cloudformation_stack_set.example example
 ```

--- a/website/docs/r/codedeploy_deployment_config.html.markdown
+++ b/website/docs/r/codedeploy_deployment_config.html.markdown
@@ -134,5 +134,5 @@ In addition to all arguments above, the following attributes are exported:
 CodeDeploy Deployment Configurations can be imported using the `deployment_config_name`, e.g.
 
 ```
-$ terraform import aws_codedeploy_app.example my-deployment-config
+$ terraform import aws_codedeploy_deployment_config.example my-deployment-config
 ```

--- a/website/docs/r/config_aggregate_authorization.markdown
+++ b/website/docs/r/config_aggregate_authorization.markdown
@@ -38,5 +38,5 @@ In addition to all arguments above, the following attributes are exported:
 Config aggregate authorizations can be imported using `account_id:region`, e.g.
 
 ```
-$ terraform import aws_config_authorization.example 123456789012:us-east-1
+$ terraform import aws_config_aggregate_authorization.example 123456789012:us-east-1
 ```

--- a/website/docs/r/ec2_client_vpn_network_association.html.markdown
+++ b/website/docs/r/ec2_client_vpn_network_association.html.markdown
@@ -55,5 +55,5 @@ In addition to all arguments above, the following attributes are exported:
 AWS Client VPN network associations can be imported using the endpoint ID and the association ID. Values are separated by a `,`.
 
 ```
-$ terraform import aws_ec2_client_vpn_authorization_rule.example cvpn-endpoint-0ac3a1abbccddd666,vpn-assoc-0b8db902465d069ad
+$ terraform import aws_ec2_client_vpn_network_association.example cvpn-endpoint-0ac3a1abbccddd666,vpn-assoc-0b8db902465d069ad
 ```

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -171,18 +171,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Route53 Records can be imported using ID of the record. The ID is made up as ZONEID_RECORDNAME_TYPE_SET-IDENTIFIER
-
-e.g.
+Route53 Records can be imported using ID of the record, which is the zone identifier, record name, and record type, separated by underscores (`_`). e.g.
 
 ```
-Z4KAPRWWNC7JR_dev.example.com_NS_dev
+$ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS
 ```
 
-In this example, `Z4KAPRWWNC7JR` is the ZoneID, `dev.example.com` is the Record Name, `NS` is the Type and `dev` is the Set Identifier.
-Only the Set Identifier is actually optional in the ID
-
-To import the ID above, it would look as follows:
+If the record also contains a delegated set identifier, it can be appended:
 
 ```
 $ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS_dev

--- a/website/docs/r/ses_identity_notification_topic.markdown
+++ b/website/docs/r/ses_identity_notification_topic.markdown
@@ -6,7 +6,7 @@ description: |-
   Setting AWS SES Identity Notification Topic
 ---
 
-# Resource: ses_identity_notification_topic
+# Resource: aws_ses_identity_notification_topic
 
 Resource for managing SES Identity Notification Topics
 

--- a/website/docs/r/workspaces_workspace.html.markdown
+++ b/website/docs/r/workspaces_workspace.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a workspaces in AWS Workspaces Service.
 ---
 
-# Resource: aws_workspace
+# Resource: aws_workspaces_workspace
 
 Provides a workspace in [AWS Workspaces](https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces.html) Service
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/15842

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously:

```console
$ tfproviderdocs check -allowed-resource-subcategories-file website/allowed-subcategories.txt -provider-name aws -require-resource-subcategory -enable-contents-check |& grep -e 'missing title' -e 'import section code block text'
	* website/docs/r/appmesh_route.html.markdown: error checking file contents: import section code block text should contain resource name: aws_appmesh_route
	* website/docs/r/cloudformation_stack_set.html.markdown: error checking file contents: import section code block text should contain resource name: aws_cloudformation_stack_set
	* website/docs/r/codedeploy_deployment_config.html.markdown: error checking file contents: import section code block text should contain resource name: aws_codedeploy_deployment_config
	* website/docs/r/config_aggregate_authorization.markdown: error checking file contents: import section code block text should contain resource name: aws_config_aggregate_authorization
	* website/docs/r/ec2_client_vpn_network_association.html.markdown: error checking file contents: import section code block text should contain resource name: aws_ec2_client_vpn_network_association
	* website/docs/r/route53_record.html.markdown: error checking file contents: import section code block text should contain resource name: aws_route53_record
	* website/docs/r/ses_identity_notification_topic.markdown: error checking file contents: missing title section: # Resource: aws_ses_identity_notification_topic
	* website/docs/r/workspaces_workspace.html.markdown: error checking file contents: missing title section: # Resource: aws_workspaces_workspace
```

Output from acceptance testing: N/A (documentation)
