### PR TITLE
tests/provider: Increase unit testing timeout from 2 to 5 minutes

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -201,7 +201,7 @@ jobs:
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-    - run: go test ./... -timeout=120s
+    - run: go test ./... -timeout=5m
 
   golangci-lint:
     needs: [go_build]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ sweep:
 	go test $(SWEEP_DIR) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
 
 test: fmtcheck
-	go test $(TEST) $(TESTARGS) -timeout=120s -parallel=4
+	go test $(TEST) $(TESTARGS) -timeout=5m -parallel=4
 
 testacc: fmtcheck
 	@if [ "$(TESTARGS)" = "-run=TestAccXXX" ]; then \


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

For a variety of reasons, the unit testing timeout is occassionally too low for many systems including the GitHub Actions runners. There are some minor optimizations that can occur, such as ensuring the main provider instance is only configured once per test execution and reducing the number of generated TLS certificates in the acceptance tests (which also occurs during unit testing compilation), but the low timeout is arbitrary and these will not overly help. Longer term the large Go package will be split and more of the acceptance testing configuration will be in HCL instead of Go, which should spread out and overall reduce the execution time against the testing timeout.

Output from acceptance testing: N/A (unit testing in CI)
