### PR TITLE
tests/provider: Standardize remaining alternate provider testing and refactor testAccProviderFactories for broad usage

### DIFF
--- a/aws/cur_test.go
+++ b/aws/cur_test.go
@@ -97,10 +97,3 @@ func testAccGetCurRegion() string {
 
 	return testAccCurRegion
 }
-
-// testAccProviderFactoriesCur initializes providers for Cost and Usage Reporting testing.
-//
-// Deprecated: This will be replaced with testAccProviderFactories when it only returns the "aws" provider
-func testAccProviderFactoriesCur() map[string]func() (*schema.Provider, error) {
-	return testAccProviderFactoriesInit(nil, []string{ProviderNameAws})
-}

--- a/aws/data_source_aws_cur_report_definition_test.go
+++ b/aws/data_source_aws_cur_report_definition_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceAwsCurReportDefinition_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
-		ProviderFactories: testAccProviderFactoriesCur(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -48,7 +48,7 @@ func TestAccDataSourceAwsCurReportDefinition_additional(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
-		ProviderFactories: testAccProviderFactoriesCur(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_db_subnet_group_test.go
+++ b/aws/data_source_aws_db_subnet_group_test.go
@@ -7,18 +7,16 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestAccAWSDbSubnetGroupDataSource_basic(t *testing.T) {
-	var providers []*schema.Provider
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_db_subnet_group.test"
 	dataSourceName := "data.aws_db_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDBSubnetGroupDataSourceConfig(rName),
@@ -36,11 +34,9 @@ func TestAccAWSDbSubnetGroupDataSource_basic(t *testing.T) {
 }
 
 func TestAccAWSDbSubnetGroupDataSource_nonexistent(t *testing.T) {
-	var providers []*schema.Provider
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSDBSubnetGroupDataSourceConfig_NonExistent,

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -104,7 +104,7 @@ func TestAccDataSourceAwsRoute53ResolverRule_SharedByMe(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSRoute53Resolver(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsRoute53ResolverRule_sharedByMe(rName),
@@ -141,7 +141,7 @@ func TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSRoute53Resolver(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsRoute53ResolverRule_sharedWithMe(rName),

--- a/aws/ec2_classic_test.go
+++ b/aws/ec2_classic_test.go
@@ -75,10 +75,3 @@ func testAccGetEc2ClassicRegion() string {
 
 	return testAccGetRegion()
 }
-
-// testAccProviderFactoriesEc2Classic initializes providers for EC2-Classic testing.
-//
-// Deprecated: This will be replaced with testAccProviderFactories when it only returns the "aws" provider
-func testAccProviderFactoriesEc2Classic() map[string]func() (*schema.Provider, error) {
-	return testAccProviderFactoriesInit(nil, []string{ProviderNameAws})
-}

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/tfawsresource"
 )
@@ -757,13 +756,12 @@ func TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Heade
 
 func TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn(t *testing.T) {
 	var distribution cloudfront.Distribution
-	var providers []*schema.Provider
 	resourceName := "aws_cloudfront_distribution.test"
 	retainOnDelete := testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloudfront", t) },
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -789,13 +787,12 @@ func TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn(t *tes
 // Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/7773
 func TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate(t *testing.T) {
 	var distribution cloudfront.Distribution
-	var providers []*schema.Provider
 	resourceName := "aws_cloudfront_distribution.test"
 	retainOnDelete := testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPartitionHasServicePreCheck("cloudfront", t) },
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -296,11 +296,10 @@ func TestAccAWSCodePipeline_multiregion_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 			testAccPreCheckAWSCodePipeline(t, testAccGetAlternateRegion())
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -343,11 +342,10 @@ func TestAccAWSCodePipeline_multiregion_Update(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 			testAccPreCheckAWSCodePipeline(t, testAccGetAlternateRegion())
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -404,11 +402,10 @@ func TestAccAWSCodePipeline_multiregion_ConvertSingleRegion(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 			testAccPreCheckAWSCodePipeline(t, testAccGetAlternateRegion())
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_cur_report_definition_test.go
+++ b/aws/resource_aws_cur_report_definition_test.go
@@ -19,7 +19,7 @@ func TestAccAwsCurReportDefinition_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
-		ProviderFactories: testAccProviderFactoriesCur(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -54,7 +54,7 @@ func TestAccAwsCurReportDefinition_textOrCsv(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
-		ProviderFactories: testAccProviderFactoriesCur(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -92,7 +92,7 @@ func TestAccAwsCurReportDefinition_parquet(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
-		ProviderFactories: testAccProviderFactoriesCur(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -129,7 +129,7 @@ func TestAccAwsCurReportDefinition_athena(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
-		ProviderFactories: testAccProviderFactoriesCur(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -167,7 +167,7 @@ func TestAccAwsCurReportDefinition_refresh(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
-		ProviderFactories: testAccProviderFactoriesCur(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -205,7 +205,7 @@ func TestAccAwsCurReportDefinition_overwrite(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckCur(t) },
-		ProviderFactories: testAccProviderFactoriesCur(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsCurReportDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_dx_gateway_association_proposal_test.go
+++ b/aws/resource_aws_dx_gateway_association_proposal_test.go
@@ -92,7 +92,7 @@ func TestAccAwsDxGatewayAssociationProposal_basicVpnGateway(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxGatewayAssociationProposalDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -130,7 +130,7 @@ func TestAccAwsDxGatewayAssociationProposal_basicTransitGateway(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxGatewayAssociationProposalDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -168,7 +168,7 @@ func TestAccAwsDxGatewayAssociationProposal_disappears(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxGatewayAssociationProposalDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -195,7 +195,7 @@ func TestAccAwsDxGatewayAssociationProposal_AllowedPrefixes(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxGatewayAssociationProposalDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -261,7 +261,7 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -340,7 +340,7 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -441,7 +441,7 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount(t *tes
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
@@ -36,7 +36,7 @@ func TestAccAwsDxHostedPrivateVirtualInterface_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxHostedPrivateVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -94,7 +94,7 @@ func TestAccAwsDxHostedPrivateVirtualInterface_AccepterTags(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxHostedPrivateVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
@@ -38,7 +38,7 @@ func TestAccAwsDxHostedPublicVirtualInterface_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxHostedPublicVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -98,7 +98,7 @@ func TestAccAwsDxHostedPublicVirtualInterface_AccepterTags(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxHostedPublicVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_dx_hosted_transit_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_transit_virtual_interface_test.go
@@ -51,7 +51,7 @@ func testAccAwsDxHostedTransitVirtualInterface_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxHostedTransitVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -110,7 +110,7 @@ func testAccAwsDxHostedTransitVirtualInterface_accepterTags(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDxHostedTransitVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestAccAWSDynamoDbGlobalTable_basic(t *testing.T) {
-	var providers []*schema.Provider
 	resourceName := "aws_dynamodb_global_table.test"
 	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
@@ -23,10 +22,9 @@ func TestAccAWSDynamoDbGlobalTable_basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSDynamodbGlobalTable(t)
-			testAccAlternateRegionPreCheck(t)
 			testAccDynamoDBGlobalTablePreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAwsDynamoDbGlobalTableDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -68,11 +66,10 @@ func TestAccAWSDynamoDbGlobalTable_multipleRegions(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckAWSDynamodbGlobalTable(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 			testAccDynamoDBGlobalTablePreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsDynamoDbGlobalTableDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -272,16 +269,14 @@ resource "aws_dynamodb_global_table" "test" {
 }
 
 func testAccDynamoDbGlobalTableConfig_invalidName(tableName string) string {
-	return composeConfig(testAccAlternateRegionProviderConfig(), fmt.Sprintf(`
-data "aws_region" "alternate" {
-  provider = "awsalternate"
-}
+	return composeConfig(fmt.Sprintf(`
+data "aws_region" "current" {}
 
 resource "aws_dynamodb_global_table" "test" {
   name = "%s"
 
   replica {
-    region_name = data.aws_region.alternate.name
+    region_name = data.aws_region.current.name
   }
 }
 `, tableName))

--- a/aws/resource_aws_ebs_snapshot_copy_test.go
+++ b/aws/resource_aws_ebs_snapshot_copy_test.go
@@ -99,10 +99,9 @@ func TestAccAWSEbsSnapshotCopy_withRegions(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckEbsSnapshotCopyDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go
@@ -26,7 +26,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayVpcAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -71,7 +71,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags(t *testing.T) {
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayVpcAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -138,7 +138,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRoute
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayVpcAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -218,7 +218,7 @@ func TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway(t *testing.T)
 			testAccAlternateAccountPreCheck(t)
 			testAccPreCheckAWSEc2TransitGateway(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSEc2TransitGatewayVpcAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_guardduty_invite_accepter_test.go
+++ b/aws/resource_aws_guardduty_invite_accepter_test.go
@@ -23,7 +23,7 @@ func testAccAwsGuardDutyInviteAccepter_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsGuardDutyInviteAccepterDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -26,7 +26,7 @@ func TestAccAwsRamResourceShareAccepter_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAwsRamResourceShareAccepterDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -762,7 +762,7 @@ func TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSClusterDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
@@ -1353,8 +1353,12 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters(t *te
 	resourceNameSecondary := "aws_rds_cluster.secondary"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(&providers),
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
+			testAccPreCheckAWSRdsGlobalCluster(t)
+		},
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -1383,7 +1387,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier(t 
 			testAccMultipleRegionPreCheck(t, 2)
 			testAccPreCheckAWSRdsGlobalCluster(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -255,7 +255,7 @@ func TestAccAWSRedshiftCluster_snapshotCopy(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSRedshiftClusterDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_redshift_security_group_test.go
+++ b/aws/resource_aws_redshift_security_group_test.go
@@ -20,7 +20,7 @@ func TestAccAWSRedshiftSecurityGroup_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +45,7 @@ func TestAccAWSRedshiftSecurityGroup_ingressCidr(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -79,7 +79,7 @@ func TestAccAWSRedshiftSecurityGroup_updateIngressCidr(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -122,7 +122,7 @@ func TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -153,7 +153,7 @@ func TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
-		ProviderFactories: testAccProviderFactoriesEc2Classic(),
+		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckAWSRedshiftSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_route53_vpc_association_authorization_test.go
+++ b/aws/resource_aws_route53_vpc_association_authorization_test.go
@@ -21,7 +21,7 @@ func TestAccAWSRoute53VpcAssociationAuthorization_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53VPCAssociationAuthorizationDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccAWSRoute53VpcAssociationAuthorization_disappears(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53VPCAssociationAuthorizationDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -106,7 +106,7 @@ func TestAccAWSRoute53ZoneAssociation_CrossAccount(t *testing.T) {
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -137,7 +137,7 @@ func TestAccAWSRoute53ZoneAssociation_CrossRegion(t *testing.T) {
 			testAccPreCheck(t)
 			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckRoute53ZoneAssociationDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -1426,10 +1426,9 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
@@ -1457,7 +1456,6 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1482,7 +1480,6 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1506,7 +1503,6 @@ func TestAccAWSS3Bucket_Replication(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1546,10 +1542,9 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
@@ -1561,7 +1556,6 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1596,7 +1590,6 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlT
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1641,10 +1634,9 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessContr
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
@@ -1656,7 +1648,6 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessContr
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1688,7 +1679,6 @@ func TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessContr
 					resource.TestCheckResourceAttr(resourceName, "replication_configuration.0.rules.#", "1"),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1724,10 +1714,9 @@ func TestAccAWSS3Bucket_ReplicationWithoutStorageClass(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
@@ -1757,10 +1746,9 @@ func TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError(t *testing.T)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
@@ -1784,10 +1772,9 @@ func TestAccAWSS3Bucket_ReplicationWithoutPrefix(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
@@ -1822,10 +1809,9 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckAWSS3BucketDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
@@ -1838,7 +1824,6 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1876,7 +1861,6 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1915,7 +1899,6 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -1958,7 +1941,6 @@ func TestAccAWSS3Bucket_ReplicationSchemaV2(t *testing.T) {
 					testAccCheckAWSS3BucketExistsWithProvider("aws_s3_bucket.destination", testAccAwsRegionProviderFunc(alternateRegion, &providers)),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccAwsRegionProviderFunc(region, &providers),
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("foobar"),
@@ -2020,7 +2002,6 @@ func TestAccAWSS3Bucket_SameRegionReplicationSchemaV2(t *testing.T) {
 					testAccCheckAWSS3BucketExists(destinationResourceName),
 					testAccCheckAWSS3BucketReplicationRules(
 						resourceName,
-						testAccProviderFunc,
 						[]*s3.ReplicationRule{
 							{
 								ID: aws.String("testid"),
@@ -2881,7 +2862,7 @@ func testAccCheckAWSS3BucketLogging(n, b, p string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAWSS3BucketReplicationRules(n string, providerF func() *schema.Provider, rules []*s3.ReplicationRule) resource.TestCheckFunc {
+func testAccCheckAWSS3BucketReplicationRules(n string, rules []*s3.ReplicationRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[n]
 		for _, rule := range rules {
@@ -2912,9 +2893,7 @@ func testAccCheckAWSS3BucketReplicationRules(n string, providerF func() *schema.
 			}
 		}
 
-		provider := providerF()
-
-		conn := provider.Meta().(*AWSClient).s3conn
+		conn := testAccProvider.Meta().(*AWSClient).s3conn
 		out, err := conn.GetBucketReplication(&s3.GetBucketReplicationInput{
 			Bucket: aws.String(rs.Primary.ID),
 		})

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -220,7 +220,7 @@ func TestAccAWSSubnet_ignoreTags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_vpc_peering_connection_accepter_test.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter_test.go
@@ -75,10 +75,9 @@ func TestAccAWSVPCPeeringConnectionAccepter_differentRegionSameAccount(t *testin
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccAwsVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -123,7 +122,7 @@ func TestAccAWSVPCPeeringConnectionAccepter_sameRegionDifferentAccount(t *testin
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccAwsVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -157,11 +156,10 @@ func TestAccAWSVPCPeeringConnectionAccepter_differentRegionDifferentAccount(t *t
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccAwsVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -109,10 +109,9 @@ func TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount(t *testing
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -207,7 +206,7 @@ func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing
 			testAccPreCheck(t)
 			testAccAlternateAccountPreCheck(t)
 		},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -447,7 +447,7 @@ func testAccCheckAWSVpcPeeringConnectionDestroy(s *terraform.State) error {
 }
 
 func testAccCheckAWSVpcPeeringConnectionExists(n string, connection *ec2.VpcPeeringConnection) resource.TestCheckFunc {
-	return testAccCheckAWSVpcPeeringConnectionExistsWithProvider(n, connection, testAccProviderFunc)
+	return testAccCheckAWSVpcPeeringConnectionExistsWithProvider(n, connection, func() *schema.Provider { return testAccProvider })
 }
 
 func testAccCheckAWSVpcPeeringConnectionExistsWithProvider(n string, connection *ec2.VpcPeeringConnection, providerF func() *schema.Provider) resource.TestCheckFunc {
@@ -480,7 +480,7 @@ func testAccCheckAWSVpcPeeringConnectionExistsWithProvider(n string, connection 
 }
 
 func testAccCheckAWSVpcPeeringConnectionOptions(n, block string, options *ec2.VpcPeeringConnectionOptionsDescription) resource.TestCheckFunc {
-	return testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(n, block, options, testAccProviderFunc)
+	return testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(n, block, options, func() *schema.Provider { return testAccProvider })
 }
 
 func testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(n, block string, options *ec2.VpcPeeringConnectionOptionsDescription, providerF func() *schema.Provider) resource.TestCheckFunc {
@@ -526,11 +526,10 @@ func TestAccAWSVPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
 		IDRefreshIgnore:   []string{"auto_accept"},
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -550,13 +549,12 @@ func TestAccAWSVPCPeeringConnection_region(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccMultipleRegionsPreCheck(t)
-			testAccAlternateRegionPreCheck(t)
+			testAccMultipleRegionPreCheck(t, 2)
 		},
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"auto_accept"},
 
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesAlternate(&providers),
 		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -165,7 +165,7 @@ func TestAccAWSVpc_ignoreTags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(&providers),
+		ProviderFactories: testAccProviderFactoriesInternal(&providers),
 		CheckDestroy:      testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8316
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/15737
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/15791

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This change set continues the work of https://github.com/terraform-providers/terraform-provider-aws/pull/15877, bringing a consistent pattern for cross-region and cross-account testing and removing previously deprecated provider-level test functions. The `testAccProviderFactories` global variable is now generically for every test that only requires a single provider and prevents the previous issues where extraneous gRPC plugins were extraneously created (sometimes causing `ulimit` issues, but broadly a performance fix to remove them).

This also removes the temporary `testAccProviderFactoriesCur()` and `testAccProviderFactoriesEc2Classic()` functions, since anything only requiring a single provider can use `ProviderFactories: testAccProviderFactories` or `Providers: testAccProviders` (for now, its deprecated in the SDK and we'll be updating these everywhere to `ProviderFactories` anyways). This should mean that other existing EC2-Classic and special service region testing should not require changes to that particular field in future change sets that continue this effort.

After this, we are off to the races to remove the problematic environment variable handling causing issues across the provider acceptance testing.

Output from acceptance testing (CUR testing done in standalone account):

```
--- PASS: TestAccDataSourceAwsCurReportDefinition_additional (21.63s)
--- PASS: TestAccDataSourceAwsCurReportDefinition_basic (18.93s)

--- PASS: TestAccDataSourceAwsRoute53ResolverRule_basic (59.47s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags (265.34s)

--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (158.62s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (159.67s)

--- PASS: TestAccAWSCodePipeline_multiregion_basic (37.37s)
--- PASS: TestAccAWSCodePipeline_multiregion_Update (58.07s)
--- PASS: TestAccAWSCodePipeline_multiregion_ConvertSingleRegion (81.33s)

--- PASS: TestAccAwsCurReportDefinition_athena (18.30s)
--- PASS: TestAccAwsCurReportDefinition_basic (23.58s)
--- PASS: TestAccAwsCurReportDefinition_overwrite (18.10s)
--- PASS: TestAccAwsCurReportDefinition_parquet (18.67s)
--- PASS: TestAccAwsCurReportDefinition_refresh (21.62s)
--- PASS: TestAccAwsCurReportDefinition_textOrCsv (21.45s)

--- PASS: TestAccAWSDbSubnetGroupDataSource_basic (66.22s)
--- PASS: TestAccAWSDbSubnetGroupDataSource_nonexistent (3.06s)

--- PASS: TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount (1998.47s)
--- PASS: TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewaySingleAccount (1957.89s)
--- PASS: TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount (865.40s)
--- PASS: TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount (1186.07s)
--- PASS: TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount (1530.51s)
--- PASS: TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount (1633.65s)
--- PASS: TestAccAwsDxGatewayAssociation_multiVpnGatewaysSingleAccount (1697.33s)
--- PASS: TestAccAwsDxGatewayAssociation_V0StateUpgrade (1187.97s)

--- PASS: TestAccAwsDxGatewayAssociationProposal_AllowedPrefixes (138.31s)
--- PASS: TestAccAwsDxGatewayAssociationProposal_basicTransitGateway (227.10s)
--- PASS: TestAccAwsDxGatewayAssociationProposal_basicVpnGateway (68.42s)
--- PASS: TestAccAwsDxGatewayAssociationProposal_disappears (64.49s)

--- SKIP: TestAccAwsDxHostedPrivateVirtualInterface_AccepterTags (0.00s)
--- SKIP: TestAccAwsDxHostedPrivateVirtualInterface_basic (0.00s)

--- SKIP: TestAccAwsDxHostedPublicVirtualInterface_AccepterTags (0.00s)
--- SKIP: TestAccAwsDxHostedPublicVirtualInterface_basic (0.00s)

--- PASS: TestAccAwsDxHostedTransitVirtualInterface_serial (0.00s)
    --- SKIP: TestAccAwsDxHostedTransitVirtualInterface_serial/accepterTags (0.00s)
    --- SKIP: TestAccAwsDxHostedTransitVirtualInterface_serial/basic (0.00s)

--- PASS: TestAccAWSDynamoDbGlobalTable_basic (84.93s)
--- PASS: TestAccAWSDynamoDbGlobalTable_multipleRegions (102.52s)

--- PASS: TestAccAWSEbsSnapshotCopy_withRegions (75.67s)

--- PASS: TestAccAwsRamResourceShareAccepter_basic (36.70s)

--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_PrimarySecondaryClusters (1969.60s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_ReplicationSourceIdentifier (1819.35s)

--- PASS: TestAccAWSRDSCluster_ReplicationSourceIdentifier_KmsKeyId (1691.11s)

--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (631.18s)

--- PASS: TestAccAWSRedshiftSecurityGroup_basic (11.11s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressCidr (11.10s)
--- PASS: TestAccAWSRedshiftSecurityGroup_ingressSecurityGroup (12.47s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressCidr (23.94s)
--- PASS: TestAccAWSRedshiftSecurityGroup_updateIngressSecurityGroup (27.22s)

--- PASS: TestAccAWSRoute53VpcAssociationAuthorization_basic (99.00s)
--- PASS: TestAccAWSRoute53VpcAssociationAuthorization_disappears (94.43s)

--- PASS: TestAccAWSRoute53ZoneAssociation_CrossAccount (124.58s)
--- PASS: TestAccAWSRoute53ZoneAssociation_CrossRegion (157.69s)

--- PASS: TestAccAWSS3Bucket_Replication (145.26s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (86.49s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AddAccessControlTranslation (84.75s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (22.79s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (174.11s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (65.38s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (85.05s)
--- PASS: TestAccAWSS3Bucket_SameRegionReplicationSchemaV2 (73.58s)

--- PASS: TestAccAWSSubnet_ignoreTags (86.24s)

--- PASS: TestAccAWSVPCPeeringConnection_accept (144.21s)
--- PASS: TestAccAWSVPCPeeringConnection_basic (65.98s)
--- PASS: TestAccAWSVPCPeeringConnection_failedState (12.38s)
--- PASS: TestAccAWSVPCPeeringConnection_options (117.22s)
--- PASS: TestAccAWSVPCPeeringConnection_optionsNoAutoAccept (29.07s)
--- PASS: TestAccAWSVPCPeeringConnection_peerRegionAutoAccept (29.13s)
--- PASS: TestAccAWSVPCPeeringConnection_plan (52.19s)
--- PASS: TestAccAWSVPCPeeringConnection_region (70.00s)
--- PASS: TestAccAWSVPCPeeringConnection_tags (150.89s)

--- PASS: TestAccAWSVPCPeeringConnectionAccepter_differentRegionDifferentAccount (68.06s)
--- PASS: TestAccAWSVPCPeeringConnectionAccepter_differentRegionSameAccount (83.92s)
--- PASS: TestAccAWSVPCPeeringConnectionAccepter_sameRegionDifferentAccount (64.85s)
--- PASS: TestAccAWSVPCPeeringConnectionAccepter_sameRegionSameAccount (56.44s)

--- PASS: TestAccAWSVpcPeeringConnectionOptions_basic (70.42s)
--- PASS: TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount (75.28s)
--- PASS: TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount (41.96s)

--- FAIL: TestAccDataSourceAwsRoute53ResolverRule_SharedByMe (227.22s)
--- FAIL: TestAccDataSourceAwsRoute53ResolverRule_SharedWithMe (228.00s)

    data_source_aws_route53_resolver_rule_test.go:101: Step 1/1 error: Error running apply: 2020/10/28 22:02:11 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: Error associating principal with RAM resource share: UnknownResourceException: Organization o-upyv668dz5 could not be found.

--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachment_SharedTransitGateway (221.84s)

    resource_aws_ec2_transit_gateway_vpc_attachment_test.go:215: Step 1/2 error: Error running apply: 2020/10/28 22:02:10 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: Error associating principal with RAM resource share: UnknownResourceException: Organization o-upyv668dz5 could not be found.

        Error: error associating RAM Resource Share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.

--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_Tags (201.45s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation (211.45s)
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentAccepter_basic (221.42s)

    resource_aws_ec2_transit_gateway_vpc_attachment_accepter_test.go:135: Step 1/4 error: Error running apply: 2020/10/28 22:02:11 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: error associating RAM Resource Share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.

        Error: Error associating principal with RAM resource share: OperationNotPermittedException: The resource you are attempting to share can only be shared within your AWS Organization. This error may also occur if you have not enabled sharing with your AWS organization, or that onboarding process is still in progress.
```
