### PR TITLE
tests/provider: Add precheck (WAF data sources)

### DIFF
--- a/aws/data_source_aws_waf_ipset_test.go
+++ b/aws/data_source_aws_waf_ipset_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceAwsWafIPSet_basic(t *testing.T) {
 	datasourceName := "data.aws_waf_ipset.ipset"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("waf", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_waf_rate_based_rule_test.go
+++ b/aws/data_source_aws_waf_rate_based_rule_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -15,7 +15,7 @@ func TestAccDataSourceAwsWafRateBasedRule_basic(t *testing.T) {
 	datasourceName := "data.aws_waf_rate_based_rule.wafrule"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("waf", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_waf_rule_test.go
+++ b/aws/data_source_aws_waf_rule_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -15,7 +15,7 @@ func TestAccDataSourceAwsWafRule_basic(t *testing.T) {
 	datasourceName := "data.aws_waf_rule.wafrule"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("waf", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_waf_web_acl_test.go
+++ b/aws/data_source_aws_waf_web_acl_test.go
@@ -2,10 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -15,7 +15,7 @@ func TestAccDataSourceAwsWafWebAcl_basic(t *testing.T) {
 	datasourceName := "data.aws_waf_web_acl.web_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("waf", t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #15873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
    provider_test.go:545: skipping tests; partition aws-us-gov does not support waf service
--- SKIP: TestAccDataSourceAwsWafWebAcl_basic (1.58s)
--- SKIP: TestAccDataSourceAwsWafRateBasedRule_basic (1.58s)
--- SKIP: TestAccDataSourceAwsWafRule_basic (1.58s)
--- SKIP: TestAccDataSourceAwsWafIPSet_basic (1.59s)
```

Output from acceptance testing (commercial):

```
--- PASS: TestAccDataSourceAwsWafRule_basic (22.86s)
--- PASS: TestAccDataSourceAwsWafWebAcl_basic (24.07s)
--- PASS: TestAccDataSourceAwsWafRateBasedRule_basic (26.32s)
--- PASS: TestAccDataSourceAwsWafIPSet_basic (27.45s)
```