### PR TITLE
r/aws_apigatewayv2_integration: Specify required parameters on update

### DIFF
--- a/aws/resource_aws_apigatewayv2_stage.go
+++ b/aws/resource_aws_apigatewayv2_stage.go
@@ -360,7 +360,7 @@ func resourceAwsApiGatewayV2StageUpdate(d *schema.ResourceData, meta interface{}
 		}
 		if d.HasChange("stage_variables") {
 			o, n := d.GetChange("stage_variables")
-			add, del := diffStringMaps(o.(map[string]interface{}), n.(map[string]interface{}))
+			add, del, _ := diffStringMaps(o.(map[string]interface{}), n.(map[string]interface{}))
 			// Variables are removed by setting the associated value to "".
 			for k := range del {
 				del[k] = aws.String("")

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1568,30 +1568,31 @@ func stringMapToPointers(m map[string]interface{}) map[string]*string {
 	return list
 }
 
-// diffStringMaps returns the set of keys and values that must be created,
-// and the set of keys and values that must be destroyed.
-// Equivalent to 'diffTagsGeneric'.
-func diffStringMaps(oldMap, newMap map[string]interface{}) (map[string]*string, map[string]*string) {
+// diffStringMaps returns the set of keys and values that must be created, the set of keys
+// and values that must be destroyed, and the set of keys and values that are unchanged.
+func diffStringMaps(oldMap, newMap map[string]interface{}) (map[string]*string, map[string]*string, map[string]*string) {
 	// First, we're creating everything we have
 	create := map[string]*string{}
 	for k, v := range newMap {
 		create[k] = aws.String(v.(string))
 	}
 
-	// Build the map of what to remove
+	// Build the maps of what to remove and what is unchanged
 	remove := map[string]*string{}
+	unchanged := map[string]*string{}
 	for k, v := range oldMap {
 		old, ok := create[k]
 		if !ok || aws.StringValue(old) != v.(string) {
 			// Delete it!
 			remove[k] = aws.String(v.(string))
 		} else if ok {
+			unchanged[k] = aws.String(v.(string))
 			// already present so remove from new
 			delete(create, k)
 		}
 	}
 
-	return create, remove
+	return create, remove, unchanged
 }
 
 func flattenDSVpcSettings(

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -22,8 +22,8 @@ import (
 
 func TestDiffStringMaps(t *testing.T) {
 	cases := []struct {
-		Old, New       map[string]interface{}
-		Create, Remove map[string]interface{}
+		Old, New                  map[string]interface{}
+		Create, Remove, Unchanged map[string]interface{}
 	}{
 		// Add
 		{
@@ -38,6 +38,9 @@ func TestDiffStringMaps(t *testing.T) {
 				"bar": "baz",
 			},
 			Remove: map[string]interface{}{},
+			Unchanged: map[string]interface{}{
+				"foo": "bar",
+			},
 		},
 
 		// Modify
@@ -54,6 +57,7 @@ func TestDiffStringMaps(t *testing.T) {
 			Remove: map[string]interface{}{
 				"foo": "bar",
 			},
+			Unchanged: map[string]interface{}{},
 		},
 
 		// Overlap
@@ -72,6 +76,9 @@ func TestDiffStringMaps(t *testing.T) {
 			Remove: map[string]interface{}{
 				"foo": "bar",
 			},
+			Unchanged: map[string]interface{}{
+				"hello": "world",
+			},
 		},
 
 		// Remove
@@ -87,18 +94,25 @@ func TestDiffStringMaps(t *testing.T) {
 			Remove: map[string]interface{}{
 				"bar": "baz",
 			},
+			Unchanged: map[string]interface{}{
+				"foo": "bar",
+			},
 		},
 	}
 
 	for i, tc := range cases {
-		c, r := diffStringMaps(tc.Old, tc.New)
+		c, r, u := diffStringMaps(tc.Old, tc.New)
 		cm := pointersMapToStringList(c)
 		rm := pointersMapToStringList(r)
+		um := pointersMapToStringList(u)
 		if !reflect.DeepEqual(cm, tc.Create) {
 			t.Fatalf("%d: bad create: %#v", i, cm)
 		}
 		if !reflect.DeepEqual(rm, tc.Remove) {
 			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+		if !reflect.DeepEqual(um, tc.Unchanged) {
+			t.Fatalf("%d: bad unchanged: %#v", i, rm)
 		}
 	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/terraform-providers/terraform-provider-aws/issues/15861.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_apigatewayv2_integration: Correctly handle update of AWS service integrations
```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayV2Integration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSAPIGatewayV2Integration_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayV2Integration_basicWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_basicWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_basicHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_basicHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_disappears
=== PAUSE TestAccAWSAPIGatewayV2Integration_disappears
=== RUN   TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_LambdaHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_LambdaHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== RUN   TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== PAUSE TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== RUN   TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
=== PAUSE TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
=== CONT  TestAccAWSAPIGatewayV2Integration_basicWebSocket
=== CONT  TestAccAWSAPIGatewayV2Integration_LambdaHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLinkHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_LambdaWebSocket
=== CONT  TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket
=== CONT  TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp
=== CONT  TestAccAWSAPIGatewayV2Integration_disappears
=== CONT  TestAccAWSAPIGatewayV2Integration_basicHttp
--- PASS: TestAccAWSAPIGatewayV2Integration_disappears (34.57s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basicHttp (38.92s)
--- PASS: TestAccAWSAPIGatewayV2Integration_basicWebSocket (39.36s)
--- PASS: TestAccAWSAPIGatewayV2Integration_LambdaWebSocket (56.08s)
--- PASS: TestAccAWSAPIGatewayV2Integration_IntegrationTypeHttp (58.04s)
--- PASS: TestAccAWSAPIGatewayV2Integration_AwsServiceIntegration (58.59s)
--- PASS: TestAccAWSAPIGatewayV2Integration_LambdaHttp (60.98s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLinkHttp (309.45s)
--- PASS: TestAccAWSAPIGatewayV2Integration_VpcLinkWebSocket (683.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	683.889s
```
