### PR TITLE
Create separate documentation category for EventBridge

### DIFF
--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -50,7 +50,7 @@ Elastic Load Balancing v2 (ALB/NLB)
 Elastic Map Reduce (EMR)
 Elastic Transcoder
 ElasticSearch
-EventBridge (fka CloudWatch Events)
+EventBridge (CloudWatch Events)
 File System (FSx)
 Firewall Manager (FMS)
 Gamelift

--- a/website/allowed-subcategories.txt
+++ b/website/allowed-subcategories.txt
@@ -50,6 +50,7 @@ Elastic Load Balancing v2 (ALB/NLB)
 Elastic Map Reduce (EMR)
 Elastic Transcoder
 ElasticSearch
+EventBridge (fka CloudWatch Events)
 File System (FSx)
 Firewall Manager (FMS)
 Gamelift

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -1,14 +1,17 @@
 ---
-subcategory: "CloudWatch"
+subcategory: "EventBridge (fka CloudWatch Events)"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_event_bus"
 description: |-
-  Provides a CloudWatch Events/EventBridge event bus resource.
+  Provides an EventBridge event bus resource.
 ---
 
 # Resource: aws_cloudwatch_event_bus
 
-Provides a CloudWatch Events/EventBridge event bus resource.
+Provides an EventBridge event bus resource.
+
+~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
+
 
 ## Example Usage
 
@@ -36,7 +39,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Cloudwatch Events event buses can be imported using the `name`, e.g.
+EventBridge event buses can be imported using the `name`, e.g.
 
 ```console
 $ terraform import aws_cloudwatch_event_bus.messenger chat-messages

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EventBridge (fka CloudWatch Events)"
+subcategory: "EventBridge (CloudWatch Events)"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_event_bus"
 description: |-

--- a/website/docs/r/cloudwatch_event_permission.html.markdown
+++ b/website/docs/r/cloudwatch_event_permission.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EventBridge (fka CloudWatch Events)"
+subcategory: "EventBridge (CloudWatch Events)"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_event_permission"
 description: |-

--- a/website/docs/r/cloudwatch_event_permission.html.markdown
+++ b/website/docs/r/cloudwatch_event_permission.html.markdown
@@ -1,14 +1,16 @@
 ---
-subcategory: "CloudWatch"
+subcategory: "EventBridge (fka CloudWatch Events)"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_event_permission"
 description: |-
-  Provides a resource to create a CloudWatch Events permission to support cross-account events in the current account default event bus.
+  Provides a resource to create an EventBridge permission to support cross-account events in the current account default event bus.
 ---
 
 # Resource: aws_cloudwatch_event_permission
 
-Provides a resource to create a CloudWatch Events permission to support cross-account events in the current account default event bus.
+Provides a resource to create an EventBridge permission to support cross-account events in the current account default event bus.
+
+~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
 
 ## Example Usage
 
@@ -55,11 +57,11 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The statement ID of the CloudWatch Events permission.
+* `id` - The statement ID of the EventBridge permission.
 
 ## Import
 
-CloudWatch Events permissions can be imported using the statement ID, e.g.
+EventBridge permissions can be imported using the statement ID, e.g.
 
 ```shell
 $ terraform import aws_cloudwatch_event_permission.DevAccountAccess DevAccountAccess

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EventBridge (fka CloudWatch Events)"
+subcategory: "EventBridge (CloudWatch Events)"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_event_rule"
 description: |-

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -1,14 +1,16 @@
 ---
-subcategory: "CloudWatch"
+subcategory: "EventBridge (fka CloudWatch Events)"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_event_rule"
 description: |-
-  Provides a CloudWatch Event Rule resource.
+  Provides an EventBridge Rule resource.
 ---
 
 # Resource: aws_cloudwatch_event_rule
 
-Provides a CloudWatch Event Rule resource.
+Provides an EventBridge Rule resource.
+
+~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
 
 ## Example Usage
 
@@ -66,7 +68,7 @@ The following arguments are supported:
 	For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`. At least one of `schedule_expression` or `event_pattern` is required. Can only be used on the default event bus.
 * `event_bus_name` - (Optional) The event bus to associate with this rule. If you omit this, the `default` event bus is used.
 * `event_pattern` - (Optional) The event pattern described a JSON object. At least one of `schedule_expression` or `event_pattern` is required.
-	See full documentation of [CloudWatch Events and Event Patterns](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CloudWatchEventsandEventPatterns.html) for details.
+	See full documentation of [Events and Event Patterns in EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html) for details.
 * `description` - (Optional) The description of the rule.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) associated with the role that is used for target invocation.
 * `is_enabled` - (Optional) Whether the rule should be enabled (defaults to `true`).
@@ -82,7 +84,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Cloudwatch Event Rules can be imported using the `event_bus_name/rule_name` (if you omit `event_bus_name`, the `default` event bus will be used), e.g.
+EventBridge Rules can be imported using the `event_bus_name/rule_name` (if you omit `event_bus_name`, the `default` event bus will be used), e.g.
 
 ```
 $ terraform import aws_cloudwatch_event_rule.console capture-console-sign-in

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "EventBridge (fka CloudWatch Events)"
+subcategory: "EventBridge (CloudWatch Events)"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_event_target"
 description: |-

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -1,14 +1,16 @@
 ---
-subcategory: "CloudWatch"
+subcategory: "EventBridge (fka CloudWatch Events)"
 layout: "aws"
 page_title: "AWS: aws_cloudwatch_event_target"
 description: |-
-  Provides a CloudWatch Event Target resource.
+  Provides an EventBridge Target resource.
 ---
 
 # Resource: aws_cloudwatch_event_target
 
-Provides a CloudWatch Event Target resource.
+Provides an EventBridge Target resource.
+
+~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
 
 ## Example Usage
 
@@ -240,7 +242,7 @@ DOC
 -> **Note:** `input` and `input_path` are mutually exclusive options.
 
 -> **Note:** In order to be able to have your AWS Lambda function or
-   SNS topic invoked by a CloudWatch Events rule, you must setup the right permissions
+   SNS topic invoked by an EventBridge rule, you must setup the right permissions
    using [`aws_lambda_permission`](https://www.terraform.io/docs/providers/aws/r/lambda_permission.html)
    or [`aws_sns_topic.policy`](https://www.terraform.io/docs/providers/aws/r/sns_topic.html#policy).
    More info [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/resource-based-policies-cwe.html).
@@ -309,7 +311,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 ## Import
 
-Cloud Watch Event Target can be imported using the role event_rule and target_id separated by `/`.
+EventBridge Targets can be imported using the role event_rule and target_id separated by `/`.
 
  ```
 $ terraform import aws_cloudwatch_event_target.test-event-target rule-name/target-id


### PR DESCRIPTION
CloudWatch Events has been rebranded as EventBridge, so create a new documentation category

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #9330

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

N/A