### PR TITLE
Adds tagging for EventBridge for aws_cloudwatch_event_* resources

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1038,6 +1038,12 @@ behavior "pull_request_path_labeler" "service_labels" {
       "**/*_emr_*",
       "**/emr_*"
     ]
+    "service/eventbridge" = [
+      # EventBridge is rebranded CloudWatch Events
+      "aws/internal/service/cloudwatchevents/**/*",
+      "**/*_cloudwatch_event_*",
+      "**/cloudwatch_event_*"
+    ]
     "service/firehose" = [
       "aws/internal/service/firehose/**/*",
       "**/*_firehose_*",

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -307,6 +307,10 @@ behavior "regexp_issue_labeler_v2" "service_labels" {
     "service/emr" = [
       "aws_emr_",
     ],
+    "service/eventbridge" = [
+      # EventBridge is rebranded CloudWatch Events
+      "aws_cloudwatch_event_",
+    ],
     "service/firehose" = [
       "aws_kinesis_firehose_",
     ],


### PR DESCRIPTION
Resources matching `aws_cloudwatch_event_*` are currently tagged with `service/cloudwatchevents`. Add tagging with `service/eventbridge` to match new branding.
