### PR TITLE
tests/provider: Fix hardcoded canoncial (EC2 Traffic Mirror)

### DIFF
--- a/aws/resource_aws_ec2_traffic_mirror_target_test.go
+++ b/aws/resource_aws_ec2_traffic_mirror_target_test.go
@@ -226,7 +226,7 @@ resource "aws_subnet" "sub2" {
 }
 
 func testAccTrafficMirrorTargetConfigNlb(rName, description string) string {
-	return testAccTrafficMirrorTargetConfigBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
 resource "aws_lb" "lb" {
   name               = %[1]q
   internal           = true
@@ -245,29 +245,16 @@ resource "aws_ec2_traffic_mirror_target" "test" {
   description               = %[2]q
   network_load_balancer_arn = aws_lb.lb.arn
 }
-`, rName, description)
+`, rName, description))
 }
 
 func testAccTrafficMirrorTargetConfigEni(rName, description string) string {
-	return testAccTrafficMirrorTargetConfigBase(rName) + fmt.Sprintf(`
-data "aws_ami" "amzn-linux" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-hvm-2.0*"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  owners = ["137112412989"]
-}
-
+	return composeConfig(
+		testAccTrafficMirrorTargetConfigBase(rName),
+		testAccLatestAmazonLinuxHvmEbsAmiConfig(),
+		fmt.Sprintf(`
 resource "aws_instance" "src" {
-  ami           = data.aws_ami.amzn-linux.id
+  ami           = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = "t2.micro"
   subnet_id     = aws_subnet.sub1.id
 
@@ -280,11 +267,11 @@ resource "aws_ec2_traffic_mirror_target" "test" {
   description          = %[2]q
   network_interface_id = aws_instance.src.primary_network_interface_id
 }
-`, rName, description)
+`, rName, description))
 }
 
 func testAccTrafficMirrorTargetConfigTags1(rName, description, tagKey1, tagValue1 string) string {
-	return testAccTrafficMirrorTargetConfigBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
 resource "aws_lb" "lb" {
   name               = %[1]q
   internal           = true
@@ -307,11 +294,11 @@ resource "aws_ec2_traffic_mirror_target" "test" {
     %[3]q = %[4]q
   }
 }
-`, rName, description, tagKey1, tagValue1)
+`, rName, description, tagKey1, tagValue1))
 }
 
 func testAccTrafficMirrorTargetConfigTags2(rName, description, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccTrafficMirrorTargetConfigBase(rName) + fmt.Sprintf(`
+	return composeConfig(testAccTrafficMirrorTargetConfigBase(rName), fmt.Sprintf(`
 resource "aws_lb" "lb" {
   name               = %[1]q
   internal           = true
@@ -335,7 +322,7 @@ resource "aws_ec2_traffic_mirror_target" "test" {
     %[5]q = %[6]q
   }
 }
-`, rName, description, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, description, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccPreCheckAWSEc2TrafficMirrorTarget(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15866 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
--- PASS: TestAccAWSEc2TrafficMirrorFilter_disappears (18.14s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_tags (51.16s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_basic (51.77s)
--- PASS: TestAccAWSEc2TrafficMirrorFilterRule_basic (55.73s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_eni (108.92s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_disappears (222.43s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_nlb (237.05s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_disappears (249.30s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_tags (276.65s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_tags (312.30s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_basic (333.06s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSEc2TrafficMirrorFilter_disappears (12.71s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_tags (38.05s)
--- PASS: TestAccAWSEc2TrafficMirrorFilter_basic (38.53s)
--- PASS: TestAccAWSEc2TrafficMirrorFilterRule_basic (41.81s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_eni (124.02s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_nlb (222.24s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_disappears (239.02s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_tags (270.76s)
--- PASS: TestAccAWSEc2TrafficMirrorTarget_tags (276.46s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_basic (279.08s)
--- PASS: TestAccAWSEc2TrafficMirrorSession_disappears (287.14s)
```