### PR TITLE
tests/provider: Fix hardcoded ARN (DB*)

### DIFF
--- a/aws/resource_aws_db_option_group_test.go
+++ b/aws/resource_aws_db_option_group_test.go
@@ -360,14 +360,14 @@ func TestAccAWSDBOptionGroup_OracleOptionsUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName, "12.1.0.4.v1"),
+				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName, "13.2.0.0.v2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
 					resource.TestCheckResourceAttr(
 						"aws_db_option_group.bar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"aws_db_option_group.bar", "option.#", "1"),
-					testAccCheckAWSDBOptionGroupOptionVersionAttribute(&v, "12.1.0.4.v1"),
+					testAccCheckAWSDBOptionGroupOptionVersionAttribute(&v, "13.2.0.0.v2"),
 				),
 			},
 			{
@@ -378,14 +378,14 @@ func TestAccAWSDBOptionGroup_OracleOptionsUpdate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"name_prefix", "option"},
 			},
 			{
-				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName, "12.1.0.5.v1"),
+				Config: testAccAWSDBOptionGroupOracleEEOptionSettings(rName, "13.3.0.0.v2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
 					resource.TestCheckResourceAttr(
 						"aws_db_option_group.bar", "name", rName),
 					resource.TestCheckResourceAttr(
 						"aws_db_option_group.bar", "option.#", "1"),
-					testAccCheckAWSDBOptionGroupOptionVersionAttribute(&v, "12.1.0.5.v1"),
+					testAccCheckAWSDBOptionGroupOptionVersionAttribute(&v, "13.3.0.0.v2"),
 				),
 			},
 		},
@@ -568,7 +568,7 @@ func testAccCheckAWSDBOptionGroupOptionSettingsIAMRole(optionGroup *rds.OptionGr
 		}
 
 		settingValue := aws.StringValue(optionGroup.Options[0].OptionSettings[0].Value)
-		iamArnRegExp := regexp.MustCompile(`^arn:aws:iam::\d{12}:role/.+`)
+		iamArnRegExp := regexp.MustCompile(fmt.Sprintf(`^arn:%s:iam::\d{12}:role/.+`, testAccGetPartition()))
 		if !iamArnRegExp.MatchString(settingValue) {
 			return fmt.Errorf("Expected option setting to be a valid IAM role but received %s", settingValue)
 		}
@@ -733,24 +733,26 @@ resource "aws_db_option_group" "bar" {
 
 func testAccAWSDBOptionGroupOptionSettingsIAMRole(r string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "rds_assume_role" {
   statement {
     actions = ["sts:AssumeRole"]
 
     principals {
       type        = "Service"
-      identifiers = ["rds.amazonaws.com"]
+      identifiers = ["rds.${data.aws_partition.current.dns_suffix}"]
     }
   }
 }
 
 resource "aws_iam_role" "sql_server_backup" {
-  name               = "rds-backup-%s"
+  name               = "rds-backup-%[1]s"
   assume_role_policy = data.aws_iam_policy_document.rds_assume_role.json
 }
 
 resource "aws_db_option_group" "bar" {
-  name                     = "%s"
+  name                     = "%[1]s"
   option_group_description = "Test option group for terraform"
   engine_name              = "sqlserver-ex"
   major_engine_version     = "14.00"
@@ -764,7 +766,7 @@ resource "aws_db_option_group" "bar" {
     }
   }
 }
-`, r, r)
+`, r)
 }
 
 func testAccAWSDBOptionGroupOptionSettings_update(r string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
