### PR TITLE
tests/provider: Add precheck (KinesisVideo)

### DIFF
--- a/aws/resource_aws_kinesis_video_stream_test.go
+++ b/aws/resource_aws_kinesis_video_stream_test.go
@@ -21,7 +21,7 @@ func TestAccAWSKinesisVideoStream_basic(t *testing.T) {
 	rInt2 := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(kinesisvideo.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisVideoStreamDestroy,
 		Steps: []resource.TestStep{
@@ -62,7 +62,7 @@ func TestAccAWSKinesisVideoStream_options(t *testing.T) {
 	rName2 := acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(kinesisvideo.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisVideoStreamDestroy,
 		Steps: []resource.TestStep{
@@ -103,7 +103,7 @@ func TestAccAWSKinesisVideoStream_Tags(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(kinesisvideo.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisVideoStreamDestroy,
 		Steps: []resource.TestStep{
@@ -148,7 +148,7 @@ func TestAccAWSKinesisVideoStream_disappears(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck(kinesisvideo.EndpointsID, t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisVideoStreamDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15868

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
    provider_test.go:545: skipping tests; partition aws-us-gov does not support kinesisvideo service
--- SKIP: TestAccAWSKinesisVideoStream_options (1.55s)
--- SKIP: TestAccAWSKinesisVideoStream_Tags (1.56s)
--- SKIP: TestAccAWSKinesisVideoStream_basic (1.56s)
--- SKIP: TestAccAWSKinesisVideoStream_disappears (1.56s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccAWSKinesisVideoStream_disappears (93.72s)
--- PASS: TestAccAWSKinesisVideoStream_options (128.51s)
--- PASS: TestAccAWSKinesisVideoStream_Tags (142.80s)
--- PASS: TestAccAWSKinesisVideoStream_basic (193.16s)
```
