### PR TITLE
tests/provider: Fix hardcoded (DS CUR)

### DIFF
--- a/aws/data_source_aws_cur_report_definition_test.go
+++ b/aws/data_source_aws_cur_report_definition_test.go
@@ -91,6 +91,8 @@ func testAccDataSourceAwsCurReportDefinitionConfig_basic(reportName string, buck
 		fmt.Sprintf(`
 data "aws_billing_service_account" "test" {}
 
+data "aws_partition" "current" {}
+
 resource "aws_s3_bucket" "test" {
   bucket        = "%[2]s"
   acl           = "private"
@@ -121,10 +123,10 @@ resource "aws_s3_bucket_policy" "test" {
       "Sid": "AllowCURPutObject",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::386209384616:root"
+        "AWS": "${data.aws_billing_service_account.test.arn}"
       },
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::${aws_s3_bucket.test.id}/*"
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.test.id}/*"
     }
   ]
 }
@@ -157,6 +159,8 @@ func testAccDataSourceAwsCurReportDefinitionConfig_additional(reportName string,
 		fmt.Sprintf(`
 data "aws_billing_service_account" "test" {}
 
+data "aws_partition" "current" {}
+
 resource "aws_s3_bucket" "test" {
   bucket        = "%[2]s"
   acl           = "private"
@@ -187,10 +191,10 @@ resource "aws_s3_bucket_policy" "test" {
       "Sid": "AllowCURPutObject",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::386209384616:root"
+        "AWS": "${data.aws_billing_service_account.test.arn}"
       },
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::${aws_s3_bucket.test.id}/*"
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.test.id}/*"
     }
   ]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #15662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing (GovCloud):

```
    provider_test.go:602: skipping tests; partition aws-us-gov does not support cur service
--- SKIP: TestAccDataSourceAwsCurReportDefinition_additional (1.57s)
--- SKIP: TestAccDataSourceAwsCurReportDefinition_basic (1.58s)
```

Output from acceptance testing (commercial):

```
    cur_test.go:66: skipping acceptance testing: AccessDeniedException: accountId: 187****** is not authorized to callDescribeReportDefinitions. Note: linked account is not allowed to modify report preference.
        	status code: 400, request id: a4cae0e5-57af-432d-ad90-ad52226f673f
--- SKIP: TestAccDataSourceAwsCurReportDefinition_additional (1.40s)
--- SKIP: TestAccDataSourceAwsCurReportDefinition_basic (1.40s)
```

Output from acceptance testing (commercial org):

```
--- PASS: TestAccDataSourceAwsCurReportDefinition_basic (34.52s)
--- PASS: TestAccDataSourceAwsCurReportDefinition_additional (34.70s)
```