### PR TITLE
tests/provider: Add precheck (SES Receipt)

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -871,6 +871,9 @@ func testAccPreCheckSkipError(err error) bool {
 	if isAWSErr(err, "InvalidInputException", "Unknown operation") {
 		return true
 	}
+	if isAWSErr(err, "InvalidAction", "Unavailable Operation") {
+		return true
+	}
 	return false
 }
 

--- a/aws/resource_aws_ses_active_receipt_rule_set_test.go
+++ b/aws/resource_aws_ses_active_receipt_rule_set_test.go
@@ -36,6 +36,7 @@ func testAccAWSSESActiveReceiptRuleSet_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
+			testAccPreCheckSESReceiptRule(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESActiveReceiptRuleSetDestroy,
@@ -58,6 +59,7 @@ func testAccAWSSESActiveReceiptRuleSet_disappears(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
+			testAccPreCheckSESReceiptRule(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESActiveReceiptRuleSetDestroy,

--- a/aws/resource_aws_ses_receipt_filter_test.go
+++ b/aws/resource_aws_ses_receipt_filter_test.go
@@ -16,7 +16,7 @@ func TestAccAWSSESReceiptFilter_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t); testAccPreCheckSESReceiptRule(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptFilterDestroy,
 		Steps: []resource.TestStep{
@@ -44,7 +44,7 @@ func TestAccAWSSESReceiptFilter_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t); testAccPreCheckSESReceiptRule(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptFilterDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_receipt_rule_set_test.go
+++ b/aws/resource_aws_ses_receipt_rule_set_test.go
@@ -85,7 +85,7 @@ func TestAccAWSSESReceiptRuleSet_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t); testAccPreCheckSESReceiptRule(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleSetDestroy,
 		Steps: []resource.TestStep{
@@ -110,7 +110,7 @@ func TestAccAWSSESReceiptRuleSet_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t); testAccPreCheckSESReceiptRule(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleSetDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -19,6 +19,7 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
+			testAccPreCheckSESReceiptRule(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
@@ -44,6 +45,7 @@ func TestAccAWSSESReceiptRule_s3Action(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
+			testAccPreCheckSESReceiptRule(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
@@ -69,6 +71,7 @@ func TestAccAWSSESReceiptRule_order(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
+			testAccPreCheckSESReceiptRule(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
@@ -94,6 +97,7 @@ func TestAccAWSSESReceiptRule_actions(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
+			testAccPreCheckSESReceiptRule(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
@@ -122,6 +126,7 @@ func TestAccAWSSESReceiptRule_disappears(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
+			testAccPreCheckSESReceiptRule(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
@@ -315,6 +320,29 @@ func testAccCheckAwsSESReceiptRuleActions(n string) resource.TestCheckFunc {
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckSESReceiptRule(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).sesconn
+
+	input := &ses.DescribeReceiptRuleInput{
+		RuleName:    aws.String("MyRule"),
+		RuleSetName: aws.String("MyRuleSet"),
+	}
+
+	_, err := conn.DescribeReceiptRule(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if isAWSErr(err, "RuleSetDoesNotExist", "") {
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15867

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
    resource_aws_ses_receipt_rule_test.go:337: skipping acceptance testing: InvalidAction: Unavailable Operation
        	status code: 400, request id: 658706b7-b4f3-431a-bf3b-065abcfb67d3
--- SKIP: TestAccAWSSESReceiptFilter_disappears (2.39s)
--- SKIP: TestAccAWSSESReceiptRuleSet_basic (2.39s)
--- SKIP: TestAccAWSSESReceiptRule_s3Action (2.42s)
--- SKIP: TestAccAWSSESReceiptRule_disappears (2.42s)
--- SKIP: TestAccAWSSESReceiptRule_order (2.43s)
--- SKIP: TestAccAWSSESReceiptFilter_basic (2.44s)
--- SKIP: TestAccAWSSESReceiptRuleSet_disappears (2.45s)
--- SKIP: TestAccAWSSESReceiptRule_actions (2.45s)
--- SKIP: TestAccAWSSESReceiptRule_basic (2.47s)

--- PASS: TestAccAWSSESActiveReceiptRuleSet_serial (4.58s)
    --- SKIP: TestAccAWSSESActiveReceiptRuleSet_serial/basic (2.40s)
    --- SKIP: TestAccAWSSESActiveReceiptRuleSet_serial/disappears (2.18s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSSESReceiptRuleSet_disappears (12.24s)
--- PASS: TestAccAWSSESReceiptFilter_disappears (12.27s)
--- PASS: TestAccAWSSESReceiptFilter_basic (16.47s)
--- PASS: TestAccAWSSESReceiptRuleSet_basic (16.54s)
--- PASS: TestAccAWSSESReceiptRule_basic (18.63s)
--- PASS: TestAccAWSSESReceiptRule_actions (18.81s)
--- PASS: TestAccAWSSESReceiptRule_order (21.62s)
--- PASS: TestAccAWSSESReceiptRule_disappears (26.86s)
--- PASS: TestAccAWSSESReceiptRule_s3Action (31.76s)

--- PASS: TestAccAWSSESActiveReceiptRuleSet_serial (40.05s)
    --- PASS: TestAccAWSSESActiveReceiptRuleSet_serial/basic (15.36s)
    --- PASS: TestAccAWSSESActiveReceiptRuleSet_serial/disappears (24.69s)
```