### PR TITLE
tests/provider: Migrate additional tests to newer ProviderFactories setup and PreCheck functions

### DIFF
--- a/aws/cloudfront_test.go
+++ b/aws/cloudfront_test.go
@@ -1,0 +1,18 @@
+package aws
+
+import "github.com/aws/aws-sdk-go/aws/endpoints"
+
+// testAccCloudfrontRegionProviderConfig is the Terraform provider configuration for CloudFront region testing
+//
+// Testing CloudFront assumes no other provider configurations
+// are necessary and overwrites the "aws" provider configuration.
+func testAccCloudfrontRegionProviderConfig() string {
+	switch testAccGetPartition() {
+	case endpoints.AwsPartitionID:
+		return testAccRegionalProviderConfig(endpoints.UsEast1RegionID)
+	case endpoints.AwsCnPartitionID:
+		return testAccRegionalProviderConfig(endpoints.CnNorthwest1RegionID)
+	default:
+		return testAccRegionalProviderConfig(testAccGetRegion())
+	}
+}

--- a/aws/data_source_aws_ec2_transit_gateway_peering_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_peering_attachment_test.go
@@ -17,10 +17,9 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_sameAccount(t
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -46,10 +45,10 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_differentAcco
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
+			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -73,10 +72,9 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_sameAccount(t *te
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -102,10 +100,10 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_differentAccount(
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
+			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -129,10 +127,9 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Tags(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -436,10 +436,9 @@ func TestAccAwsBackupPlan_Rule_CopyAction_CrossRegion(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSBackup(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -2538,10 +2538,8 @@ func testAccAWSCloudFrontDistributionConfigViewerCertificateAcmCertificateArnBas
 	key := tlsRsaPrivateKeyPem(2048)
 	certificate := tlsRsaX509SelfSignedCertificatePem(key, commonName)
 
-	return testAccUsEast1RegionProviderConfig() + fmt.Sprintf(`
+	return testAccCloudfrontRegionProviderConfig() + fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {
-  provider = "awsus-east-1"
-
   certificate_body = "%[1]s"
   private_key      = "%[2]s"
 }

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -355,7 +355,7 @@ func TestAccAWSDBInstance_DbSubnetGroupName_RamShared(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccOrganizationsEnabledPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -778,10 +778,9 @@ func TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -808,12 +807,11 @@ func TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared(t *testi
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 			testAccAlternateAccountPreCheck(t)
 			testAccOrganizationsEnabledPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternateAccountAndAlternateRegion(&providers),
 		CheckDestroy:      testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -840,10 +838,9 @@ func TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupId
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1443,7 +1440,7 @@ func TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared(t *test
 			testAccAlternateAccountPreCheck(t)
 			testAccOrganizationsEnabledPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -1402,7 +1402,7 @@ func TestAccAWSDynamoDbTable_Replica_Multiple(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 3)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesMultipleRegion(&providers, 3),
 		CheckDestroy:      testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1447,7 +1447,7 @@ func TestAccAWSDynamoDbTable_Replica_Single(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesMultipleRegion(&providers, 3), // 3 due to shared test configuration
 		CheckDestroy:      testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment_accepter_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment_accepter_test.go
@@ -22,11 +22,10 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_sameAccount(t *t
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 			testAccPreCheckAWSEc2TransitGateway(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -60,11 +59,10 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_Tags_sameAccount(t *te
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 			testAccPreCheckAWSEc2TransitGateway(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -114,7 +112,7 @@ func TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_differentAccount
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_peering_attachment_test.go
@@ -91,10 +91,9 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -128,10 +127,9 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_disappears(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -156,10 +154,9 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_Tags_sameAccount(t *testing.T)
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -210,10 +207,10 @@ func TestAccAWSEc2TransitGatewayPeeringAttachment_differentAccount(t *testing.T)
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
+			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayPeeringAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/docs/contributing/running-and-writing-acceptance-tests.md
+++ b/docs/contributing/running-and-writing-acceptance-tests.md
@@ -659,8 +659,8 @@ When testing requires AWS infrastructure in a second AWS account, the below chan
 
 - In the `PreCheck` function, include `testAccAlternateAccountPreCheck(t)` to ensure a standardized set of information is required for cross-account testing credentials
 - Declare a `providers` variable at the top of the test function: `var providers []*schema.Provider`
-- Switch usage of `Providers: testAccProviders` to `ProviderFactories: testAccProviderFactories(&providers)`
-- Add `testAccAlternateAccountProviderConfig()` to the test configuration and use `provider = "awsalternate"` for cross-account resources. The resource that is the focus of the acceptance test should _not_ use the alternate provider identification to simplify the testing setup.
+- Switch usage of `Providers: testAccProviders` to `ProviderFactories: testAccProviderFactoriesAlternate(&providers)`
+- Add `testAccAlternateAccountProviderConfig()` to the test configuration and use `provider = awsalternate` for cross-account resources. The resource that is the focus of the acceptance test should _not_ use the alternate provider identification to simplify the testing setup.
 - For any `TestStep` that includes `ImportState: true`, add the `Config` that matches the previous `TestStep` `Config`
 
 An example acceptance test implementation can be seen below:
@@ -675,7 +675,7 @@ func TestAccAwsExample_basic(t *testing.T) {
       testAccPreCheck(t)
       testAccAlternateAccountPreCheck(t)
     },
-    ProviderFactories: testAccProviderFactories(&providers),
+    ProviderFactories: testAccProviderFactoriesAlternate(&providers),
     CheckDestroy:      testAccCheckAwsExampleDestroy,
     Steps: []resource.TestStep{
       {
@@ -700,7 +700,7 @@ func testAccAwsExampleConfig() string {
 # Cross account resources should be handled by the cross account provider.
 # The standardized provider block to use is awsalternate as seen below.
 resource "aws_cross_account_example" "test" {
-  provider = "awsalternate"
+  provider = awsalternate
 
   # ... configuration ...
 }
@@ -722,8 +722,8 @@ When testing requires AWS infrastructure in a second or third AWS region, the be
 
 - In the `PreCheck` function, include `testAccMultipleRegionPreCheck(t, ###)` to ensure a standardized set of information is required for cross-region testing configuration. If the infrastructure in the second AWS region is also in a second AWS account also include `testAccAlternateAccountPreCheck(t)`
 - Declare a `providers` variable at the top of the test function: `var providers []*schema.Provider`
-- Switch usage of `Providers: testAccProviders` to `ProviderFactories: testAccProviderFactories(&providers)`
-- Add `testAccMultipleRegionProviderConfig(###)` to the test configuration and use `provider = "awsalternate"` (and/or `provider = "awsthird"`) for cross-region resources. The resource that is the focus of the acceptance test should _not_ use the alternative providers to simplify the testing setup. If the infrastructure in the second AWS region is also in a second AWS account use `testAccAlternateAccountAlternateRegionProviderConfig()` instead
+- Switch usage of `Providers: testAccProviders` to `ProviderFactories: testAccProviderFactoriesMultipleRegion(&providers, 2)` (where the last parameter is number of regions)
+- Add `testAccMultipleRegionProviderConfig(###)` to the test configuration and use `provider = awsalternate` (and potentially `provider = awsthird`) for cross-region resources. The resource that is the focus of the acceptance test should _not_ use the alternative providers to simplify the testing setup. If the infrastructure in the second AWS region is also in a second AWS account use `testAccAlternateAccountAlternateRegionProviderConfig()` instead
 - For any `TestStep` that includes `ImportState: true`, add the `Config` that matches the previous `TestStep` `Config`
 
 An example acceptance test implementation can be seen below:
@@ -738,7 +738,7 @@ func TestAccAwsExample_basic(t *testing.T) {
       testAccPreCheck(t)
       testAccMultipleRegionPreCheck(t, 2)
     },
-    ProviderFactories: testAccProviderFactories(&providers),
+    ProviderFactories: testAccProviderFactoriesMultipleRegion(&providers, 2),
     CheckDestroy:      testAccCheckAwsExampleDestroy,
     Steps: []resource.TestStep{
       {
@@ -763,7 +763,7 @@ func testAccAwsExampleConfig() string {
 # Cross region resources should be handled by the cross region provider.
 # The standardized provider is awsalternate as seen below.
 resource "aws_cross_region_example" "test" {
-  provider = "awsalternate"
+  provider = awsalternate
 
   # ... configuration ...
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/7702
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8316
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/15737
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/15791

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This creates the remaining special `ProviderFactories` functions (as they need to exist currently), updates the Contributing Guide documentation, and migrates a portion of the tests over to them. Further changesets will continue these efforts by:

* Migrating the rest of the `awsalternate` provider test configurations to `testAccProviderFactoriesAlternate()`
* Migrating the rest of the `testAccMultipleRegionsPreCheck()` and `testAccAlternateRegionPreCheck()` usage to `testAccMultipleRegionPreCheck()` (bundling with the above as its fairly common together)
* Flipping `testAccProviderFactories` to a variable with only the `aws` provider and replacing `testAccProviderFactoriesEc2Classic` and `testAccProviderFactoriesCur()`
* Continuing efforts to remove environment variable handling in test functions

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_CrossRegion (20.85s)

--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (157.90s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (157.61s)

# These failures are previously existing due to an AWS account migration issue and not failing due to provider initialization issues after this particular code update:

--- FAIL: TestAccAWSDBInstance_DbSubnetGroupName_RamShared (18.95s)
    resource_aws_db_instance_test.go:352: Step 1/1 error: Error running apply: 2020/10/27 23:13:26 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: Error associating principal with RAM resource share: UnknownResourceException: Organization o-upyv668dz5 could not be found.

        Error: error associating RAM Resource Share: InvalidParameterException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.

        Error: error associating RAM Resource Share: InvalidParameterException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.

--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_RamShared (604.80s)
    resource_aws_db_instance_test.go:808: Step 1/1 error: Error running apply: 2020/10/27 21:59:55 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: Error associating principal with RAM resource share: UnknownResourceException: Organization o-upyv668dz5 could not be found.

        Error: error associating RAM Resource Share: InvalidParameterException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.

        Error: error associating RAM Resource Share: InvalidParameterException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.

--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_DbSubnetGroupName_RamShared (615.89s)
    resource_aws_db_instance_test.go:1437: Step 1/1 error: Error running apply: 2020/10/27 23:13:26 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: Error associating principal with RAM resource share: UnknownResourceException: Organization o-upyv668dz5 could not be found.

        Error: error associating RAM Resource Share: InvalidParameterException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.

        Error: error associating RAM Resource Share: InvalidParameterException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.

--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName (2252.27s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_DbSubnetGroupName_VpcSecurityGroupIds (1908.33s)

--- PASS: TestAccAWSDynamoDbTable_Replica_Multiple (766.22s)
--- PASS: TestAccAWSDynamoDbTable_Replica_Single (412.01s)

--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachment_basic (376.21s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachment_differentAccount (360.55s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachment_disappears (363.16s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachment_Tags_sameAccount (365.29s)

--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_differentAccount (780.52s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_basic_sameAccount (773.52s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentAccepter_Tags_sameAccount (815.32s)

--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_differentAccount (389.30s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Filter_sameAccount (397.06s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_differentAccount (333.33s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_ID_sameAccount (333.84s)
--- PASS: TestAccAWSEc2TransitGatewayPeeringAttachmentDataSource_Tags (332.99s)

--- PASS: TestAccAWSProvider_AssumeRole_Empty (16.67s)
--- PASS: TestAccAWSProvider_Endpoints (14.28s)
--- PASS: TestAccAWSProvider_IgnoreTags_EmptyConfigurationBlock (14.21s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_Multiple (14.15s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_None (14.28s)
--- PASS: TestAccAWSProvider_IgnoreTags_KeyPrefixes_One (14.05s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_Multiple (14.11s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_None (14.19s)
--- PASS: TestAccAWSProvider_IgnoreTags_Keys_One (14.31s)
--- PASS: TestAccAWSProvider_Region_AwsChina (11.20s)
--- PASS: TestAccAWSProvider_Region_AwsCommercial (11.54s)
--- PASS: TestAccAWSProvider_Region_AwsGovCloudUs (11.22s)
```
Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAwsBackupPlan_Rule_CopyAction_CrossRegion (24.77s)

--- SKIP: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (1.52s)
--- SKIP: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (1.55s)
```